### PR TITLE
Fix polling regressions (CPU + page flicker) and polish settings update version display

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -359,3 +359,32 @@ Add a cross-platform status bar / tray icon experience for Izwi desktop with:
 - Follow-up fix:
   - The underlying `NewTranscriptionModal` now prevents outside-dismiss interactions while the stacked model modal is open, so clicks in the top modal no longer close the transcription modal underneath.
   - The route test now verifies a click inside the stacked model modal still triggers model selection while keeping the transcription modal open.
+
+# History Polling UX Reload Fix
+
+## Goal
+
+Stop `/transcription` list view from flashing a full-screen loading state during background polling after returning from a newly created record, and enforce the same no-reload UX for `/text-to-speech` and `/diarization`.
+
+## Plan
+
+- [x] Reproduce and isolate why list pages appear to reload while jobs are still pending.
+- [x] Update route history hooks so polling uses background refresh semantics and does not toggle the table-level full loading shell on every interval.
+- [x] Apply the same fix pattern to transcription and text-to-speech; confirm diarization behavior does not regress.
+- [x] Add focused route-level regression tests proving history content stays visible during polling.
+- [x] Run targeted verification (`vitest` route tests + `typecheck`) and capture results.
+
+## Review
+
+- `useTranscriptionHistory` and `useTextToSpeechHistory` now keep existing rows visible during interval polling by using background refresh semantics when data is already on screen.
+- Foreground loading behavior is preserved for initial loads and explicit refresh actions; only polling refreshes avoid the full table loading shell.
+- Added regression tests:
+  - `ui/src/features/transcription/route.test.tsx`
+  - `ui/src/features/text-to-speech/route.test.tsx`
+  Both assert history rows remain visible while a polling refresh request is in flight.
+- `/diarization` was verified via existing route coverage and remains stable; its list route still does not poll history continuously.
+- Verification:
+  - `npm run test -- src/features/transcription/route.test.tsx`
+  - `npm run test -- src/features/text-to-speech/route.test.tsx`
+  - `npm run test -- src/features/diarization/route.test.tsx`
+  - `npm run typecheck`

--- a/ui/src/app/providers/AppUpdateProvider.tsx
+++ b/ui/src/app/providers/AppUpdateProvider.tsx
@@ -4,6 +4,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
@@ -68,28 +69,43 @@ export function AppUpdateProvider({ children }: AppUpdateProviderProps) {
   const [isPromptOpen, setIsPromptOpen] = useState(false);
   const [progressPercent, setProgressPercent] = useState<number | null>(null);
   const [health, setHealth] = useState<UpdaterHealthStatus | null>(null);
+  const statusRef = useRef<UpdateStatus>("idle");
+  const healthRef = useRef<UpdaterHealthStatus | null>(null);
+
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
+
+  useEffect(() => {
+    healthRef.current = health;
+  }, [health]);
 
   const checkForUpdates = useCallback(
     async (manual = false) => {
       if (!isTauri()) {
         return;
       }
-      if (health && !health.enabled) {
+      const currentHealth = healthRef.current;
+      if (currentHealth && !currentHealth.enabled) {
+        statusRef.current = "error";
         setStatus("error");
-        setErrorMessage(health.disableReason ?? "Updates are disabled.");
+        setErrorMessage(currentHealth.disableReason ?? "Updates are disabled.");
         if (manual) {
           notify({
             title: "Updates are disabled",
-            description: health.disableReason ?? "Runtime policy has disabled updates.",
+            description:
+              currentHealth.disableReason ?? "Runtime policy has disabled updates.",
             tone: "warning",
           });
         }
         return;
       }
-      if (status === "checking" || status === "downloading") {
+      const currentStatus = statusRef.current;
+      if (currentStatus === "checking" || currentStatus === "downloading") {
         return;
       }
 
+      statusRef.current = "checking";
       setStatus("checking");
       setErrorMessage(null);
       setProgressPercent(null);
@@ -101,6 +117,7 @@ export function AppUpdateProvider({ children }: AppUpdateProviderProps) {
 
         if (!update) {
           setAvailableUpdate(null);
+          statusRef.current = "idle";
           setStatus("idle");
           void trackUpdateCheckCompleted("no_update");
           if (manual) {
@@ -114,6 +131,7 @@ export function AppUpdateProvider({ children }: AppUpdateProviderProps) {
         }
 
         setAvailableUpdate(update);
+        statusRef.current = "available";
         setStatus("available");
         setIsPromptOpen(true);
         void trackUpdateCheckCompleted("update_available", update.version);
@@ -128,6 +146,7 @@ export function AppUpdateProvider({ children }: AppUpdateProviderProps) {
       } catch (error) {
         const message =
           error instanceof Error ? error.message : "Unknown update-check error.";
+        statusRef.current = "error";
         setStatus("error");
         setErrorMessage(message);
         void trackUpdateCheckCompleted("failed", undefined, message);
@@ -140,7 +159,7 @@ export function AppUpdateProvider({ children }: AppUpdateProviderProps) {
         }
       }
     },
-    [health, notify, status],
+    [notify],
   );
 
   const installUpdate = useCallback(async () => {
@@ -236,9 +255,11 @@ export function AppUpdateProvider({ children }: AppUpdateProviderProps) {
 
     getUpdaterHealthSnapshot()
       .then((snapshot) => {
+        healthRef.current = snapshot;
         setHealth(snapshot);
       })
       .catch(() => {
+        healthRef.current = null;
         setHealth(null);
       });
 

--- a/ui/src/features/settings/route.tsx
+++ b/ui/src/features/settings/route.tsx
@@ -511,7 +511,7 @@ export function SettingsPage() {
           <SettingsSection
             icon={<RefreshCw className="h-4 w-4" />}
             title="Updates"
-            description={`Current version v${APP_VERSION}`}
+            description="Check for new releases and install updates."
           >
             <SettingsRow
               description={
@@ -529,6 +529,12 @@ export function SettingsPage() {
               }
               action={
                 <div className="flex flex-wrap items-center gap-2">
+                  <span className="inline-flex items-center gap-1 rounded-full border border-border/70 bg-[var(--bg-surface-0)] px-2.5 py-1 text-xs text-[var(--text-secondary)] whitespace-nowrap">
+                    <span>Version</span>
+                    <span className="font-mono font-semibold text-[var(--text-primary)]">
+                      v{APP_VERSION}
+                    </span>
+                  </span>
                   <StatusBadge tone={updateBadge.tone}>{updateBadge.label}</StatusBadge>
                   <Button
                     type="button"

--- a/ui/src/features/text-to-speech/hooks/useTextToSpeechHistory.ts
+++ b/ui/src/features/text-to-speech/hooks/useTextToSpeechHistory.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { api, type SpeechHistoryRecordSummary } from "@/api";
 import { normalizeSpeechProcessingStatus } from "@/features/text-to-speech/support";
@@ -14,13 +14,24 @@ export function useTextToSpeechHistory(): UseTextToSpeechHistoryResult {
   const [records, setRecords] = useState<SpeechHistoryRecordSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const recordsRef = useRef<SpeechHistoryRecordSummary[]>([]);
 
-  const refresh = useCallback(async () => {
-    setLoading(true);
-    setError(null);
+  useEffect(() => {
+    recordsRef.current = records;
+  }, [records]);
+
+  const loadRecords = useCallback(async (background = false) => {
+    const hasVisibleRecords = recordsRef.current.length > 0;
+    const backgroundRefresh = background && hasVisibleRecords;
+    if (!backgroundRefresh) {
+      setLoading(true);
+      setError(null);
+    }
+
     try {
       const nextRecords = await api.listTextToSpeechRecords();
       setRecords(nextRecords);
+      setError(null);
     } catch (err) {
       setError(
         err instanceof Error
@@ -31,6 +42,10 @@ export function useTextToSpeechHistory(): UseTextToSpeechHistoryResult {
       setLoading(false);
     }
   }, []);
+
+  const refresh = useCallback(async () => {
+    await loadRecords(false);
+  }, [loadRecords]);
 
   useEffect(() => {
     void refresh();
@@ -54,13 +69,13 @@ export function useTextToSpeechHistory(): UseTextToSpeechHistoryResult {
     }
 
     const intervalId = window.setInterval(() => {
-      void refresh();
+      void loadRecords(true);
     }, 2500);
 
     return () => {
       window.clearInterval(intervalId);
     };
-  }, [pollingRequired, refresh]);
+  }, [loadRecords, pollingRequired]);
 
   return {
     records,

--- a/ui/src/features/text-to-speech/route.test.tsx
+++ b/ui/src/features/text-to-speech/route.test.tsx
@@ -140,6 +140,16 @@ function renderRoute(initialEntry: string) {
   );
 }
 
+function deferredPromise<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("TextToSpeechPage", () => {
   beforeEach(() => {
     apiMocks.listTextToSpeechRecords.mockReset();
@@ -211,6 +221,76 @@ describe("TextToSpeechPage", () => {
     expect(
       screen.getByRole("heading", { name: "No text-to-speech jobs yet" }),
     ).toBeInTheDocument();
+  });
+
+  it("keeps history rows visible while text-to-speech polling refreshes in the background", async () => {
+    const intervalCallbacks: Array<() => void> = [];
+    const setIntervalSpy = vi
+      .spyOn(window, "setInterval")
+      .mockImplementation((handler) => {
+        if (typeof handler === "function") {
+          intervalCallbacks.push(handler);
+        }
+        return 1 as unknown as ReturnType<typeof window.setInterval>;
+      });
+    const clearIntervalSpy = vi
+      .spyOn(window, "clearInterval")
+      .mockImplementation(() => {});
+    const backgroundRefresh =
+      deferredPromise<Awaited<ReturnType<typeof apiMocks.listTextToSpeechRecords>>>();
+    apiMocks.listTextToSpeechRecords
+      .mockResolvedValueOnce([
+        buildSummary({
+          id: "tts-history-polling-1",
+          processing_status: "processing",
+          audio_filename: "voice-note.wav",
+          input_preview: "Rendering still in progress",
+        }),
+      ])
+      .mockImplementationOnce(() => backgroundRefresh.promise);
+
+    const view = renderRoute("/text-to-speech");
+
+    try {
+      expect(
+        await screen.findByText("Rendering still in progress"),
+      ).toBeInTheDocument();
+
+      await waitFor(() => expect(setIntervalSpy).toHaveBeenCalled());
+      if (intervalCallbacks.length === 0) {
+        throw new Error("Expected text-to-speech history polling to register an interval.");
+      }
+
+      intervalCallbacks.forEach((callback) => callback());
+
+      await waitFor(() =>
+        expect(apiMocks.listTextToSpeechRecords).toHaveBeenCalledTimes(2),
+      );
+
+      expect(screen.getByText("Rendering still in progress")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Loading text-to-speech history..."),
+      ).not.toBeInTheDocument();
+
+      backgroundRefresh.resolve([
+        buildSummary({
+          id: "tts-history-polling-1",
+          processing_status: "ready",
+          audio_filename: "voice-note.wav",
+          input_preview: "Rendering complete",
+          audio_duration_secs: 2.3,
+          generation_time_ms: 80,
+          rtf: 0.4,
+          tokens_generated: 42,
+        }),
+      ]);
+
+      expect(await screen.findByText("Rendering complete")).toBeInTheDocument();
+    } finally {
+      view.unmount();
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+    }
   });
 
   it("hides status column and uses saved voice names in history rows", async () => {

--- a/ui/src/features/transcription/hooks/useTranscriptionHistory.ts
+++ b/ui/src/features/transcription/hooks/useTranscriptionHistory.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { api, type TranscriptionRecordSummary } from "@/api";
 import {
@@ -17,13 +17,24 @@ export function useTranscriptionHistory(): UseTranscriptionHistoryResult {
   const [records, setRecords] = useState<TranscriptionRecordSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const recordsRef = useRef<TranscriptionRecordSummary[]>([]);
 
-  const refresh = useCallback(async () => {
-    setLoading(true);
-    setError(null);
+  useEffect(() => {
+    recordsRef.current = records;
+  }, [records]);
+
+  const loadRecords = useCallback(async (background = false) => {
+    const hasVisibleRecords = recordsRef.current.length > 0;
+    const backgroundRefresh = background && hasVisibleRecords;
+    if (!backgroundRefresh) {
+      setLoading(true);
+      setError(null);
+    }
+
     try {
       const nextRecords = await api.listTranscriptionRecords();
       setRecords(nextRecords);
+      setError(null);
     } catch (err) {
       setError(
         err instanceof Error
@@ -34,6 +45,10 @@ export function useTranscriptionHistory(): UseTranscriptionHistoryResult {
       setLoading(false);
     }
   }, []);
+
+  const refresh = useCallback(async () => {
+    await loadRecords(false);
+  }, [loadRecords]);
 
   useEffect(() => {
     void refresh();
@@ -67,13 +82,13 @@ export function useTranscriptionHistory(): UseTranscriptionHistoryResult {
     }
 
     const intervalId = window.setInterval(() => {
-      void refresh();
+      void loadRecords(true);
     }, 2500);
 
     return () => {
       window.clearInterval(intervalId);
     };
-  }, [pollingRequired, refresh]);
+  }, [loadRecords, pollingRequired]);
 
   return {
     records,

--- a/ui/src/features/transcription/route.test.tsx
+++ b/ui/src/features/transcription/route.test.tsx
@@ -215,6 +215,96 @@ describe("TranscriptionPage detail route", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps history rows visible while transcription polling refreshes in the background", async () => {
+    const intervalCallbacks: Array<() => void> = [];
+    const setIntervalSpy = vi
+      .spyOn(window, "setInterval")
+      .mockImplementation((handler) => {
+        if (typeof handler === "function") {
+          intervalCallbacks.push(handler);
+        }
+        return 1 as unknown as ReturnType<typeof window.setInterval>;
+      });
+    const clearIntervalSpy = vi
+      .spyOn(window, "clearInterval")
+      .mockImplementation(() => {});
+    const backgroundRefresh =
+      deferredPromise<Awaited<ReturnType<typeof apiMocks.listTranscriptionRecords>>>();
+    apiMocks.listTranscriptionRecords
+      .mockResolvedValueOnce([
+        {
+          id: "txr-history-polling-1",
+          created_at: 1,
+          model_id: "Parakeet-TDT-0.6B-v3",
+          aligner_model_id: null,
+          language: "English",
+          processing_status: "processing",
+          processing_error: null,
+          duration_secs: null,
+          processing_time_ms: null,
+          rtf: null,
+          audio_mime_type: "audio/wav",
+          audio_filename: "meeting.wav",
+          transcription_preview: "Still transcribing...",
+          transcription_chars: 20,
+          summary_status: "pending",
+          summary_preview: null,
+          summary_chars: 0,
+          summary_model_id: "Qwen3.5-4B",
+        },
+      ])
+      .mockImplementationOnce(() => backgroundRefresh.promise);
+
+    const view = renderRoute("/transcription");
+
+    try {
+      expect(await screen.findByText("Still transcribing...")).toBeInTheDocument();
+
+      await waitFor(() => expect(setIntervalSpy).toHaveBeenCalled());
+      if (intervalCallbacks.length === 0) {
+        throw new Error("Expected transcription history polling to register an interval.");
+      }
+
+      intervalCallbacks.forEach((callback) => callback());
+
+      await waitFor(() =>
+        expect(apiMocks.listTranscriptionRecords).toHaveBeenCalledTimes(2),
+      );
+
+      expect(screen.getByText("Still transcribing...")).toBeInTheDocument();
+      expect(screen.queryByText("Loading transcriptions...")).not.toBeInTheDocument();
+
+      backgroundRefresh.resolve([
+        {
+          id: "txr-history-polling-1",
+          created_at: 1,
+          model_id: "Parakeet-TDT-0.6B-v3",
+          aligner_model_id: null,
+          language: "English",
+          processing_status: "ready",
+          processing_error: null,
+          duration_secs: 5,
+          processing_time_ms: 120,
+          rtf: 0.8,
+          audio_mime_type: "audio/wav",
+          audio_filename: "meeting.wav",
+          transcription_preview: "Transcription complete.",
+          transcription_chars: 23,
+          summary_status: "ready",
+          summary_preview: "Summary complete.",
+          summary_chars: 17,
+          summary_model_id: "Qwen3.5-4B",
+        },
+      ]);
+
+      expect(await screen.findByText("Transcription complete.")).toBeInTheDocument();
+    } finally {
+      view.unmount();
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+    }
+  });
+
   it("shows standard row actions from the history menu", async () => {
     apiMocks.listTranscriptionRecords.mockResolvedValue([
       {


### PR DESCRIPTION
Prevents updater idle CPU spikes and transcription/TTS history reload flicker by using safer polling behavior, and refines the settings page update-version layout.


