### PR TITLE
Add runtime probes, JSON logging, and preview API hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7789,6 +7789,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7798,12 +7808,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ rustfft = "6.2"
 anyhow = "1.0"
 thiserror = "1.0"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 bytes = "1.9"
 base64 = "0.22"

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,7 @@ USER izwi
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD curl -f http://localhost:8080/v1/health || exit 1
+    CMD curl -f http://localhost:8080/readyz || exit 1
 
 # Start the server
 CMD ["izwi-server"]
@@ -178,7 +178,7 @@ USER izwi
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
-    CMD curl -f http://localhost:8080/v1/health || exit 1
+    CMD curl -f http://localhost:8080/readyz || exit 1
 
 # Start the server
 CMD ["izwi-server"]

--- a/crates/izwi-cli/src/app/cli.rs
+++ b/crates/izwi-cli/src/app/cli.rs
@@ -123,6 +123,10 @@ pub enum Commands {
         #[arg(long, default_value = "warn", env = "RUST_LOG")]
         log_level: String,
 
+        /// Log output format
+        #[arg(long, value_enum, default_value = "text", env = "IZWI_LOG_FORMAT")]
+        log_format: LogFormat,
+
         /// Enable development mode with hot reload
         #[arg(long, hide = true)]
         dev: bool,
@@ -613,6 +617,21 @@ pub enum ServeMode {
     Desktop,
     /// Start API server and open the web UI in a browser tab
     Web,
+}
+
+#[derive(Clone, ValueEnum)]
+pub enum LogFormat {
+    Text,
+    Json,
+}
+
+impl LogFormat {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Text => "text",
+            Self::Json => "json",
+        }
+    }
 }
 
 #[derive(Clone, ValueEnum)]

--- a/crates/izwi-cli/src/app/mod.rs
+++ b/crates/izwi-cli/src/app/mod.rs
@@ -6,7 +6,7 @@ use crate::style::Theme;
 use izwi_core::{ServeRuntimeConfig, ServeRuntimeConfigOverrides};
 use std::path::PathBuf;
 
-use self::cli::{Backend, Cli, Commands, ServeMode};
+use self::cli::{Backend, Cli, Commands, LogFormat, ServeMode};
 
 pub async fn run(cli: Cli, theme: Theme) -> Result<()> {
     let Cli {
@@ -30,6 +30,7 @@ pub async fn run(cli: Cli, theme: Theme) -> Result<()> {
             max_concurrent,
             timeout,
             log_level,
+            log_format,
             dev,
             cors,
             no_ui,
@@ -46,6 +47,7 @@ pub async fn run(cli: Cli, theme: Theme) -> Result<()> {
                 max_concurrent,
                 timeout,
                 log_level,
+                log_format,
                 dev,
                 cors,
                 no_ui,
@@ -203,6 +205,7 @@ fn build_serve_args(
     max_concurrent: Option<usize>,
     timeout: Option<u64>,
     log_level: String,
+    log_format: LogFormat,
     dev: bool,
     cors: bool,
     no_ui: bool,
@@ -226,6 +229,7 @@ fn build_serve_args(
         mode,
         runtime,
         log_level,
+        log_format,
         dev,
     })
 }
@@ -275,6 +279,7 @@ mod tests {
         std::env::remove_var(izwi_core::serve_runtime::ENV_UI_DIR);
         std::env::remove_var(izwi_core::serve_runtime::LEGACY_ENV_MAX_CONCURRENT[0]);
         std::env::remove_var(izwi_core::serve_runtime::LEGACY_ENV_TIMEOUT[0]);
+        std::env::remove_var("IZWI_LOG_FORMAT");
     }
 
     #[test]
@@ -313,6 +318,7 @@ mod tests {
             None,
             None,
             "info".to_string(),
+            LogFormat::Text,
             false,
             true,
             false,
@@ -349,6 +355,7 @@ mod tests {
             None,
             None,
             "warn".to_string(),
+            LogFormat::Text,
             false,
             false,
             false,

--- a/crates/izwi-cli/src/commands/bench.rs
+++ b/crates/izwi-cli/src/commands/bench.rs
@@ -525,7 +525,7 @@ async fn bench_throughput(
         &format!("Throughput test: {}s, {} concurrent", duration, concurrent),
     );
 
-    println!("Running throughput benchmark against /v1/health...");
+    println!("Running throughput benchmark against /livez...");
     let client = http::client(Some(std::time::Duration::from_secs(5)))?;
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(duration);
 
@@ -537,7 +537,7 @@ async fn bench_throughput(
             let mut success = 0u64;
             let mut failed = 0u64;
             while std::time::Instant::now() < deadline {
-                match client.get(format!("{}/v1/health", server)).send().await {
+                match client.get(format!("{}/livez", server)).send().await {
                     Ok(resp) if resp.status().is_success() => success += 1,
                     _ => failed += 1,
                 }

--- a/crates/izwi-cli/src/commands/serve.rs
+++ b/crates/izwi-cli/src/commands/serve.rs
@@ -98,8 +98,10 @@ pub async fn execute(args: ServeArgs) -> Result<()> {
             if !args.runtime.ui_enabled {
                 eprintln!(
                     "{}",
-                    style("Web mode requested with --no-ui; opening the health endpoint instead.")
-                        .yellow()
+                    style(
+                        "Web mode requested with --no-ui; opening the readiness endpoint instead.",
+                    )
+                    .yellow()
                 );
             }
 
@@ -398,11 +400,11 @@ async fn wait_for_server_ready(api_endpoint: &str, timeout: Duration) -> Result<
         .timeout(Duration::from_secs(2))
         .build()?;
 
-    let health_url = format!("{}/health", api_endpoint);
+    let ready_url = readiness_url(api_endpoint);
     let deadline = Instant::now() + timeout;
 
     loop {
-        if let Ok(resp) = client.get(&health_url).send().await {
+        if let Ok(resp) = client.get(&ready_url).send().await {
             if resp.status().is_success() {
                 return Ok(());
             }
@@ -412,12 +414,16 @@ async fn wait_for_server_ready(api_endpoint: &str, timeout: Duration) -> Result<
             return Err(CliError::Other(format!(
                 "Server did not become ready within {}s ({})",
                 timeout.as_secs(),
-                health_url
+                ready_url
             )));
         }
 
         tokio::time::sleep(Duration::from_millis(250)).await;
     }
+}
+
+fn readiness_url(api_endpoint: &str) -> String {
+    format!("{}/ready", api_endpoint)
 }
 
 async fn supervise_desktop_mode(server: &mut Child, desktop: &mut Child) -> Result<()> {
@@ -509,7 +515,7 @@ fn server_connect_host(host: &str) -> String {
 
 fn browser_target(host: &str, port: u16, no_ui: bool) -> String {
     if no_ui {
-        format!("http://{}:{}/v1/health", host, port)
+        format!("http://{}:{}/v1/ready", host, port)
     } else {
         format!("http://{}:{}", host, port)
     }
@@ -596,14 +602,22 @@ mod tests {
     }
 
     #[test]
-    fn browser_target_uses_health_when_ui_is_disabled() {
+    fn browser_target_uses_readiness_when_ui_is_disabled() {
         assert_eq!(
             browser_target("127.0.0.1", 8080, true),
-            "http://127.0.0.1:8080/v1/health"
+            "http://127.0.0.1:8080/v1/ready"
         );
         assert_eq!(
             browser_target("127.0.0.1", 8080, false),
             "http://127.0.0.1:8080"
+        );
+    }
+
+    #[test]
+    fn startup_wait_uses_readiness_endpoint() {
+        assert_eq!(
+            readiness_url("http://127.0.0.1:8080/v1"),
+            "http://127.0.0.1:8080/v1/ready"
         );
     }
 }

--- a/crates/izwi-cli/src/commands/serve.rs
+++ b/crates/izwi-cli/src/commands/serve.rs
@@ -1,6 +1,6 @@
 use crate::error::{CliError, Result};
 use crate::style::Theme;
-use crate::ServeMode;
+use crate::{LogFormat, ServeMode};
 use console::style;
 use izwi_core::ServeRuntimeConfig;
 use std::path::PathBuf;
@@ -12,6 +12,7 @@ pub struct ServeArgs {
     pub mode: ServeMode,
     pub runtime: ServeRuntimeConfig,
     pub log_level: String,
+    pub log_format: LogFormat,
     pub dev: bool,
 }
 
@@ -38,6 +39,7 @@ pub async fn execute(args: ServeArgs) -> Result<()> {
     println!("  Timeout:        {}s", args.runtime.request_timeout_secs);
     println!("  Backend:        {}", args.runtime.backend.as_str());
     println!("  Log level:      {}", args.log_level);
+    println!("  Log format:     {}", args.log_format.as_str());
 
     set_server_env(&args);
 
@@ -157,6 +159,7 @@ fn serve_mode_label(mode: &ServeMode) -> &'static str {
 
 fn set_server_env(args: &ServeArgs) {
     std::env::set_var("RUST_LOG", &args.log_level);
+    std::env::set_var("IZWI_LOG_FORMAT", args.log_format.as_str());
     std::env::set_var("IZWI_HOST", &args.runtime.host);
     std::env::set_var("IZWI_PORT", args.runtime.port.to_string());
     std::env::set_var(
@@ -229,6 +232,7 @@ fn spawn_server(args: &ServeArgs) -> Result<Child> {
     };
 
     cmd.env("RUST_LOG", &args.log_level);
+    cmd.env("IZWI_LOG_FORMAT", args.log_format.as_str());
     cmd.stdout(Stdio::inherit());
     cmd.stderr(Stdio::inherit());
 
@@ -549,6 +553,7 @@ mod tests {
 
     fn clear_serve_env() {
         std::env::remove_var("RUST_LOG");
+        std::env::remove_var("IZWI_LOG_FORMAT");
         std::env::remove_var("IZWI_HOST");
         std::env::remove_var("IZWI_PORT");
         std::env::remove_var("IZWI_MAX_BATCH_SIZE");
@@ -582,6 +587,7 @@ mod tests {
                 ui_dir: PathBuf::from("/tmp/ui"),
             },
             log_level: "info".to_string(),
+            log_format: LogFormat::Text,
             dev: false,
         }
     }
@@ -594,10 +600,23 @@ mod tests {
 
         assert_eq!(std::env::var("IZWI_CORS").as_deref(), Ok("1"));
         assert_eq!(std::env::var("IZWI_NO_UI").as_deref(), Ok("1"));
+        assert_eq!(std::env::var("IZWI_LOG_FORMAT").as_deref(), Ok("text"));
         assert_eq!(
             std::env::var("IZWI_MODELS_DIR").as_deref(),
             Ok("/tmp/models")
         );
+        clear_serve_env();
+    }
+
+    #[test]
+    fn set_server_env_passes_json_log_format() {
+        clear_serve_env();
+
+        let mut args = sample_args();
+        args.log_format = LogFormat::Json;
+        set_server_env(&args);
+
+        assert_eq!(std::env::var("IZWI_LOG_FORMAT").as_deref(), Ok("json"));
         clear_serve_env();
     }
 

--- a/crates/izwi-cli/src/main.rs
+++ b/crates/izwi-cli/src/main.rs
@@ -14,7 +14,7 @@ mod style;
 mod utils;
 
 pub use app::cli::{
-    AudioFormat, Backend, BenchCommands, Cli, Commands, ConfigCommands, ModelCommands,
+    AudioFormat, Backend, BenchCommands, Cli, Commands, ConfigCommands, LogFormat, ModelCommands,
     OutputFormat, ServeMode, Shell, TranscriptFormat,
 };
 use error::Result;

--- a/crates/izwi-server/src/api/internal/mod.rs
+++ b/crates/izwi-server/src/api/internal/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod health;
 pub mod metrics;
+pub mod probes;
 
 use axum::{routing::get, Router};
 
@@ -10,6 +11,8 @@ use crate::state::AppState;
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/health", get(health::health_check))
+        .route("/live", get(probes::live_check))
+        .route("/ready", get(probes::ready_check))
         .route("/metrics", get(metrics::metrics_json))
         .route("/metrics/prometheus", get(metrics::metrics_prometheus))
 }

--- a/crates/izwi-server/src/api/internal/probes.rs
+++ b/crates/izwi-server/src/api/internal/probes.rs
@@ -1,0 +1,227 @@
+//! Liveness and readiness probes.
+
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::Serialize;
+
+use crate::state::AppState;
+
+#[derive(Debug, Serialize)]
+pub struct ProbeCheck {
+    pub name: &'static str,
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LiveResponse {
+    pub status: &'static str,
+    pub version: &'static str,
+    pub uptime_secs: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReadyResponse {
+    pub status: &'static str,
+    pub version: &'static str,
+    pub ready: bool,
+    pub phase: String,
+    pub draining: bool,
+    pub uptime_secs: u64,
+    pub checks: Vec<ProbeCheck>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub startup_warnings: Vec<String>,
+}
+
+pub async fn live_check(State(state): State<AppState>) -> Json<LiveResponse> {
+    let lifecycle = state.lifecycle.snapshot();
+    Json(LiveResponse {
+        status: "alive",
+        version: env!("CARGO_PKG_VERSION"),
+        uptime_secs: now_saturating_sub(lifecycle.started_at),
+    })
+}
+
+pub async fn ready_check(State(state): State<AppState>) -> Response {
+    let response = readiness_response(&state).await;
+    let status = if response.ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (status, Json(response)).into_response()
+}
+
+async fn readiness_response(state: &AppState) -> ReadyResponse {
+    let lifecycle = state.lifecycle.snapshot();
+    let backend_context = state.runtime.backend_context();
+    let telemetry = state.runtime.telemetry_snapshot().await;
+
+    let mut checks = vec![
+        ProbeCheck {
+            name: "lifecycle_ready",
+            ok: lifecycle.ready,
+            message: (!lifecycle.ready).then(|| format!("phase is {}", lifecycle.phase)),
+        },
+        ProbeCheck {
+            name: "not_draining",
+            ok: !lifecycle.draining,
+            message: lifecycle
+                .draining
+                .then(|| "server is draining for shutdown".to_string()),
+        },
+        ProbeCheck {
+            name: "backend_available",
+            ok: backend_context.matches_preference(),
+            message: (!backend_context.matches_preference()).then(|| {
+                format!(
+                    "requested backend {} selected {}",
+                    backend_context.preference.as_str(),
+                    backend_context.backend_kind.as_str()
+                )
+            }),
+        },
+        ProbeCheck {
+            name: "stores_available",
+            ok: true,
+            message: None,
+        },
+        ProbeCheck {
+            name: "request_capacity",
+            ok: state.request_semaphore.available_permits() > 0,
+            message: (state.request_semaphore.available_permits() == 0)
+                .then(|| "all request permits are currently in use".to_string()),
+        },
+    ];
+
+    let worker_healthy = telemetry.worker_panics <= telemetry.worker_restarts;
+    checks.push(ProbeCheck {
+        name: "worker_health",
+        ok: worker_healthy,
+        message: (!worker_healthy).then(|| {
+            format!(
+                "worker panics ({}) exceed restarts ({})",
+                telemetry.worker_panics, telemetry.worker_restarts
+            )
+        }),
+    });
+
+    let ready = checks.iter().all(|check| check.ok);
+
+    ReadyResponse {
+        status: if ready { "ready" } else { "unready" },
+        version: env!("CARGO_PKG_VERSION"),
+        ready,
+        phase: lifecycle.phase,
+        draining: lifecycle.draining,
+        uptime_secs: now_saturating_sub(lifecycle.started_at),
+        checks,
+        startup_warnings: lifecycle.startup_warnings,
+    }
+}
+
+fn now_saturating_sub(started_at: u64) -> u64 {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    now.saturating_sub(started_at)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::AppState;
+    use izwi_core::{backends::BackendPreference, RuntimeService, ServeRuntimeConfig};
+    use std::sync::{Mutex, OnceLock};
+
+    #[tokio::test]
+    async fn readiness_reports_ready_after_lifecycle_mark_ready() {
+        let (_guard, state) = test_state("readiness_ready");
+        state.lifecycle.mark_ready();
+
+        let response = readiness_response(&state).await;
+
+        assert!(response.ready);
+        assert_eq!(response.status, "ready");
+        assert!(response.checks.iter().all(|check| check.ok));
+    }
+
+    #[tokio::test]
+    async fn readiness_reports_unready_when_draining() {
+        let (_guard, state) = test_state("readiness_draining");
+        state.lifecycle.mark_ready();
+        state.lifecycle.mark_draining();
+
+        let response = readiness_response(&state).await;
+
+        assert!(!response.ready);
+        assert_eq!(response.status, "unready");
+        assert!(response
+            .checks
+            .iter()
+            .any(|check| check.name == "not_draining" && !check.ok));
+    }
+
+    fn test_state(name: &str) -> (TempDirGuard, AppState) {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "izwi-probes-{name}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("time should be monotonic")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&temp_dir).expect("temp dir should be created");
+        let db_path = temp_dir.join("izwi.sqlite3");
+        let media_dir = temp_dir.join("media");
+        let models_dir = temp_dir.join("models");
+        std::fs::create_dir_all(&models_dir).expect("models dir should be created");
+
+        let guard = env_lock();
+        std::env::set_var("IZWI_DB_PATH", &db_path);
+        std::env::set_var("IZWI_MEDIA_DIR", &media_dir);
+
+        let serve_config = ServeRuntimeConfig {
+            backend: BackendPreference::Cpu,
+            ui_enabled: false,
+            models_dir,
+            ..ServeRuntimeConfig::default()
+        };
+        let runtime = RuntimeService::new(serve_config.engine_config()).expect("runtime");
+        let state = AppState::new(runtime, &serve_config).expect("state");
+        std::env::remove_var("IZWI_DB_PATH");
+        std::env::remove_var("IZWI_MEDIA_DIR");
+
+        (
+            TempDirGuard {
+                path: temp_dir,
+                _env: guard,
+            },
+            state,
+        )
+    }
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("environment lock poisoned")
+    }
+
+    struct TempDirGuard {
+        path: std::path::PathBuf,
+        _env: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl Drop for TempDirGuard {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+}

--- a/crates/izwi-server/src/api/internal/probes.rs
+++ b/crates/izwi-server/src/api/internal/probes.rs
@@ -61,6 +61,8 @@ async fn readiness_response(state: &AppState) -> ReadyResponse {
     let lifecycle = state.lifecycle.snapshot();
     let backend_context = state.runtime.backend_context();
     let telemetry = state.runtime.telemetry_snapshot().await;
+    let startup_warnings = lifecycle.startup_warnings.clone();
+    let preload_complete = startup_warnings.is_empty();
 
     let mut checks = vec![
         ProbeCheck {
@@ -74,6 +76,11 @@ async fn readiness_response(state: &AppState) -> ReadyResponse {
             message: lifecycle
                 .draining
                 .then(|| "server is draining for shutdown".to_string()),
+        },
+        ProbeCheck {
+            name: "preload_complete",
+            ok: preload_complete,
+            message: (!preload_complete).then(|| startup_warnings.join("; ")),
         },
         ProbeCheck {
             name: "backend_available",
@@ -121,7 +128,7 @@ async fn readiness_response(state: &AppState) -> ReadyResponse {
         draining: lifecycle.draining,
         uptime_secs: now_saturating_sub(lifecycle.started_at),
         checks,
-        startup_warnings: lifecycle.startup_warnings,
+        startup_warnings,
     }
 }
 
@@ -166,6 +173,28 @@ mod tests {
             .checks
             .iter()
             .any(|check| check.name == "not_draining" && !check.ok));
+    }
+
+    #[tokio::test]
+    async fn readiness_reports_unready_when_startup_warnings_exist() {
+        let (_guard, state) = test_state("readiness_startup_warnings");
+        state
+            .lifecycle
+            .record_startup_warnings(vec!["failed to preload model test".to_string()]);
+        state.lifecycle.mark_ready();
+
+        let response = readiness_response(&state).await;
+
+        assert!(!response.ready);
+        assert_eq!(response.status, "unready");
+        assert_eq!(
+            response.startup_warnings,
+            vec!["failed to preload model test"]
+        );
+        assert!(response
+            .checks
+            .iter()
+            .any(|check| check.name == "preload_complete" && !check.ok));
     }
 
     fn test_state(name: &str) -> (TempDirGuard, AppState) {

--- a/crates/izwi-server/src/api/openai/responses/handlers.rs
+++ b/crates/izwi-server/src/api/openai/responses/handlers.rs
@@ -824,7 +824,9 @@ fn sse_event(event_name: &str, payload: &str) -> String {
 mod tests {
     use super::super::dto::{ResponseInputContentPart, ResponseInputItem};
     use super::*;
+    use izwi_core::{backends::BackendPreference, RuntimeService, ServeRuntimeConfig};
     use serde_json::json;
+    use std::sync::{Mutex, OnceLock};
 
     #[test]
     fn builds_messages_from_text_and_instructions() {
@@ -1035,5 +1037,82 @@ mod tests {
         assert_eq!(item.content.len(), 1);
         assert_eq!(item.content[0].content_type, "output_text");
         assert_eq!(item.content[0].text, "hello");
+    }
+
+    #[tokio::test]
+    async fn store_false_does_not_retain_response_record() {
+        let _guard = env_lock();
+        let (state, _temp_dir) = test_app_state("responses_store_false");
+
+        persist_response(&state, response_record("resp-skip"), Some(false)).await;
+        assert!(
+            state.response_store.read().await.is_empty(),
+            "store:false should skip in-memory retention"
+        );
+
+        persist_response(&state, response_record("resp-store"), None).await;
+        assert!(
+            state.response_store.read().await.contains_key("resp-store"),
+            "default store behavior should retain completed responses"
+        );
+    }
+
+    fn response_record(id: &str) -> StoredResponseRecord {
+        StoredResponseRecord {
+            id: id.to_string(),
+            created_at: now_unix_secs(),
+            status: "completed".to_string(),
+            model: "test".to_string(),
+            input_items: Vec::new(),
+            output_text: Some("ok".to_string()),
+            input_tokens: 1,
+            output_tokens: 1,
+            error: None,
+            metadata: None,
+        }
+    }
+
+    fn test_app_state(name: &str) -> (AppState, tempfile::TempDir) {
+        let temp_dir = tempfile::tempdir().expect("temp dir should create");
+        let models_dir = temp_dir.path().join("models");
+        let media_dir = temp_dir.path().join("media");
+        std::fs::create_dir_all(&models_dir).expect("models dir should be created");
+
+        std::env::set_var(
+            "IZWI_DB_PATH",
+            temp_dir.path().join(format!("{name}.sqlite3")),
+        );
+        std::env::set_var("IZWI_MEDIA_DIR", &media_dir);
+
+        let serve_config = ServeRuntimeConfig {
+            backend: BackendPreference::Cpu,
+            models_dir,
+            ..ServeRuntimeConfig::default()
+        };
+        let runtime =
+            with_suppressed_panic_hook(|| RuntimeService::new(serve_config.engine_config()))
+                .expect("runtime should initialize");
+        let state = AppState::new(runtime, &serve_config).expect("state should initialize");
+
+        std::env::remove_var("IZWI_DB_PATH");
+        std::env::remove_var("IZWI_MEDIA_DIR");
+
+        (state, temp_dir)
+    }
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("environment lock poisoned")
+    }
+
+    fn with_suppressed_panic_hook<T>(f: impl FnOnce() -> T) -> T {
+        let default_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let result = f();
+        std::panic::set_hook(default_hook);
+        result
     }
 }

--- a/crates/izwi-server/src/api/request_context.rs
+++ b/crates/izwi-server/src/api/request_context.rs
@@ -1,4 +1,5 @@
 use axum::extract::Request;
+use axum::http::HeaderValue;
 use axum::middleware::Next;
 use axum::response::Response;
 use uuid::Uuid;
@@ -24,9 +25,106 @@ pub async fn attach_request_context(mut req: Request, next: Next) -> Response {
         correlation_id: correlation_id.clone(),
     });
 
+    if let Ok(value) = HeaderValue::from_str(&correlation_id) {
+        req.headers_mut().insert(REQUEST_ID_HEADER, value);
+    }
+
     let mut response = next.run(req).await;
     if let Ok(value) = correlation_id.parse() {
         response.headers_mut().insert(REQUEST_ID_HEADER, value);
     }
     response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        extract::Extension,
+        http::{header::HeaderName, HeaderMap, Request},
+        middleware,
+        routing::get,
+        Router,
+    };
+    use tower::Service;
+
+    async fn echo_context(Extension(context): Extension<RequestContext>) -> String {
+        context.correlation_id
+    }
+
+    async fn echo_context_and_header(
+        headers: HeaderMap,
+        Extension(context): Extension<RequestContext>,
+    ) -> String {
+        let header = headers
+            .get(REQUEST_ID_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+        format!("{}|{}", context.correlation_id, header)
+    }
+
+    #[tokio::test]
+    async fn generated_request_id_is_inserted_and_returned() {
+        let response = send_request(
+            Router::new()
+                .route("/", get(echo_context_and_header))
+                .layer(middleware::from_fn(attach_request_context)),
+            Request::builder()
+                .uri("/")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await;
+
+        let request_id = response
+            .headers()
+            .get(REQUEST_ID_HEADER)
+            .expect("request id header should exist")
+            .to_str()
+            .expect("request id should be ascii")
+            .to_string();
+        Uuid::parse_str(&request_id).expect("generated request id should be a UUID");
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should read");
+        assert_eq!(body, format!("{request_id}|{request_id}").as_bytes());
+    }
+
+    #[tokio::test]
+    async fn supplied_request_id_is_preserved() {
+        let supplied = "client-request-123";
+        let response = send_request(
+            Router::new()
+                .route("/", get(echo_context))
+                .layer(middleware::from_fn(attach_request_context)),
+            Request::builder()
+                .uri("/")
+                .header(HeaderName::from_static(REQUEST_ID_HEADER), supplied)
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await;
+
+        assert_eq!(
+            response
+                .headers()
+                .get(REQUEST_ID_HEADER)
+                .and_then(|value| value.to_str().ok()),
+            Some(supplied)
+        );
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should read");
+        assert_eq!(body, supplied.as_bytes());
+    }
+
+    async fn send_request(mut app: Router, request: Request<Body>) -> Response {
+        app.as_service::<Body>()
+            .call(request)
+            .await
+            .expect("request should succeed")
+    }
 }

--- a/crates/izwi-server/src/api/router.rs
+++ b/crates/izwi-server/src/api/router.rs
@@ -1,7 +1,9 @@
 use axum::{
     extract::Request,
     http::{HeaderValue, StatusCode},
-    middleware, Router,
+    middleware,
+    routing::get,
+    Router,
 };
 use izwi_core::ServeRuntimeConfig;
 use tower_http::cors::{Any, CorsLayer};
@@ -57,6 +59,8 @@ pub fn create_router(state: AppState, serve_config: &ServeRuntimeConfig) -> Rout
         .fallback(api_not_found);
 
     let app = Router::new()
+        .route("/livez", get(crate::api::internal::probes::live_check))
+        .route("/readyz", get(crate::api::internal::probes::ready_check))
         .nest("/v1", v1_routes)
         // Compatibility mount for tooling that queries /internal/* directly.
         .nest("/internal", crate::api::internal::router())
@@ -455,7 +459,11 @@ mod tests {
 
         let transcription_create = send_request(
             app.clone(),
-            build_request(Method::POST, "/v1/transcriptions", Some("{\"audio_base64\":\"AQ==\"}")),
+            build_request(
+                Method::POST,
+                "/v1/transcriptions",
+                Some("{\"audio_base64\":\"AQ==\"}"),
+            ),
         )
         .await;
         assert_eq!(transcription_create.status(), StatusCode::ACCEPTED);
@@ -468,7 +476,11 @@ mod tests {
 
         let diarization_create = send_request(
             app.clone(),
-            build_request(Method::POST, "/v1/diarizations", Some("{\"audio_base64\":\"AQ==\"}")),
+            build_request(
+                Method::POST,
+                "/v1/diarizations",
+                Some("{\"audio_base64\":\"AQ==\"}"),
+            ),
         )
         .await;
         assert_eq!(diarization_create.status(), StatusCode::ACCEPTED);
@@ -481,11 +493,7 @@ mod tests {
 
         let unified_list = send_request(
             app.clone(),
-            build_request(
-                Method::GET,
-                "/v1/transcriptions/jobs?job_kind=all",
-                None,
-            ),
+            build_request(Method::GET, "/v1/transcriptions/jobs?job_kind=all", None),
         )
         .await;
         assert_eq!(unified_list.status(), StatusCode::OK);
@@ -760,7 +768,11 @@ mod tests {
         // Compatibility check: legacy mutation route still works.
         let legacy_create = send_request(
             app,
-            build_request(Method::POST, "/v1/diarizations", Some("{\"audio_base64\":\"AQ==\"}")),
+            build_request(
+                Method::POST,
+                "/v1/diarizations",
+                Some("{\"audio_base64\":\"AQ==\"}"),
+            ),
         )
         .await;
         assert_eq!(legacy_create.status(), StatusCode::ACCEPTED);
@@ -1146,6 +1158,42 @@ mod tests {
         drop(temp_dir);
     }
 
+    #[tokio::test]
+    async fn root_and_v1_probe_routes_are_available() {
+        let (app, temp_dir) = test_api_app("probe_routes_available", false);
+
+        assert_route_status(app.clone(), Method::GET, "/livez", None, StatusCode::OK).await;
+        assert_route_status(app.clone(), Method::GET, "/readyz", None, StatusCode::OK).await;
+        assert_route_status(app.clone(), Method::GET, "/v1/live", None, StatusCode::OK).await;
+        assert_route_status(app, Method::GET, "/v1/ready", None, StatusCode::OK).await;
+
+        drop(temp_dir);
+    }
+
+    #[tokio::test]
+    async fn readyz_returns_unavailable_when_lifecycle_is_draining() {
+        let (state, temp_dir) = test_state("readyz_draining", false);
+        state.lifecycle.mark_ready();
+        state.lifecycle.mark_draining();
+        let serve_config = ServeRuntimeConfig {
+            backend: izwi_core::backends::BackendPreference::Cpu,
+            ui_enabled: false,
+            ..ServeRuntimeConfig::default()
+        };
+        let app = create_router(state, &serve_config);
+
+        assert_route_status(
+            app,
+            Method::GET,
+            "/readyz",
+            None,
+            StatusCode::SERVICE_UNAVAILABLE,
+        )
+        .await;
+
+        drop(temp_dir);
+    }
+
     async fn send_request(mut app: Router, request: Request<Body>) -> Response {
         app.as_service::<Body>()
             .call(request)
@@ -1202,6 +1250,17 @@ mod tests {
     }
 
     fn test_api_app(name: &str, ui_enabled: bool) -> (Router, TempDirGuard) {
+        let (state, temp_dir) = test_state(name, ui_enabled);
+        state.lifecycle.mark_ready();
+        let serve_config = ServeRuntimeConfig {
+            backend: izwi_core::backends::BackendPreference::Cpu,
+            ui_enabled,
+            ..ServeRuntimeConfig::default()
+        };
+        (create_router(state, &serve_config), temp_dir)
+    }
+
+    fn test_state(name: &str, ui_enabled: bool) -> (AppState, TempDirGuard) {
         let temp_dir = test_ui_dir(name);
         let ui_dir = temp_dir.join("ui");
         let models_dir = temp_dir.join("models");
@@ -1234,7 +1293,7 @@ mod tests {
         std::env::remove_var("IZWI_DB_PATH");
         std::env::remove_var("IZWI_MEDIA_DIR");
 
-        (create_router(state, &serve_config), TempDirGuard(temp_dir))
+        (state, TempDirGuard(temp_dir))
     }
 
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {

--- a/crates/izwi-server/src/api/router.rs
+++ b/crates/izwi-server/src/api/router.rs
@@ -2,16 +2,20 @@ use axum::{
     extract::Request,
     http::{HeaderValue, StatusCode},
     middleware,
+    response::Response,
     routing::get,
     Router,
 };
 use izwi_core::ServeRuntimeConfig;
+use std::time::Duration;
+use tower_http::classify::ServerErrorsFailureClass;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::TraceLayer;
-use tracing::{info_span, warn};
+use tracing::{field, info, info_span, warn, Span};
 
 use crate::api::request_context::attach_request_context;
+use crate::logging::{SERVICE_NAME, SERVICE_VERSION};
 use crate::state::AppState;
 
 const DESKTOP_CORS_ORIGINS: &[&str] = &[
@@ -26,19 +30,55 @@ async fn api_not_found() -> StatusCode {
 
 /// Create the main API router.
 pub fn create_router(state: AppState, serve_config: &ServeRuntimeConfig) -> Router {
-    let trace_layer = TraceLayer::new_for_http().make_span_with(|request: &Request| {
-        let request_id = request
-            .headers()
-            .get("x-request-id")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("-");
-        info_span!(
-            "http_request",
-            method = %request.method(),
-            uri = %request.uri(),
-            correlation_id = %request_id
-        )
-    });
+    let trace_layer = TraceLayer::new_for_http()
+        .make_span_with(|request: &Request| {
+            let request_id = request
+                .headers()
+                .get("x-request-id")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("-");
+            info_span!(
+                "http_request",
+                service = SERVICE_NAME,
+                version = SERVICE_VERSION,
+                method = %request.method(),
+                path = %request.uri().path(),
+                uri = %request.uri(),
+                correlation_id = %request_id,
+                status = field::Empty,
+                latency_ms = field::Empty,
+                error = field::Empty
+            )
+        })
+        .on_response(|response: &Response, latency: Duration, span: &Span| {
+            let status = response.status().as_u16();
+            let latency_ms = latency.as_millis() as u64;
+            span.record("status", status);
+            span.record("latency_ms", latency_ms);
+            info!(
+                parent: span,
+                service = SERVICE_NAME,
+                version = SERVICE_VERSION,
+                status,
+                latency_ms,
+                "HTTP request completed"
+            );
+        })
+        .on_failure(
+            |failure: ServerErrorsFailureClass, latency: Duration, span: &Span| {
+                let latency_ms = latency.as_millis() as u64;
+                span.record("latency_ms", latency_ms);
+                span.record("error", field::display(&failure));
+                warn!(
+                    parent: span,
+                    service = SERVICE_NAME,
+                    version = SERVICE_VERSION,
+                    error = %failure,
+                    latency_ms,
+                    "HTTP request failed"
+                );
+            },
+        );
 
     let v1_routes = Router::new()
         .merge(crate::api::internal::router())

--- a/crates/izwi-server/src/logging.rs
+++ b/crates/izwi-server/src/logging.rs
@@ -30,7 +30,13 @@ pub fn init_tracing(log_format: LogFormat) {
             .init(),
         LogFormat::Json => tracing_subscriber::registry()
             .with(filter)
-            .with(tracing_subscriber::fmt::layer().json().flatten_event(true))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .json()
+                    .flatten_event(true)
+                    .with_current_span(true)
+                    .with_span_list(true),
+            )
             .init(),
     }
 }

--- a/crates/izwi-server/src/logging.rs
+++ b/crates/izwi-server/src/logging.rs
@@ -1,0 +1,36 @@
+use clap::ValueEnum;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+pub const SERVICE_NAME: &str = "izwi-server";
+pub const SERVICE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum LogFormat {
+    Text,
+    Json,
+}
+
+impl LogFormat {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Text => "text",
+            Self::Json => "json",
+        }
+    }
+}
+
+pub fn init_tracing(log_format: LogFormat) {
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| "izwi_server=warn,izwi_core=warn,tower_http=warn".into());
+
+    match log_format {
+        LogFormat::Text => tracing_subscriber::registry()
+            .with(filter)
+            .with(tracing_subscriber::fmt::layer())
+            .init(),
+        LogFormat::Json => tracing_subscriber::registry()
+            .with(filter)
+            .with(tracing_subscriber::fmt::layer().json().flatten_event(true))
+            .init(),
+    }
+}

--- a/crates/izwi-server/src/main.rs
+++ b/crates/izwi-server/src/main.rs
@@ -7,7 +7,6 @@ use std::process::Command;
 use std::time::Duration;
 use tokio::signal;
 use tracing::{info, warn};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod api;
 mod app;
@@ -15,6 +14,7 @@ mod chat_store;
 mod diarization_store;
 mod error;
 mod ids;
+mod logging;
 mod onboarding_store;
 mod saved_voice_store;
 mod speech_history_store;
@@ -31,6 +31,7 @@ use izwi_core::backends::{self, BackendPreference, CudaRuntimeDiagnostics};
 use izwi_core::{
     parse_model_variant, RuntimeService, ServeRuntimeConfig, ServeRuntimeConfigOverrides,
 };
+use logging::{LogFormat, SERVICE_NAME, SERVICE_VERSION};
 use state::AppState;
 
 #[derive(Debug, Parser)]
@@ -51,6 +52,10 @@ struct ServerArgs {
     /// Backend preference (`auto`, `cpu`, `metal`, `cuda`)
     #[arg(long, value_enum, env = "IZWI_BACKEND")]
     backend: Option<BackendArg>,
+
+    /// Log output format (`text`, `json`)
+    #[arg(long, value_enum, env = "IZWI_LOG_FORMAT", default_value = "text")]
+    log_format: LogFormat,
 }
 
 #[derive(Debug, Clone, ValueEnum)]
@@ -83,16 +88,14 @@ async fn main() -> anyhow::Result<()> {
     let args = ServerArgs::parse();
     maybe_delegate_to_private_cuda_runtime(&args)?;
 
-    // Initialize logging
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "izwi_server=warn,izwi_core=warn,tower_http=warn".into()),
-        )
-        .with(tracing_subscriber::fmt::layer())
-        .init();
+    logging::init_tracing(args.log_format);
 
-    info!("Starting Izwi TTS Server");
+    info!(
+        service = SERVICE_NAME,
+        version = SERVICE_VERSION,
+        log_format = args.log_format.as_str(),
+        "Starting Izwi TTS Server"
+    );
 
     let serve_config = resolve_serve_runtime_config(&args);
     let config = serve_config.engine_config();
@@ -485,6 +488,7 @@ mod tests {
         std::env::remove_var("IZWI_HOST");
         std::env::remove_var("IZWI_PORT");
         std::env::remove_var("IZWI_BACKEND");
+        std::env::remove_var("IZWI_LOG_FORMAT");
         std::env::remove_var("IZWI_MAX_BATCH_SIZE");
         std::env::remove_var("IZWI_NUM_THREADS");
         std::env::remove_var("IZWI_MAX_CONCURRENT");
@@ -575,6 +579,40 @@ mod tests {
         assert!(
             result.is_err(),
             "invalid backend should fail argument parsing"
+        );
+    }
+
+    #[test]
+    fn log_format_defaults_to_text() {
+        let _guard = env_lock();
+        clear_bind_env();
+
+        let args = parse(&["izwi-server"]);
+
+        assert_eq!(args.log_format, LogFormat::Text);
+        clear_bind_env();
+    }
+
+    #[test]
+    fn log_format_accepts_cli_and_environment() {
+        let _guard = env_lock();
+        clear_bind_env();
+        std::env::set_var("IZWI_LOG_FORMAT", "json");
+
+        let env_args = parse(&["izwi-server"]);
+        let cli_args = parse(&["izwi-server", "--log-format", "text"]);
+
+        assert_eq!(env_args.log_format, LogFormat::Json);
+        assert_eq!(cli_args.log_format, LogFormat::Text);
+        clear_bind_env();
+    }
+
+    #[test]
+    fn invalid_log_format_value_is_rejected() {
+        let result = ServerArgs::try_parse_from(["izwi-server", "--log-format", "ndjson"]);
+        assert!(
+            result.is_err(),
+            "invalid log format should fail argument parsing"
         );
     }
 

--- a/crates/izwi-server/src/main.rs
+++ b/crates/izwi-server/src/main.rs
@@ -101,8 +101,17 @@ async fn main() -> anyhow::Result<()> {
     // Create runtime service
     let runtime = RuntimeService::new(config)?;
     let state = AppState::new(runtime, &serve_config)?;
-    preload_configured_models(&state).await;
-    warmup_preloaded_asr_models(&state).await;
+    let mut startup_warnings = preload_configured_models(&state).await;
+    startup_warnings.extend(warmup_preloaded_asr_models(&state).await);
+    if !startup_warnings.is_empty() {
+        state
+            .lifecycle
+            .record_startup_warnings(startup_warnings.clone());
+        for warning in startup_warnings {
+            warn!(warning = %warning, "Startup readiness warning");
+        }
+    }
+    state.lifecycle.mark_ready();
 
     info!("Runtime service initialized");
 
@@ -320,10 +329,11 @@ fn build_asr_warmup_wav(sample_rate: u32, duration_ms: u32) -> anyhow::Result<Ve
     Ok(wav_bytes)
 }
 
-async fn preload_configured_models(state: &AppState) {
+async fn preload_configured_models(state: &AppState) -> Vec<String> {
+    let mut warnings = Vec::new();
     let configured = configured_preload_models();
     if configured.is_empty() {
-        return;
+        return warnings;
     }
 
     info!(
@@ -338,39 +348,44 @@ async fn preload_configured_models(state: &AppState) {
                     info!(model = %variant, "Preloaded model");
                 }
                 Err(err) => {
+                    warnings.push(format!("failed to preload model {model_id}: {err}"));
                     warn!(model_id = %model_id, "Failed to preload model: {err}");
                 }
             },
             Err(err) => {
+                warnings.push(format!("unknown preload model {model_id}: {err}"));
                 warn!(model_id = %model_id, "Skipping unknown preload model id: {err}");
             }
         }
     }
+
+    warnings
 }
 
-async fn warmup_preloaded_asr_models(state: &AppState) {
+async fn warmup_preloaded_asr_models(state: &AppState) -> Vec<String> {
+    let mut warnings = Vec::new();
     if !warmup_preloaded_models_enabled() {
-        return;
+        return warnings;
     }
 
     let configured = configured_preload_models();
     if configured.is_empty() {
-        return;
+        return warnings;
     }
 
     let duration_ms = asr_warmup_duration_ms();
     let warmup_wav = match build_asr_warmup_wav(16_000, duration_ms) {
         Ok(bytes) => bytes,
         Err(err) => {
+            warnings.push(format!("failed to build ASR warmup WAV bytes: {err}"));
             warn!("Failed to build ASR warmup WAV bytes: {err}");
-            return;
+            return warnings;
         }
     };
 
     info!(
         count = configured.len(),
-        duration_ms,
-        "Running ASR warmup pass for preloaded models"
+        duration_ms, "Running ASR warmup pass for preloaded models"
     );
 
     for model_id in configured {
@@ -385,14 +400,20 @@ async fn warmup_preloaded_asr_models(state: &AppState) {
                     .await
                 {
                     Ok(_) => info!(model = %model_id, "ASR warmup completed"),
-                    Err(err) => warn!(model_id = %model_id, "ASR warmup failed: {err}"),
+                    Err(err) => {
+                        warnings.push(format!("ASR warmup failed for {model_id}: {err}"));
+                        warn!(model_id = %model_id, "ASR warmup failed: {err}");
+                    }
                 }
             }
             Err(err) => {
+                warnings.push(format!("unknown warmup model {model_id}: {err}"));
                 warn!(model_id = %model_id, "Skipping unknown warmup model id: {err}");
             }
         }
     }
+
+    warnings
 }
 
 /// Wait for shutdown signal and cleanup
@@ -422,6 +443,8 @@ async fn shutdown_signal(state: AppState) {
             info!("Received SIGTERM, shutting down...");
         },
     }
+
+    state.lifecycle.mark_draining();
 
     const CLEANUP_TIMEOUT: Duration = Duration::from_secs(20);
     match tokio::time::timeout(CLEANUP_TIMEOUT, state.runtime.unload_all_models()).await {

--- a/crates/izwi-server/src/state.rs
+++ b/crates/izwi-server/src/state.rs
@@ -14,6 +14,7 @@ use izwi_core::{RuntimeService, ServeRuntimeConfig};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{RwLock, Semaphore};
 
 const DEFAULT_RESPONSE_STORE_LIMIT: usize = 512;
@@ -52,11 +53,100 @@ pub struct StoredAgentSessionRecord {
     pub updated_at: u64,
 }
 
+#[derive(Clone, Debug, Serialize)]
+pub struct LifecycleSnapshot {
+    pub phase: String,
+    pub ready: bool,
+    pub draining: bool,
+    pub started_at: u64,
+    pub updated_at: u64,
+    pub startup_warnings: Vec<String>,
+}
+
+#[derive(Debug)]
+struct LifecycleInner {
+    phase: String,
+    ready: bool,
+    draining: bool,
+    started_at: u64,
+    updated_at: u64,
+    startup_warnings: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ServerLifecycle {
+    inner: Arc<std::sync::RwLock<LifecycleInner>>,
+}
+
+impl ServerLifecycle {
+    fn new() -> Self {
+        let now = now_unix_secs();
+        Self {
+            inner: Arc::new(std::sync::RwLock::new(LifecycleInner {
+                phase: "initializing".to_string(),
+                ready: false,
+                draining: false,
+                started_at: now,
+                updated_at: now,
+                startup_warnings: Vec::new(),
+            })),
+        }
+    }
+
+    pub fn mark_ready(&self) {
+        self.update(|inner| {
+            inner.phase = "ready".to_string();
+            inner.ready = true;
+            inner.draining = false;
+        });
+    }
+
+    pub fn mark_draining(&self) {
+        self.update(|inner| {
+            inner.phase = "draining".to_string();
+            inner.ready = false;
+            inner.draining = true;
+        });
+    }
+
+    pub fn record_startup_warnings(&self, warnings: impl IntoIterator<Item = String>) {
+        self.update(|inner| {
+            inner.startup_warnings.extend(warnings);
+        });
+    }
+
+    pub fn snapshot(&self) -> LifecycleSnapshot {
+        let guard = self
+            .inner
+            .read()
+            .unwrap_or_else(|poison| poison.into_inner());
+        LifecycleSnapshot {
+            phase: guard.phase.clone(),
+            ready: guard.ready,
+            draining: guard.draining,
+            started_at: guard.started_at,
+            updated_at: guard.updated_at,
+            startup_warnings: guard.startup_warnings.clone(),
+        }
+    }
+
+    fn update(&self, f: impl FnOnce(&mut LifecycleInner)) {
+        let mut guard = self
+            .inner
+            .write()
+            .unwrap_or_else(|poison| poison.into_inner());
+        f(&mut guard);
+        guard.updated_at = now_unix_secs();
+    }
+}
+
 /// Shared application state with fine-grained locking and backpressure
 #[derive(Clone)]
 pub struct AppState {
     /// Runtime service reference - using Arc for cheap clones
     pub runtime: Arc<RuntimeService>,
+    /// Server lifecycle state used by readiness and liveness probes.
+    pub lifecycle: ServerLifecycle,
     /// Concurrency limiter to prevent resource exhaustion
     pub request_semaphore: Arc<Semaphore>,
     /// Request timeout configuration (seconds)
@@ -113,6 +203,7 @@ impl AppState {
 
         Ok(Self {
             runtime: Arc::new(runtime),
+            lifecycle: ServerLifecycle::new(),
             request_semaphore: Arc::new(Semaphore::new(max_concurrent_requests)),
             request_timeout_secs,
             response_store_limit,
@@ -169,6 +260,13 @@ impl AppState {
     }
 }
 
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
 fn request_limits(serve_config: &ServeRuntimeConfig) -> (usize, u64) {
     (
         serve_config.max_concurrent_requests.max(1),
@@ -208,8 +306,8 @@ fn trim_store_by<T>(
 #[cfg(test)]
 mod tests {
     use super::{
-        request_limits, trim_store_by, StoredAgentSessionRecord, StoredResponseInputItem,
-        StoredResponseRecord,
+        now_unix_secs, request_limits, trim_store_by, ServerLifecycle, StoredAgentSessionRecord,
+        StoredResponseInputItem, StoredResponseRecord,
     };
     use izwi_agent::planner::PlanningMode;
     use izwi_core::ServeRuntimeConfig;
@@ -306,5 +404,28 @@ mod tests {
 
         assert_eq!(request_timeout_secs, 91);
         assert_eq!(max_concurrent_requests, 7);
+    }
+
+    #[test]
+    fn server_lifecycle_transitions_to_ready_and_draining() {
+        let lifecycle = ServerLifecycle::new();
+        let initial = lifecycle.snapshot();
+        assert!(!initial.ready);
+        assert_eq!(initial.phase, "initializing");
+
+        lifecycle.record_startup_warnings(vec!["preload failed".to_string()]);
+        lifecycle.mark_ready();
+        let ready = lifecycle.snapshot();
+        assert!(ready.ready);
+        assert_eq!(ready.phase, "ready");
+        assert_eq!(ready.startup_warnings, vec!["preload failed"]);
+
+        lifecycle.mark_draining();
+        let draining = lifecycle.snapshot();
+        assert!(!draining.ready);
+        assert!(draining.draining);
+        assert_eq!(draining.phase, "draining");
+        assert!(draining.updated_at >= ready.updated_at);
+        assert!(draining.updated_at >= now_unix_secs().saturating_sub(1));
     }
 }

--- a/crates/izwi-server/src/state.rs
+++ b/crates/izwi-server/src/state.rs
@@ -306,12 +306,13 @@ fn trim_store_by<T>(
 #[cfg(test)]
 mod tests {
     use super::{
-        now_unix_secs, request_limits, trim_store_by, ServerLifecycle, StoredAgentSessionRecord,
-        StoredResponseInputItem, StoredResponseRecord,
+        now_unix_secs, request_limits, trim_store_by, AppState, ServerLifecycle,
+        StoredAgentSessionRecord, StoredResponseInputItem, StoredResponseRecord,
     };
     use izwi_agent::planner::PlanningMode;
-    use izwi_core::ServeRuntimeConfig;
+    use izwi_core::{backends::BackendPreference, RuntimeService, ServeRuntimeConfig};
     use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
 
     #[test]
     fn trim_store_by_evicts_oldest_response_record() {
@@ -427,5 +428,128 @@ mod tests {
         assert_eq!(draining.phase, "draining");
         assert!(draining.updated_at >= ready.updated_at);
         assert!(draining.updated_at >= now_unix_secs().saturating_sub(1));
+    }
+
+    #[tokio::test]
+    async fn app_state_response_store_limit_evicts_oldest_record() {
+        let _guard = env_lock();
+        let (state, _temp_dir) = test_app_state("response_store_limit", 1, 8);
+
+        state
+            .store_response_record(response_record("resp-old", 10))
+            .await;
+        state
+            .store_response_record(response_record("resp-new", 20))
+            .await;
+
+        let store = state.response_store.read().await;
+        assert!(store.contains_key("resp-new"));
+        assert!(!store.contains_key("resp-old"));
+    }
+
+    #[tokio::test]
+    async fn app_state_agent_session_store_limit_evicts_oldest_record() {
+        let _guard = env_lock();
+        let (state, _temp_dir) = test_app_state("agent_session_store_limit", 8, 1);
+
+        state
+            .store_agent_session_record(agent_session_record("sess-old", 5))
+            .await;
+        state
+            .store_agent_session_record(agent_session_record("sess-new", 15))
+            .await;
+
+        let store = state.agent_session_store.read().await;
+        assert!(store.contains_key("sess-new"));
+        assert!(!store.contains_key("sess-old"));
+    }
+
+    fn response_record(id: &str, created_at: u64) -> StoredResponseRecord {
+        StoredResponseRecord {
+            id: id.to_string(),
+            created_at,
+            status: "completed".to_string(),
+            model: "test".to_string(),
+            input_items: Vec::new(),
+            output_text: Some(id.to_string()),
+            input_tokens: 1,
+            output_tokens: 1,
+            error: None,
+            metadata: None,
+        }
+    }
+
+    fn agent_session_record(id: &str, updated_at: u64) -> StoredAgentSessionRecord {
+        StoredAgentSessionRecord {
+            id: id.to_string(),
+            agent_id: "agent".to_string(),
+            thread_id: format!("thread-{id}"),
+            model_id: "model".to_string(),
+            system_prompt: "prompt".to_string(),
+            planning_mode: PlanningMode::Auto,
+            created_at: updated_at,
+            updated_at,
+        }
+    }
+
+    fn test_app_state(
+        name: &str,
+        response_limit: usize,
+        agent_session_limit: usize,
+    ) -> (AppState, tempfile::TempDir) {
+        let temp_dir = tempfile::tempdir().expect("temp dir should create");
+        let models_dir = temp_dir.path().join("models");
+        let media_dir = temp_dir.path().join("media");
+        std::fs::create_dir_all(&models_dir).expect("models dir should be created");
+
+        std::env::set_var(
+            "IZWI_DB_PATH",
+            temp_dir.path().join(format!("{name}.sqlite3")),
+        );
+        std::env::set_var("IZWI_MEDIA_DIR", &media_dir);
+        std::env::set_var(
+            "IZWI_MAX_RESPONSE_STORE_ENTRIES",
+            response_limit.to_string(),
+        );
+        std::env::set_var(
+            "IZWI_MAX_AGENT_SESSION_STORE_ENTRIES",
+            agent_session_limit.to_string(),
+        );
+
+        let serve_config = ServeRuntimeConfig {
+            backend: BackendPreference::Cpu,
+            models_dir,
+            ..ServeRuntimeConfig::default()
+        };
+        let runtime =
+            with_suppressed_panic_hook(|| RuntimeService::new(serve_config.engine_config()))
+                .expect("runtime should initialize");
+        let state = AppState::new(runtime, &serve_config).expect("state should initialize");
+        clear_store_env();
+
+        (state, temp_dir)
+    }
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("environment lock poisoned")
+    }
+
+    fn clear_store_env() {
+        std::env::remove_var("IZWI_DB_PATH");
+        std::env::remove_var("IZWI_MEDIA_DIR");
+        std::env::remove_var("IZWI_MAX_RESPONSE_STORE_ENTRIES");
+        std::env::remove_var("IZWI_MAX_AGENT_SESSION_STORE_ENTRIES");
+    }
+
+    fn with_suppressed_panic_hook<T>(f: impl FnOnce() -> T) -> T {
+        let default_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let result = f();
+        std::panic::set_hook(default_hook);
+        result
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - HF_HOME=/app/models/huggingface
       - TRANSFORMERS_CACHE=/app/models/huggingface
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/v1/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/readyz"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -82,7 +82,7 @@ services:
               count: 1
               capabilities: [gpu]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/v1/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/readyz"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/dev/INFERENCE_ENGINE.md
+++ b/docs/dev/INFERENCE_ENGINE.md
@@ -545,9 +545,17 @@ These routes back the desktop UI's saved history and reusable assets. Canonical 
 | `POST` | `/v1/audio/translations` | Speech translation |
 | `POST` | `/v1/chat/completions` | Chat / LLM completions |
 | `GET` | `/v1/models` | List available models |
-| `POST` | `/v1/responses` | Structured response generation |
+| `POST` | `/v1/responses` | Structured response generation; preview process-local response-object storage |
+| `GET, DELETE` | `/v1/responses/:response_id` | Fetch or delete a process-local stored response object |
+| `POST` | `/v1/responses/:response_id/cancel` | Preview lifecycle route for process-local response records |
+| `GET` | `/v1/responses/:response_id/input_items` | Fetch input items for a process-local stored response object |
 
 Sub-routers: `audio`, `chat`, `models`, `responses` (defined in `api/openai/mod.rs`).
+
+Responses object storage is a compatibility convenience, not a durable product
+store. Stored response objects are retained in bounded process memory and can be
+evicted or lost on server restart. Durable local history is provided by the
+SQLite-backed first-party chat and voice stores.
 
 ### 10.3 Admin Endpoints
 

--- a/docs/dev/INFERENCE_ENGINE.md
+++ b/docs/dev/INFERENCE_ENGINE.md
@@ -557,6 +557,21 @@ store. Stored response objects are retained in bounded process memory and can be
 evicted or lost on server restart. Durable local history is provided by the
 SQLite-backed first-party chat and voice stores.
 
+Current preview retention rules:
+
+- `store: false` skips even process-local response retention.
+- Stored response records are capped by `IZWI_MAX_RESPONSE_STORE_ENTRIES` and default to 512 entries.
+- When the cap is exceeded, the oldest response records by `created_at` are evicted.
+- Streaming response records are stored only after terminal completion or failure, not as a durable in-progress lifecycle object.
+- `GET`, `DELETE`, `cancel`, and `input_items` operate only on currently retained process-local records.
+
+Agent session metadata has the same preview shape: `/v1/agent/sessions` stores
+session id, agent id, model id, planning mode, and the linked chat thread id in
+bounded process memory. The cap is `IZWI_MAX_AGENT_SESSION_STORE_ENTRIES`, also
+defaulting to 512 entries, and eviction uses `updated_at`. The linked chat
+thread and messages are SQLite-backed durable local history; the agent-session
+id and metadata are not durable across server restarts.
+
 ### 10.3 Admin Endpoints
 
 | Method | Path | Description |

--- a/docs/openai-compatibility-contract.json
+++ b/docs/openai-compatibility-contract.json
@@ -11,6 +11,28 @@
       "/v1/audio/transcriptions",
       "/v1/audio/speech"
     ],
+    "preview_endpoints": {
+      "/v1/responses": {
+        "contract": "compatible request/response shape and streaming events",
+        "durability": "process_local",
+        "retention": "bounded in-memory store; records are lost on server restart"
+      },
+      "/v1/responses/:response_id": {
+        "contract": "lookup of process-local stored response records",
+        "durability": "process_local",
+        "retention": "not available after server restart or memory-store eviction"
+      },
+      "/v1/responses/:response_id/cancel": {
+        "contract": "preview lifecycle route for process-local response records",
+        "durability": "process_local",
+        "retention": "does not provide durable active-response cancellation semantics"
+      },
+      "/v1/responses/:response_id/input_items": {
+        "contract": "input-item lookup for process-local stored response records",
+        "durability": "process_local",
+        "retention": "not available after server restart or memory-store eviction"
+      }
+    },
     "out_of_scope_endpoints": [
       "/v1/audio/translations",
       "/v1/realtime/client_secrets",

--- a/docs/user/cli/bench.md
+++ b/docs/user/cli/bench.md
@@ -104,7 +104,7 @@ izwi bench asr --model Whisper-Large-v3-Turbo --file test.wav --language en --it
 
 ## izwi bench throughput
 
-Benchmark overall system throughput.
+Benchmark lightweight HTTP server overhead against `/livez`.
 
 ```bash
 izwi bench throughput [OPTIONS]

--- a/docs/user/cli/index.md
+++ b/docs/user/cli/index.md
@@ -148,6 +148,7 @@ izwi tts --help
 | `IZWI_MAX_CONCURRENT` | Maximum concurrent requests |
 | `IZWI_TIMEOUT` | Request timeout (seconds) |
 | `RUST_LOG` | Log level |
+| `IZWI_LOG_FORMAT` | Log output format (`text`, `json`) |
 | `NO_COLOR` | Disable colored output |
 
 ---

--- a/docs/user/cli/serve.md
+++ b/docs/user/cli/serve.md
@@ -41,6 +41,7 @@ The resolved settings are passed through to the spawned `izwi-server` process, s
 | `--max-concurrent <N>` | Max concurrent requests | `100` |
 | `--timeout <SECONDS>` | Request timeout | `300` |
 | `--log-level <LEVEL>` | Log level | `warn` |
+| `--log-format <FORMAT>` | Log output format: `text` or `json` | `text` |
 | `--cors` | Enable wildcard CORS responses | Disabled |
 | `--no-ui` | Disable static web UI serving | UI enabled |
 
@@ -127,6 +128,7 @@ izwi serve --mode web --no-ui
 | `IZWI_NO_UI` | `--no-ui` |
 | `IZWI_UI_DIR` | Config-only UI build directory |
 | `RUST_LOG` | `--log-level` |
+| `IZWI_LOG_FORMAT` | `--log-format` |
 | `IZWI_SERVE_MODE` | `--mode` |
 
 Legacy aliases still resolve for one release cycle:
@@ -161,6 +163,20 @@ timeout = 300
 enabled = true
 dir = "ui/dist"
 ```
+
+---
+
+## Logging
+
+Text logs are the default. Use JSON logs when a collector needs machine-readable application events:
+
+```bash
+izwi serve --log-format json
+```
+
+`--log-format json` controls Izwi's application log lines. Docker's `json-file` logging driver only frames container stdout/stderr and is separate from the application log format.
+
+JSON logs include the normal tracing fields such as timestamp, level, target, and message. HTTP request events also include service, version, correlation ID, method, path, status, latency in milliseconds, and error fields when a request fails.
 
 ---
 

--- a/docs/user/cli/serve.md
+++ b/docs/user/cli/serve.md
@@ -73,7 +73,7 @@ Starts the server and opens the browser.
 izwi serve --mode web
 ```
 
-When `--no-ui` is set, web mode opens `http://<host>:<port>/v1/health` instead of the UI root.
+When `--no-ui` is set, web mode opens `http://<host>:<port>/v1/ready` instead of the UI root.
 
 ---
 
@@ -167,6 +167,8 @@ dir = "ui/dist"
 ## Graceful Shutdown
 
 Press `Ctrl+C` to gracefully shut down the server. Active requests finish before shutdown.
+
+During startup, `izwi serve` waits for the readiness endpoint before opening desktop or web clients. Use `/readyz` for deployment readiness checks and `/livez` for cheap liveness checks; `/v1/health` remains the richer status payload used by `izwi status`.
 
 ---
 

--- a/docs/user/cli/status.md
+++ b/docs/user/cli/status.md
@@ -14,7 +14,7 @@ izwi status [OPTIONS]
 
 ## Description
 
-Displays the current state of the Izwi server, including health, loaded models, and runtime backend selection.
+Displays the current state of the Izwi server, including health, loaded models, and runtime backend selection. This command reads `/v1/health`, the rich runtime status payload.
 
 ---
 
@@ -49,6 +49,8 @@ This reads the server health payload and reports:
 - whether the selection came from the request or a fallback path
 - which backends were compiled into the running binary
 - detected device capabilities such as BF16, unified memory, batch size, and memory when available
+
+Deployment healthchecks should use `/readyz` for readiness and `/livez` for liveness. `izwi status` intentionally stays on `/v1/health` so it can report backend and model details.
 
 ### Watch mode
 

--- a/docs/user/support-matrix.md
+++ b/docs/user/support-matrix.md
@@ -56,10 +56,10 @@ The runtime exposes both compatibility APIs and first-party local workflow APIs 
 | **`POST /v1/chat/completions`** | Stable | Core OpenAI-compatible chat surface. |
 | **`GET /v1/models`** | Stable | Live model catalog / availability surface. |
 | **Local CLI workflows (`izwi serve`, `izwi pull`, `izwi tts`, `izwi transcribe`)** | Stable | Primary user-facing local runtime workflows. |
-| **`POST /v1/responses`** | Preview | Available today, but persistence/runtime contract is still being clarified. |
+| **`POST /v1/responses` and response-object lifecycle routes** | Preview | Response objects are stored in bounded process memory for compatibility convenience. They can be evicted and are lost on server restart. |
 | **`/v1/admin/*` model-management APIs** | Preview | Operator-oriented local admin APIs; auth and long-term contract are not finalized. |
 | **Persisted first-party workflow APIs (`/v1/transcriptions/jobs`, `/v1/diarizations`, `/v1/text-to-speech-generations`, `/v1/studio/*`, `/v1/voices*`)** | Preview | Powerful local product APIs, but the public compatibility/support contract is still evolving. |
-| **Local agent/session features** | Preview | Available for local use, but not yet positioned as a stable deployment contract. |
+| **Local agent/session features** | Preview | Agent session metadata is process-local today. Chat threads, voice sessions, voice turns, and voice observations are the durable SQLite-backed local stores. |
 
 ---
 

--- a/docs/user/support-matrix.md
+++ b/docs/user/support-matrix.md
@@ -57,10 +57,10 @@ The runtime exposes both compatibility APIs and first-party local workflow APIs 
 | **`GET /v1/models`** | Stable | Live model catalog / availability surface. |
 | **Operational probes (`/livez`, `/readyz`, `/v1/live`, `/v1/ready`)** | Stable | Use `/livez` for cheap liveness and `/readyz` for readiness or deployment healthchecks. `/v1/health` remains the richer status payload. |
 | **Local CLI workflows (`izwi serve`, `izwi pull`, `izwi tts`, `izwi transcribe`)** | Stable | Primary user-facing local runtime workflows. |
-| **`POST /v1/responses` and response-object lifecycle routes** | Preview | Response objects are stored in bounded process memory for compatibility convenience. They can be evicted and are lost on server restart. |
+| **`POST /v1/responses` and response-object lifecycle routes** | Preview | Response objects are stored in bounded process memory for compatibility convenience. `store:false` skips retention; retained records can be evicted and are lost on server restart. |
 | **`/v1/admin/*` model-management APIs** | Preview | Operator-oriented local admin APIs; auth and long-term contract are not finalized. |
 | **Persisted first-party workflow APIs (`/v1/transcriptions/jobs`, `/v1/diarizations`, `/v1/text-to-speech-generations`, `/v1/studio/*`, `/v1/voices*`)** | Preview | Powerful local product APIs, but the public compatibility/support contract is still evolving. |
-| **Local agent/session features** | Preview | Agent session metadata is process-local today. Chat threads, voice sessions, voice turns, and voice observations are the durable SQLite-backed local stores. |
+| **Local agent/session features** | Preview | Agent session metadata is process-local and bounded today. Linked chat threads, voice sessions, voice turns, and voice observations are the durable SQLite-backed local stores. |
 
 ---
 

--- a/docs/user/support-matrix.md
+++ b/docs/user/support-matrix.md
@@ -55,6 +55,7 @@ The runtime exposes both compatibility APIs and first-party local workflow APIs 
 | **`POST /v1/audio/transcriptions`** | Stable | Core OpenAI-compatible transcription surface. |
 | **`POST /v1/chat/completions`** | Stable | Core OpenAI-compatible chat surface. |
 | **`GET /v1/models`** | Stable | Live model catalog / availability surface. |
+| **Operational probes (`/livez`, `/readyz`, `/v1/live`, `/v1/ready`)** | Stable | Use `/livez` for cheap liveness and `/readyz` for readiness or deployment healthchecks. `/v1/health` remains the richer status payload. |
 | **Local CLI workflows (`izwi serve`, `izwi pull`, `izwi tts`, `izwi transcribe`)** | Stable | Primary user-facing local runtime workflows. |
 | **`POST /v1/responses` and response-object lifecycle routes** | Preview | Response objects are stored in bounded process memory for compatibility convenience. They can be evicted and are lost on server restart. |
 | **`/v1/admin/*` model-management APIs** | Preview | Operator-oriented local admin APIs; auth and long-term contract are not finalized. |

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -71,12 +71,18 @@ izwi serve
    izwi status
    ```
 
-2. Check the correct URL:
+2. Check the operational probes:
+   ```bash
+   curl -f http://localhost:8080/livez
+   curl -f http://localhost:8080/readyz
+   ```
+
+3. Check the correct URL:
    ```
    http://localhost:8080
    ```
 
-3. Check firewall settings
+4. Check firewall settings
 
 ### Server crashes on startup
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,6 +1,7 @@
 # Lessons
 
 - When the user narrows a planning scope by saying to skip a workstream, remove that workstream from implementation phases instead of carrying it forward as planned work; keep prior analysis only as explicitly out-of-scope context when useful.
+- When closing review findings, turn documented runtime contracts into executable checks: readiness warnings must affect readiness status, and structured logging promises must be verified against the actual emitted JSON shape rather than inferred from span construction.
 - When a user says Linux installers, cover every shipped Linux surface (`.deb`, AppImage/updater, terminal tarball, and future Linux bundle paths) unless they explicitly narrow to Ubuntu.
 - When a user says one installer or binary must support CPU and CUDA, preserve the public binary names unless they explicitly approve renamed CUDA commands; use private runtime layout or loader work, not public `*-cuda` names.
 - When requirements include hardware support scope (for example Docker-only vs all distributions), treat scope as a hard contract and reconfirm before finalizing implementation plans.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,6 @@
 # Lessons
 
+- When the user narrows a planning scope by saying to skip a workstream, remove that workstream from implementation phases instead of carrying it forward as planned work; keep prior analysis only as explicitly out-of-scope context when useful.
 - When a user says Linux installers, cover every shipped Linux surface (`.deb`, AppImage/updater, terminal tarball, and future Linux bundle paths) unless they explicitly narrow to Ubuntu.
 - When a user says one installer or binary must support CPU and CUDA, preserve the public binary names unless they explicitly approve renamed CUDA commands; use private runtime layout or loader work, not public `*-cuda` names.
 - When requirements include hardware support scope (for example Docker-only vs all distributions), treat scope as a hard contract and reconfirm before finalizing implementation plans.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -232,25 +232,32 @@ Notes:
 
 ### Phase 4: Preview Semantics Hardening For Responses And Agent Sessions
 
+Status: complete.
+
 Goal:
 
 - Make the current non-durable decision intentional, tested, and legible.
 
 Tasks:
 
-- [ ] Add clear docs for `/v1/responses` retention: process-local, bounded memory, evicted by age, lost on restart.
-- [ ] Add clear docs for `/v1/agent/sessions`: session metadata process-local, chat thread/messages durable.
-- [ ] Add tests for `store:false` not retaining response records.
-- [ ] Add tests for bounded response eviction.
-- [ ] Add tests for bounded agent-session eviction.
-- [ ] Consider preview headers or response metadata for preview/process-local APIs if useful.
-- [ ] Align UI/client assumptions so durable history uses chat/voice stores, not response/agent-session ids.
+- [x] Add clear docs for `/v1/responses` retention: process-local, bounded memory, evicted by age, lost on restart.
+- [x] Add clear docs for `/v1/agent/sessions`: session metadata process-local, chat thread/messages durable.
+- [x] Add tests for `store:false` not retaining response records.
+- [x] Add tests for bounded response eviction.
+- [x] Add tests for bounded agent-session eviction.
+- [x] Consider preview headers or response metadata for preview/process-local APIs if useful.
+- [x] Align UI/client assumptions so durable history uses chat/voice stores, not response/agent-session ids.
 
 Verification:
 
-- [ ] Targeted server tests for response and agent session memory semantics.
-- [ ] Docs grep confirms preview/non-durable wording.
-- [ ] `cargo check --locked -p izwi-server`.
+- [x] Targeted server tests for response and agent session memory semantics.
+- [x] Docs grep confirms preview/non-durable wording.
+- [x] `cargo check --locked -p izwi-server`.
+
+Notes:
+
+- Preview headers were not added because the support matrix and dev docs now carry the explicit contract, and adding headers would broaden the API surface for preview routes.
+- UI audit found the chat title helper already uses `/v1/responses` with `store: false`; durable chat history uses the chat-thread APIs rather than response or agent-session ids.
 
 ### Phase 5: Optional Durable Promotion Path
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -150,27 +150,29 @@ Out of scope:
 
 ### Phase 1: Probe Contract And Lifecycle State
 
+Status: complete.
+
 Goal:
 
 - Add real liveness/readiness semantics without breaking existing `/v1/health` clients.
 
 Tasks:
 
-- [ ] Keep `/v1/health` backward-compatible as the rich status summary.
-- [ ] Add root `/livez` and `/readyz`.
-- [ ] Consider `/v1/live` and `/v1/ready` aliases for API namespace consistency.
-- [ ] Add a small lifecycle state to server/AppState: startup time, phase, ready flag, degraded reasons, preload/warmup errors, shutdown/draining flag.
-- [ ] Mark server unready before graceful shutdown starts.
-- [ ] Define readiness reason codes, for example `runtime_initialized`, `stores_available`, `backend_available`, `preload_complete`, `worker_health`, `not_draining`.
-- [ ] Return compact JSON and `200` when ready, compact JSON and `503` when unready.
-- [ ] Keep liveness cheap and independent of model readiness.
+- [x] Keep `/v1/health` backward-compatible as the rich status summary.
+- [x] Add root `/livez` and `/readyz`.
+- [x] Consider `/v1/live` and `/v1/ready` aliases for API namespace consistency.
+- [x] Add a small lifecycle state to server/AppState: startup time, phase, ready flag, degraded reasons, preload/warmup errors, shutdown/draining flag.
+- [x] Mark server unready before graceful shutdown starts.
+- [x] Define readiness reason codes, for example `runtime_initialized`, `stores_available`, `backend_available`, `preload_complete`, `worker_health`, `not_draining`.
+- [x] Return compact JSON and `200` when ready, compact JSON and `503` when unready.
+- [x] Keep liveness cheap and independent of model readiness.
 
 Verification:
 
-- [ ] Router tests for `/livez` returning `200`.
-- [ ] Router tests for `/readyz` returning `200` when initialized.
-- [ ] Unit tests for unready/degraded reason rendering.
-- [ ] Shutdown/drain state test where practical.
+- [x] Router tests for `/livez` returning `200`.
+- [x] Router tests for `/readyz` returning `200` when initialized.
+- [x] Unit tests for unready/degraded reason rendering.
+- [x] Shutdown/drain state test where practical.
 
 ### Phase 2: Switch Dependents To The Right Probe
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -289,6 +289,18 @@ Deferral reason:
 
 - No product decision was made to promote `/v1/responses` lifecycle objects or `/v1/agent/sessions` metadata from preview process-local convenience APIs to durable product features. Phase 4 intentionally hardened the preview contract instead.
 
+## Review Follow-Up Fixes
+
+Status: complete.
+
+- [x] Make startup preload/warmup warnings fail readiness through a `preload_complete` check.
+- [x] Include current span and span list data in JSON logs so HTTP request events carry method, path, and correlation id fields.
+
+Verification:
+
+- [x] `cargo test -p izwi-server probes`
+- [x] `cargo check --locked -p izwi-server`
+
 ## Elegance Review
 
 The elegant path is to avoid turning `/v1/health` into a catch-all contract. Keep it as the existing rich status endpoint, add small Unix/Kubernetes-style probes for orchestration, and keep durability decisions separate from OpenAI compatibility routing. That minimizes breakage while giving enterprise packaging the precise hooks it needs.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -261,6 +261,8 @@ Notes:
 
 ### Phase 5: Optional Durable Promotion Path
 
+Status: deferred.
+
 Goal:
 
 - Only if product decides durable Responses/agent sessions are needed, promote them deliberately.
@@ -282,6 +284,10 @@ Verification:
 - [ ] Streaming lifecycle persistence tests pass.
 - [ ] Agent session turn after restart works.
 - [ ] Docs and contract promote surfaces from preview only after tests prove durability.
+
+Deferral reason:
+
+- No product decision was made to promote `/v1/responses` lifecycle objects or `/v1/agent/sessions` metadata from preview process-local convenience APIs to durable product features. Phase 4 intentionally hardened the preview contract instead.
 
 ## Elegance Review
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -176,25 +176,27 @@ Verification:
 
 ### Phase 2: Switch Dependents To The Right Probe
 
+Status: complete.
+
 Goal:
 
 - Make internal tooling and deployment assets use liveness/readiness correctly.
 
 Tasks:
 
-- [ ] Switch Dockerfile healthchecks from `/v1/health` to `/readyz`.
-- [ ] Switch Docker Compose healthchecks to `/readyz`.
-- [ ] Switch `izwi serve` startup wait to readiness.
-- [ ] Keep `izwi status` on `/v1/health`, but optionally show readiness summary.
-- [ ] Switch bench HTTP-overhead throughput test from `/v1/health` to `/livez` if it is measuring server overhead rather than runtime readiness.
-- [ ] Update CLI docs, Docker docs, troubleshooting, and status docs.
+- [x] Switch Dockerfile healthchecks from `/v1/health` to `/readyz`.
+- [x] Switch Docker Compose healthchecks to `/readyz`.
+- [x] Switch `izwi serve` startup wait to readiness.
+- [x] Keep `izwi status` on `/v1/health`, but optionally show readiness summary.
+- [x] Switch bench HTTP-overhead throughput test from `/v1/health` to `/livez` if it is measuring server overhead rather than runtime readiness.
+- [x] Update CLI docs, Docker docs, troubleshooting, and status docs.
 
 Verification:
 
-- [ ] CLI serve wait test updated.
-- [ ] Docker healthcheck grep confirms `/readyz`.
-- [ ] Bench docs and command text mention `/livez` if changed.
-- [ ] `cargo check --locked -p izwi-server -p izwi-cli`.
+- [x] CLI serve wait test updated.
+- [x] Docker healthcheck grep confirms `/readyz`.
+- [x] Bench docs and command text mention `/livez` if changed.
+- [x] `cargo check --locked -p izwi-server -p izwi-cli`.
 
 ### Phase 3: Structured JSON Logging Mode
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,292 @@
+# OSS Runtime P0 Backlog Analysis And Implementation Plan
+
+## Goal
+
+Analyze `/Users/lennex/Code/clients/izwi-knowledge/open-source-runtime-roadmap.md`, especially the Prioritized Backlog P0 items, against the current OSS codebase and produce a phased implementation plan only.
+
+## Constraints
+
+- Research, analysis, and planning only.
+- No runtime or product implementation in this phase.
+- Treat the roadmap as a snapshot, not guaranteed current truth.
+- Prefer current code/docs/CI evidence over stale roadmap claims.
+- Skip Docker and CUDA truth closure implementation planning per user direction.
+- Keep changes scoped to this planning artifact.
+
+## Research Checklist
+
+- [x] Review project lessons and current task notes.
+- [x] Read the roadmap and P0 backlog.
+- [x] Audit release/Docker CUDA backend truth.
+- [x] Audit support matrix and stable/preview API surface documentation.
+- [x] Audit readiness/liveness health contract.
+- [x] Audit structured JSON logging support.
+- [x] Audit `/v1/responses` and agent-session durability.
+- [x] Run lightweight verification of current server/CLI code.
+- [x] Produce phased implementation plan.
+
+## P0 Current-State Summary
+
+### 1. Fix release and Docker backend truth for CUDA/NVIDIA support
+
+Status: partially implemented, not fully closed.
+
+Already implemented:
+
+- Release workflow builds CPU-safe public Linux/Windows CLI/server binaries, then CUDA variants in a separate target directory and stages them under `runtime/cuda`.
+- Release verification scripts enforce stable public binary names and private CUDA runtime layout.
+- Dockerfile has separate CPU and CUDA build/runtime targets, and the CUDA target builds `izwi-server --features cuda`.
+- Backend Truth CI checks CPU cargo, CUDA cargo, CPU Docker build, and CUDA Docker build.
+- Runtime CUDA diagnostics exist in `izwi-core` and are exposed through `/v1/health` and `izwi status --detailed`.
+- README, release docs, and `docs/user/support-matrix.md` describe the unified CPU-safe public binary plus private CUDA runtime contract.
+
+Still missing or inconsistent:
+
+- Docker Compose CUDA instructions are likely wrong: `docker compose --profile cuda up -d` starts the default CPU service plus the profiled CUDA service, and both bind `8080:8080`.
+- CI builds Docker CUDA but does not run the image, query `/v1/health`, or assert CUDA selection.
+- No automated NVIDIA-host smoke test proves release/runtime CUDA selection or inference on a real GPU.
+- Runtime CUDA delegation docs say `auto` should delegate only when a usable CUDA device is indicated, but the current gate checks packaged runtime, runtime libraries, and driver availability, not `device_usable`.
+- Windows private runtime health can report active but not packaged after delegation because the delegation path does not set `IZWI_CUDA_RUNTIME_BINARY`, and Windows discovery lacks the Linux-style installed fallback.
+- Final packaged artifact checks are weaker than staging checks because they omit some CUDA library families required by staging verification.
+
+### 2. Publish runtime support matrix: OS, hardware, deployment targets, stable API surfaces
+
+Status: mostly implemented, needs consistency hardening.
+
+Already implemented:
+
+- `docs/user/support-matrix.md` now exists and covers backend matrix, deployment matrix, API surface maturity, CUDA caveats, and verification guidance.
+- README and installation/getting-started docs point to the support matrix.
+- The matrix correctly marks `/v1/responses`, `/v1/admin/*`, persisted first-party workflow APIs, and local agent/session features as preview.
+
+Still missing or inconsistent:
+
+- `docs/openai-compatibility-contract.json` lists `/v1/responses/:id`, cancel, and input-items as supported without saying those lifecycle routes are process-local preview behavior.
+- Dev docs list `POST /v1/responses` but do not clearly document retrieval/cancel/input-items maturity.
+- Docker Compose CUDA support text should be revised after the Compose service/profile contract is fixed.
+- The support matrix should link to operational probe/logging contracts once those P0 items land.
+
+### 3. Add real readiness and liveness endpoints
+
+Status: missing.
+
+What exists:
+
+- `/v1/health` and `/internal/health` return status/version/backend/device/CUDA diagnostics.
+- `/v1/metrics`, `/internal/metrics`, and Prometheus metrics expose runtime telemetry.
+- CLI status, CLI serve readiness wait, bench throughput, Dockerfile healthchecks, and Docker Compose healthchecks depend on `/v1/health`.
+
+What is missing:
+
+- No `/livez`, `/readyz`, or equivalent.
+- `/health` always returns `200` with `status: "ok"` and is a summary, not readiness or liveness.
+- No `503` readiness path.
+- No lifecycle state for starting, ready, degraded, draining, or shutdown.
+- No readiness checks for store health, selected backend availability, preload failures, required model residency, semaphore saturation, worker panic/restart thresholds, or shutdown drain state.
+- Since the server only listens after preload/warmup, probes cannot observe alive-but-not-ready startup work.
+
+### 4. Add structured JSON logging as a supported runtime mode
+
+Status: missing.
+
+What exists:
+
+- Server uses `tracing_subscriber::fmt::layer()` with `RUST_LOG`/`EnvFilter`.
+- HTTP `TraceLayer` spans include method, URI, and an inbound `x-request-id` when present.
+- Request middleware generates/returns `x-request-id`.
+- CLI exposes `--log-level` and passes `RUST_LOG` to the server.
+
+What is missing:
+
+- No `--log-format json`, `IZWI_LOG_FORMAT`, or config key.
+- Workspace `tracing-subscriber` does not enable the JSON formatter feature.
+- No stable JSON log schema for service/version/level/target/request id/method/path/status/latency/error.
+- The trace span does not use the generated request id from request middleware when the caller does not provide one.
+- No tests or docs for JSON log mode.
+- Docker `json-file` logging is container framing, not application JSON logs.
+
+### 5. Decide whether `/v1/responses` and agent sessions are durable product features or preview-only local conveniences
+
+Status: decision should be preview-only now.
+
+Current behavior:
+
+- `/v1/responses` records live in an in-memory `HashMap` with a default 512-entry limit.
+- `store: false` skips even in-memory storage.
+- Streaming responses are stored only when completed or failed, not at `response.created`, so in-progress lookup/cancel is not a real durable lifecycle.
+- `/v1/agent/sessions` session metadata also lives in an in-memory `HashMap`.
+- Agent session creation does create a durable chat thread, but the agent session id and metadata are lost after restart.
+- Voice profiles, voice sessions, voice turns, observations, and chat threads/messages are SQLite-backed; those are the durable local product surfaces today.
+
+Decision:
+
+- Keep `/v1/responses` and `/v1/agent/sessions` as preview, process-local, bounded-memory convenience APIs for now.
+- Do not promote them to durable product features until SQLite storage, lifecycle semantics, restart tests, and docs are implemented together.
+
+## Phased Implementation Plan
+
+### Phase 0: Contract Cleanup And No-Code Truth Fixes
+
+Status: complete.
+
+Goal:
+
+- Close the easy trust gaps before changing runtime behavior.
+
+Tasks:
+
+- [x] Update `docs/openai-compatibility-contract.json` or its surrounding docs to mark Responses lifecycle routes as preview/process-local where applicable.
+- [x] Update dev docs to list all Responses lifecycle routes and describe their current non-durable behavior.
+- [x] Keep `/v1/responses` and `/v1/agent/sessions` explicitly preview in the support matrix.
+- [x] Add a short note in this planning artifact that Docker/CUDA truth closure is intentionally deferred/out of scope.
+
+Verification:
+
+- [x] Docs grep confirms no stale claim that `/v1/responses` object lifecycle or agent sessions are durable.
+
+Out of scope:
+
+- Docker and CUDA truth closure remains analyzed above for context, but is intentionally skipped in this implementation plan.
+
+### Phase 1: Probe Contract And Lifecycle State
+
+Goal:
+
+- Add real liveness/readiness semantics without breaking existing `/v1/health` clients.
+
+Tasks:
+
+- [ ] Keep `/v1/health` backward-compatible as the rich status summary.
+- [ ] Add root `/livez` and `/readyz`.
+- [ ] Consider `/v1/live` and `/v1/ready` aliases for API namespace consistency.
+- [ ] Add a small lifecycle state to server/AppState: startup time, phase, ready flag, degraded reasons, preload/warmup errors, shutdown/draining flag.
+- [ ] Mark server unready before graceful shutdown starts.
+- [ ] Define readiness reason codes, for example `runtime_initialized`, `stores_available`, `backend_available`, `preload_complete`, `worker_health`, `not_draining`.
+- [ ] Return compact JSON and `200` when ready, compact JSON and `503` when unready.
+- [ ] Keep liveness cheap and independent of model readiness.
+
+Verification:
+
+- [ ] Router tests for `/livez` returning `200`.
+- [ ] Router tests for `/readyz` returning `200` when initialized.
+- [ ] Unit tests for unready/degraded reason rendering.
+- [ ] Shutdown/drain state test where practical.
+
+### Phase 2: Switch Dependents To The Right Probe
+
+Goal:
+
+- Make internal tooling and deployment assets use liveness/readiness correctly.
+
+Tasks:
+
+- [ ] Switch Dockerfile healthchecks from `/v1/health` to `/readyz`.
+- [ ] Switch Docker Compose healthchecks to `/readyz`.
+- [ ] Switch `izwi serve` startup wait to readiness.
+- [ ] Keep `izwi status` on `/v1/health`, but optionally show readiness summary.
+- [ ] Switch bench HTTP-overhead throughput test from `/v1/health` to `/livez` if it is measuring server overhead rather than runtime readiness.
+- [ ] Update CLI docs, Docker docs, troubleshooting, and status docs.
+
+Verification:
+
+- [ ] CLI serve wait test updated.
+- [ ] Docker healthcheck grep confirms `/readyz`.
+- [ ] Bench docs and command text mention `/livez` if changed.
+- [ ] `cargo check --locked -p izwi-server -p izwi-cli`.
+
+### Phase 3: Structured JSON Logging Mode
+
+Goal:
+
+- Support machine-readable runtime logs while preserving current text default.
+
+Tasks:
+
+- [ ] Enable `tracing-subscriber` JSON formatter feature.
+- [ ] Add `LogFormat { text, json }` parsing.
+- [ ] Add direct server flag `--log-format`.
+- [ ] Add env var `IZWI_LOG_FORMAT`.
+- [ ] Add CLI `izwi serve --log-format` and pass it through to child server processes.
+- [ ] Centralize tracing initialization in a small helper so parsing/defaults are testable.
+- [ ] Define stable fields: timestamp, level, target, service, version, message, correlation_id, method, path, status, latency_ms, error.
+- [ ] Make request-id middleware and TraceLayer agree on generated request IDs.
+- [ ] Add response/failure events with status and latency.
+- [ ] Document Docker usage with application JSON logs, distinct from Docker `json-file`.
+
+Verification:
+
+- [ ] Unit tests for log format parsing and defaults.
+- [ ] Router/middleware test proves generated `x-request-id` is returned.
+- [ ] Integration-style smoke captures one JSON log line and validates basic keys where feasible.
+- [ ] `cargo check --locked -p izwi-server -p izwi-cli`.
+
+### Phase 4: Preview Semantics Hardening For Responses And Agent Sessions
+
+Goal:
+
+- Make the current non-durable decision intentional, tested, and legible.
+
+Tasks:
+
+- [ ] Add clear docs for `/v1/responses` retention: process-local, bounded memory, evicted by age, lost on restart.
+- [ ] Add clear docs for `/v1/agent/sessions`: session metadata process-local, chat thread/messages durable.
+- [ ] Add tests for `store:false` not retaining response records.
+- [ ] Add tests for bounded response eviction.
+- [ ] Add tests for bounded agent-session eviction.
+- [ ] Consider preview headers or response metadata for preview/process-local APIs if useful.
+- [ ] Align UI/client assumptions so durable history uses chat/voice stores, not response/agent-session ids.
+
+Verification:
+
+- [ ] Targeted server tests for response and agent session memory semantics.
+- [ ] Docs grep confirms preview/non-durable wording.
+- [ ] `cargo check --locked -p izwi-server`.
+
+### Phase 5: Optional Durable Promotion Path
+
+Goal:
+
+- Only if product decides durable Responses/agent sessions are needed, promote them deliberately.
+
+Tasks:
+
+- [ ] Add SQLite store/tables for response objects and response input items.
+- [ ] Persist streaming lifecycle from created/in-progress through completed/failed.
+- [ ] Implement meaningful active-response cancellation, or document cancel as best-effort if runtime cancellation is unavailable.
+- [ ] Add SQLite store/tables for agent session metadata.
+- [ ] Reconstruct agent sessions after restart using stored session metadata plus durable chat thread/messages.
+- [ ] Add migrations and storage versioning tests.
+- [ ] Add restart integration tests for Responses and agent sessions.
+- [ ] Update compatibility contract, support matrix, dev docs, and UI copy only after behavior is durable.
+
+Verification:
+
+- [ ] Restart durability tests pass.
+- [ ] Streaming lifecycle persistence tests pass.
+- [ ] Agent session turn after restart works.
+- [ ] Docs and contract promote surfaces from preview only after tests prove durability.
+
+## Elegance Review
+
+The elegant path is to avoid turning `/v1/health` into a catch-all contract. Keep it as the existing rich status endpoint, add small Unix/Kubernetes-style probes for orchestration, and keep durability decisions separate from OpenAI compatibility routing. That minimizes breakage while giving enterprise packaging the precise hooks it needs.
+
+For Responses and agent sessions, the lowest-risk decision is preview-only now. There are already durable SQLite-backed product surfaces for chat and voice. Promoting the compatibility lifecycle to durable storage is valuable only if it is done with full lifecycle semantics, not a partial table bolted onto the current in-memory map.
+
+## Verification Completed In This Planning Phase
+
+- [x] `cargo check --locked -p izwi-server -p izwi-cli`
+
+Result:
+
+- Server and CLI compile successfully in the current codebase.
+
+## Review
+
+- The roadmap is stale on at least two P0 points: a support matrix exists, and CUDA release packaging has already been significantly implemented.
+- Docker and CUDA truth closure was analyzed but intentionally skipped from the implementation plan per user direction.
+- The remaining P0 implementation work in scope is contract hardening around real probes, JSON logging, and explicit preview semantics.
+- No runtime implementation was performed in this phase.
+
 # CPU + CUDA Unified Installer Feasibility Plan
 
 ## Goal

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -200,29 +200,35 @@ Verification:
 
 ### Phase 3: Structured JSON Logging Mode
 
+Status: complete.
+
 Goal:
 
 - Support machine-readable runtime logs while preserving current text default.
 
 Tasks:
 
-- [ ] Enable `tracing-subscriber` JSON formatter feature.
-- [ ] Add `LogFormat { text, json }` parsing.
-- [ ] Add direct server flag `--log-format`.
-- [ ] Add env var `IZWI_LOG_FORMAT`.
-- [ ] Add CLI `izwi serve --log-format` and pass it through to child server processes.
-- [ ] Centralize tracing initialization in a small helper so parsing/defaults are testable.
-- [ ] Define stable fields: timestamp, level, target, service, version, message, correlation_id, method, path, status, latency_ms, error.
-- [ ] Make request-id middleware and TraceLayer agree on generated request IDs.
-- [ ] Add response/failure events with status and latency.
-- [ ] Document Docker usage with application JSON logs, distinct from Docker `json-file`.
+- [x] Enable `tracing-subscriber` JSON formatter feature.
+- [x] Add `LogFormat { text, json }` parsing.
+- [x] Add direct server flag `--log-format`.
+- [x] Add env var `IZWI_LOG_FORMAT`.
+- [x] Add CLI `izwi serve --log-format` and pass it through to child server processes.
+- [x] Centralize tracing initialization in a small helper so parsing/defaults are testable.
+- [x] Define stable fields: timestamp, level, target, service, version, message, correlation_id, method, path, status, latency_ms, error.
+- [x] Make request-id middleware and TraceLayer agree on generated request IDs.
+- [x] Add response/failure events with status and latency.
+- [x] Document Docker usage with application JSON logs, distinct from Docker `json-file`.
 
 Verification:
 
-- [ ] Unit tests for log format parsing and defaults.
-- [ ] Router/middleware test proves generated `x-request-id` is returned.
-- [ ] Integration-style smoke captures one JSON log line and validates basic keys where feasible.
-- [ ] `cargo check --locked -p izwi-server -p izwi-cli`.
+- [x] Unit tests for log format parsing and defaults.
+- [x] Router/middleware test proves generated `x-request-id` is returned.
+- [x] Integration-style smoke captures one JSON log line and validates basic keys where feasible.
+- [x] `cargo check --locked -p izwi-server -p izwi-cli`.
+
+Notes:
+
+- JSON smoke emitted a structured startup line with timestamp, level, message, service, version, and `log_format=json`; the sandbox denied the subsequent localhost bind after logging.
 
 ### Phase 4: Preview Semantics Hardening For Responses And Agent Sessions
 


### PR DESCRIPTION
Adds readiness/liveness probes, switches tooling to them, supports structured JSON request logs, and documents/tests preview retention semantics for Responses and agent sessions.