### PR TITLE
Improve diarization reliability and review workflow 

### DIFF
--- a/crates/izwi-cli/src/app/cli.rs
+++ b/crates/izwi-cli/src/app/cli.rs
@@ -301,11 +301,11 @@ pub enum Commands {
         #[arg(short, long, value_name = "PATH")]
         output: Option<PathBuf>,
 
-        /// Include transcription with speaker labels
+        /// Compatibility flag (transcript output is now included by default)
         #[arg(long)]
         transcribe: bool,
 
-        /// ASR model for transcription (used with --transcribe)
+        /// ASR model used for transcript generation
         #[arg(long, default_value = "parakeet-tdt-0.6b-v3")]
         asr_model: String,
     },

--- a/crates/izwi-cli/src/commands/diarize.rs
+++ b/crates/izwi-cli/src/commands/diarize.rs
@@ -44,24 +44,27 @@ pub async fn execute(args: DiarizeArgs, server: &str) -> Result<()> {
         TranscriptFormat::VerboseJson => "verbose_json",
     };
 
+    if transcribe {
+        eprintln!(
+            "Note: --transcribe is now a compatibility flag; diarization responses already include transcript output."
+        );
+    }
+
     let mut request_body = serde_json::json!({
         "model": model,
         "audio_base64": audio_base64,
         "response_format": format_str,
-        "transcribe": transcribe,
+        "asr_model": asr_model,
     });
 
     if let Some(num) = num_speakers {
-        request_body["num_speakers"] = serde_json::Value::Number(num.into());
-    }
-
-    if transcribe {
-        request_body["asr_model"] = serde_json::Value::String(asr_model);
+        request_body["min_speakers"] = serde_json::Value::Number(num.into());
+        request_body["max_speakers"] = serde_json::Value::Number(num.into());
     }
 
     let client = http::client(Some(std::time::Duration::from_secs(600)))?;
     let response = client
-        .post(format!("{}/v1/audio/diarize", server))
+        .post(format!("{}/v1/audio/diarizations", server))
         .json(&request_body)
         .send()
         .await

--- a/crates/izwi-server/src/api/diarization/handlers.rs
+++ b/crates/izwi-server/src/api/diarization/handlers.rs
@@ -200,7 +200,7 @@ pub async fn rerun_record(
     Extension(ctx): Extension<RequestContext>,
     Path(record_id): Path<String>,
     Json(req): Json<RerunDiarizationRecordRequest>,
-) -> Result<Json<DiarizationRecord>, ApiError> {
+) -> Result<Response, ApiError> {
     let source_record = state
         .diarization_store
         .get_record(record_id.clone())
@@ -215,16 +215,49 @@ pub async fn rerun_record(
         .ok_or_else(|| ApiError::not_found("Diarization audio not found"))?;
 
     let rerun_request = build_rerun_create_request(&source_record, source_audio, req);
-    let record = execute_diarization_record(&state, rerun_request).await?;
-    maybe_spawn_summary_generation(
+    let placeholder = create_pending_record(&state, &rerun_request).await?;
+    spawn_diarization_processing_task(
         state.runtime.clone(),
         state.diarization_store.clone(),
         state.request_semaphore.clone(),
-        &record,
+        state.request_timeout_secs,
+        placeholder.id.clone(),
+        rerun_request,
         Some(ctx.correlation_id),
     );
 
-    Ok(Json(record))
+    Ok((StatusCode::ACCEPTED, Json(placeholder)).into_response())
+}
+
+pub async fn cancel_record(
+    State(state): State<AppState>,
+    Path(record_id): Path<String>,
+) -> Result<Json<DiarizationRecord>, ApiError> {
+    let existing = state
+        .diarization_store
+        .get_record(record_id.clone())
+        .await
+        .map_err(map_store_error)?
+        .ok_or_else(|| ApiError::not_found("Diarization record not found"))?;
+
+    if existing.processing_status != DiarizationProcessingStatus::Pending
+        && existing.processing_status != DiarizationProcessingStatus::Processing
+    {
+        return Ok(Json(existing));
+    }
+
+    let cancelled = state
+        .diarization_store
+        .update_processing_status(
+            record_id,
+            DiarizationProcessingStatus::Failed,
+            Some("Cancelled by user.".to_string()),
+        )
+        .await
+        .map_err(map_store_error)?
+        .ok_or_else(|| ApiError::not_found("Diarization record not found"))?;
+
+    Ok(Json(cancelled))
 }
 
 pub async fn create_record(
@@ -284,63 +317,6 @@ pub async fn regenerate_summary(
     );
 
     Ok(Json(record))
-}
-
-async fn execute_diarization_record(
-    state: &AppState,
-    parsed: ParsedDiarizationCreateRequest,
-) -> Result<DiarizationRecord, ApiError> {
-    validate_speaker_bounds(parsed.min_speakers, parsed.max_speakers)?;
-    let artifacts = generate_diarization_artifacts(
-        state.runtime.clone(),
-        state.request_semaphore.clone(),
-        state.request_timeout_secs,
-        &parsed,
-        None,
-    )
-    .await?;
-
-    state
-        .diarization_store
-        .create_record(NewDiarizationRecord {
-            model_id: parsed.model_id,
-            asr_model_id: parsed.asr_model_id,
-            aligner_model_id: parsed.aligner_model_id,
-            llm_model_id: parsed.llm_model_id,
-            processing_status: DiarizationProcessingStatus::Ready,
-            processing_error: None,
-            min_speakers: parsed.min_speakers,
-            max_speakers: parsed.max_speakers,
-            min_speech_duration_ms: parsed.min_speech_duration_ms,
-            min_silence_duration_ms: parsed.min_silence_duration_ms,
-            enable_llm_refinement: parsed.enable_llm_refinement.unwrap_or(false),
-            processing_time_ms: artifacts.processing_time_ms,
-            duration_secs: Some(artifacts.duration_secs),
-            rtf: artifacts.rtf,
-            speaker_count: artifacts.speaker_count,
-            alignment_coverage: artifacts.alignment_coverage,
-            unattributed_words: artifacts.unattributed_words,
-            llm_refined: artifacts.llm_refined,
-            asr_text: artifacts.asr_text,
-            raw_transcript: artifacts.raw_transcript,
-            transcript: artifacts.transcript,
-            summary_status: artifacts.summary_status,
-            summary_model_id: artifacts.summary_model_id,
-            summary_text: None,
-            summary_error: None,
-            summary_updated_at: None,
-            segments: artifacts.segments,
-            words: artifacts.words,
-            utterances: artifacts.utterances,
-            audio_mime_type: parsed
-                .audio_mime_type
-                .unwrap_or_else(|| "audio/wav".to_string()),
-            audio_filename: parsed.audio_filename,
-            speaker_name_overrides: BTreeMap::new(),
-            audio_bytes: parsed.audio_bytes,
-        })
-        .await
-        .map_err(map_store_error)
 }
 
 async fn create_pending_record(

--- a/crates/izwi-server/src/api/diarization/handlers.rs
+++ b/crates/izwi-server/src/api/diarization/handlers.rs
@@ -312,6 +312,7 @@ pub async fn regenerate_summary(
         state.runtime.clone(),
         state.diarization_store.clone(),
         state.request_semaphore.clone(),
+        state.request_timeout_secs,
         &record,
         Some(ctx.correlation_id),
     );
@@ -456,6 +457,7 @@ fn spawn_diarization_processing_task(
                             runtime.clone(),
                             diarization_store.clone(),
                             semaphore.clone(),
+                            request_timeout_secs,
                             &record,
                             correlation_id,
                         );
@@ -644,6 +646,7 @@ fn maybe_spawn_summary_generation(
     runtime: Arc<RuntimeService>,
     diarization_store: Arc<DiarizationStore>,
     semaphore: Arc<tokio::sync::Semaphore>,
+    summary_timeout_secs: u64,
     record: &DiarizationRecord,
     correlation_id: Option<String>,
 ) {
@@ -655,6 +658,7 @@ fn maybe_spawn_summary_generation(
         runtime,
         diarization_store,
         semaphore,
+        summary_timeout_secs,
         record.id.clone(),
         record.transcript.clone(),
         correlation_id,
@@ -665,22 +669,38 @@ fn spawn_summary_generation_task(
     runtime: Arc<RuntimeService>,
     diarization_store: Arc<DiarizationStore>,
     semaphore: Arc<tokio::sync::Semaphore>,
+    summary_timeout_secs: u64,
     record_id: String,
     transcript: String,
     correlation_id: Option<String>,
 ) {
     tokio::spawn(async move {
-        let _permit = match semaphore.acquire_owned().await {
+        let permit = match semaphore.acquire_owned().await {
             Ok(permit) => permit,
-            Err(_) => return,
+            Err(_) => {
+                persist_summary_update(
+                    &diarization_store,
+                    record_id.as_str(),
+                    summary_failure_update("Summary generation unavailable: request queue closed."),
+                )
+                .await;
+                return;
+            }
         };
 
         let summary_result = if transcript.trim().is_empty() {
             Err("Summary generation failed: transcript is empty".to_string())
         } else {
-            generate_diarization_summary(runtime, transcript.as_str(), correlation_id.as_deref())
-                .await
+            generate_diarization_summary_with_timeout(
+                runtime,
+                transcript.as_str(),
+                correlation_id.as_deref(),
+                summary_timeout_secs,
+            )
+            .await
         };
+
+        drop(permit);
 
         let summary_update = match summary_result {
             Ok(summary_text) => UpdateDiarizationSummary {
@@ -690,26 +710,25 @@ fn spawn_summary_generation_task(
                 error: None,
                 updated_at: None,
             },
-            Err(err) => UpdateDiarizationSummary {
-                status: DiarizationSummaryStatus::Failed,
-                model_id: Some(DEFAULT_DIARIZATION_SUMMARY_MODEL.to_string()),
-                text: None,
-                error: Some(truncate_summary_error(err.as_str())),
-                updated_at: None,
-            },
+            Err(err) => summary_failure_update(err.as_str()),
         };
 
-        if let Err(err) = diarization_store
-            .update_summary(record_id.clone(), summary_update)
-            .await
-        {
-            tracing::warn!(
-                "diarization summary persist failed: record_id={} error={}",
-                record_id,
-                err
-            );
-        }
+        persist_summary_update(&diarization_store, record_id.as_str(), summary_update).await;
     });
+}
+
+async fn generate_diarization_summary_with_timeout(
+    runtime: Arc<RuntimeService>,
+    transcript: &str,
+    correlation_id: Option<&str>,
+    timeout_secs: u64,
+) -> Result<String, String> {
+    tokio::time::timeout(
+        Duration::from_secs(timeout_secs.max(1)),
+        generate_diarization_summary(runtime, transcript, correlation_id),
+    )
+    .await
+    .map_err(|_| summary_timeout_error(timeout_secs))?
 }
 
 async fn generate_diarization_summary(
@@ -750,6 +769,49 @@ async fn generate_diarization_summary(
 
     sanitize_summary_output(generation.text.as_str())
         .ok_or_else(|| "Summary generation returned empty text".to_string())
+}
+
+fn summary_failure_update(error: &str) -> UpdateDiarizationSummary {
+    UpdateDiarizationSummary {
+        status: DiarizationSummaryStatus::Failed,
+        model_id: Some(DEFAULT_DIARIZATION_SUMMARY_MODEL.to_string()),
+        text: None,
+        error: Some(truncate_summary_error(error)),
+        updated_at: None,
+    }
+}
+
+fn summary_timeout_error(timeout_secs: u64) -> String {
+    format!(
+        "Summary generation timed out after {} seconds.",
+        timeout_secs.max(1)
+    )
+}
+
+async fn persist_summary_update(
+    diarization_store: &DiarizationStore,
+    record_id: &str,
+    update: UpdateDiarizationSummary,
+) {
+    match diarization_store
+        .update_summary(record_id.to_string(), update)
+        .await
+    {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            tracing::warn!(
+                "diarization summary persist skipped: record_id={} not found",
+                record_id
+            );
+        }
+        Err(err) => {
+            tracing::warn!(
+                "diarization summary persist failed: record_id={} error={}",
+                record_id,
+                err
+            );
+        }
+    }
 }
 
 fn sanitize_summary_output(raw: &str) -> Option<String> {
@@ -1179,6 +1241,31 @@ mod tests {
             sanitize_summary_output(raw).as_deref(),
             Some("Summary text.")
         );
+    }
+
+    #[test]
+    fn summary_timeout_error_enforces_minimum_one_second() {
+        assert_eq!(
+            summary_timeout_error(0),
+            "Summary generation timed out after 1 seconds."
+        );
+        assert_eq!(
+            summary_timeout_error(12),
+            "Summary generation timed out after 12 seconds."
+        );
+    }
+
+    #[test]
+    fn summary_failure_update_sets_failed_status_and_truncates_error() {
+        let update = summary_failure_update("x".repeat(500).as_str());
+        assert_eq!(update.status, DiarizationSummaryStatus::Failed);
+        assert_eq!(
+            update.model_id.as_deref(),
+            Some(DEFAULT_DIARIZATION_SUMMARY_MODEL)
+        );
+        assert!(update.text.is_none());
+        let error = update.error.expect("error should be populated");
+        assert_eq!(error.len(), 320);
     }
 }
 

--- a/crates/izwi-server/src/api/diarization/mod.rs
+++ b/crates/izwi-server/src/api/diarization/mod.rs
@@ -16,6 +16,7 @@ pub fn router() -> Router<AppState> {
     const CANONICAL_MEMBER: &str = "/diarizations/:record_id";
     const CANONICAL_AUDIO: &str = "/diarizations/:record_id/audio";
     const CANONICAL_RERUNS: &str = "/diarizations/:record_id/reruns";
+    const CANONICAL_CANCEL: &str = "/diarizations/:record_id/cancel";
     const CANONICAL_SUMMARY_REGENERATE: &str = "/diarizations/:record_id/summary/regenerate";
 
     Router::new()
@@ -37,6 +38,7 @@ pub fn router() -> Router<AppState> {
             CANONICAL_RERUNS,
             axum::routing::post(handlers::rerun_record),
         )
+        .route(CANONICAL_CANCEL, post(handlers::cancel_record))
         .route(
             CANONICAL_SUMMARY_REGENERATE,
             post(handlers::regenerate_summary),

--- a/crates/izwi-server/src/api/openai/audio/diarizations.rs
+++ b/crates/izwi-server/src/api/openai/audio/diarizations.rs
@@ -25,6 +25,7 @@ struct DiarizationRequest {
     aligner_model: Option<String>,
     llm_model: Option<String>,
     response_format: Option<String>,
+    num_speakers: Option<usize>,
     min_speakers: Option<usize>,
     max_speakers: Option<usize>,
     min_speech_duration_ms: Option<f32>,
@@ -103,10 +104,12 @@ pub async fn diarizations(
         .ok_or_else(|| ApiError::bad_request("Missing audio input (`file` or `audio_base64`)"))?;
 
     let _permit = state.acquire_permit().await;
+    let (min_speakers, max_speakers) =
+        resolve_speaker_bounds(req.min_speakers, req.max_speakers, req.num_speakers)?;
 
     let config = DiarizationConfig {
-        min_speakers: req.min_speakers,
-        max_speakers: req.max_speakers,
+        min_speakers,
+        max_speakers,
         min_speech_duration_ms: req.min_speech_duration_ms,
         min_silence_duration_ms: req.min_silence_duration_ms,
     };
@@ -261,6 +264,8 @@ struct JsonRequestBody {
     #[serde(default)]
     response_format: Option<String>,
     #[serde(default)]
+    num_speakers: Option<usize>,
+    #[serde(default)]
     min_speakers: Option<usize>,
     #[serde(default)]
     max_speakers: Option<usize>,
@@ -295,6 +300,7 @@ async fn parse_diarization_request(req: Request) -> Result<DiarizationRequest, A
             aligner_model: payload.aligner_model,
             llm_model: payload.llm_model,
             response_format: payload.response_format,
+            num_speakers: payload.num_speakers,
             min_speakers: payload.min_speakers,
             max_speakers: payload.max_speakers,
             min_speech_duration_ms: payload.min_speech_duration_ms,
@@ -401,6 +407,14 @@ async fn parse_diarization_request(req: Request) -> Result<DiarizationRequest, A
                     })?;
                     out.min_speakers = text.trim().parse::<usize>().ok();
                 }
+                "num_speakers" => {
+                    let text = field.text().await.map_err(|e| {
+                        ApiError::bad_request(format!(
+                            "Failed reading multipart 'num_speakers' field: {e}"
+                        ))
+                    })?;
+                    out.num_speakers = text.trim().parse::<usize>().ok();
+                }
                 "max_speakers" => {
                     let text = field.text().await.map_err(|e| {
                         ApiError::bad_request(format!(
@@ -458,4 +472,45 @@ async fn parse_diarization_request(req: Request) -> Result<DiarizationRequest, A
         status: StatusCode::UNSUPPORTED_MEDIA_TYPE,
         message: "Expected `Content-Type: application/json` or `multipart/form-data`".to_string(),
     })
+}
+
+fn resolve_speaker_bounds(
+    min_speakers: Option<usize>,
+    max_speakers: Option<usize>,
+    num_speakers: Option<usize>,
+) -> Result<(Option<usize>, Option<usize>), ApiError> {
+    let resolved_min = min_speakers.or(num_speakers);
+    let resolved_max = max_speakers.or(num_speakers);
+
+    if let (Some(min), Some(max)) = (resolved_min, resolved_max) {
+        if min > max {
+            return Err(ApiError::bad_request(
+                "`min_speakers` cannot be greater than `max_speakers`.",
+            ));
+        }
+    }
+
+    Ok((resolved_min, resolved_max))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_speaker_bounds;
+
+    #[test]
+    fn num_speakers_backfills_missing_bounds() {
+        let (min, max) = resolve_speaker_bounds(None, None, Some(3)).expect("bounds should resolve");
+        assert_eq!(min, Some(3));
+        assert_eq!(max, Some(3));
+    }
+
+    #[test]
+    fn rejects_invalid_speaker_bounds() {
+        let err = resolve_speaker_bounds(Some(4), Some(2), None)
+            .expect_err("min should not exceed max");
+        assert_eq!(
+            err.message,
+            "`min_speakers` cannot be greater than `max_speakers`."
+        );
+    }
 }

--- a/crates/izwi-server/src/api/openai/audio/mod.rs
+++ b/crates/izwi-server/src/api/openai/audio/mod.rs
@@ -27,4 +27,9 @@ pub fn router() -> Router<AppState> {
             "/audio/diarizations",
             post(diarizations::diarizations).layer(DefaultBodyLimit::max(AUDIO_UPLOAD_LIMIT_BYTES)),
         )
+        // Legacy alias kept for older clients. Canonical route is /audio/diarizations.
+        .route(
+            "/audio/diarize",
+            post(diarizations::diarizations).layer(DefaultBodyLimit::max(AUDIO_UPLOAD_LIMIT_BYTES)),
+        )
 }

--- a/crates/izwi-server/src/diarization_store.rs
+++ b/crates/izwi-server/src/diarization_store.rs
@@ -1005,7 +1005,7 @@ impl DiarizationStore {
                     segments_json = ?27,
                     words_json = ?28,
                     utterances_json = ?29
-                WHERE id = ?1
+                WHERE id = ?1 AND processing_status IN ('pending', 'processing')
                 "#,
                 params![
                     record_id,
@@ -1702,6 +1702,38 @@ mod tests {
         }
     }
 
+    fn sample_complete_record() -> CompleteDiarizationRecord {
+        CompleteDiarizationRecord {
+            model_id: Some("diar_streaming_sortformer_4spk-v2.1".to_string()),
+            asr_model_id: Some("Parakeet-TDT-0.6B-v3".to_string()),
+            aligner_model_id: Some("Qwen3-ForcedAligner-0.6B".to_string()),
+            llm_model_id: Some("Qwen3.5-4B".to_string()),
+            min_speakers: Some(1),
+            max_speakers: Some(4),
+            min_speech_duration_ms: Some(240.0),
+            min_silence_duration_ms: Some(200.0),
+            enable_llm_refinement: true,
+            processing_time_ms: 480.0,
+            duration_secs: Some(12.0),
+            rtf: Some(0.4),
+            speaker_count: 2,
+            alignment_coverage: Some(0.95),
+            unattributed_words: 0,
+            llm_refined: true,
+            asr_text: "hello there".to_string(),
+            raw_transcript: "SPEAKER_00 [0.00s - 1.20s]: Hello there.".to_string(),
+            transcript: "SPEAKER_00 [0.00s - 1.20s]: Hello there.".to_string(),
+            summary_status: DiarizationSummaryStatus::Pending,
+            summary_model_id: Some("Qwen3.5-4B".to_string()),
+            summary_text: None,
+            summary_error: None,
+            summary_updated_at: None,
+            segments: sample_record().segments,
+            words: sample_record().words,
+            utterances: sample_record().utterances,
+        }
+    }
+
     #[tokio::test]
     async fn persists_speaker_name_overrides_and_corrected_summary() {
         let (store, root) = build_test_store();
@@ -1862,35 +1894,7 @@ mod tests {
         let completed = store
             .complete_record(
                 created.id.clone(),
-                CompleteDiarizationRecord {
-                    model_id: Some("diar_streaming_sortformer_4spk-v2.1".to_string()),
-                    asr_model_id: Some("Parakeet-TDT-0.6B-v3".to_string()),
-                    aligner_model_id: Some("Qwen3-ForcedAligner-0.6B".to_string()),
-                    llm_model_id: Some("Qwen3.5-4B".to_string()),
-                    min_speakers: Some(1),
-                    max_speakers: Some(4),
-                    min_speech_duration_ms: Some(240.0),
-                    min_silence_duration_ms: Some(200.0),
-                    enable_llm_refinement: true,
-                    processing_time_ms: 480.0,
-                    duration_secs: Some(12.0),
-                    rtf: Some(0.4),
-                    speaker_count: 2,
-                    alignment_coverage: Some(0.95),
-                    unattributed_words: 0,
-                    llm_refined: true,
-                    asr_text: "hello there".to_string(),
-                    raw_transcript: "SPEAKER_00 [0.00s - 1.20s]: Hello there.".to_string(),
-                    transcript: "SPEAKER_00 [0.00s - 1.20s]: Hello there.".to_string(),
-                    summary_status: DiarizationSummaryStatus::Pending,
-                    summary_model_id: Some("Qwen3.5-4B".to_string()),
-                    summary_text: None,
-                    summary_error: None,
-                    summary_updated_at: None,
-                    segments: sample_record().segments,
-                    words: sample_record().words,
-                    utterances: sample_record().utterances,
-                },
+                sample_complete_record(),
             )
             .await
             .expect("completion should succeed")
@@ -1903,6 +1907,66 @@ mod tests {
         assert!(completed.processing_error.is_none());
         assert_eq!(completed.speaker_count, 2);
         assert!(!completed.transcript.trim().is_empty());
+
+        std::fs::remove_dir_all(root).expect("test temp dir should be removable");
+    }
+
+    #[tokio::test]
+    async fn completion_does_not_overwrite_terminal_records() {
+        let (store, root) = build_test_store();
+        let mut pending = sample_record();
+        pending.processing_status = DiarizationProcessingStatus::Pending;
+        pending.processing_time_ms = 0.0;
+        pending.duration_secs = None;
+        pending.rtf = None;
+        pending.speaker_count = 0;
+        pending.alignment_coverage = None;
+        pending.unattributed_words = 0;
+        pending.llm_refined = false;
+        pending.asr_text = String::new();
+        pending.raw_transcript = String::new();
+        pending.transcript = String::new();
+        pending.summary_status = DiarizationSummaryStatus::NotRequested;
+        pending.summary_model_id = None;
+        pending.summary_text = None;
+        pending.summary_error = None;
+        pending.summary_updated_at = None;
+        pending.segments = Vec::new();
+        pending.words = Vec::new();
+        pending.utterances = Vec::new();
+
+        let created = store
+            .create_record(pending)
+            .await
+            .expect("pending record should be created");
+
+        let cancelled = store
+            .update_processing_status(
+                created.id.clone(),
+                DiarizationProcessingStatus::Failed,
+                Some("Cancelled by user.".to_string()),
+            )
+            .await
+            .expect("cancel status update should succeed")
+            .expect("record should exist");
+        assert_eq!(cancelled.processing_status, DiarizationProcessingStatus::Failed);
+
+        let completion = store
+            .complete_record(created.id.clone(), sample_complete_record())
+            .await
+            .expect("completion should execute");
+        assert!(
+            completion.is_none(),
+            "terminal records should not be overwritten by async completion"
+        );
+
+        let current = store
+            .get_record(created.id)
+            .await
+            .expect("record lookup should succeed")
+            .expect("record should exist");
+        assert_eq!(current.processing_status, DiarizationProcessingStatus::Failed);
+        assert_eq!(current.processing_error.as_deref(), Some("Cancelled by user."));
 
         std::fs::remove_dir_all(root).expect("test temp dir should be removable");
     }

--- a/docs/user/cli/diarize.md
+++ b/docs/user/cli/diarize.md
@@ -34,8 +34,8 @@ Analyzes audio to identify different speakers and when they spoke. Optionally in
 | `-n, --num-speakers <N>` | Expected number of speakers | Auto-detect |
 | `-f, --format <FORMAT>` | Output format: `text`, `json`, `verbose_json` | `text` |
 | `-o, --output <PATH>` | Output file (default: stdout) | — |
-| `--transcribe` | Include transcription with speaker labels | — |
-| `--asr-model <MODEL>` | ASR model for transcription | `parakeet-tdt-0.6b-v3` |
+| `--transcribe` | Compatibility flag (transcript output is included by default) | — |
+| `--asr-model <MODEL>` | ASR model used for transcript generation | `parakeet-tdt-0.6b-v3` |
 
 ---
 
@@ -53,10 +53,10 @@ izwi diarize meeting.wav
 izwi diarize meeting.wav --num-speakers 3
 ```
 
-### With transcription
+### Transcript output (default behavior)
 
 ```bash
-izwi diarize meeting.wav --transcribe
+izwi diarize meeting.wav --num-speakers 2
 ```
 
 ### JSON output
@@ -69,7 +69,6 @@ izwi diarize meeting.wav --format json --output diarization.json
 
 ```bash
 izwi diarize interview.wav \
-  --transcribe \
   --asr-model Qwen3-ASR-1.7B-GGUF \
   --format verbose_json \
   --output interview_transcript.json
@@ -95,7 +94,7 @@ izwi diarize interview.wav \
     {"speaker": "Speaker 1", "start": 0.0, "end": 5.2},
     {"speaker": "Speaker 2", "start": 5.5, "end": 12.1}
   ],
-  "num_speakers": 2
+  "speaker_count": 2
 }
 ```
 
@@ -117,7 +116,7 @@ izwi diarize interview.wav \
       "text": "Thanks for having me."
     }
   ],
-  "num_speakers": 2,
+  "speaker_count": 2,
   "duration": 120.5
 }
 ```

--- a/docs/user/cli/index.md
+++ b/docs/user/cli/index.md
@@ -106,7 +106,7 @@ izwi transcribe audio.wav --format json
 
 ```bash
 izwi diarize meeting.wav
-izwi diarize meeting.wav --transcribe --num-speakers 3
+izwi diarize meeting.wav --num-speakers 3
 ```
 
 ### Forced alignment

--- a/docs/user/features/diarization.md
+++ b/docs/user/features/diarization.md
@@ -64,6 +64,12 @@ Example output:
 ### Endpoint
 
 ```
+POST /v1/audio/diarizations
+```
+
+Legacy alias still accepted for older clients:
+
+```
 POST /v1/audio/diarize
 ```
 
@@ -76,16 +82,22 @@ POST /v1/audio/diarize
 | `asr_model` | String | Optional ASR model override |
 | `aligner_model` | String | Optional forced aligner model override |
 | `llm_model` | String | Optional transcript refinement model |
-| `num_speakers` | Integer | Expected speakers (optional) |
+| `min_speakers` | Integer | Optional minimum expected speakers |
+| `max_speakers` | Integer | Optional maximum expected speakers |
+| `num_speakers` | Integer | Legacy shortcut; maps to both min/max when provided |
+| `response_format` | String | `json`, `verbose_json`, or `text` |
 
 ### Example (curl)
 
 ```bash
-curl -X POST http://localhost:8080/v1/audio/diarize \
+curl -X POST http://localhost:8080/v1/audio/diarizations \
   -F "file=@meeting.wav" \
   -F "model=diar_streaming_sortformer_4spk-v2.1" \
   -F "asr_model=Parakeet-TDT-0.6B-v3" \
-  -F "aligner_model=Qwen3-ForcedAligner-0.6B"
+  -F "aligner_model=Qwen3-ForcedAligner-0.6B" \
+  -F "min_speakers=2" \
+  -F "max_speakers=2" \
+  -F "response_format=verbose_json"
 ```
 
 ### Response
@@ -94,19 +106,18 @@ curl -X POST http://localhost:8080/v1/audio/diarize \
 {
   "segments": [
     {
-      "speaker": "Speaker 1",
+      "speaker": "SPEAKER_00",
       "start": 0.0,
-      "end": 5.2,
-      "text": "Welcome to the meeting."
+      "end": 5.2
     },
     {
-      "speaker": "Speaker 2",
+      "speaker": "SPEAKER_01",
       "start": 5.5,
-      "end": 12.1,
-      "text": "Thanks for having me."
+      "end": 12.1
     }
   ],
-  "num_speakers": 2,
+  "speaker_count": 2,
+  "transcript": "SPEAKER_00 [0.00s - 5.20s]: Welcome to the meeting.\nSPEAKER_01 [5.50s - 12.10s]: Thanks for having me.",
   "duration": 120.5
 }
 ```
@@ -121,9 +132,10 @@ If you know how many speakers are in the audio, specify it for better accuracy:
 
 ```bash
 # Via API
-curl -X POST http://localhost:8080/v1/audio/diarize \
+curl -X POST http://localhost:8080/v1/audio/diarizations \
   -F "file=@meeting.wav" \
-  -F "num_speakers=3"
+  -F "min_speakers=3" \
+  -F "max_speakers=3"
 ```
 
 ### Speaker Labels

--- a/ui/src/components/DiarizationReviewWorkspace.test.tsx
+++ b/ui/src/components/DiarizationReviewWorkspace.test.tsx
@@ -70,6 +70,60 @@ const record = {
   audio_filename: "meeting.wav",
 } satisfies DiarizationRecord;
 
+const lowConfidenceRecord = {
+  ...record,
+  words: [
+    {
+      word: "Hello",
+      speaker: "SPEAKER_00",
+      start: 0,
+      end: 0.4,
+      speaker_confidence: 0.95,
+      overlaps_segment: true,
+    },
+    {
+      word: "there",
+      speaker: "SPEAKER_00",
+      start: 0.4,
+      end: 0.9,
+      speaker_confidence: 0.9,
+      overlaps_segment: true,
+    },
+    {
+      word: "Follow",
+      speaker: "SPEAKER_00",
+      start: 1,
+      end: 2,
+      speaker_confidence: 0.45,
+      overlaps_segment: true,
+    },
+    {
+      word: "up",
+      speaker: "SPEAKER_00",
+      start: 2,
+      end: 2.9,
+      speaker_confidence: 0.48,
+      overlaps_segment: true,
+    },
+    {
+      word: "Response",
+      speaker: "SPEAKER_01",
+      start: 3,
+      end: 4.5,
+      speaker_confidence: 0.93,
+      overlaps_segment: false,
+    },
+    {
+      word: ".",
+      speaker: "SPEAKER_01",
+      start: 4.5,
+      end: 6,
+      speaker_confidence: 0.9,
+      overlaps_segment: true,
+    },
+  ],
+} satisfies DiarizationRecord;
+
 describe("DiarizationReviewWorkspace", () => {
   beforeEach(() => {
     vi.spyOn(window.HTMLMediaElement.prototype, "pause").mockImplementation(
@@ -200,5 +254,36 @@ describe("DiarizationReviewWorkspace", () => {
     expect(screen.getByTestId("diarization-review-player")).toHaveClass(
       "lg:left-[var(--app-shell-left)]",
     );
+  });
+
+  it("flags uncertain turns and supports quick-jump navigation", () => {
+    const { container } = render(
+      <DiarizationReviewWorkspace
+        record={lowConfidenceRecord}
+        audioUrl="/audio/meeting.wav"
+      />,
+    );
+
+    const audio = container.querySelector("audio");
+    expect(audio).not.toBeNull();
+    Object.defineProperty(audio, "currentTime", {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    expect(screen.getByTestId("diarization-confidence-nav")).toBeInTheDocument();
+    expect(screen.getByText("2 flagged")).toBeInTheDocument();
+    expect(
+      screen.getByText("Average speaker confidence 47%."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("1 word drifted from segment boundaries."),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Jump to flagged turn 1" }),
+    );
+    expect(audio!.currentTime).toBe(1);
   });
 });

--- a/ui/src/components/DiarizationReviewWorkspace.tsx
+++ b/ui/src/components/DiarizationReviewWorkspace.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
+  AlertTriangle,
   Loader2,
   Pause,
   Play,
@@ -59,7 +60,16 @@ type SpeakerAccent = {
   border: string;
 };
 
+type ConfidenceFlag = {
+  entryIndex: number;
+  start: number;
+  speaker: string;
+  averageConfidence: number | null;
+  reason: string;
+};
+
 const PLAYBACK_SPEEDS = [0.75, 1, 1.25, 1.5, 2];
+const LOW_CONFIDENCE_THRESHOLD = 0.72;
 
 function formatClockTime(totalSeconds: number): string {
   if (!Number.isFinite(totalSeconds) || totalSeconds < 0) {
@@ -102,6 +112,85 @@ function isEntryActive(
   );
 }
 
+function resolveEntryWords(
+  record: NonNullable<DiarizationReviewWorkspaceProps["record"]>,
+  entryIndex: number,
+  start: number,
+  end: number,
+) {
+  const utterance = record.utterances[entryIndex];
+  if (
+    utterance &&
+    Number.isInteger(utterance.word_start) &&
+    Number.isInteger(utterance.word_end)
+  ) {
+    const min = Math.max(0, utterance.word_start);
+    const max = Math.min(record.words.length - 1, utterance.word_end);
+    if (max >= min) {
+      return record.words.slice(min, max + 1);
+    }
+  }
+
+  return record.words.filter(
+    (word) =>
+      Number.isFinite(word.start) &&
+      Number.isFinite(word.end) &&
+      word.end > start &&
+      word.start < end,
+  );
+}
+
+function computeConfidenceFlags(
+  record: NonNullable<DiarizationReviewWorkspaceProps["record"]>,
+  entries: ReturnType<typeof transcriptEntriesFromRecord>,
+): ConfidenceFlag[] {
+  return entries.flatMap((entry, entryIndex) => {
+    const words = resolveEntryWords(record, entryIndex, entry.start, entry.end);
+    if (words.length === 0) {
+      return [];
+    }
+
+    const confidenceValues = words
+      .map((word) =>
+        typeof word.speaker_confidence === "number" &&
+        Number.isFinite(word.speaker_confidence)
+          ? word.speaker_confidence
+          : null,
+      )
+      .filter((value): value is number => value !== null);
+
+    const averageConfidence =
+      confidenceValues.length > 0
+        ? confidenceValues.reduce((sum, value) => sum + value, 0) /
+          confidenceValues.length
+        : null;
+    const overlapMismatches = words.filter(
+      (word) => word.overlaps_segment === false,
+    ).length;
+    const lowConfidence =
+      averageConfidence !== null && averageConfidence < LOW_CONFIDENCE_THRESHOLD;
+
+    if (!lowConfidence && overlapMismatches === 0) {
+      return [];
+    }
+
+    const reason =
+      overlapMismatches > 0
+        ? `${overlapMismatches} word${overlapMismatches === 1 ? "" : "s"} drifted from segment boundaries.`
+        : `Average speaker confidence ${Math.round((averageConfidence ?? 0) * 100)}%.`;
+
+    return [
+      {
+        entryIndex,
+        start: entry.start,
+        speaker: entry.speaker,
+        averageConfidence,
+        reason,
+      },
+    ];
+  });
+}
+
 export function DiarizationReviewWorkspace({
   record,
   audioUrl = null,
@@ -122,6 +211,7 @@ export function DiarizationReviewWorkspace({
   const [isPlaying, setIsPlaying] = useState(false);
   const [playbackRate, setPlaybackRate] = useState(1);
   const [audioError, setAudioError] = useState<string | null>(null);
+  const [focusedFlagIndex, setFocusedFlagIndex] = useState<number | null>(null);
 
   const transcriptEntries = useMemo(
     () => (record ? transcriptEntriesFromRecord(record) : []),
@@ -191,6 +281,36 @@ export function DiarizationReviewWorkspace({
     activeEntryIndex >= 0
       ? (transcriptEntries[activeEntryIndex]?.speaker ?? null)
       : null;
+  const confidenceFlags = useMemo(
+    () => (record ? computeConfidenceFlags(record, transcriptEntries) : []),
+    [record, transcriptEntries],
+  );
+  const confidenceFlagsByEntry = useMemo(
+    () =>
+      new Map(confidenceFlags.map((flag) => [flag.entryIndex, flag] as const)),
+    [confidenceFlags],
+  );
+  const activeFlagIndex = useMemo(
+    () =>
+      confidenceFlags.findIndex((flag) => flag.entryIndex === activeEntryIndex),
+    [activeEntryIndex, confidenceFlags],
+  );
+  const selectedFlagIndex = useMemo(() => {
+    if (confidenceFlags.length === 0) {
+      return null;
+    }
+    if (
+      focusedFlagIndex !== null &&
+      focusedFlagIndex >= 0 &&
+      focusedFlagIndex < confidenceFlags.length
+    ) {
+      return focusedFlagIndex;
+    }
+    if (activeFlagIndex >= 0) {
+      return activeFlagIndex;
+    }
+    return 0;
+  }, [activeFlagIndex, confidenceFlags, focusedFlagIndex]);
 
   useEffect(() => {
     const audio = audioRef.current;
@@ -204,6 +324,7 @@ export function DiarizationReviewWorkspace({
     setIsPlaying(false);
     setPlaybackRate(1);
     setAudioError(null);
+    setFocusedFlagIndex(null);
     lastAutoScrolledEntryRef.current = null;
   }, [audioUrl, record?.id]);
 
@@ -266,6 +387,27 @@ export function DiarizationReviewWorkspace({
       audio.playbackRate = nextRate;
     }
     setPlaybackRate(nextRate);
+  }
+
+  function jumpToConfidenceFlag(flagIndex: number): void {
+    if (confidenceFlags.length === 0) {
+      return;
+    }
+
+    const normalizedIndex =
+      ((flagIndex % confidenceFlags.length) + confidenceFlags.length) %
+      confidenceFlags.length;
+    const target = confidenceFlags[normalizedIndex];
+    setFocusedFlagIndex(normalizedIndex);
+    seek(target.start);
+  }
+
+  function stepConfidenceFlag(step: number): void {
+    if (confidenceFlags.length === 0) {
+      return;
+    }
+    const baseIndex = selectedFlagIndex ?? 0;
+    jumpToConfidenceFlag(baseIndex + step);
   }
 
   if (loading) {
@@ -384,9 +526,78 @@ export function DiarizationReviewWorkspace({
             <h3 className="mb-3 text-[13px] font-semibold tracking-wide text-[var(--text-primary)]">
               Transcript
             </h3>
+            {confidenceFlags.length > 0 ? (
+              <div
+                data-testid="diarization-confidence-nav"
+                className="mb-3 rounded-lg border border-[var(--status-warning-border)] bg-[var(--status-warning-bg)] px-3 py-2.5"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="flex items-center gap-2 text-[12px] font-semibold text-[var(--status-warning-text)]">
+                    <AlertTriangle className="h-4 w-4" />
+                    Uncertain turns
+                    <span className="rounded-full bg-[var(--bg-surface-0)] px-2 py-0.5 text-[11px] font-medium text-[var(--text-primary)]">
+                      {confidenceFlags.length} flagged
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-7 border-[var(--status-warning-border)] text-[var(--status-warning-text)] hover:bg-[var(--status-warning-bg)]"
+                      onClick={() => stepConfidenceFlag(-1)}
+                      disabled={confidenceFlags.length === 0}
+                      aria-label="Previous flagged turn"
+                    >
+                      Prev flagged
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-7 border-[var(--status-warning-border)] text-[var(--status-warning-text)] hover:bg-[var(--status-warning-bg)]"
+                      onClick={() => stepConfidenceFlag(1)}
+                      disabled={confidenceFlags.length === 0}
+                      aria-label="Next flagged turn"
+                    >
+                      Next flagged
+                    </Button>
+                  </div>
+                </div>
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {confidenceFlags.map((flag, flagIndex) => {
+                    const selected = selectedFlagIndex === flagIndex;
+                    const confidenceLabel =
+                      flag.averageConfidence !== null
+                        ? `${Math.round(flag.averageConfidence * 100)}%`
+                        : "Review";
+                    return (
+                      <button
+                        key={`${flag.entryIndex}-${flag.start}`}
+                        type="button"
+                        className="rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors"
+                        style={{
+                          borderColor: "var(--status-warning-border)",
+                          backgroundColor: selected
+                            ? "var(--bg-surface-0)"
+                            : "transparent",
+                          color: "var(--status-warning-text)",
+                        }}
+                        aria-label={`Jump to flagged turn ${flagIndex + 1}`}
+                        onClick={() => jumpToConfidenceFlag(flagIndex)}
+                      >
+                        {formatClockTime(flag.start)} · {flag.speaker} ·{" "}
+                        {confidenceLabel}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : null}
             <div className="space-y-2.5">
               {transcriptEntries.map((entry, index) => {
                 const active = index === activeEntryIndex;
+                const confidenceFlag = confidenceFlagsByEntry.get(index) ?? null;
                 const speakerIndex = speakerSummaries.findIndex(
                   (s) => s.displaySpeaker === entry.speaker,
                 );
@@ -437,6 +648,16 @@ export function DiarizationReviewWorkspace({
                         </span>
                       ) : null}
                     </div>
+                    {confidenceFlag ? (
+                      <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                        <span className="rounded-full border border-[var(--status-warning-border)] bg-[var(--status-warning-bg)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--status-warning-text)]">
+                          Review
+                        </span>
+                        <span className="text-[11px] text-[var(--status-warning-text)]">
+                          {confidenceFlag.reason}
+                        </span>
+                      </div>
+                    ) : null}
                     <p className="mt-1.5 text-[15px] leading-7 text-[var(--text-secondary)]">
                       {entry.text}
                     </p>

--- a/ui/src/features/diarization/components/DiarizationRecordDetail.tsx
+++ b/ui/src/features/diarization/components/DiarizationRecordDetail.tsx
@@ -76,6 +76,7 @@ interface DiarizationRecordDetailProps {
     recordId: string,
     request: DiarizationRecordRerunRequest,
   ) => Promise<void> | void;
+  onCancelProcessing?: (recordId: string) => Promise<void> | void;
   onRegenerateSummary?: (recordId: string) => Promise<void> | void;
 }
 
@@ -89,6 +90,7 @@ export function DiarizationRecordDetail({
   onDelete,
   onSaveSpeakerCorrections,
   onRerun,
+  onCancelProcessing,
   onRegenerateSummary,
 }: DiarizationRecordDetailProps) {
   const [workspaceTab, setWorkspaceTab] = useState("transcript");
@@ -102,6 +104,8 @@ export function DiarizationRecordDetail({
   );
   const [rerunPending, setRerunPending] = useState(false);
   const [rerunError, setRerunError] = useState<string | null>(null);
+  const [cancelPending, setCancelPending] = useState(false);
+  const [cancelError, setCancelError] = useState<string | null>(null);
   const [summaryRefreshPending, setSummaryRefreshPending] = useState(false);
   const [summaryRefreshError, setSummaryRefreshError] = useState<string | null>(
     null,
@@ -154,6 +158,8 @@ export function DiarizationRecordDetail({
         return null;
     }
   }, [record?.summary_error, summaryStatus]);
+  const canCancelProcessing =
+    processingStatus === "pending" || processingStatus === "processing";
 
   useEffect(() => {
     setWorkspaceTab("transcript");
@@ -165,6 +171,8 @@ export function DiarizationRecordDetail({
     setSpeakerUpdateError(null);
     setRerunPending(false);
     setRerunError(null);
+    setCancelPending(false);
+    setCancelError(null);
     setSummaryRefreshPending(false);
     setSummaryRefreshError(null);
   }, [record?.id]);
@@ -238,6 +246,31 @@ export function DiarizationRecordDetail({
     }
   }
 
+  async function handleCancelProcessing(): Promise<void> {
+    if (
+      !record ||
+      !onCancelProcessing ||
+      cancelPending ||
+      !canCancelProcessing
+    ) {
+      return;
+    }
+
+    setCancelPending(true);
+    setCancelError(null);
+    try {
+      await onCancelProcessing(record.id);
+    } catch (err) {
+      setCancelError(
+        err instanceof Error
+          ? err.message
+          : "Failed to cancel diarization processing.",
+      );
+    } finally {
+      setCancelPending(false);
+    }
+  }
+
   async function handleRegenerateSummary(): Promise<void> {
     if (!record || !onRegenerateSummary || summaryRefreshPending) {
       return;
@@ -298,7 +331,9 @@ export function DiarizationRecordDetail({
             size="sm"
             className="h-9 gap-2"
             onClick={() => void handleRegenerateSummary()}
-            disabled={!record || summaryRefreshPending || !hasTranscript}
+            disabled={
+              !record || summaryRefreshPending || !hasTranscript || cancelPending
+            }
           >
             {summaryRefreshPending ? (
               <Loader2 className="h-4 w-4 animate-spin" />
@@ -347,6 +382,21 @@ export function DiarizationRecordDetail({
               Delete
             </Button>
           ) : null}
+          {onCancelProcessing && canCancelProcessing ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-9 gap-2 border-[var(--status-warning-border)] text-[var(--status-warning-text)] hover:bg-[var(--status-warning-bg)]"
+              onClick={() => void handleCancelProcessing()}
+              disabled={cancelPending}
+            >
+              {cancelPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : null}
+              {cancelPending ? "Cancelling" : "Cancel run"}
+            </Button>
+          ) : null}
         </div>
       </div>
 
@@ -359,6 +409,12 @@ export function DiarizationRecordDetail({
       {summaryRefreshError ? (
         <Card className="border-[var(--danger-border)] bg-[var(--danger-bg)] p-4 text-sm text-[var(--danger-text)]">
           {summaryRefreshError}
+        </Card>
+      ) : null}
+
+      {cancelError ? (
+        <Card className="border-[var(--danger-border)] bg-[var(--danger-bg)] p-4 text-sm text-[var(--danger-text)]">
+          {cancelError}
         </Card>
       ) : null}
 

--- a/ui/src/features/diarization/route.test.tsx
+++ b/ui/src/features/diarization/route.test.tsx
@@ -12,6 +12,7 @@ const apiMocks = vi.hoisted(() => ({
   getDiarizationRecord: vi.fn(),
   updateDiarizationRecord: vi.fn(),
   rerunDiarizationRecord: vi.fn(),
+  cancelDiarizationRecord: vi.fn(),
   regenerateDiarizationSummary: vi.fn(),
   deleteDiarizationRecord: vi.fn(),
   createDiarizationRecord: vi.fn(),
@@ -25,6 +26,7 @@ vi.mock("@/api", () => ({
     getDiarizationRecord: apiMocks.getDiarizationRecord,
     updateDiarizationRecord: apiMocks.updateDiarizationRecord,
     rerunDiarizationRecord: apiMocks.rerunDiarizationRecord,
+    cancelDiarizationRecord: apiMocks.cancelDiarizationRecord,
     regenerateDiarizationSummary: apiMocks.regenerateDiarizationSummary,
     deleteDiarizationRecord: apiMocks.deleteDiarizationRecord,
     createDiarizationRecord: apiMocks.createDiarizationRecord,
@@ -202,6 +204,7 @@ describe("DiarizationPage routes", () => {
     apiMocks.getDiarizationRecord.mockReset();
     apiMocks.updateDiarizationRecord.mockReset();
     apiMocks.rerunDiarizationRecord.mockReset();
+    apiMocks.cancelDiarizationRecord.mockReset();
     apiMocks.regenerateDiarizationSummary.mockReset();
     apiMocks.deleteDiarizationRecord.mockReset();
     apiMocks.createDiarizationRecord.mockReset();
@@ -217,6 +220,11 @@ describe("DiarizationPage routes", () => {
       },
     }));
     apiMocks.getDiarizationRecord.mockResolvedValue(fullRecord);
+    apiMocks.cancelDiarizationRecord.mockResolvedValue({
+      ...fullRecord,
+      processing_status: "failed",
+      processing_error: "Cancelled by user.",
+    });
     apiMocks.createDiarizationRecord.mockResolvedValue(fullRecord);
     apiMocks.diarizationRecordAudioUrl.mockReturnValue("/audio/meeting.wav");
   });
@@ -668,6 +676,34 @@ describe("DiarizationPage routes", () => {
     expect(
       await screen.findByRole("heading", { name: "Diarization" }),
     ).toBeInTheDocument();
+  });
+
+  it("cancels a pending diarization record from the detail page", async () => {
+    apiMocks.listDiarizationRecords.mockResolvedValue([pendingSummaryRecord]);
+    apiMocks.getDiarizationRecord.mockResolvedValue({
+      ...fullRecord,
+      processing_status: "processing" as const,
+      processing_error: null,
+      transcript: "",
+      raw_transcript: "",
+      utterances: [],
+      words: [],
+      segments: [],
+      summary_status: "not_requested" as const,
+      summary_text: null,
+    });
+
+    renderRoute("/diarization/diar-1");
+
+    await waitFor(() =>
+      expect(apiMocks.getDiarizationRecord).toHaveBeenCalledWith("diar-1"),
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Cancel run/i }));
+
+    await waitFor(() =>
+      expect(apiMocks.cancelDiarizationRecord).toHaveBeenCalledWith("diar-1"),
+    );
   });
 
   it("deletes from the diarization history menu and refreshes the table", async () => {

--- a/ui/src/features/diarization/route.tsx
+++ b/ui/src/features/diarization/route.tsx
@@ -508,6 +508,20 @@ export function DiarizationPage({
     [latestRecord?.id, navigate, refreshHistory],
   );
 
+  const handleCancelProcessing = useCallback(
+    async (targetRecordId: string) => {
+      const cancelledRecord = await api.cancelDiarizationRecord(targetRecordId);
+      await Promise.all([
+        refreshHistory(),
+        recordId === targetRecordId ? refreshRecord() : Promise.resolve(),
+      ]);
+      if (latestRecord?.id === targetRecordId) {
+        setLatestRecord(cancelledRecord);
+      }
+    },
+    [latestRecord?.id, recordId, refreshHistory, refreshRecord],
+  );
+
   const handleRegenerateSummary = useCallback(
     async (targetRecordId: string) => {
       if (!summaryModelReady) {
@@ -565,6 +579,7 @@ export function DiarizationPage({
             onDelete={handleDeleteRecord}
             onSaveSpeakerCorrections={handleSaveSpeakerCorrections}
             onRerun={handleRerunRecord}
+            onCancelProcessing={handleCancelProcessing}
             onRegenerateSummary={handleRegenerateSummary}
           />
         </>

--- a/ui/src/shared/api/audio.test.ts
+++ b/ui/src/shared/api/audio.test.ts
@@ -308,6 +308,28 @@ describe("AudioApiClient.updateDiarizationRecord", () => {
     );
   });
 
+  it("posts diarization cancels to the canonical cancel route", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(updatedRecord), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new AudioApiClient(new ApiHttpClient("http://localhost/v1"));
+    const result = await client.cancelDiarizationRecord("diar-1");
+
+    expect(result).toEqual(updatedRecord);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost/v1/diarizations/diar-1/cancel",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
   it("posts diarization summary regenerations to the canonical summary route", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify(updatedRecord), {

--- a/ui/src/shared/api/audio.ts
+++ b/ui/src/shared/api/audio.ts
@@ -2016,6 +2016,15 @@ export class AudioApiClient {
     );
   }
 
+  async cancelDiarizationRecord(recordId: string): Promise<DiarizationRecord> {
+    return this.http.request(
+      `${this.diarizationRecordPath(recordId)}/cancel`,
+      {
+        method: "POST",
+      },
+    );
+  }
+
   async createDiarizationRecord(
     request: DiarizationRecordCreateRequest,
   ): Promise<DiarizationRecord> {

--- a/ui/src/shared/api/client.ts
+++ b/ui/src/shared/api/client.ts
@@ -97,6 +97,7 @@ const audioMethodNames = [
   "getDiarizationRecord",
   "updateDiarizationRecord",
   "rerunDiarizationRecord",
+  "cancelDiarizationRecord",
   "regenerateDiarizationSummary",
   "createDiarizationRecord",
   "diarizationRecordAudioUrl",


### PR DESCRIPTION
Align diarization CLI/docs/API contracts, switch reruns to async with explicit cancel, prevent stuck summary pending states via timeout/fail-fast handling, and add confidence-flagged transcript navigation to speed manual review.