### PR TITLE
feat(ui/server): refine tts model flow and remove dead code warnings

### DIFF
--- a/crates/izwi-server/src/diarization_store.rs
+++ b/crates/izwi-server/src/diarization_store.rs
@@ -328,14 +328,6 @@ impl DiarizationStore {
         })
     }
 
-    pub async fn list_records(
-        &self,
-        limit: usize,
-    ) -> anyhow::Result<Vec<DiarizationRecordSummary>> {
-        let (records, _) = self.list_records_page(limit, None).await?;
-        Ok(records)
-    }
-
     pub async fn list_records_page(
         &self,
         limit: usize,
@@ -1744,8 +1736,12 @@ mod tests {
             Some(&"Alice".to_string())
         );
 
-        let summaries = store.list_records(10).await.expect("list should succeed");
+        let (summaries, next_cursor) = store
+            .list_records_page(10, None)
+            .await
+            .expect("list should succeed");
         assert_eq!(summaries.len(), 1);
+        assert!(next_cursor.is_none());
         assert_eq!(
             summaries[0].processing_status,
             DiarizationProcessingStatus::Ready

--- a/crates/izwi-server/src/saved_voice_store.rs
+++ b/crates/izwi-server/src/saved_voice_store.rs
@@ -138,11 +138,6 @@ impl SavedVoiceStore {
         })
     }
 
-    pub async fn list_voices(&self, limit: usize) -> anyhow::Result<Vec<SavedVoiceSummary>> {
-        let (voices, _) = self.list_voices_page(limit, None).await?;
-        Ok(voices)
-    }
-
     pub async fn list_voices_page(
         &self,
         limit: usize,

--- a/crates/izwi-server/src/speech_history_store.rs
+++ b/crates/izwi-server/src/speech_history_store.rs
@@ -239,15 +239,6 @@ impl SpeechHistoryStore {
         })
     }
 
-    pub async fn list_records(
-        &self,
-        route_kind: SpeechRouteKind,
-        limit: usize,
-    ) -> anyhow::Result<Vec<SpeechHistoryRecordSummary>> {
-        let (records, _) = self.list_records_page(route_kind, limit, None).await?;
-        Ok(records)
-    }
-
     pub async fn list_records_page(
         &self,
         route_kind: SpeechRouteKind,

--- a/crates/izwi-server/src/studio_project_store.rs
+++ b/crates/izwi-server/src/studio_project_store.rs
@@ -402,11 +402,6 @@ impl StudioProjectStore {
         Ok(Self { db_path })
     }
 
-    pub async fn list_projects(&self, limit: usize) -> anyhow::Result<Vec<StudioProjectSummary>> {
-        let (projects, _) = self.list_projects_page(limit, None).await?;
-        Ok(projects)
-    }
-
     pub async fn list_projects_page(
         &self,
         limit: usize,

--- a/crates/izwi-server/src/transcription_store.rs
+++ b/crates/izwi-server/src/transcription_store.rs
@@ -262,14 +262,6 @@ impl TranscriptionStore {
         })
     }
 
-    pub async fn list_records(
-        &self,
-        limit: usize,
-    ) -> anyhow::Result<Vec<TranscriptionRecordSummary>> {
-        let (records, _) = self.list_records_page(limit, None).await?;
-        Ok(records)
-    }
-
     pub async fn list_records_page(
         &self,
         limit: usize,
@@ -1405,8 +1397,12 @@ mod tests {
         );
         assert!(created.summary_text.is_none());
 
-        let summaries = store.list_records(10).await.expect("list should succeed");
+        let (summaries, next_cursor) = store
+            .list_records_page(10, None)
+            .await
+            .expect("list should succeed");
         assert_eq!(summaries.len(), 1);
+        assert!(next_cursor.is_none());
         assert!(summaries[0].transcription_preview.contains("Hello there."));
         assert_eq!(
             summaries[0].summary_status,
@@ -1543,7 +1539,11 @@ mod tests {
             Some("Runtime unavailable")
         );
 
-        let summaries = store.list_records(10).await.expect("list should succeed");
+        let (summaries, next_cursor) = store
+            .list_records_page(10, None)
+            .await
+            .expect("list should succeed");
+        assert!(next_cursor.is_none());
         assert_eq!(
             summaries[0].processing_status,
             TranscriptionProcessingStatus::Failed

--- a/ui/src/features/text-to-speech/components/NewTextToSpeechModal.tsx
+++ b/ui/src/features/text-to-speech/components/NewTextToSpeechModal.tsx
@@ -16,7 +16,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { Slider } from "@/components/ui/slider";
 import { StatusBadge } from "@/components/ui/status-badge";
 import {
   Select,
@@ -35,6 +34,8 @@ interface NewTextToSpeechModalProps {
   selectedModelReady: boolean;
   initialSavedVoiceId?: string | null;
   initialSpeaker?: string | null;
+  onLoadSelectedModel?: (variant: string) => Promise<void> | void;
+  onUnloadSelectedModel?: (variant: string) => Promise<void> | void;
   onModelRequired: () => void;
   onCreated: (record: SpeechHistoryRecord) => Promise<void> | void;
   onStreamingStart?: () => void;
@@ -67,6 +68,8 @@ export function NewTextToSpeechModal({
   selectedModelReady,
   initialSavedVoiceId = null,
   initialSpeaker = null,
+  onLoadSelectedModel,
+  onUnloadSelectedModel,
   onModelRequired,
   onCreated,
   onStreamingStart,
@@ -78,9 +81,11 @@ export function NewTextToSpeechModal({
   const [speaker, setSpeaker] = useState(initialSpeaker || "Vivian");
   const [savedVoiceId, setSavedVoiceId] = useState(initialSavedVoiceId || "");
   const [voiceDescription, setVoiceDescription] = useState("");
-  const [speed, setSpeed] = useState(1);
   const [streamingEnabled, setStreamingEnabled] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [modelActionPending, setModelActionPending] = useState<
+    "load" | "unload" | null
+  >(null);
   const [error, setError] = useState<string | null>(null);
   const [savedVoices, setSavedVoices] = useState<SavedVoiceSummary[]>([]);
   const [savedVoicesLoading, setSavedVoicesLoading] = useState(false);
@@ -94,7 +99,6 @@ export function NewTextToSpeechModal({
   const supportsVoiceDescription =
     capabilities?.supports_voice_description ?? false;
   const supportsStreaming = capabilities?.supports_streaming ?? false;
-  const supportsSpeedControl = capabilities?.supports_speed_control ?? false;
   const effectiveVoiceWorkflow: EffectiveVoiceWorkflow = supportsReferenceVoices
     ? "saved_voice"
     : supportsBuiltInVoices
@@ -124,14 +128,67 @@ export function NewTextToSpeechModal({
     setSpeaker(initialSpeaker || "Vivian");
     setSavedVoiceId(initialSavedVoiceId || "");
     setVoiceDescription("");
-    setSpeed(1);
     setStreamingEnabled(true);
     setIsSubmitting(false);
+    setModelActionPending(null);
     setError(null);
     setSavedVoices([]);
     setSavedVoicesLoading(false);
     setSavedVoicesError(null);
   }, [initialSavedVoiceId, initialSpeaker]);
+
+  const handleModelAction = useCallback(async () => {
+    if (!selectedModel || modelActionPending) {
+      if (!selectedModel) {
+        onModelRequired();
+      }
+      return;
+    }
+
+    setError(null);
+
+    if (selectedModelReady) {
+      if (!onUnloadSelectedModel) {
+        return;
+      }
+      try {
+        const result = onUnloadSelectedModel(selectedModel);
+        if (result && typeof (result as Promise<void>).then === "function") {
+          setModelActionPending("unload");
+          await result;
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to unload model.");
+      } finally {
+        setModelActionPending(null);
+      }
+      return;
+    }
+
+    if (!onLoadSelectedModel) {
+      onModelRequired();
+      return;
+    }
+
+    try {
+      const result = onLoadSelectedModel(selectedModel);
+      if (result && typeof (result as Promise<void>).then === "function") {
+        setModelActionPending("load");
+        await result;
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load model.");
+    } finally {
+      setModelActionPending(null);
+    }
+  }, [
+    modelActionPending,
+    onLoadSelectedModel,
+    onModelRequired,
+    onUnloadSelectedModel,
+    selectedModel,
+    selectedModelReady,
+  ]);
 
   useEffect(() => {
     const wasOpen = wasOpenRef.current;
@@ -233,7 +290,6 @@ export function NewTextToSpeechModal({
       speaker: usesBuiltInVoiceSelection ? speaker : undefined,
       saved_voice_id: usesSavedVoiceSelection ? savedVoiceId : undefined,
       voice_description: usesVoiceDescription ? trimmedVoiceDescription : undefined,
-      speed: supportsSpeedControl ? speed : undefined,
     };
 
     setIsSubmitting(true);
@@ -318,10 +374,8 @@ export function NewTextToSpeechModal({
     selectedModel,
     selectedModelReady,
     speaker,
-    speed,
     streamAvailable,
     streamingEnabled,
-    supportsSpeedControl,
     text,
     voiceDescription,
     usesBuiltInVoiceSelection,
@@ -330,6 +384,25 @@ export function NewTextToSpeechModal({
   ]);
 
   const modelStatus = selectedModelReady ? "ready" : "not_ready";
+  const modelStatusCode = selectedModelInfo?.status ?? null;
+  const modelStatusBusy =
+    modelStatusCode === "loading" || modelStatusCode === "downloading";
+  const modelActionBusy = modelStatusBusy || modelActionPending !== null;
+  const isUnloadAction = selectedModelReady || modelActionPending === "unload";
+  const modelActionLabel = modelStatusCode === "downloading"
+    ? "Downloading model..."
+    : modelStatusCode === "loading"
+      ? "Loading model..."
+      : modelActionPending === "load"
+        ? "Loading model..."
+        : modelActionPending === "unload"
+          ? "Unloading model..."
+          : isUnloadAction
+            ? "Unload model"
+            : "Load model";
+  const modelActionButtonClass = isUnloadAction
+    ? "mt-3 h-9 w-full gap-2 border-[var(--danger-border)] bg-[var(--danger-bg)] text-[var(--danger-text)] hover:bg-[var(--danger-bg-hover)] hover:text-[var(--danger-text)]"
+    : "mt-3 h-9 w-full gap-2";
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -416,6 +489,19 @@ export function NewTextToSpeechModal({
                     {selectedModel || "No model selected"}
                   </span>
                 </div>
+                <Button
+                  type="button"
+                  variant={isUnloadAction ? "outline" : "default"}
+                  size="sm"
+                  className={modelActionButtonClass}
+                  onClick={() => void handleModelAction()}
+                  disabled={isSubmitting || !selectedModel || modelActionBusy}
+                >
+                  {modelActionBusy ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : null}
+                  {modelActionLabel}
+                </Button>
               </div>
 
               {usesBuiltInVoiceSelection ? (
@@ -488,27 +574,6 @@ export function NewTextToSpeechModal({
                     onChange={(event) => setVoiceDescription(event.target.value)}
                     disabled={isSubmitting}
                     placeholder="Optional style guidance"
-                  />
-                </div>
-              ) : null}
-
-              {supportsSpeedControl ? (
-                <div className="rounded-2xl border border-[var(--border-muted)] bg-[var(--bg-surface-1)] p-3.5">
-                  <div className="mb-1.5 flex items-center justify-between gap-3">
-                    <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
-                      Speed
-                    </span>
-                    <span className="text-xs font-medium text-[var(--text-primary)]">
-                      {speed.toFixed(2)}x
-                    </span>
-                  </div>
-                  <Slider
-                    value={[speed]}
-                    min={0.25}
-                    max={4}
-                    step={0.05}
-                    onValueChange={(value) => setSpeed(value[0] ?? 1)}
-                    disabled={isSubmitting}
                   />
                 </div>
               ) : null}

--- a/ui/src/features/text-to-speech/route.test.tsx
+++ b/ui/src/features/text-to-speech/route.test.tsx
@@ -123,18 +123,34 @@ function buildSavedVoice(id: string, name: string) {
   };
 }
 
-function renderRoute(initialEntry: string) {
+function buildSpeechCapabilities(overrides: Partial<Record<string, boolean>> = {}) {
+  return {
+    supports_builtin_voices: true,
+    supports_reference_voice: false,
+    supports_voice_description: true,
+    supports_streaming: true,
+    supports_speed_control: true,
+    supports_auto_long_form: false,
+    ...overrides,
+  };
+}
+
+function renderRoute(
+  initialEntry: string,
+  propsOverrides: Partial<typeof baseProps> = {},
+) {
+  const routeProps = { ...baseProps, ...propsOverrides };
   return render(
     <NotificationProvider>
       <MemoryRouter initialEntries={[initialEntry]}>
         <Routes>
           <Route
             path="/text-to-speech"
-            element={<TextToSpeechPage {...baseProps} />}
+            element={<TextToSpeechPage {...routeProps} />}
           />
           <Route
             path="/text-to-speech/:recordId"
-            element={<TextToSpeechPage {...baseProps} />}
+            element={<TextToSpeechPage {...routeProps} />}
           />
         </Routes>
       </MemoryRouter>
@@ -564,6 +580,172 @@ describe("TextToSpeechPage", () => {
 
     expect(screen.getByText("Alice")).toBeInTheDocument();
     expect(screen.queryByText("bf_alice")).not.toBeInTheDocument();
+  });
+
+  it("loads the selected model from the modal readiness action", async () => {
+    const onLoad = vi.fn();
+
+    hookMocks.useRouteModelSelection.mockReturnValue({
+      routeModels: [],
+      resolvedSelectedModel: "Qwen3-TTS-12Hz-1.7B-Chat",
+      selectedModelInfo: {
+        variant: "Qwen3-TTS-12Hz-1.7B-Chat",
+        status: "downloaded",
+        speech_capabilities: {
+          supports_builtin_voices: true,
+          supports_reference_voice: false,
+          supports_voice_description: true,
+          supports_streaming: true,
+          supports_speed_control: true,
+        },
+      },
+      selectedModelReady: false,
+      isModelModalOpen: false,
+      intentVariant: null,
+      closeModelModal: vi.fn(),
+      openModelManager: vi.fn(),
+      requestModel: vi.fn(),
+    });
+
+    renderRoute("/text-to-speech", { onLoad });
+
+    await waitFor(() =>
+      expect(apiMocks.listTextToSpeechRecords).toHaveBeenCalled(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /New generation/i }));
+    await screen.findByRole("heading", { name: "New text-to-speech job" });
+
+    fireEvent.click(screen.getByRole("button", { name: /Load model/i }));
+    expect(onLoad).toHaveBeenCalledWith("Qwen3-TTS-12Hz-1.7B-Chat");
+  });
+
+  it("unloads the selected model from the modal readiness action", async () => {
+    const onUnload = vi.fn();
+
+    renderRoute("/text-to-speech", { onUnload });
+
+    await waitFor(() =>
+      expect(apiMocks.listTextToSpeechRecords).toHaveBeenCalled(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /New generation/i }));
+    await screen.findByRole("heading", { name: "New text-to-speech job" });
+
+    fireEvent.click(screen.getByRole("button", { name: /Unload model/i }));
+    expect(onUnload).toHaveBeenCalledWith("Qwen3-TTS-12Hz-1.7B-Chat");
+  });
+
+  it("selects a saved-voice-capable model when opening with a saved voice id", async () => {
+    const onSelect = vi.fn();
+
+    hookMocks.useRouteModelSelection.mockReturnValue({
+      routeModels: [
+        {
+          variant: "Kokoro-82M",
+          status: "ready",
+          speech_capabilities: buildSpeechCapabilities({
+            supports_reference_voice: false,
+            supports_voice_description: false,
+          }),
+        },
+        {
+          variant: "Qwen3-TTS-12Hz-0.6B-CustomVoice",
+          status: "downloaded",
+          speech_capabilities: buildSpeechCapabilities({
+            supports_reference_voice: true,
+            supports_voice_description: false,
+          }),
+        },
+      ],
+      resolvedSelectedModel: "Kokoro-82M",
+      selectedModelInfo: {
+        variant: "Kokoro-82M",
+        status: "ready",
+        speech_capabilities: buildSpeechCapabilities({
+          supports_reference_voice: false,
+          supports_voice_description: false,
+        }),
+      },
+      selectedModelReady: true,
+      isModelModalOpen: false,
+      intentVariant: null,
+      closeModelModal: vi.fn(),
+      openModelManager: vi.fn(),
+      requestModel: vi.fn(),
+    });
+
+    renderRoute("/text-to-speech?voiceId=voice-1", { onSelect });
+
+    await waitFor(() =>
+      expect(onSelect).toHaveBeenCalledWith(
+        "Qwen3-TTS-12Hz-0.6B-CustomVoice",
+      ),
+    );
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries redirect model selection after route model options hydrate", async () => {
+    const onSelect = vi.fn();
+
+    const emptySelection = {
+      routeModels: [],
+      resolvedSelectedModel: "Kokoro-82M",
+      selectedModelInfo: {
+        variant: "Kokoro-82M",
+        status: "ready",
+        speech_capabilities: buildSpeechCapabilities({
+          supports_reference_voice: false,
+          supports_voice_description: false,
+        }),
+      },
+      selectedModelReady: true,
+      isModelModalOpen: false,
+      intentVariant: null,
+      closeModelModal: vi.fn(),
+      openModelManager: vi.fn(),
+      requestModel: vi.fn(),
+    };
+
+    const hydratedSelection = {
+      routeModels: [
+        {
+          variant: "Qwen3-TTS-12Hz-0.6B-CustomVoice",
+          status: "downloaded",
+          speech_capabilities: buildSpeechCapabilities({
+            supports_reference_voice: true,
+            supports_voice_description: false,
+          }),
+        },
+      ],
+      resolvedSelectedModel: "Kokoro-82M",
+      selectedModelInfo: {
+        variant: "Kokoro-82M",
+        status: "ready",
+        speech_capabilities: buildSpeechCapabilities({
+          supports_reference_voice: false,
+          supports_voice_description: false,
+        }),
+      },
+      selectedModelReady: true,
+      isModelModalOpen: false,
+      intentVariant: null,
+      closeModelModal: vi.fn(),
+      openModelManager: vi.fn(),
+      requestModel: vi.fn(),
+    };
+
+    hookMocks.useRouteModelSelection
+      .mockReturnValueOnce(emptySelection)
+      .mockReturnValue(hydratedSelection);
+
+    renderRoute("/text-to-speech?voiceId=voice-1", { onSelect });
+
+    await waitFor(() =>
+      expect(onSelect).toHaveBeenCalledWith(
+        "Qwen3-TTS-12Hz-0.6B-CustomVoice",
+      ),
+    );
   });
 
   it("navigates to /text-to-speech/:id after stream created event", async () => {

--- a/ui/src/features/text-to-speech/route.tsx
+++ b/ui/src/features/text-to-speech/route.tsx
@@ -137,20 +137,86 @@ export function TextToSpeechPage({
   }, []);
 
   useEffect(() => {
-    if (appliedQueryModelRef.current || routeModels.length === 0) {
+    if (appliedQueryModelRef.current || recordId) {
       return;
     }
 
     const requestedModel = searchParams.get("model");
-    if (
-      requestedModel &&
-      routeModels.some((model) => model.variant === requestedModel)
-    ) {
-      onSelect(requestedModel);
+    const requestedSavedVoiceId = searchParams.get("voiceId");
+    const requestedSpeaker = searchParams.get("speaker");
+
+    if (!requestedModel && !requestedSavedVoiceId && !requestedSpeaker) {
+      appliedQueryModelRef.current = true;
+      return;
+    }
+
+    const requestedModelInfo = requestedModel
+      ? routeModels.find((model) => model.variant === requestedModel) ?? null
+      : null;
+
+    const resolveModelForCapability = (
+      capability: "supports_reference_voice" | "supports_builtin_voices",
+    ) => {
+      const capabilityModels = routeModels.filter(
+        (model) => model.speech_capabilities?.[capability] === true,
+      );
+      if (capabilityModels.length === 0) {
+        return null;
+      }
+
+      const selectedCapabilityModel =
+        resolvedSelectedModel &&
+        capabilityModels.some((model) => model.variant === resolvedSelectedModel)
+          ? resolvedSelectedModel
+          : null;
+
+      return resolvePreferredRouteModel({
+        models: capabilityModels,
+        selectedModel: selectedCapabilityModel,
+        preferredVariants: TEXT_TO_SPEECH_PREFERRED_MODELS,
+      });
+    };
+
+    let targetModel: string | null = null;
+
+    if (requestedSavedVoiceId) {
+      targetModel =
+        requestedModelInfo?.speech_capabilities?.supports_reference_voice
+          ? requestedModelInfo.variant
+          : resolveModelForCapability("supports_reference_voice");
+    } else if (requestedSpeaker) {
+      targetModel =
+        requestedModelInfo?.speech_capabilities?.supports_builtin_voices
+          ? requestedModelInfo.variant
+          : resolveModelForCapability("supports_builtin_voices");
+    } else if (requestedModelInfo) {
+      targetModel = requestedModelInfo.variant;
+    }
+
+    if (!targetModel) {
+      if (loading || routeModels.length === 0) {
+        return;
+      }
+      if (!requestedSavedVoiceId && !requestedSpeaker) {
+        appliedQueryModelRef.current = true;
+      }
+      return;
+    }
+
+    if (selectedModel !== targetModel) {
+      onSelect(targetModel);
     }
 
     appliedQueryModelRef.current = true;
-  }, [onSelect, routeModels, searchParams]);
+  }, [
+    loading,
+    onSelect,
+    recordId,
+    resolvedSelectedModel,
+    routeModels,
+    searchParams,
+    selectedModel,
+  ]);
 
   useEffect(() => {
     void refreshSavedVoiceNames();
@@ -401,6 +467,12 @@ export function TextToSpeechPage({
         selectedModelReady={selectedModelReady}
         initialSavedVoiceId={searchParams.get("voiceId")}
         initialSpeaker={searchParams.get("speaker")}
+        onLoadSelectedModel={(variant) => {
+          onLoad(variant);
+        }}
+        onUnloadSelectedModel={(variant) => {
+          onUnload(variant);
+        }}
         onModelRequired={() => {
           requestModel();
           onError(

--- a/ui/src/features/voice-studio/route.tsx
+++ b/ui/src/features/voice-studio/route.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Plus, Settings2 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import type { ModelInfo } from "@/api";
@@ -6,6 +6,7 @@ import { PageHeader, PageShell } from "@/components/PageShell";
 import { Button } from "@/components/ui/button";
 import { VoiceCreationModal } from "@/components/VoiceCreationModal";
 import {
+  TEXT_TO_SPEECH_PREFERRED_MODELS,
   VOICE_DESIGN_PREFERRED_MODELS,
   resolvePreferredRouteModel,
 } from "@/features/models/catalog/routeModelCatalog";
@@ -80,6 +81,29 @@ export function VoiceStudioPage({
       }),
   });
 
+  const preferredSavedVoiceModel = useMemo(() => {
+    const savedVoiceModels = models.filter(
+      (model) =>
+        !model.variant.includes("Tokenizer") &&
+        model.speech_capabilities?.supports_reference_voice === true,
+    );
+    if (savedVoiceModels.length === 0) {
+      return null;
+    }
+
+    const selectedSavedVoiceModel =
+      selectedModel &&
+      savedVoiceModels.some((model) => model.variant === selectedModel)
+        ? selectedModel
+        : null;
+
+    return resolvePreferredRouteModel({
+      models: savedVoiceModels,
+      selectedModel: selectedSavedVoiceModel,
+      preferredVariants: TEXT_TO_SPEECH_PREFERRED_MODELS,
+    });
+  }, [models, selectedModel]);
+
   return (
     <PageShell>
       <PageHeader
@@ -135,9 +159,14 @@ export function VoiceStudioPage({
         onVoiceCreated={() => {
           setVoicesRefreshKey((current) => current + 1);
         }}
-        onUseSavedVoiceInTts={(voiceId) =>
-          navigate(`/text-to-speech?voiceId=${encodeURIComponent(voiceId)}`)
-        }
+        onUseSavedVoiceInTts={(voiceId) => {
+          const params = new URLSearchParams();
+          params.set("voiceId", voiceId);
+          if (preferredSavedVoiceModel) {
+            params.set("model", preferredSavedVoiceModel);
+          }
+          navigate(`/text-to-speech?${params.toString()}`);
+        }}
         designModel={designResolvedModel}
         designModelReady={designModelReady}
         designModelOptions={designModelOptions}

--- a/ui/src/features/voices/route.test.tsx
+++ b/ui/src/features/voices/route.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ModelInfo, SavedVoiceSummary } from "@/api";
@@ -65,6 +65,11 @@ function buildModel(overrides: Partial<ModelInfo> = {}): ModelInfo {
     },
     ...overrides,
   };
+}
+
+function LocationSearchEcho() {
+  const location = useLocation();
+  return <div data-testid="tts-location-search">{location.search}</div>;
 }
 
 describe("VoicesPage", () => {
@@ -208,6 +213,25 @@ describe("VoicesPage", () => {
       await screen.findByText("Generating a preview sample for this speaker."),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Preview" })).toBeDisabled();
+  });
+
+  it("includes a saved-voice-capable model when redirecting saved voices to text to speech", async () => {
+    render(
+      <MemoryRouter initialEntries={["/voices"]}>
+        <Routes>
+          <Route path="/voices" element={<VoicesPage {...baseProps} />} />
+          <Route path="/text-to-speech" element={<LocationSearchEcho />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(apiMocks.listSavedVoices).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole("button", { name: "Use in TTS" }));
+
+    const searchEcho = await screen.findByTestId("tts-location-search");
+    expect(searchEcho).toHaveTextContent("voiceId=voice-balanced");
+    expect(searchEcho).toHaveTextContent("model=MockVoiceModel");
   });
 
   it("loads more saved voices", async () => {

--- a/ui/src/features/voices/route.tsx
+++ b/ui/src/features/voices/route.tsx
@@ -296,8 +296,41 @@ export function VoicesPage({
     [resolvedSelectedModel],
   );
 
+  const savedVoiceModels = useMemo(
+    () =>
+      models.filter(
+        (model) =>
+          !model.variant.includes("Tokenizer") &&
+          model.speech_capabilities?.supports_reference_voice === true,
+      ),
+    [models],
+  );
+
+  const preferredSavedVoiceModel = useMemo(() => {
+    if (savedVoiceModels.length === 0) {
+      return null;
+    }
+
+    const selectedSavedVoiceModel =
+      resolvedSelectedModel &&
+      savedVoiceModels.some((model) => model.variant === resolvedSelectedModel)
+        ? resolvedSelectedModel
+        : null;
+
+    return resolvePreferredRouteModel({
+      models: savedVoiceModels,
+      selectedModel: selectedSavedVoiceModel,
+      preferredVariants: TEXT_TO_SPEECH_PREFERRED_MODELS,
+    });
+  }, [resolvedSelectedModel, savedVoiceModels]);
+
   const handleUseSavedVoice = (voiceId: string) => {
-    navigate(`/text-to-speech?voiceId=${encodeURIComponent(voiceId)}`);
+    const params = new URLSearchParams();
+    params.set("voiceId", voiceId);
+    if (preferredSavedVoiceModel) {
+      params.set("model", preferredSavedVoiceModel);
+    }
+    navigate(`/text-to-speech?${params.toString()}`);
   };
 
   const handleUseBuiltInVoice = (speaker: string) => {


### PR DESCRIPTION
Keeps selected voice/model when redirecting from /voices to /text-to-speech even before models load, removes the TTS speed control, adds a full-width load/unload action with loading UX and friendlier styling, updates related UI tests, and removes unused server list wrapper methods to eliminate izwi-server dead_code warnings.