### PR TITLE
Refactor /studio to route-style project history table and consistent detail/create UI

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -698,3 +698,57 @@ Improve `LFM2.5-1.2B-Instruct-GGUF` and `LFM2.5-1.2B-Thinking-GGUF` chat latency
   - `cargo check -p izwi-core`
   - `cargo test -p izwi-core lfm2::chat -- --nocapture`
   - user-host benchmark rerun pending (source of truth for TTFT impact)
+
+# Studio Route History Table Refactor Plan
+
+## Goal
+
+Refactor `/studio` project listing to align with the route pattern used by `/transcription`, `/diarization`, and `/text-to-speech`: operational history in a table with row actions, consistent loading/empty/error states, and cursor pagination behavior.
+
+## Plan
+
+- [x] Audit current `/studio` list UX and map matching history-table conventions from other routes.
+- [x] Introduce a dedicated Studio history table component with:
+  - row click navigation to `/studio/:projectId`
+  - columns for key project metadata and progress
+  - standardized overflow row actions (open + delete)
+  - loading, empty, and load-more states
+- [x] Replace the current card-grid listing in `StudioWorkspace` with the new table component while preserving delete confirmation behavior.
+- [x] Add focused tests for the new Studio history table behavior.
+- [x] Verify with typecheck and targeted UI tests.
+
+## Review
+
+- Added `StudioProjectHistoryTable` and aligned it with existing route table conventions:
+  - loading state, error state with retry, empty state with create CTA
+  - clickable rows that navigate to `/studio/:projectId`
+  - row overflow actions with `Open project` and `Delete`
+  - integrated cursor-based `Load more` control in table footer
+- Replaced Studio index card-grid listing with the new history table while keeping the existing project count summary header and existing delete confirmation dialog flow.
+- Kept the user-requested simplification by removing list search/filter/sort controls.
+- Added focused tests for the new Studio history table interactions:
+  - row open navigation
+  - row action delete callback
+  - empty-state create action
+  - load-more callback
+- Verification:
+  - `npm run typecheck` (in `ui/`)
+  - `npm run test -- src/features/studio/components/StudioProjectHistoryTable.test.tsx src/features/PageHeaderHistoryButtons.test.tsx`
+
+# Studio List Controls Removal
+
+## Goal
+
+Remove filter/sort controls from the `/studio` project listing UI.
+
+## Plan
+
+- [x] Remove search, status-filter, and sort controls from the Studio list header.
+- [x] Simplify list-state logic to render projects without filter/sort state.
+- [x] Verify UI compiles cleanly.
+
+## Review
+
+- Removed the `Search`, `All statuses`, and `Sort` controls from the Studio list surface.
+- Simplified `visibleProjects` to stable recency ordering without local filter/sort state.
+- Verification: `npm run typecheck` in `ui/`.

--- a/ui/src/components/StudioWorkspace.tsx
+++ b/ui/src/components/StudioWorkspace.tsx
@@ -13,7 +13,6 @@ import {
   ChevronLeft,
   CheckCircle2,
   Download,
-  FileAudio,
   FilePlus2,
   Library,
   Loader2,
@@ -77,6 +76,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { StudioSegmentEditor } from "@/features/studio/components/StudioSegmentEditor";
+import { StudioProjectHistoryTable } from "@/features/studio/components/StudioProjectHistoryTable";
 import { StudioWorkspaceScaffold } from "@/features/studio/components/StudioWorkspaceScaffold";
 import { useDownloadIndicator } from "@/utils/useDownloadIndicator";
 import { getSpeakerProfilesForVariant } from "@/types";
@@ -171,13 +171,6 @@ export function StudioWorkspace({
   const [projectMetaById, setProjectMetaById] = useState<
     Record<string, StudioProjectMetaRecord>
   >({});
-  const [projectSearch, setProjectSearch] = useState("");
-  const [projectStatusFilter, setProjectStatusFilter] = useState<
-    "all" | "in_progress" | "ready"
-  >("all");
-  const [projectSort, setProjectSort] = useState<"recent" | "name" | "progress">(
-    "recent",
-  );
   const [selectedProjectIdState, setSelectedProjectIdState] = useState<
     string | null
   >(null);
@@ -348,48 +341,10 @@ export function StudioWorkspace({
     [projects, selectedProjectId],
   );
 
-  const visibleProjects = useMemo(() => {
-    const search = projectSearch.trim().toLowerCase();
-    const filtered = projects.filter((project) => {
-      const meta = projectMetaById[project.id];
-      const tags = meta?.tags ?? [];
-      const completionReady =
-        project.segment_count > 0 &&
-        project.rendered_segment_count === project.segment_count;
-      const statusMatch =
-        projectStatusFilter === "all" ||
-        (projectStatusFilter === "ready" && completionReady) ||
-        (projectStatusFilter === "in_progress" && !completionReady);
-      const searchMatch =
-        !search ||
-        project.name.toLowerCase().includes(search) ||
-        project.model_id?.toLowerCase().includes(search) ||
-        tags.some((tag) => tag.toLowerCase().includes(search));
-      return statusMatch && searchMatch;
-    });
-
-    const sorted = [...filtered];
-    if (projectSort === "name") {
-      sorted.sort((left, right) => left.name.localeCompare(right.name));
-      return sorted;
-    }
-    if (projectSort === "progress") {
-      sorted.sort((left, right) => {
-        const leftRatio =
-          left.segment_count > 0
-            ? left.rendered_segment_count / left.segment_count
-            : 0;
-        const rightRatio =
-          right.segment_count > 0
-            ? right.rendered_segment_count / right.segment_count
-            : 0;
-        return rightRatio - leftRatio || right.updated_at - left.updated_at;
-      });
-      return sorted;
-    }
-    sorted.sort((left, right) => right.updated_at - left.updated_at);
-    return sorted;
-  }, [projectMetaById, projectSearch, projectSort, projectStatusFilter, projects]);
+  const visibleProjects = useMemo(
+    () => [...projects].sort((left, right) => right.updated_at - left.updated_at),
+    [projects],
+  );
 
   const projectDirty = useMemo(() => {
     if (!selectedProject) {
@@ -2220,7 +2175,7 @@ export function StudioWorkspace({
   );
   const projectLibraryCountLabel = `${projects.length}${projectsHasMore ? "+" : ""}`;
 
-  const projectLibraryFilters = (
+  const projectLibrarySummary = (
     <Card className="rounded-2xl border-0 bg-[var(--bg-surface-0)] p-0 shadow-none">
       <div className="flex items-start justify-between gap-3">
         <div>
@@ -2233,46 +2188,6 @@ export function StudioWorkspace({
         </div>
         <div className="rounded-lg border border-[var(--border-muted)] bg-[var(--bg-surface-1)] p-2 text-[var(--text-muted)]">
           <Library className="h-4 w-4" />
-        </div>
-      </div>
-      <div className="mt-4 space-y-2 rounded-xl bg-[var(--bg-surface-1)] p-3">
-        <Input
-          value={projectSearch}
-          onChange={(event) => setProjectSearch(event.target.value)}
-          placeholder="Search projects, models, or tags"
-          className="bg-[var(--bg-surface-0)]"
-        />
-        <div className="grid gap-2 sm:grid-cols-2">
-          <Select
-            value={projectStatusFilter}
-            onValueChange={(value) =>
-              setProjectStatusFilter(value as "all" | "in_progress" | "ready")
-            }
-          >
-            <SelectTrigger className="h-9 bg-[var(--bg-surface-0)] px-2 text-xs">
-              <SelectValue placeholder="All statuses" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All statuses</SelectItem>
-              <SelectItem value="in_progress">In progress</SelectItem>
-              <SelectItem value="ready">Ready to export</SelectItem>
-            </SelectContent>
-          </Select>
-          <Select
-            value={projectSort}
-            onValueChange={(value) =>
-              setProjectSort(value as "recent" | "name" | "progress")
-            }
-          >
-            <SelectTrigger className="h-9 bg-[var(--bg-surface-0)] px-2 text-xs">
-              <SelectValue placeholder="Sort: Recent" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="recent">Sort: Recent</SelectItem>
-              <SelectItem value="name">Sort: Name</SelectItem>
-              <SelectItem value="progress">Sort: Progress</SelectItem>
-            </SelectContent>
-          </Select>
         </div>
       </div>
     </Card>
@@ -2813,159 +2728,31 @@ export function StudioWorkspace({
 
         {!activeProjectId ? (
           <div className="space-y-5">
-            {projectLibraryFilters}
-
-            {projectsLoading ? (
-              <div className="flex items-center gap-2 rounded-xl border border-[var(--border-muted)] bg-[var(--bg-surface-1)] px-3 py-2 text-xs text-[var(--text-muted)]">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                Loading projects...
-              </div>
-            ) : projects.length === 0 ? (
-              <div className="bg-[var(--bg-surface-0)] p-8 sm:p-10">
-                <div className="flex min-h-[420px] flex-col items-center justify-center gap-6 text-center">
-                  <div className="rounded-2xl border border-[var(--border-muted)] bg-[var(--bg-surface-1)] p-4">
-                    <FileAudio className="h-6 w-6 text-[var(--text-muted)]" />
-                  </div>
-                  <div className="space-y-2">
-                    <p className="text-xl font-semibold text-[var(--text-primary)]">
-                      Create your first Studio project
-                    </p>
-                    <p className="max-w-xl text-sm leading-relaxed text-[var(--text-secondary)]">
-                      Projects keep script segments, voice settings, render progress,
-                      and export workflow in one place.
-                    </p>
-                  </div>
-                  <Button onClick={openCreateProjectDialog}>
-                    <FilePlus2 className="h-4 w-4" />
-                    New project
-                  </Button>
-                </div>
-              </div>
-            ) : visibleProjects.length === 0 ? (
-              <div className="rounded-xl border border-dashed border-[var(--border-muted)] bg-[var(--bg-surface-1)] px-4 py-4 text-sm text-[var(--text-muted)]">
-                No projects match the current search or filters.
-              </div>
-            ) : (
-              <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-                {visibleProjects.map((project) => {
-                  const meta = projectMetaById[project.id];
-                  const progressPercent =
-                    project.segment_count > 0
-                      ? Math.round(
-                          (project.rendered_segment_count / project.segment_count) * 100,
-                        )
-                      : 0;
-                  const completionLabel = `${project.rendered_segment_count}/${project.segment_count} rendered`;
-                  const projectStatus =
-                    progressPercent >= 100
-                      ? "Ready"
-                      : project.rendered_segment_count > 0
-                        ? "In progress"
-                        : "Not rendered";
-                  return (
-                    <Card
-                      key={project.id}
-                      role="button"
-                      tabIndex={0}
-                      onClick={() => {
-                        setSelectedProjectId(project.id);
-                      }}
-                      onKeyDown={(event) => {
-                        if (event.currentTarget !== event.target) {
-                          return;
-                        }
-                        if (event.key === "Enter" || event.key === " ") {
-                          event.preventDefault();
-                          setSelectedProjectId(project.id);
-                        }
-                      }}
-                      className="group rounded-2xl border-[var(--border-muted)] bg-[var(--bg-surface-0)] p-4 text-left shadow-none transition-colors hover:border-[var(--border-strong)] hover:bg-[var(--bg-surface-1)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                    >
-                      <div className="flex items-center justify-between gap-2">
-                        <h3 className="truncate text-base font-semibold text-[var(--text-primary)]">
-                          {project.name}
-                        </h3>
-                        <button
-                          type="button"
-                          onPointerDown={(event) => {
-                            event.stopPropagation();
-                          }}
-                          onClick={(event) => {
-                            event.preventDefault();
-                            event.stopPropagation();
-                            openDeleteProjectConfirm(project.id, project.name);
-                          }}
-                          className="app-sidebar-delete-btn"
-                          title="Delete project"
-                          aria-label={`Delete project ${project.name}`}
-                          disabled={deletingProject}
-                        >
-                          <Trash2 className="h-3.5 w-3.5" />
-                        </button>
-                      </div>
-
-                      <div className="mt-2 flex flex-wrap items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.12em]">
-                        <span
-                          className={cn(
-                            "rounded-full border px-2 py-0.5",
-                            progressPercent >= 100
-                              ? "border-[var(--status-positive-border)] bg-[var(--status-positive-bg)] text-[var(--status-positive-text)]"
-                              : "border-[var(--status-warning-border)] bg-[var(--status-warning-bg)] text-[var(--status-warning-text)]",
-                          )}
-                        >
-                          {projectStatus}
-                        </span>
-                      </div>
-
-                      <div className="mt-3 flex items-center gap-2">
-                        <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-[var(--bg-surface-3)]">
-                          <div
-                            className="h-full rounded-full bg-[var(--accent-solid)] transition-[width] duration-300"
-                            style={{ width: `${progressPercent}%` }}
-                          />
-                        </div>
-                        <span className="text-[11px] text-[var(--text-muted)]">
-                          {progressPercent}%
-                        </span>
-                      </div>
-
-                      <div className="mt-2 flex items-center justify-between text-xs text-[var(--text-muted)]">
-                        <span>{completionLabel}</span>
-                        <span>{project.total_chars} chars</span>
-                      </div>
-
-                      <p className="mt-2 line-clamp-2 text-xs text-[var(--text-secondary)]">
-                        {project.model_id || "No model selected"}
-                        {meta?.tags?.length ? ` · ${meta.tags.slice(0, 2).join(" · ")}` : ""}
-                      </p>
-                      <div className="mt-3 text-[11px] text-[var(--text-muted)]">
-                        Updated {formatRelativeDate(project.updated_at)}
-                      </div>
-                    </Card>
-                  );
-                })}
-              </div>
-            )}
-
-            {projects.length > 0 &&
-            projectsHasMore &&
-            Boolean(projectsNextCursor) ? (
-              <div className="flex justify-center rounded-xl border border-[var(--border-muted)] bg-[var(--bg-surface-0)] px-3 py-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="h-9 gap-2"
-                  onClick={() => void loadMoreProjects()}
-                  disabled={projectsLoadingMore}
-                >
-                  {projectsLoadingMore ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : null}
-                  Load more
-                </Button>
-              </div>
-            ) : null}
+            {projectLibrarySummary}
+            <StudioProjectHistoryTable
+              projects={visibleProjects}
+              projectMetaById={projectMetaById}
+              loading={projectsLoading}
+              error={projects.length === 0 ? workspaceError : null}
+              deletePending={deletingProject}
+              loadMore={{
+                canLoadMore: projectsHasMore && Boolean(projectsNextCursor),
+                loading: projectsLoadingMore,
+                onLoadMore: () => {
+                  void loadMoreProjects();
+                },
+              }}
+              onRefresh={() => {
+                void loadProjects();
+              }}
+              onCreateProject={openCreateProjectDialog}
+              onOpenProject={(projectId) => {
+                setSelectedProjectId(projectId);
+              }}
+              onRequestDeleteProject={(project) => {
+                openDeleteProjectConfirm(project.id, project.name);
+              }}
+            />
           </div>
         ) : !selectedProject ? (
           <Card className="rounded-2xl border-[var(--border-muted)] bg-[var(--bg-surface-0)] p-6 shadow-none">

--- a/ui/src/components/StudioWorkspace.tsx
+++ b/ui/src/components/StudioWorkspace.tsx
@@ -8,9 +8,9 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import {
+  ArrowLeft,
   AlertCircle,
   AlertTriangle,
-  ChevronLeft,
   CheckCircle2,
   Download,
   FilePlus2,
@@ -2737,12 +2737,12 @@ export function StudioWorkspace({
             <div className="flex flex-col items-start gap-3">
               <Button
                 type="button"
-                variant="ghost"
+                variant="outline"
                 size="sm"
                 onClick={() => onNavigateProject?.(null)}
-                className="h-8 px-2 text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+                className="h-10 gap-2 rounded-full border-[var(--border-muted)] bg-[var(--bg-surface-0)] px-4 text-sm font-medium text-[var(--text-secondary)] shadow-sm hover:bg-[var(--bg-surface-1)]"
               >
-                <ChevronLeft className="h-3.5 w-3.5" />
+                <ArrowLeft className="h-4 w-4" />
                 Back to Studio
               </Button>
               <div className="text-sm text-[var(--text-muted)]">
@@ -2758,12 +2758,12 @@ export function StudioWorkspace({
                   {onNavigateProject ? (
                     <Button
                       type="button"
-                      variant="ghost"
+                      variant="outline"
                       size="sm"
                       onClick={() => onNavigateProject(null)}
-                      className="mb-2 h-8 px-2 text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+                      className="mb-4 h-10 gap-2 rounded-full border-[var(--border-muted)] bg-[var(--bg-surface-0)] px-4 text-sm font-medium text-[var(--text-secondary)] shadow-sm hover:bg-[var(--bg-surface-1)]"
                     >
-                      <ChevronLeft className="h-3.5 w-3.5" />
+                      <ArrowLeft className="h-4 w-4" />
                       Back to Studio
                     </Button>
                   ) : null}

--- a/ui/src/components/StudioWorkspace.tsx
+++ b/ui/src/components/StudioWorkspace.tsx
@@ -14,7 +14,6 @@ import {
   CheckCircle2,
   Download,
   FilePlus2,
-  Library,
   Loader2,
   PencilLine,
   Settings2,
@@ -2173,26 +2172,6 @@ export function StudioWorkspace({
       ) : null}
     </div>
   );
-  const projectLibraryCountLabel = `${projects.length}${projectsHasMore ? "+" : ""}`;
-
-  const projectLibrarySummary = (
-    <Card className="rounded-2xl border-0 bg-[var(--bg-surface-0)] p-0 shadow-none">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <div className="text-[11px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-            Project Library
-          </div>
-          <div className="mt-1 text-base font-semibold text-[var(--text-primary)]">
-            {projectLibraryCountLabel} project{projects.length === 1 ? "" : "s"}
-          </div>
-        </div>
-        <div className="rounded-lg border border-[var(--border-muted)] bg-[var(--bg-surface-1)] p-2 text-[var(--text-muted)]">
-          <Library className="h-4 w-4" />
-        </div>
-      </div>
-    </Card>
-  );
-
   return (
     <>
       {headerActionContainer === undefined
@@ -2728,7 +2707,6 @@ export function StudioWorkspace({
 
         {!activeProjectId ? (
           <div className="space-y-5">
-            {projectLibrarySummary}
             <StudioProjectHistoryTable
               projects={visibleProjects}
               projectMetaById={projectMetaById}

--- a/ui/src/components/StudioWorkspace.tsx
+++ b/ui/src/components/StudioWorkspace.tsx
@@ -2222,6 +2222,7 @@ export function StudioWorkspace({
                   value={newProjectName}
                   onChange={(event) => setNewProjectName(event.target.value)}
                   placeholder="Optional project name"
+                  className="bg-[var(--bg-surface-1)] border-[var(--border-muted)]"
                 />
               </div>
 

--- a/ui/src/features/studio/components/StudioProjectHistoryTable.test.tsx
+++ b/ui/src/features/studio/components/StudioProjectHistoryTable.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { StudioProjectSummary } from "@/api";
+import { StudioProjectHistoryTable } from "@/features/studio/components/StudioProjectHistoryTable";
+
+function buildProject(overrides: Partial<StudioProjectSummary> = {}): StudioProjectSummary {
+  return {
+    id: "studio-project-1",
+    created_at: Date.UTC(2026, 3, 1, 9, 30),
+    updated_at: Date.UTC(2026, 3, 2, 11, 15),
+    name: "Narration Project",
+    source_filename: "script.txt",
+    model_id: "Orpheus-3B-0.1-ft-Q8_0-GGUF",
+    voice_mode: "built_in",
+    speaker: "Vivian",
+    saved_voice_id: null,
+    speed: 1,
+    segment_count: 12,
+    rendered_segment_count: 7,
+    total_chars: 3200,
+    ...overrides,
+  };
+}
+
+describe("StudioProjectHistoryTable", () => {
+  it("opens a project when a row is clicked", () => {
+    const onOpenProject = vi.fn();
+    render(
+      <StudioProjectHistoryTable
+        projects={[buildProject()]}
+        onOpenProject={onOpenProject}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("row", { name: /Open Studio project Narration Project/i }),
+    );
+
+    expect(onOpenProject).toHaveBeenCalledWith("studio-project-1");
+  });
+
+  it("forwards delete requests from row actions", async () => {
+    const onRequestDeleteProject = vi.fn();
+    render(
+      <StudioProjectHistoryTable
+        projects={[buildProject()]}
+        onOpenProject={vi.fn()}
+        onRequestDeleteProject={onRequestDeleteProject}
+      />,
+    );
+
+    const rowActionsButton = screen.getByRole("button", {
+      name: /More actions for Narration Project/i,
+    });
+    fireEvent.pointerDown(rowActionsButton);
+    fireEvent.click(rowActionsButton);
+    fireEvent.click(await screen.findByRole("menuitem", { name: /^Delete$/i }));
+
+    expect(onRequestDeleteProject).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "studio-project-1", name: "Narration Project" }),
+    );
+  });
+
+  it("shows empty state with create action", () => {
+    const onCreateProject = vi.fn();
+    render(
+      <StudioProjectHistoryTable
+        projects={[]}
+        onOpenProject={vi.fn()}
+        onCreateProject={onCreateProject}
+      />,
+    );
+
+    expect(screen.getByText("No Studio projects yet")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /New project/i }));
+    expect(onCreateProject).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders load-more controls and triggers callback", () => {
+    const onLoadMore = vi.fn();
+    render(
+      <StudioProjectHistoryTable
+        projects={[buildProject()]}
+        onOpenProject={vi.fn()}
+        loadMore={{
+          canLoadMore: true,
+          loading: false,
+          onLoadMore,
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Load more/i }));
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/features/studio/components/StudioProjectHistoryTable.tsx
+++ b/ui/src/features/studio/components/StudioProjectHistoryTable.tsx
@@ -193,17 +193,6 @@ export function StudioProjectHistoryTable({
                       >
                         {statusLabel}
                       </span>
-                      <div className="flex items-center gap-2">
-                        <div className="h-1.5 w-24 overflow-hidden rounded-full bg-[var(--bg-surface-2)]">
-                          <div
-                            className="h-full rounded-full bg-[var(--accent-solid)] transition-[width] duration-300"
-                            style={{ width: `${progressPercent}%` }}
-                          />
-                        </div>
-                        <span className="text-xs text-[var(--text-secondary)]">
-                          {progressPercent}%
-                        </span>
-                      </div>
                     </div>
                   </td>
                   <td className="px-4 py-3 align-top text-[var(--text-secondary)]">

--- a/ui/src/features/studio/components/StudioProjectHistoryTable.tsx
+++ b/ui/src/features/studio/components/StudioProjectHistoryTable.tsx
@@ -1,0 +1,281 @@
+import {
+  AlertTriangle,
+  ExternalLink,
+  Loader2,
+  MoreVertical,
+  Trash2,
+} from "lucide-react";
+import type { StudioProjectMetaRecord, StudioProjectSummary } from "@/api";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+interface StudioProjectHistoryTableProps {
+  projects: StudioProjectSummary[];
+  projectMetaById?: Record<string, StudioProjectMetaRecord>;
+  loading?: boolean;
+  error?: string | null;
+  deletePending?: boolean;
+  loadMore?: {
+    canLoadMore: boolean;
+    loading: boolean;
+    onLoadMore: () => void;
+  };
+  onRefresh?: () => void;
+  onCreateProject?: () => void;
+  onOpenProject: (projectId: string) => void;
+  onRequestDeleteProject?: (project: StudioProjectSummary) => void;
+}
+
+function formatCreatedAt(timestampMs: number): string {
+  if (!Number.isFinite(timestampMs)) {
+    return "Unknown time";
+  }
+  const value = new Date(timestampMs);
+  if (Number.isNaN(value.getTime())) {
+    return "Unknown time";
+  }
+  return value.toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function rowLabel(project: StudioProjectSummary): string {
+  return project.name || project.model_id || project.id;
+}
+
+export function StudioProjectHistoryTable({
+  projects,
+  projectMetaById = {},
+  loading = false,
+  error = null,
+  deletePending = false,
+  loadMore,
+  onRefresh,
+  onCreateProject,
+  onOpenProject,
+  onRequestDeleteProject,
+}: StudioProjectHistoryTableProps) {
+  if (loading) {
+    return (
+      <div className="mb-6 flex min-h-[20rem] items-center justify-center rounded-2xl border border-[var(--border-muted)] bg-[var(--bg-surface-0)] text-sm text-[var(--text-muted)]">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        Loading Studio projects...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="mb-6 rounded-2xl border border-[var(--danger-border)] bg-[var(--danger-bg)] p-4 text-sm text-[var(--danger-text)]">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            <p>{error}</p>
+          </div>
+          {onRefresh ? (
+            <Button type="button" variant="outline" size="sm" onClick={onRefresh}>
+              Retry
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  if (projects.length === 0) {
+    return (
+      <div className="mb-6 rounded-2xl border border-[var(--border-muted)] bg-[var(--bg-surface-0)] p-10 text-center">
+        <h3 className="text-lg font-semibold text-[var(--text-primary)]">
+          No Studio projects yet
+        </h3>
+        <p className="mt-2 text-sm text-[var(--text-muted)]">
+          Saved long-form text-to-speech projects will appear here.
+        </p>
+        {onCreateProject ? (
+          <div className="mt-4">
+            <Button type="button" onClick={onCreateProject}>
+              New project
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-6 overflow-hidden rounded-2xl border border-[var(--border-muted)] bg-[var(--bg-surface-0)]">
+      <div className="overflow-x-auto">
+        <table className="min-w-full border-collapse text-sm">
+          <thead className="bg-[var(--bg-surface-1)] text-left text-xs uppercase tracking-[0.14em] text-[var(--text-muted)]">
+            <tr>
+              <th className="px-4 py-3 font-semibold sm:px-5">Created</th>
+              <th className="px-4 py-3 font-semibold">Project</th>
+              <th className="px-4 py-3 font-semibold">Progress</th>
+              <th className="px-4 py-3 font-semibold">Segments</th>
+              <th className="px-4 py-3 font-semibold">Model</th>
+              <th className="w-[56px] px-3 py-3 text-right font-semibold sm:px-4">
+                <span className="sr-only">Actions</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {projects.map((project) => {
+              const progressPercent =
+                project.segment_count > 0
+                  ? Math.round(
+                      (project.rendered_segment_count / project.segment_count) * 100,
+                    )
+                  : 0;
+              const statusLabel =
+                progressPercent >= 100
+                  ? "Ready"
+                  : project.rendered_segment_count > 0
+                    ? "In progress"
+                    : "Not rendered";
+              const statusClass =
+                progressPercent >= 100
+                  ? "border-[var(--status-positive-border)] bg-[var(--status-positive-bg)] text-[var(--status-positive-text)]"
+                  : "border-[var(--status-warning-border)] bg-[var(--status-warning-bg)] text-[var(--status-warning-text)]";
+              const tags = projectMetaById[project.id]?.tags ?? [];
+
+              return (
+                <tr
+                  key={project.id}
+                  aria-label={`Open Studio project ${rowLabel(project)}`}
+                  className="cursor-pointer border-t border-[var(--border-muted)] transition-colors hover:bg-[var(--bg-surface-1)]"
+                  onClick={(event) => {
+                    if ((event.target as HTMLElement).closest("[data-row-action]")) {
+                      return;
+                    }
+                    onOpenProject(project.id);
+                  }}
+                  onKeyDown={(event) => {
+                    if ((event.target as HTMLElement).closest("[data-row-action]")) {
+                      return;
+                    }
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      onOpenProject(project.id);
+                    }
+                  }}
+                  tabIndex={0}
+                >
+                  <td className="px-4 py-3 align-top text-[var(--text-secondary)] sm:px-5">
+                    {formatCreatedAt(project.created_at)}
+                  </td>
+                  <td className="px-4 py-3 align-top">
+                    <div className="font-medium text-[var(--text-primary)]">
+                      {project.name}
+                    </div>
+                    <div className="mt-1 max-w-[28rem] text-xs text-[var(--text-muted)]">
+                      {tags.length > 0
+                        ? tags.slice(0, 3).join(" · ")
+                        : project.source_filename || "Script project"}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 align-top">
+                    <div className="space-y-2">
+                      <span
+                        className={cn(
+                          "inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.12em]",
+                          statusClass,
+                        )}
+                      >
+                        {statusLabel}
+                      </span>
+                      <div className="flex items-center gap-2">
+                        <div className="h-1.5 w-24 overflow-hidden rounded-full bg-[var(--bg-surface-2)]">
+                          <div
+                            className="h-full rounded-full bg-[var(--accent-solid)] transition-[width] duration-300"
+                            style={{ width: `${progressPercent}%` }}
+                          />
+                        </div>
+                        <span className="text-xs text-[var(--text-secondary)]">
+                          {progressPercent}%
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 align-top text-[var(--text-secondary)]">
+                    <div className="font-medium text-[var(--text-primary)]">
+                      {project.rendered_segment_count}/{project.segment_count}
+                    </div>
+                    <div className="mt-1 text-xs text-[var(--text-muted)]">
+                      {project.total_chars} chars
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 align-top text-[var(--text-secondary)]">
+                    {project.model_id || "Not set"}
+                  </td>
+                  <td className="px-3 py-2 align-top text-right sm:px-4">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          data-row-action
+                          className="h-8 w-8 rounded-full text-[var(--text-muted)] hover:bg-[var(--bg-surface-2)] hover:text-[var(--text-primary)]"
+                          aria-label={`More actions for ${rowLabel(project)}`}
+                          onClick={(event) => event.stopPropagation()}
+                          onKeyDown={(event) => event.stopPropagation()}
+                        >
+                          <MoreVertical className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent
+                        align="end"
+                        className="w-48"
+                        onClick={(event) => event.stopPropagation()}
+                      >
+                        <DropdownMenuItem onSelect={() => onOpenProject(project.id)}>
+                          <ExternalLink className="mr-2 h-4 w-4" />
+                          Open project
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          disabled={!onRequestDeleteProject || deletePending}
+                          onSelect={() => onRequestDeleteProject?.(project)}
+                          className="text-[var(--danger-text)] focus:text-[var(--danger-text)]"
+                        >
+                          <Trash2 className="mr-2 h-4 w-4" />
+                          Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {loadMore?.canLoadMore ? (
+        <div className="flex justify-center border-t border-[var(--border-muted)] px-4 py-3 sm:px-5">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-9 gap-2"
+            onClick={loadMore.onLoadMore}
+            disabled={loadMore.loading}
+          >
+            {loadMore.loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+            Load more
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
Replaces the Studio card grid with a paginated history table (row open/delete actions), removes extra listing chrome (filters/sorting/library summary/progress bar), and aligns /studio/:id back-button plus create-modal input styling with other routes.