### PR TITLE
Add CUDA support policy, kernel scaffolding, and Qwen primitive hooks

### DIFF
--- a/crates/izwi-core/Cargo.toml
+++ b/crates/izwi-core/Cargo.toml
@@ -4,6 +4,7 @@ description = "Core TTS inference engine for Qwen3-TTS models on Apple Silicon"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+build = "build.rs"
 
 [dependencies]
 izwi-asr-toolkit = { path = "../izwi-asr-toolkit" }

--- a/crates/izwi-core/build.rs
+++ b/crates/izwi-core/build.rs
@@ -1,0 +1,60 @@
+use std::env;
+
+const ARCH_ENV: &str = "IZWI_CUDA_KERNEL_ARCH";
+const CANDLE_ARCH_ENV: &str = "CUDA_COMPUTE_CAP";
+
+fn main() {
+    println!("cargo:rerun-if-env-changed={ARCH_ENV}");
+    println!("cargo:rerun-if-env-changed={CANDLE_ARCH_ENV}");
+    println!("cargo:rustc-check-cfg=cfg(izwi_cuda_kernel_arch_configured)");
+
+    if env::var_os("CARGO_FEATURE_CUDA").is_none() {
+        return;
+    }
+
+    let raw_arch = env::var(ARCH_ENV)
+        .ok()
+        .or_else(|| env::var(CANDLE_ARCH_ENV).ok());
+
+    let Some(raw_arch) = raw_arch else {
+        println!("cargo:warning=CUDA kernels will use runtime/default architecture selection");
+        return;
+    };
+
+    match normalize_arch(&raw_arch) {
+        Some(arch) => {
+            println!("cargo:rustc-env={ARCH_ENV}={arch}");
+            println!("cargo:rustc-cfg=izwi_cuda_kernel_arch_configured");
+        }
+        None => {
+            println!(
+                "cargo:warning=Ignoring invalid CUDA kernel architecture override {raw_arch:?}; expected native, sm_80, compute_80, 80, or 8.0 style values"
+            );
+        }
+    }
+}
+
+fn normalize_arch(raw: &str) -> Option<String> {
+    let trimmed = raw.trim().to_ascii_lowercase();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed == "native" {
+        return Some(trimmed);
+    }
+
+    let normalized = trimmed
+        .strip_prefix("sm_")
+        .or_else(|| trimmed.strip_prefix("compute_"))
+        .unwrap_or(trimmed.as_str())
+        .replace('.', "");
+
+    if normalized.len() < 2 || normalized.len() > 3 {
+        return None;
+    }
+    if !normalized.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+
+    Some(format!("sm_{normalized}"))
+}

--- a/crates/izwi-core/src/backends/device.rs
+++ b/crates/izwi-core/src/backends/device.rs
@@ -5,14 +5,14 @@
 //! - Memory pool integration for reduced allocation overhead
 //! - Unified memory awareness for Apple Silicon
 
-use candle_core::{DType, Device};
+use candle_core::{DType, Device, DeviceLocation};
 use std::any::Any;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
 use super::types::{BackendKind, BackendPreference};
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::models::shared::memory::metal::{metal_pool_for_device, MetalMemoryPool};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -59,6 +59,8 @@ pub struct DeviceCapabilities {
     pub recommended_batch_size: usize,
     /// Available memory in bytes (if detectable)
     pub available_memory_bytes: Option<usize>,
+    /// CUDA-specific capabilities, populated only for CUDA devices.
+    pub cuda: Option<CudaDeviceCapabilities>,
 }
 
 impl Default for DeviceCapabilities {
@@ -69,6 +71,50 @@ impl Default for DeviceCapabilities {
             has_unified_memory: false,
             recommended_batch_size: 1,
             available_memory_bytes: None,
+            cuda: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CudaDeviceCapabilities {
+    pub device_name: Option<String>,
+    pub compute_capability: Option<(u32, u32)>,
+    pub total_memory_bytes: Option<usize>,
+    pub supports_bf16: bool,
+    pub supports_fp16: bool,
+    pub supports_int8_tensor_cores: bool,
+}
+
+impl CudaDeviceCapabilities {
+    pub fn unknown() -> Self {
+        Self {
+            device_name: None,
+            compute_capability: None,
+            total_memory_bytes: None,
+            supports_bf16: false,
+            supports_fp16: false,
+            supports_int8_tensor_cores: false,
+        }
+    }
+
+    pub fn from_compute_capability(
+        device_name: Option<String>,
+        compute_capability: Option<(u32, u32)>,
+        total_memory_bytes: Option<usize>,
+    ) -> Self {
+        let supports_bf16 = compute_capability.is_some_and(cuda_supports_bf16);
+        let supports_fp16 = compute_capability.is_some_and(cuda_supports_fp16);
+        let supports_int8_tensor_cores =
+            compute_capability.is_some_and(cuda_supports_int8_tensor_cores);
+
+        Self {
+            device_name,
+            compute_capability,
+            total_memory_bytes,
+            supports_bf16,
+            supports_fp16,
+            supports_int8_tensor_cores,
         }
     }
 }
@@ -110,13 +156,7 @@ impl DeviceProfile {
                     debug!("Metal device: using F32 instead of BF16 for better performance");
                     DType::F32
                 }
-                DeviceKind::Cuda => {
-                    if self.capabilities.supports_bf16 {
-                        DType::BF16
-                    } else {
-                        DType::F32
-                    }
-                }
+                DeviceKind::Cuda => select_cuda_dtype(self.capabilities.cuda.as_ref(), requested),
             },
             "float16" | "f16" => match self.kind {
                 DeviceKind::Cpu => DType::F32,
@@ -125,7 +165,7 @@ impl DeviceProfile {
                     debug!("Metal device: using F32 instead of F16 for better performance");
                     DType::F32
                 }
-                _ => DType::F16,
+                DeviceKind::Cuda => select_cuda_dtype(self.capabilities.cuda.as_ref(), requested),
             },
             "float32" | "f32" => DType::F32,
             // Default selection based on device optimization
@@ -136,13 +176,7 @@ impl DeviceProfile {
                     // due to unified memory architecture and lack of Tensor Cores
                     DType::F32
                 }
-                DeviceKind::Cuda => {
-                    if self.capabilities.supports_bf16 {
-                        DType::BF16
-                    } else {
-                        DType::F32
-                    }
-                }
+                DeviceKind::Cuda => select_cuda_dtype(self.capabilities.cuda.as_ref(), requested),
             },
         };
 
@@ -152,6 +186,14 @@ impl DeviceProfile {
         );
 
         dtype
+    }
+
+    /// Select dtype while rejecting unsupported explicit CUDA overrides.
+    pub fn try_select_dtype(&self, requested: Option<&str>) -> Result<DType> {
+        if self.kind == DeviceKind::Cuda {
+            validate_cuda_dtype_request(self.capabilities.cuda.as_ref(), requested)?;
+        }
+        Ok(self.select_dtype(requested))
     }
 
     /// Get the optimal dtype for this device without any specific request
@@ -226,6 +268,7 @@ impl DeviceSelector {
                     has_unified_memory: true,     // Apple Silicon has unified memory
                     recommended_batch_size: 4,    // Conservative for unified memory
                     available_memory_bytes: None, // Could be detected via system APIs
+                    cuda: None,
                 },
                 memory_pool,
             })
@@ -239,18 +282,22 @@ impl DeviceSelector {
             .ok()?
             .ok()?;
         if device.is_cuda() {
-            // Detect CUDA capabilities
-            let supports_bf16 = Self::detect_cuda_bf16_support();
+            let gpu_id = match device.location() {
+                DeviceLocation::Cuda { gpu_id } => gpu_id,
+                _ => 0,
+            };
+            let cuda = Self::detect_cuda_capabilities(gpu_id);
 
             Some(DeviceProfile {
                 device,
                 kind: DeviceKind::Cuda,
                 capabilities: DeviceCapabilities {
                     prefers_f32: false,
-                    supports_bf16,
+                    supports_bf16: cuda.supports_bf16,
                     has_unified_memory: false,
                     recommended_batch_size: 8, // CUDA can handle larger batches
-                    available_memory_bytes: Self::detect_cuda_memory(),
+                    available_memory_bytes: cuda.total_memory_bytes,
+                    cuda: Some(cuda),
                 },
                 memory_pool: None, // CUDA uses its own memory management
             })
@@ -259,15 +306,8 @@ impl DeviceSelector {
         }
     }
 
-    fn detect_cuda_bf16_support() -> bool {
-        // BF16 support requires Compute Capability 8.0+ (Ampere)
-        // This is a simplified check - in production, query the device properties
-        true // Assume modern CUDA supports BF16
-    }
-
-    fn detect_cuda_memory() -> Option<usize> {
-        // Could use CUDA APIs to detect available memory
-        None
+    fn detect_cuda_capabilities(gpu_id: usize) -> CudaDeviceCapabilities {
+        query_cuda_capabilities(gpu_id).unwrap_or_else(CudaDeviceCapabilities::unknown)
     }
 
     pub fn detect() -> Result<DeviceProfile> {
@@ -323,6 +363,96 @@ impl DeviceSelector {
             .map(Self::detect_for_preference)
             .unwrap_or_else(Self::detect)
     }
+}
+
+fn cuda_supports_bf16((major, _minor): (u32, u32)) -> bool {
+    major >= 8
+}
+
+fn cuda_supports_fp16((major, minor): (u32, u32)) -> bool {
+    major > 5 || (major == 5 && minor >= 3)
+}
+
+fn cuda_supports_int8_tensor_cores((major, _minor): (u32, u32)) -> bool {
+    major >= 7
+}
+
+fn select_cuda_dtype(cuda: Option<&CudaDeviceCapabilities>, requested: Option<&str>) -> DType {
+    let capabilities = cuda
+        .cloned()
+        .unwrap_or_else(CudaDeviceCapabilities::unknown);
+    match requested.unwrap_or("").trim().to_ascii_lowercase().as_str() {
+        "float32" | "f32" => DType::F32,
+        "float16" | "f16" if capabilities.supports_fp16 => DType::F16,
+        "float16" | "f16" => DType::F32,
+        "bfloat16" | "bf16" if capabilities.supports_bf16 => DType::BF16,
+        "bfloat16" | "bf16" if capabilities.supports_fp16 => DType::F16,
+        "bfloat16" | "bf16" => DType::F32,
+        _ if capabilities.supports_bf16 => DType::BF16,
+        _ if capabilities.supports_fp16 => DType::F16,
+        _ => DType::F32,
+    }
+}
+
+fn validate_cuda_dtype_request(
+    cuda: Option<&CudaDeviceCapabilities>,
+    requested: Option<&str>,
+) -> Result<()> {
+    let Some(raw) = requested.map(str::trim).filter(|raw| !raw.is_empty()) else {
+        return Ok(());
+    };
+    let capabilities = cuda
+        .cloned()
+        .unwrap_or_else(CudaDeviceCapabilities::unknown);
+    match raw.to_ascii_lowercase().as_str() {
+        "float32" | "f32" => Ok(()),
+        "float16" | "f16" if capabilities.supports_fp16 => Ok(()),
+        "float16" | "f16" => Err(Error::InvalidInput(
+            "CUDA device does not report FP16 support".to_string(),
+        )),
+        "bfloat16" | "bf16" if capabilities.supports_bf16 => Ok(()),
+        "bfloat16" | "bf16" => Err(Error::InvalidInput(
+            "CUDA device does not report BF16 support".to_string(),
+        )),
+        other => Err(Error::InvalidInput(format!(
+            "Unsupported CUDA dtype override: {other}"
+        ))),
+    }
+}
+
+#[cfg(feature = "cuda")]
+fn query_cuda_capabilities(gpu_id: usize) -> Option<CudaDeviceCapabilities> {
+    use candle_core::cuda_backend::cudarc::driver::{result, sys};
+
+    result::init().ok()?;
+    let device = result::device::get(gpu_id as i32).ok()?;
+    let device_name = result::device::get_name(device).ok();
+    let major = unsafe {
+        result::device::get_attribute(
+            device,
+            sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
+        )
+        .ok()
+    }?;
+    let minor = unsafe {
+        result::device::get_attribute(
+            device,
+            sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
+        )
+        .ok()
+    }?;
+    let total_memory_bytes = unsafe { result::device::total_mem(device).ok() };
+
+    Some(CudaDeviceCapabilities::from_compute_capability(
+        device_name,
+        Some((major as u32, minor as u32)),
+        total_memory_bytes,
+    ))
+}
+
+#[cfg(not(feature = "cuda"))]
+fn query_cuda_capabilities(_gpu_id: usize) -> Option<CudaDeviceCapabilities> {
+    None
 }
 
 #[cfg(test)]
@@ -398,6 +528,11 @@ mod tests {
             kind: DeviceKind::Cuda,
             capabilities: DeviceCapabilities {
                 supports_bf16: true,
+                cuda: Some(CudaDeviceCapabilities::from_compute_capability(
+                    Some("test ampere".to_string()),
+                    Some((8, 0)),
+                    Some(16 * 1024 * 1024 * 1024),
+                )),
                 ..Default::default()
             },
             memory_pool: None,
@@ -410,6 +545,67 @@ mod tests {
         assert_eq!(cuda_profile.select_dtype(Some("f32")), DType::F32);
         assert_eq!(cuda_profile.select_dtype(Some("f16")), DType::F16);
         assert_eq!(cuda_profile.select_dtype(Some("bf16")), DType::BF16);
+    }
+
+    #[test]
+    fn test_cuda_dtype_selection_without_bf16_uses_f16() {
+        let cuda_profile = DeviceProfile {
+            device: Device::Cpu,
+            kind: DeviceKind::Cuda,
+            capabilities: DeviceCapabilities {
+                supports_bf16: false,
+                cuda: Some(CudaDeviceCapabilities::from_compute_capability(
+                    Some("test turing".to_string()),
+                    Some((7, 5)),
+                    None,
+                )),
+                ..Default::default()
+            },
+            memory_pool: None,
+        };
+
+        assert_eq!(cuda_profile.select_dtype(None), DType::F16);
+        assert_eq!(cuda_profile.select_dtype(Some("bf16")), DType::F16);
+        assert!(cuda_profile.try_select_dtype(Some("bf16")).is_err());
+        assert_eq!(
+            cuda_profile.try_select_dtype(Some("f16")).unwrap(),
+            DType::F16
+        );
+    }
+
+    #[test]
+    fn test_cuda_dtype_selection_without_half_support_uses_f32() {
+        let cuda_profile = DeviceProfile {
+            device: Device::Cpu,
+            kind: DeviceKind::Cuda,
+            capabilities: DeviceCapabilities {
+                supports_bf16: false,
+                cuda: Some(CudaDeviceCapabilities::from_compute_capability(
+                    Some("test old cuda".to_string()),
+                    Some((5, 2)),
+                    None,
+                )),
+                ..Default::default()
+            },
+            memory_pool: None,
+        };
+
+        assert_eq!(cuda_profile.select_dtype(None), DType::F32);
+        assert_eq!(cuda_profile.select_dtype(Some("f16")), DType::F32);
+        assert!(cuda_profile.try_select_dtype(Some("f16")).is_err());
+    }
+
+    #[test]
+    fn test_cuda_capability_flags_follow_compute_capability() {
+        let volta = CudaDeviceCapabilities::from_compute_capability(None, Some((7, 0)), Some(1024));
+        assert!(!volta.supports_bf16);
+        assert!(volta.supports_fp16);
+        assert!(volta.supports_int8_tensor_cores);
+        assert_eq!(volta.total_memory_bytes, Some(1024));
+
+        let ampere = CudaDeviceCapabilities::from_compute_capability(None, Some((8, 0)), None);
+        assert!(ampere.supports_bf16);
+        assert!(ampere.supports_fp16);
     }
 
     #[test]

--- a/crates/izwi-core/src/kernels/cuda.rs
+++ b/crates/izwi-core/src/kernels/cuda.rs
@@ -37,8 +37,28 @@ pub enum CudaKernelDecision {
     Skip(CudaKernelFallbackReason),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CudaKernelBuildMode {
+    NotCompiled,
+    RuntimeDefault,
+    ConfiguredArch(&'static str),
+}
+
 pub fn cuda_kernels_compiled() -> bool {
     cfg!(feature = "cuda")
+}
+
+pub fn configured_cuda_kernel_arch() -> Option<&'static str> {
+    option_env!("IZWI_CUDA_KERNEL_ARCH")
+}
+
+pub fn cuda_kernel_build_mode() -> CudaKernelBuildMode {
+    if !cuda_kernels_compiled() {
+        return CudaKernelBuildMode::NotCompiled;
+    }
+    configured_cuda_kernel_arch()
+        .map(CudaKernelBuildMode::ConfiguredArch)
+        .unwrap_or(CudaKernelBuildMode::RuntimeDefault)
 }
 
 pub fn cuda_kernels_available(device: &Device) -> bool {
@@ -126,7 +146,8 @@ fn record_cuda_scaffold_attempt(device: &Device) -> Result<Option<Tensor>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        cuda_kernel_preflight, cuda_kernels_available, cuda_kernels_compiled, try_cuda_attention,
+        configured_cuda_kernel_arch, cuda_kernel_build_mode, cuda_kernel_preflight,
+        cuda_kernels_available, cuda_kernels_compiled, try_cuda_attention, CudaKernelBuildMode,
         CudaKernelDecision, CudaKernelKind,
     };
     use crate::models::shared::telemetry;
@@ -144,6 +165,21 @@ mod tests {
     #[test]
     fn cuda_kernel_compiled_reflects_feature_flag() {
         assert_eq!(cuda_kernels_compiled(), cfg!(feature = "cuda"));
+    }
+
+    #[test]
+    fn cuda_kernel_build_mode_reflects_compile_state() {
+        match cuda_kernel_build_mode() {
+            CudaKernelBuildMode::NotCompiled => assert!(!cuda_kernels_compiled()),
+            CudaKernelBuildMode::RuntimeDefault => {
+                assert!(cuda_kernels_compiled());
+                assert!(configured_cuda_kernel_arch().is_none());
+            }
+            CudaKernelBuildMode::ConfiguredArch(arch) => {
+                assert!(cuda_kernels_compiled());
+                assert_eq!(configured_cuda_kernel_arch(), Some(arch));
+            }
+        }
     }
 
     #[test]

--- a/crates/izwi-core/src/kernels/cuda.rs
+++ b/crates/izwi-core/src/kernels/cuda.rs
@@ -105,6 +105,24 @@ pub fn try_cuda_rotary(
     record_cuda_scaffold_attempt(x.device())
 }
 
+pub fn try_cuda_rotary_pair(
+    q: &Tensor,
+    k: &Tensor,
+    cos: &Tensor,
+    sin: &Tensor,
+    kind: CudaKernelKind,
+) -> Result<Option<(Tensor, Tensor)>> {
+    if !q.device().is_cuda() {
+        return Ok(None);
+    }
+    let q_out = try_cuda_rotary(q, cos, sin, kind)?;
+    let k_out = try_cuda_rotary(k, cos, sin, kind)?;
+    Ok(match (q_out, k_out) {
+        (Some(q_out), Some(k_out)) => Some((q_out, k_out)),
+        _ => None,
+    })
+}
+
 pub fn try_cuda_norm(
     x: &Tensor,
     _weight: &Tensor,

--- a/crates/izwi-core/src/kernels/cuda.rs
+++ b/crates/izwi-core/src/kernels/cuda.rs
@@ -1,0 +1,166 @@
+//! CUDA kernel dispatch scaffolding.
+//!
+//! These functions are no-op contracts for future CUDA kernels. They record
+//! CUDA-specific attempts/fallbacks and return `Ok(None)` until an implementation
+//! lands in a later phase.
+
+use candle_core::{Device, Tensor};
+
+use crate::error::Result;
+use crate::models::shared::telemetry::{
+    record_cuda_kernel_attempt, record_cuda_kernel_fallback, CudaKernelFallbackReason,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CudaKernelKind {
+    UnmaskedAttention,
+    MaskedAttention,
+    PagedDecodeAttention,
+    Rope,
+    MRope,
+    RmsNorm,
+    GatedRmsNorm,
+    L2Norm,
+    SiluMul,
+    SwiGlu,
+    KvQuantize,
+    KvDequantize,
+    QuantizedMatmul,
+    ShortConv,
+    DeltaNet,
+    ArgmaxSampling,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CudaKernelDecision {
+    Try,
+    Skip(CudaKernelFallbackReason),
+}
+
+pub fn cuda_kernels_compiled() -> bool {
+    cfg!(feature = "cuda")
+}
+
+pub fn cuda_kernels_available(device: &Device) -> bool {
+    matches!(cuda_kernel_preflight(device), CudaKernelDecision::Try)
+}
+
+pub fn cuda_kernel_preflight(device: &Device) -> CudaKernelDecision {
+    if !device.is_cuda() {
+        return CudaKernelDecision::Skip(CudaKernelFallbackReason::NotCudaDevice);
+    }
+    if !cuda_kernels_compiled() {
+        return CudaKernelDecision::Skip(CudaKernelFallbackReason::NotCompiled);
+    }
+    CudaKernelDecision::Try
+}
+
+pub fn try_cuda_attention(
+    q: &Tensor,
+    _k: &Tensor,
+    _v: &Tensor,
+    _mask: Option<&Tensor>,
+    _head_dim: usize,
+    _causal: bool,
+    _kind: CudaKernelKind,
+) -> Result<Option<Tensor>> {
+    record_cuda_scaffold_attempt(q.device())
+}
+
+pub fn try_cuda_paged_decode_attention(
+    q: &Tensor,
+    _head_dim: usize,
+    _num_heads: usize,
+    _num_kv_heads: usize,
+) -> Result<Option<Tensor>> {
+    record_cuda_scaffold_attempt(q.device())
+}
+
+pub fn try_cuda_rotary(
+    x: &Tensor,
+    _cos: &Tensor,
+    _sin: &Tensor,
+    _kind: CudaKernelKind,
+) -> Result<Option<Tensor>> {
+    record_cuda_scaffold_attempt(x.device())
+}
+
+pub fn try_cuda_norm(
+    x: &Tensor,
+    _weight: &Tensor,
+    _eps: f64,
+    _kind: CudaKernelKind,
+) -> Result<Option<Tensor>> {
+    record_cuda_scaffold_attempt(x.device())
+}
+
+pub fn try_cuda_binary_activation(
+    lhs: &Tensor,
+    _rhs: &Tensor,
+    _kind: CudaKernelKind,
+) -> Result<Option<Tensor>> {
+    record_cuda_scaffold_attempt(lhs.device())
+}
+
+pub fn try_cuda_kv_quantize(page: &Tensor, _kind: CudaKernelKind) -> Result<Option<Tensor>> {
+    record_cuda_scaffold_attempt(page.device())
+}
+
+pub fn try_cuda_quantized_matmul(input: &Tensor, _kind: CudaKernelKind) -> Result<Option<Tensor>> {
+    record_cuda_scaffold_attempt(input.device())
+}
+
+fn record_cuda_scaffold_attempt(device: &Device) -> Result<Option<Tensor>> {
+    record_cuda_kernel_attempt();
+    match cuda_kernel_preflight(device) {
+        CudaKernelDecision::Try => {
+            record_cuda_kernel_fallback(CudaKernelFallbackReason::NotImplemented);
+        }
+        CudaKernelDecision::Skip(reason) => {
+            record_cuda_kernel_fallback(reason);
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        cuda_kernel_preflight, cuda_kernels_available, cuda_kernels_compiled, try_cuda_attention,
+        CudaKernelDecision, CudaKernelKind,
+    };
+    use crate::models::shared::telemetry;
+    use candle_core::{DType, Device, Tensor};
+
+    #[test]
+    fn cuda_kernel_preflight_skips_cpu_device() {
+        assert_eq!(
+            cuda_kernel_preflight(&Device::Cpu),
+            CudaKernelDecision::Skip(telemetry::CudaKernelFallbackReason::NotCudaDevice)
+        );
+        assert!(!cuda_kernels_available(&Device::Cpu));
+    }
+
+    #[test]
+    fn cuda_kernel_compiled_reflects_feature_flag() {
+        assert_eq!(cuda_kernels_compiled(), cfg!(feature = "cuda"));
+    }
+
+    #[test]
+    fn cuda_attention_scaffold_records_cpu_fallback() {
+        telemetry::reset_for_tests();
+        let device = Device::Cpu;
+        let q = Tensor::zeros((1, 1, 1, 8), DType::F32, &device).expect("q tensor");
+        let k = Tensor::zeros((1, 1, 1, 8), DType::F32, &device).expect("k tensor");
+        let v = Tensor::zeros((1, 1, 1, 8), DType::F32, &device).expect("v tensor");
+
+        let out = try_cuda_attention(&q, &k, &v, None, 8, true, CudaKernelKind::UnmaskedAttention)
+            .expect("scaffold call");
+
+        assert!(out.is_none());
+        let snapshot = telemetry::snapshot();
+        assert_eq!(snapshot.cuda_kernel_attempts_total, 1);
+        assert_eq!(snapshot.cuda_kernel_fallback_total, 1);
+        assert_eq!(snapshot.cuda_kernel_fallback_not_cuda_device_total, 1);
+    }
+}

--- a/crates/izwi-core/src/kernels/cuda_support.rs
+++ b/crates/izwi-core/src/kernels/cuda_support.rs
@@ -1,0 +1,284 @@
+//! CUDA kernel support inventory.
+//!
+//! This module is intentionally declarative. It records where CUDA kernel work
+//! is expected to live without changing runtime dispatch or fallback behavior.
+
+use crate::catalog::{ModelFamily, ModelVariant};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CudaKernelOwnership {
+    /// Izwi owns enough of the Rust model path to add CUDA-only kernel hooks.
+    NativeIzwiOwned,
+    /// The hot model path is primarily owned by Candle model implementations.
+    CandleOwned,
+    /// The current runtime path is CPU-only until routing is made explicit.
+    CpuOnlyUntilRouted,
+    /// The model variant is implemented or known, but not enabled for users.
+    Disabled,
+    /// The variant has no standalone model kernels but may use shared helpers.
+    SharedOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CudaKernelPrimitive {
+    Attention,
+    PagedKv,
+    Rope,
+    MRope,
+    Norm,
+    Activation,
+    KvQuantization,
+    QuantizedMatmul,
+    Conformer,
+    ShortConv,
+    DeltaNet,
+    ArgmaxSampling,
+    AudioPostprocess,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CudaKernelSupport {
+    pub variant: ModelVariant,
+    pub family: ModelFamily,
+    pub ownership: CudaKernelOwnership,
+    pub planned_primitives: &'static [CudaKernelPrimitive],
+}
+
+pub fn support_for_variant(variant: ModelVariant) -> CudaKernelSupport {
+    let family = variant.family();
+    let ownership = ownership_for_variant(variant, family);
+    let planned_primitives = planned_primitives_for(variant, family, ownership);
+
+    CudaKernelSupport {
+        variant,
+        family,
+        ownership,
+        planned_primitives,
+    }
+}
+
+pub fn all_support_records() -> impl Iterator<Item = CudaKernelSupport> {
+    ModelVariant::all().iter().copied().map(support_for_variant)
+}
+
+fn ownership_for_variant(variant: ModelVariant, family: ModelFamily) -> CudaKernelOwnership {
+    if !variant.is_enabled() {
+        return CudaKernelOwnership::Disabled;
+    }
+
+    match family {
+        ModelFamily::Tokenizer => CudaKernelOwnership::SharedOnly,
+        ModelFamily::Gemma3Chat | ModelFamily::Lfm2Chat => CudaKernelOwnership::CandleOwned,
+        ModelFamily::Qwen3Chat if variant.is_qwen_chat_gguf() => CudaKernelOwnership::CandleOwned,
+        ModelFamily::SortformerDiarization => CudaKernelOwnership::CpuOnlyUntilRouted,
+        ModelFamily::Qwen3Tts
+        | ModelFamily::KokoroTts
+        | ModelFamily::ParakeetAsr
+        | ModelFamily::WhisperAsr
+        | ModelFamily::Qwen3Asr
+        | ModelFamily::Qwen35Chat
+        | ModelFamily::Lfm25Audio
+        | ModelFamily::Qwen3ForcedAligner
+        | ModelFamily::Voxtral
+        | ModelFamily::Qwen3Chat => CudaKernelOwnership::NativeIzwiOwned,
+    }
+}
+
+fn planned_primitives_for(
+    _variant: ModelVariant,
+    family: ModelFamily,
+    ownership: CudaKernelOwnership,
+) -> &'static [CudaKernelPrimitive] {
+    use CudaKernelOwnership::*;
+    use CudaKernelPrimitive::*;
+    use ModelFamily::*;
+
+    if ownership == Disabled {
+        return &[];
+    }
+
+    match family {
+        Qwen3Tts => &[
+            Attention,
+            PagedKv,
+            Rope,
+            MRope,
+            Norm,
+            Activation,
+            KvQuantization,
+            QuantizedMatmul,
+            ArgmaxSampling,
+            AudioPostprocess,
+        ],
+        KokoroTts => &[Attention, Norm, Activation, AudioPostprocess],
+        ParakeetAsr => &[Attention, Conformer, ArgmaxSampling],
+        WhisperAsr => &[Attention, ArgmaxSampling],
+        Qwen3Asr => &[
+            Attention,
+            PagedKv,
+            Rope,
+            MRope,
+            Norm,
+            Activation,
+            KvQuantization,
+            QuantizedMatmul,
+            ArgmaxSampling,
+        ],
+        SortformerDiarization => &[Attention, Conformer, AudioPostprocess],
+        Qwen3Chat => &[
+            Attention,
+            PagedKv,
+            Rope,
+            Norm,
+            Activation,
+            KvQuantization,
+            QuantizedMatmul,
+            ArgmaxSampling,
+        ],
+        Qwen35Chat => &[
+            Attention,
+            PagedKv,
+            Rope,
+            MRope,
+            Norm,
+            Activation,
+            KvQuantization,
+            QuantizedMatmul,
+            DeltaNet,
+            ShortConv,
+            ArgmaxSampling,
+        ],
+        Lfm2Chat => &[
+            Attention,
+            Rope,
+            Norm,
+            Activation,
+            QuantizedMatmul,
+            ShortConv,
+        ],
+        Lfm25Audio => &[
+            Attention,
+            Rope,
+            Norm,
+            Activation,
+            QuantizedMatmul,
+            ShortConv,
+            Conformer,
+            ArgmaxSampling,
+            AudioPostprocess,
+        ],
+        Gemma3Chat => &[Attention, Norm, Activation, QuantizedMatmul, ArgmaxSampling],
+        Qwen3ForcedAligner => &[
+            Attention,
+            PagedKv,
+            Rope,
+            MRope,
+            Norm,
+            Activation,
+            KvQuantization,
+            QuantizedMatmul,
+        ],
+        Voxtral => &[Attention, PagedKv, Rope, Norm, Activation, ArgmaxSampling],
+        Tokenizer => &[],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::{
+        all_support_records, support_for_variant, CudaKernelOwnership, CudaKernelPrimitive,
+    };
+    use crate::catalog::{ModelFamily, ModelVariant};
+
+    #[test]
+    fn cuda_support_inventory_covers_every_variant_once() {
+        let records = all_support_records().collect::<Vec<_>>();
+        assert_eq!(records.len(), ModelVariant::all().len());
+
+        let unique = records
+            .iter()
+            .map(|record| record.variant)
+            .collect::<HashSet<_>>();
+        assert_eq!(unique.len(), ModelVariant::all().len());
+    }
+
+    #[test]
+    fn enabled_variants_are_not_marked_disabled() {
+        for record in all_support_records() {
+            if record.variant.is_enabled() {
+                assert_ne!(
+                    record.ownership,
+                    CudaKernelOwnership::Disabled,
+                    "{} is enabled but marked disabled",
+                    record.variant
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn disabled_variants_are_explicitly_marked_disabled() {
+        for record in all_support_records() {
+            if !record.variant.is_enabled() {
+                assert_eq!(
+                    record.ownership,
+                    CudaKernelOwnership::Disabled,
+                    "{} is disabled but classified as {:?}",
+                    record.variant,
+                    record.ownership
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn non_tokenizer_enabled_variants_have_planned_primitives() {
+        for record in all_support_records() {
+            if record.variant.is_enabled() && record.family != ModelFamily::Tokenizer {
+                assert!(
+                    !record.planned_primitives.is_empty(),
+                    "{} has no planned CUDA primitives",
+                    record.variant
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn candle_owned_family_boundaries_are_explicit() {
+        let gemma = support_for_variant(ModelVariant::Gemma31BIt);
+        assert_eq!(gemma.ownership, CudaKernelOwnership::CandleOwned);
+        assert!(gemma
+            .planned_primitives
+            .contains(&CudaKernelPrimitive::Attention));
+
+        let lfm = support_for_variant(ModelVariant::Lfm2512BInstructGguf);
+        assert_eq!(lfm.ownership, CudaKernelOwnership::CandleOwned);
+
+        let qwen_gguf = support_for_variant(ModelVariant::Qwen38BGguf);
+        assert_eq!(qwen_gguf.ownership, CudaKernelOwnership::CandleOwned);
+    }
+
+    #[test]
+    fn cpu_only_until_routed_family_is_explicit() {
+        let sortformer = support_for_variant(ModelVariant::DiarStreamingSortformer4SpkV21);
+        assert_eq!(
+            sortformer.ownership,
+            CudaKernelOwnership::CpuOnlyUntilRouted
+        );
+        assert!(sortformer
+            .planned_primitives
+            .contains(&CudaKernelPrimitive::Conformer));
+    }
+
+    #[test]
+    fn izwi_owned_qwen35_records_delta_net_work() {
+        let qwen35 = support_for_variant(ModelVariant::Qwen354BGguf);
+        assert_eq!(qwen35.ownership, CudaKernelOwnership::NativeIzwiOwned);
+        assert!(qwen35
+            .planned_primitives
+            .contains(&CudaKernelPrimitive::DeltaNet));
+    }
+}

--- a/crates/izwi-core/src/kernels/mod.rs
+++ b/crates/izwi-core/src/kernels/mod.rs
@@ -8,8 +8,11 @@
 //! - Fallback to Candle operations for other backends
 
 pub mod buffer_pool;
+pub mod cuda;
 pub mod cuda_support;
 pub mod metal;
+
+use candle_core::Device;
 
 use crate::error::Error;
 
@@ -23,6 +26,11 @@ pub fn fused_kernels_available() -> bool {
     {
         false // TODO: CUDA support
     }
+}
+
+/// Whether fused kernels are available for a specific device.
+pub fn fused_kernels_available_for_device(device: &Device) -> bool {
+    (device.is_metal() && fused_kernels_available()) || cuda::cuda_kernels_available(device)
 }
 
 /// Whether to use fused kernels (can be disabled via environment).

--- a/crates/izwi-core/src/kernels/mod.rs
+++ b/crates/izwi-core/src/kernels/mod.rs
@@ -8,6 +8,7 @@
 //! - Fallback to Candle operations for other backends
 
 pub mod buffer_pool;
+pub mod cuda_support;
 pub mod metal;
 
 use crate::error::Error;

--- a/crates/izwi-core/src/models/architectures/qwen3/core.rs
+++ b/crates/izwi-core/src/models/architectures/qwen3/core.rs
@@ -9,6 +9,7 @@ use candle_transformers::utils::repeat_kv as candle_repeat_kv;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{Error, Result};
+use crate::kernels::cuda::{try_cuda_binary_activation, try_cuda_rotary_pair, CudaKernelKind};
 use crate::kernels::metal::try_fused_silu_mul;
 use crate::models::shared::attention::batched::{
     batched_scaled_dot_product_attention, BatchedAttentionConfig, BatchedAttentionInput,
@@ -272,9 +273,21 @@ impl Qwen3Attention {
             )?
         };
 
+        let cos = cos_half.unsqueeze(0)?.contiguous()?;
+        let sin = sin_half.unsqueeze(0)?.contiguous()?;
+        if q.device().is_cuda() {
+            let kind = if self.use_mrope {
+                CudaKernelKind::MRope
+            } else {
+                CudaKernelKind::Rope
+            };
+            if let Some((q_out, k_out)) = try_cuda_rotary_pair(&q, &k, &cos, &sin, kind)? {
+                record_rope_kernel();
+                record_rope_kernel();
+                return Ok((q_out, k_out));
+            }
+        }
         if self.should_try_rope_kernel(q.dtype()) {
-            let cos = cos_half.unsqueeze(0)?.contiguous()?;
-            let sin = sin_half.unsqueeze(0)?.contiguous()?;
             if let Some((q_out, k_out)) = try_apply_rope_pair_thd(&q, &k, &cos, &sin)? {
                 record_rope_kernel();
                 record_rope_kernel();
@@ -463,7 +476,16 @@ impl Qwen3Mlp {
     fn forward(&self, x: &Tensor) -> Result<Tensor> {
         let gate = self.gate_proj.forward(x)?;
         let up = self.up_proj.forward(x)?;
-        let hidden = if let Some(fused) = try_fused_silu_mul(&gate, &up) {
+        let hidden = if gate.device().is_cuda() {
+            if let Some(fused) = try_cuda_binary_activation(&gate, &up, CudaKernelKind::SiluMul)? {
+                fused
+            } else if let Some(fused) = try_fused_silu_mul(&gate, &up) {
+                fused
+            } else {
+                let act = ops::silu(&gate)?;
+                act.broadcast_mul(&up)?
+            }
+        } else if let Some(fused) = try_fused_silu_mul(&gate, &up) {
             fused
         } else {
             let act = ops::silu(&gate)?;

--- a/crates/izwi-core/src/models/architectures/qwen35/text.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/text.rs
@@ -11,6 +11,7 @@ use crate::error::{Error, Result};
 use crate::kernels::buffer_pool::{
     global_buffer_pool_for_device, maybe_init_global_buffer_pool, SharedBufferPool,
 };
+use crate::kernels::cuda::{try_cuda_binary_activation, try_cuda_rotary_pair, CudaKernelKind};
 use crate::kernels::metal::{
     try_fused_gated_delta_recurrent, try_fused_gated_rms_norm, try_fused_l2_norm,
     try_tiled_deltanet_recurrence, use_block_fusion,
@@ -506,7 +507,20 @@ impl Qwen35Mlp {
         let gate_proj_out = self.gate.forward(hidden_states)?;
         let up_proj_out = self.up.forward(hidden_states)?;
 
-        let hidden = if let Some(fused) =
+        let hidden = if gate_proj_out.device().is_cuda() {
+            if let Some(fused) =
+                try_cuda_binary_activation(&gate_proj_out, &up_proj_out, CudaKernelKind::SiluMul)?
+            {
+                fused
+            } else if let Some(fused) =
+                crate::kernels::metal::try_fused_silu_mul(&gate_proj_out, &up_proj_out)
+            {
+                fused
+            } else {
+                let gate = ops::silu(&gate_proj_out)?;
+                (&gate * &up_proj_out)?
+            }
+        } else if let Some(fused) =
             crate::kernels::metal::try_fused_silu_mul(&gate_proj_out, &up_proj_out)
         {
             fused
@@ -914,6 +928,24 @@ impl Qwen35FullAttention {
 
         let query_rot = query_states.narrow(3, 0, self.rope_dim)?.contiguous()?;
         let key_rot = key_states.narrow(3, 0, self.rope_dim)?.contiguous()?;
+        if query_rot.device().is_cuda() {
+            if let Some((query_rot, key_rot)) =
+                try_cuda_rotary_pair(&query_rot, &key_rot, &cos, &sin, CudaKernelKind::MRope)?
+            {
+                record_rope_kernel();
+                if self.rope_dim == self.head_dim {
+                    return Ok((query_rot, key_rot));
+                }
+                let query_pass =
+                    query_states.narrow(3, self.rope_dim, self.head_dim - self.rope_dim)?;
+                let key_pass =
+                    key_states.narrow(3, self.rope_dim, self.head_dim - self.rope_dim)?;
+                return Ok((
+                    Tensor::cat(&[&query_rot, &query_pass], 3)?,
+                    Tensor::cat(&[&key_rot, &key_pass], 3)?,
+                ));
+            }
+        }
         let (query_rot, key_rot) = if self.should_try_rope_kernel(query_states.dtype()) {
             match try_apply_rope_thd(&query_rot, &key_rot, &cos, &sin)? {
                 Some((query_rot, key_rot)) => {
@@ -981,6 +1013,26 @@ impl Qwen35FullAttention {
 
         let query_rot = query_states.narrow(3, 0, self.rope_dim)?.contiguous()?;
         let key_rot = key_states.narrow(3, 0, self.rope_dim)?.contiguous()?;
+        if query_rot.device().is_cuda() {
+            if let Some((query_rot, key_rot)) =
+                try_cuda_rotary_pair(&query_rot, &key_rot, &cos, &sin, CudaKernelKind::MRope)?
+            {
+                for _ in 0..seq_len {
+                    record_rope_kernel();
+                }
+                if self.rope_dim == self.head_dim {
+                    return Ok((query_rot, key_rot));
+                }
+                let query_pass =
+                    query_states.narrow(3, self.rope_dim, self.head_dim - self.rope_dim)?;
+                let key_pass =
+                    key_states.narrow(3, self.rope_dim, self.head_dim - self.rope_dim)?;
+                return Ok((
+                    Tensor::cat(&[&query_rot, &query_pass], 3)?,
+                    Tensor::cat(&[&key_rot, &key_pass], 3)?,
+                ));
+            }
+        }
         let (query_rot, key_rot) = if self.should_try_rope_kernel(query_states.dtype()) {
             match try_apply_rope_thd(&query_rot, &key_rot, &cos, &sin)? {
                 Some((query_rot, key_rot)) => {

--- a/crates/izwi-core/src/models/architectures/whisper/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/whisper/asr/mod.rs
@@ -15,7 +15,7 @@ use std::time::Instant;
 
 use candle_core::{DType, IndexOp, Tensor};
 use candle_nn::VarBuilder;
-use candle_transformers::models::whisper::{self, model::Whisper, Config as WhisperConfig};
+use candle_transformers::models::whisper::{self, Config as WhisperConfig};
 use flate2::write::ZlibEncoder;
 use flate2::Compression;
 use rand::Rng;
@@ -27,6 +27,8 @@ use crate::audio::{MelConfig, MelSpectrogram};
 use crate::backends::DeviceProfile;
 use crate::error::{Error, Result};
 use crate::tokenizer::Tokenizer;
+
+use super::model::Whisper;
 
 const SAMPLE_RATE: u32 = whisper::SAMPLE_RATE as u32;
 const DEFAULT_MAX_NEW_TOKENS: usize = 448;

--- a/crates/izwi-core/src/models/architectures/whisper/mod.rs
+++ b/crates/izwi-core/src/models/architectures/whisper/mod.rs
@@ -1,3 +1,4 @@
 //! Whisper family implementations.
 
 pub mod asr;
+mod model;

--- a/crates/izwi-core/src/models/architectures/whisper/model.rs
+++ b/crates/izwi-core/src/models/architectures/whisper/model.rs
@@ -1,0 +1,442 @@
+//! Whisper model shim adapted from Candle's implementation so generated
+//! positional/mask tensors follow the active Izwi model dtype.
+
+use candle_core::{DType, Device, IndexOp, Result, Tensor, D};
+use candle_nn::{embedding, Conv1d, Conv1dConfig, Embedding, LayerNorm, Module, VarBuilder};
+use candle_transformers::models::whisper::Config;
+use candle_transformers::models::with_tracing::{linear, linear_no_bias, Linear};
+
+fn conv1d(
+    in_channels: usize,
+    out_channels: usize,
+    kernel_size: usize,
+    config: Conv1dConfig,
+    vb: VarBuilder,
+) -> Result<Conv1d> {
+    let weight = vb.get((out_channels, in_channels, kernel_size), "weight")?;
+    let bias = vb.get(out_channels, "bias")?;
+    Ok(Conv1d::new(weight, Some(bias), config))
+}
+
+fn layer_norm(size: usize, vb: VarBuilder) -> Result<LayerNorm> {
+    let weight = vb.get(size, "weight")?;
+    let bias = vb.get(size, "bias")?;
+    Ok(LayerNorm::new(weight, bias, 1e-5))
+}
+
+fn to_add_dtype(tensor: Tensor, dtype: DType) -> Result<Tensor> {
+    if tensor.dtype() == dtype {
+        Ok(tensor)
+    } else {
+        tensor.to_dtype(dtype)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MultiHeadAttention {
+    query: Linear,
+    key: Linear,
+    value: Linear,
+    out: Linear,
+    n_head: usize,
+    span: tracing::Span,
+    softmax_span: tracing::Span,
+    matmul_span: tracing::Span,
+    kv_cache: Option<(Tensor, Tensor)>,
+}
+
+impl MultiHeadAttention {
+    fn load(n_state: usize, n_head: usize, vb: VarBuilder) -> Result<Self> {
+        let span = tracing::span!(tracing::Level::TRACE, "multi-head-attn");
+        let softmax_span = tracing::span!(tracing::Level::TRACE, "multi-head-attn-softmax");
+        let matmul_span = tracing::span!(tracing::Level::TRACE, "multi-head-attn-matmul");
+        let query = linear(n_state, n_state, vb.pp("q_proj"))?;
+        let value = linear(n_state, n_state, vb.pp("v_proj"))?;
+        let key = linear_no_bias(n_state, n_state, vb.pp("k_proj"))?;
+        let out = linear(n_state, n_state, vb.pp("out_proj"))?;
+        Ok(Self {
+            query,
+            key,
+            value,
+            out,
+            n_head,
+            span,
+            softmax_span,
+            matmul_span,
+            kv_cache: None,
+        })
+    }
+
+    fn forward(
+        &mut self,
+        x: &Tensor,
+        xa: Option<&Tensor>,
+        mask: Option<&Tensor>,
+        flush_cache: bool,
+    ) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let q = self.query.forward(x)?;
+        let (k, v) = match xa {
+            None => {
+                let k = self.key.forward(x)?;
+                let v = self.value.forward(x)?;
+                (k, v)
+            }
+            Some(x) => {
+                if flush_cache {
+                    self.kv_cache = None;
+                }
+                if let Some((k, v)) = &self.kv_cache {
+                    (k.clone(), v.clone())
+                } else {
+                    let k = self.key.forward(x)?;
+                    let v = self.value.forward(x)?;
+                    self.kv_cache = Some((k.clone(), v.clone()));
+                    (k, v)
+                }
+            }
+        };
+        let wv = self.qkv_attention(&q, &k, &v, mask)?;
+        let out = self.out.forward(&wv)?;
+        Ok(out)
+    }
+
+    fn reshape_head(&self, x: &Tensor) -> Result<Tensor> {
+        let (n_batch, n_ctx, n_state) = x.dims3()?;
+        let target_dims = &[n_batch, n_ctx, self.n_head, n_state / self.n_head];
+        x.reshape(target_dims)?.transpose(1, 2)
+    }
+
+    fn qkv_attention(
+        &self,
+        q: &Tensor,
+        k: &Tensor,
+        v: &Tensor,
+        mask: Option<&Tensor>,
+    ) -> Result<Tensor> {
+        let (_, n_ctx, n_state) = q.dims3()?;
+        let scale = ((n_state / self.n_head) as f64).powf(-0.25);
+        let q = (self.reshape_head(q)? * scale)?;
+        let k = (self.reshape_head(k)?.transpose(2, 3)? * scale)?;
+        let v = self.reshape_head(v)?.contiguous()?;
+        let mut qk = {
+            let _enter = self.matmul_span.enter();
+            q.matmul(&k)?
+        };
+        if let Some(mask) = mask {
+            let mask = mask.i((0..n_ctx, 0..n_ctx))?;
+            let mask = to_add_dtype(mask, qk.dtype())?;
+            qk = qk.broadcast_add(&mask)?
+        }
+        let w = {
+            let _enter = self.softmax_span.enter();
+            candle_nn::ops::softmax_last_dim(&qk)?
+        };
+        let wv = {
+            let _enter = self.matmul_span.enter();
+            w.matmul(&v)?
+        }
+        .transpose(1, 2)?
+        .flatten_from(2)?;
+        Ok(wv)
+    }
+
+    fn reset_kv_cache(&mut self) {
+        self.kv_cache = None;
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResidualAttentionBlock {
+    attn: MultiHeadAttention,
+    attn_ln: LayerNorm,
+    cross_attn: Option<(MultiHeadAttention, LayerNorm)>,
+    mlp_linear1: Linear,
+    mlp_linear2: Linear,
+    mlp_ln: LayerNorm,
+    span: tracing::Span,
+}
+
+impl ResidualAttentionBlock {
+    fn load(n_state: usize, n_head: usize, ca: bool, vb: VarBuilder) -> Result<Self> {
+        let span = tracing::span!(tracing::Level::TRACE, "residual-attn");
+        let attn = MultiHeadAttention::load(n_state, n_head, vb.pp("self_attn"))?;
+        let attn_ln = layer_norm(n_state, vb.pp("self_attn_layer_norm"))?;
+        let cross_attn = if ca {
+            let cross_attn = MultiHeadAttention::load(n_state, n_head, vb.pp("encoder_attn"))?;
+            let cross_attn_ln = layer_norm(n_state, vb.pp("encoder_attn_layer_norm"))?;
+            Some((cross_attn, cross_attn_ln))
+        } else {
+            None
+        };
+        let n_mlp = n_state * 4;
+        let mlp_linear1 = linear(n_state, n_mlp, vb.pp("fc1"))?;
+        let mlp_linear2 = linear(n_mlp, n_state, vb.pp("fc2"))?;
+        let mlp_ln = layer_norm(n_state, vb.pp("final_layer_norm"))?;
+        Ok(Self {
+            attn,
+            attn_ln,
+            cross_attn,
+            mlp_linear1,
+            mlp_linear2,
+            mlp_ln,
+            span,
+        })
+    }
+
+    fn forward(
+        &mut self,
+        x: &Tensor,
+        xa: Option<&Tensor>,
+        mask: Option<&Tensor>,
+        flush_kv_cache: bool,
+    ) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let attn = self
+            .attn
+            .forward(&self.attn_ln.forward(x)?, None, mask, flush_kv_cache)?;
+        let mut x = (x + attn)?;
+        if let Some((attn, ln)) = &mut self.cross_attn {
+            x = (&x + attn.forward(&ln.forward(&x)?, xa, None, flush_kv_cache)?)?;
+        }
+        let mlp = self.mlp_linear2.forward(
+            &self
+                .mlp_linear1
+                .forward(&self.mlp_ln.forward(&x)?)?
+                .gelu()?,
+        )?;
+        x + mlp
+    }
+
+    fn reset_kv_cache(&mut self) {
+        self.attn.reset_kv_cache();
+        if let Some((attn, _)) = &mut self.cross_attn {
+            attn.reset_kv_cache();
+        }
+    }
+}
+
+fn sinusoids(length: usize, channels: usize, device: &Device, dtype: DType) -> Result<Tensor> {
+    let max_timescale = 10000f32;
+    let log_timescale_increment = max_timescale.ln() / (channels / 2 - 1) as f32;
+    let inv_timescales: Vec<_> = (0..channels / 2)
+        .map(|i| (i as f32 * (-log_timescale_increment)).exp())
+        .collect();
+    let inv_timescales = Tensor::new(inv_timescales.as_slice(), device)?.unsqueeze(0)?;
+    let arange = Tensor::arange(0, length as u32, device)?
+        .to_dtype(DType::F32)?
+        .unsqueeze(1)?;
+    let sh = (length, channels / 2);
+    let scaled_time = (arange.broadcast_as(sh)? * inv_timescales.broadcast_as(sh)?)?;
+    let sincos = Tensor::cat(&[scaled_time.sin()?, scaled_time.cos()?], 1)?;
+    to_add_dtype(sincos, dtype)
+}
+
+#[derive(Debug, Clone)]
+pub struct AudioEncoder {
+    conv1: Conv1d,
+    conv2: Conv1d,
+    positional_embedding: Tensor,
+    blocks: Vec<ResidualAttentionBlock>,
+    ln_post: LayerNorm,
+    span: tracing::Span,
+    conv1_span: tracing::Span,
+    conv2_span: tracing::Span,
+}
+
+impl AudioEncoder {
+    fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
+        let span = tracing::span!(tracing::Level::TRACE, "audio-encoder");
+        let conv1_span = tracing::span!(tracing::Level::TRACE, "conv1");
+        let conv2_span = tracing::span!(tracing::Level::TRACE, "conv2");
+        let n_state = cfg.d_model;
+        let n_head = cfg.encoder_attention_heads;
+        let n_ctx = cfg.max_source_positions;
+        let cfg1 = Conv1dConfig {
+            padding: 1,
+            stride: 1,
+            groups: 1,
+            dilation: 1,
+            cudnn_fwd_algo: None,
+        };
+        let cfg2 = Conv1dConfig {
+            padding: 1,
+            stride: 2,
+            groups: 1,
+            dilation: 1,
+            cudnn_fwd_algo: None,
+        };
+        let conv1 = conv1d(cfg.num_mel_bins, n_state, 3, cfg1, vb.pp("conv1"))?;
+        let conv2 = conv1d(n_state, n_state, 3, cfg2, vb.pp("conv2"))?;
+        let positional_embedding = sinusoids(n_ctx, n_state, vb.device(), vb.dtype())?;
+        let blocks = (0..cfg.encoder_layers)
+            .map(|i| {
+                ResidualAttentionBlock::load(n_state, n_head, false, vb.pp(format!("layers.{i}")))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let ln_post = layer_norm(n_state, vb.pp("layer_norm"))?;
+        Ok(Self {
+            conv1,
+            conv2,
+            positional_embedding,
+            blocks,
+            ln_post,
+            conv1_span,
+            conv2_span,
+            span,
+        })
+    }
+
+    pub fn forward(&mut self, x: &Tensor, flush_kv_cache: bool) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let x = {
+            let _enter = self.conv1_span.enter();
+            self.conv1.forward(x)?.gelu()?
+        };
+        let x = {
+            let _enter = self.conv2_span.enter();
+            self.conv2.forward(&x)?.gelu()?
+        };
+        let x = x.transpose(1, 2)?;
+        let (_bsize, seq_len, _hidden) = x.dims3()?;
+        let positional_embedding = self.positional_embedding.narrow(0, 0, seq_len)?;
+        let positional_embedding = to_add_dtype(positional_embedding, x.dtype())?;
+        let mut x = x.broadcast_add(&positional_embedding)?;
+        for block in self.blocks.iter_mut() {
+            x = block.forward(&x, None, None, flush_kv_cache)?
+        }
+        let x = self.ln_post.forward(&x)?;
+        Ok(x)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TextDecoder {
+    token_embedding: Embedding,
+    positional_embedding: Tensor,
+    blocks: Vec<ResidualAttentionBlock>,
+    ln: LayerNorm,
+    mask: Tensor,
+    span: tracing::Span,
+    span_final: tracing::Span,
+}
+
+impl TextDecoder {
+    fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
+        let span = tracing::span!(tracing::Level::TRACE, "text-decoder");
+        let span_final = tracing::span!(tracing::Level::TRACE, "text-decoder-final");
+        let n_state = cfg.d_model;
+        let n_head = cfg.decoder_attention_heads;
+        let n_ctx = cfg.max_target_positions;
+        let token_embedding = embedding(cfg.vocab_size, n_state, vb.pp("embed_tokens"))?;
+        let positional_embedding = vb.get((n_ctx, n_state), "embed_positions.weight")?;
+        let blocks = (0..cfg.decoder_layers)
+            .map(|i| {
+                ResidualAttentionBlock::load(n_state, n_head, true, vb.pp(format!("layers.{i}")))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let ln = layer_norm(n_state, vb.pp("layer_norm"))?;
+        let mask = causal_attention_mask(n_ctx, vb.dtype(), vb.device())?;
+        Ok(Self {
+            token_embedding,
+            positional_embedding,
+            blocks,
+            ln,
+            mask,
+            span,
+            span_final,
+        })
+    }
+
+    pub fn forward(&mut self, x: &Tensor, xa: &Tensor, flush_kv_cache: bool) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let last = x.dim(D::Minus1)?;
+        let token_embedding = self.token_embedding.forward(x)?;
+        let positional_embedding = self.positional_embedding.narrow(0, 0, last)?;
+        let positional_embedding = to_add_dtype(positional_embedding, token_embedding.dtype())?;
+        let mut x = token_embedding.broadcast_add(&positional_embedding)?;
+        for block in self.blocks.iter_mut() {
+            x = block.forward(&x, Some(xa), Some(&self.mask), flush_kv_cache)?;
+        }
+        self.ln.forward(&x)
+    }
+
+    pub fn final_linear(&self, x: &Tensor) -> Result<Tensor> {
+        let b_size = x.dim(0)?;
+        let w = self.token_embedding.embeddings().broadcast_left(b_size)?;
+        let logits = {
+            let _enter = self.span_final.enter();
+            x.matmul(&w.t()?)?
+        };
+        Ok(logits)
+    }
+
+    pub fn reset_kv_cache(&mut self) {
+        for block in self.blocks.iter_mut() {
+            block.reset_kv_cache();
+        }
+    }
+}
+
+fn causal_attention_mask(n_ctx: usize, dtype: DType, device: &Device) -> Result<Tensor> {
+    let mask: Vec<_> = (0..n_ctx)
+        .flat_map(|i| (0..n_ctx).map(move |j| if j > i { f32::NEG_INFINITY } else { 0f32 }))
+        .collect();
+    let mask = Tensor::from_vec(mask, (n_ctx, n_ctx), device)?;
+    to_add_dtype(mask, dtype)
+}
+
+#[derive(Debug, Clone)]
+pub struct Whisper {
+    pub encoder: AudioEncoder,
+    pub decoder: TextDecoder,
+    pub config: Config,
+}
+
+impl Whisper {
+    pub fn load(vb: &VarBuilder, config: Config) -> Result<Self> {
+        let encoder = AudioEncoder::load(vb.pp("model.encoder"), &config)?;
+        let decoder = TextDecoder::load(vb.pp("model.decoder"), &config)?;
+        Ok(Self {
+            encoder,
+            decoder,
+            config,
+        })
+    }
+
+    pub fn reset_kv_cache(&mut self) {
+        self.encoder
+            .blocks
+            .iter_mut()
+            .for_each(|b| b.reset_kv_cache());
+        self.decoder.reset_kv_cache();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{causal_attention_mask, sinusoids};
+    use candle_core::{DType, Device, Tensor};
+
+    #[test]
+    fn sinusoidal_embedding_uses_requested_dtype() {
+        let device = Device::Cpu;
+        let pos = sinusoids(4, 8, &device, DType::F16).expect("sinusoids");
+        assert_eq!(pos.dtype(), DType::F16);
+
+        let activations = Tensor::zeros((1, 4, 8), DType::F16, &device).expect("activations");
+        activations
+            .broadcast_add(&pos)
+            .expect("same-dtype positional add");
+    }
+
+    #[test]
+    fn decoder_mask_uses_requested_dtype() {
+        let device = Device::Cpu;
+        let mask = causal_attention_mask(4, DType::F16, &device).expect("mask");
+        assert_eq!(mask.dtype(), DType::F16);
+
+        let scores = Tensor::zeros((1, 2, 4, 4), DType::F16, &device).expect("scores");
+        scores.broadcast_add(&mask).expect("same-dtype mask add");
+    }
+}

--- a/crates/izwi-core/src/models/shared/attention/flash.rs
+++ b/crates/izwi-core/src/models/shared/attention/flash.rs
@@ -13,8 +13,7 @@ use crate::error::Result;
 use crate::models::shared::telemetry::{
     record_fused_attention_attempt, record_fused_attention_fallback,
     record_fused_attention_masked_attempt, record_fused_attention_masked_fallback,
-    record_fused_attention_masked_success, record_fused_attention_success,
-    AttentionFallbackReason,
+    record_fused_attention_masked_success, record_fused_attention_success, AttentionFallbackReason,
 };
 
 /// Runtime opt-in for fused attention paths.
@@ -40,6 +39,17 @@ pub fn should_enable_flash_attention_v2(device: &candle_core::Device) -> bool {
     flash_attention_requested() && device.is_cuda() && flash_attention_compiled()
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CudaAttentionBackend {
+    FlashAttention2,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum CudaAttentionDecision {
+    Try(CudaAttentionBackend),
+    Skip(AttentionFallbackReason),
+}
+
 /// Try a fused self-attention kernel and return `None` when unsupported.
 ///
 /// Input/output layout: `[batch, heads, seq, head_dim]`.
@@ -59,12 +69,12 @@ pub fn try_fused_self_attention(
     }
     let mut fallback_reason = AttentionFallbackReason::UnsupportedBackend;
 
-    #[cfg(feature = "flash-attn")]
-    {
-        if should_enable_flash_attention_v2(q.device()) {
-            if mask.is_none() {
-                if dtype_supported_for_flash(q.dtype()) {
-                    if q.dtype() == k.dtype() && k.dtype() == v.dtype() {
+    if q.device().is_cuda() {
+        match select_cuda_attention_backend(q, k, v, mask)? {
+            CudaAttentionDecision::Try(CudaAttentionBackend::FlashAttention2) => {
+                fallback_reason = {
+                    #[cfg(feature = "flash-attn")]
+                    {
                         let q = q.transpose(1, 2)?.contiguous()?;
                         let k = k.transpose(1, 2)?.contiguous()?;
                         let v = v.transpose(1, 2)?.contiguous()?;
@@ -80,32 +90,18 @@ pub fn try_fused_self_attention(
                                 }
                                 return Ok(Some(out.transpose(1, 2)?));
                             }
-                            Ok(Err(_)) | Err(_) => {
-                                fallback_reason = AttentionFallbackReason::FlashRuntimeError;
-                            }
+                            Ok(Err(_)) | Err(_) => AttentionFallbackReason::FlashRuntimeError,
                         }
-                    } else {
-                        fallback_reason = AttentionFallbackReason::FlashDTypeMismatch;
                     }
-                } else {
-                    fallback_reason = AttentionFallbackReason::FlashDTypeUnsupported;
-                }
-            } else {
-                fallback_reason = AttentionFallbackReason::FlashMaskUnsupported;
+                    #[cfg(not(feature = "flash-attn"))]
+                    {
+                        AttentionFallbackReason::FlashNotCompiled
+                    }
+                };
             }
-        } else if q.device().is_cuda() {
-            fallback_reason = AttentionFallbackReason::FlashNotRequested;
-        }
-    }
-
-    #[cfg(not(feature = "flash-attn"))]
-    {
-        if q.device().is_cuda() {
-            fallback_reason = if flash_attention_requested() {
-                AttentionFallbackReason::FlashNotCompiled
-            } else {
-                AttentionFallbackReason::FlashNotRequested
-            };
+            CudaAttentionDecision::Skip(reason) => {
+                fallback_reason = reason;
+            }
         }
     }
 
@@ -145,6 +141,48 @@ pub fn try_fused_self_attention(
         record_fused_attention_masked_fallback();
     }
     Ok(None)
+}
+
+pub fn select_cuda_attention_backend(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    mask: Option<&Tensor>,
+) -> Result<CudaAttentionDecision> {
+    Ok(select_cuda_flash_policy(
+        flash_attention_requested(),
+        flash_attention_compiled(),
+        mask.is_some(),
+        q.dtype(),
+        k.dtype(),
+        v.dtype(),
+    ))
+}
+
+fn select_cuda_flash_policy(
+    flash_requested: bool,
+    flash_compiled: bool,
+    masked: bool,
+    q_dtype: DType,
+    k_dtype: DType,
+    v_dtype: DType,
+) -> CudaAttentionDecision {
+    if !flash_requested {
+        return CudaAttentionDecision::Skip(AttentionFallbackReason::FlashNotRequested);
+    }
+    if !flash_compiled {
+        return CudaAttentionDecision::Skip(AttentionFallbackReason::FlashNotCompiled);
+    }
+    if masked {
+        return CudaAttentionDecision::Skip(AttentionFallbackReason::FlashMaskUnsupported);
+    }
+    if !dtype_supported_for_flash_policy(q_dtype) {
+        return CudaAttentionDecision::Skip(AttentionFallbackReason::FlashDTypeUnsupported);
+    }
+    if q_dtype != k_dtype || k_dtype != v_dtype {
+        return CudaAttentionDecision::Skip(AttentionFallbackReason::FlashDTypeMismatch);
+    }
+    CudaAttentionDecision::Try(CudaAttentionBackend::FlashAttention2)
 }
 
 /// Conservative preflight for Metal SDPA.
@@ -350,13 +388,81 @@ fn dtype_supported_for_flash(dtype: candle_core::DType) -> bool {
     matches!(dtype, candle_core::DType::F16 | candle_core::DType::BF16)
 }
 
+fn dtype_supported_for_flash_policy(dtype: candle_core::DType) -> bool {
+    matches!(dtype, candle_core::DType::F16 | candle_core::DType::BF16)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        metal_sdpa_mask_shape_supported, metal_sdpa_shape_supported, should_use_metal_sdpa_f16_cast,
+        metal_sdpa_mask_shape_supported, metal_sdpa_shape_supported, select_cuda_flash_policy,
+        should_use_metal_sdpa_f16_cast, CudaAttentionBackend, CudaAttentionDecision,
     };
     use candle_core::DType;
     use candle_core::{Device, Tensor};
+
+    use crate::models::shared::telemetry::AttentionFallbackReason;
+
+    fn assert_skips(decision: CudaAttentionDecision, expected: AttentionFallbackReason) {
+        match decision {
+            CudaAttentionDecision::Skip(reason) => {
+                assert_eq!(
+                    std::mem::discriminant(&reason),
+                    std::mem::discriminant(&expected)
+                );
+            }
+            CudaAttentionDecision::Try(backend) => {
+                panic!("expected skip {expected:?}, got try {backend:?}");
+            }
+        }
+    }
+
+    fn assert_tries(decision: CudaAttentionDecision, expected: CudaAttentionBackend) {
+        match decision {
+            CudaAttentionDecision::Try(backend) => {
+                assert_eq!(backend, expected);
+            }
+            CudaAttentionDecision::Skip(reason) => {
+                panic!("expected try {expected:?}, got skip {reason:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn cuda_flash_policy_records_skip_reasons() {
+        assert_skips(
+            select_cuda_flash_policy(false, true, false, DType::F16, DType::F16, DType::F16),
+            AttentionFallbackReason::FlashNotRequested,
+        );
+        assert_skips(
+            select_cuda_flash_policy(true, false, false, DType::F16, DType::F16, DType::F16),
+            AttentionFallbackReason::FlashNotCompiled,
+        );
+        assert_skips(
+            select_cuda_flash_policy(true, true, true, DType::F16, DType::F16, DType::F16),
+            AttentionFallbackReason::FlashMaskUnsupported,
+        );
+        assert_skips(
+            select_cuda_flash_policy(true, true, false, DType::F32, DType::F32, DType::F32),
+            AttentionFallbackReason::FlashDTypeUnsupported,
+        );
+        assert_skips(
+            select_cuda_flash_policy(true, true, false, DType::F16, DType::BF16, DType::F16),
+            AttentionFallbackReason::FlashDTypeMismatch,
+        );
+    }
+
+    #[test]
+    fn cuda_flash_policy_accepts_supported_unmasked_half_attention() {
+        assert_tries(
+            select_cuda_flash_policy(true, true, false, DType::F16, DType::F16, DType::F16),
+            CudaAttentionBackend::FlashAttention2,
+        );
+        assert_tries(
+            select_cuda_flash_policy(true, true, false, DType::BF16, DType::BF16, DType::BF16),
+            CudaAttentionBackend::FlashAttention2,
+        );
+    }
 
     #[test]
     fn metal_sdpa_shape_gate_accepts_supported_shapes() {

--- a/crates/izwi-core/src/models/shared/attention/paged.rs
+++ b/crates/izwi-core/src/models/shared/attention/paged.rs
@@ -61,6 +61,51 @@ pub fn default_kv_quantization() -> KvCacheQuantization {
         .unwrap_or(KvCacheQuantization::None)
 }
 
+/// Resolve KV quantization for the target append device.
+///
+/// CUDA Q4_0 currently uses host-vector pack/unpack. Keep that fallback explicit
+/// until a Rust-owned CUDA kernel exists for this format.
+pub fn resolve_kv_cache_quantization(
+    device: &candle_core::Device,
+    requested: KvCacheQuantization,
+) -> Result<KvCacheQuantization> {
+    kv_cache_quantization_policy(
+        device.is_cuda(),
+        requested,
+        env_bool("IZWI_CUDA_KV_Q4_0_HOST_FALLBACK", false),
+    )
+}
+
+fn kv_cache_quantization_policy(
+    is_cuda: bool,
+    requested: KvCacheQuantization,
+    cuda_q4_0_host_fallback_enabled: bool,
+) -> Result<KvCacheQuantization> {
+    if is_cuda
+        && requested == KvCacheQuantization::Q4_0
+        && !cuda_q4_0_host_fallback_enabled
+    {
+        return Err(Error::InvalidInput(
+            "CUDA Q4_0 KV cache quantization requires a CUDA kernel or explicit \
+             IZWI_CUDA_KV_Q4_0_HOST_FALLBACK=1 host fallback"
+                .to_string(),
+        ));
+    }
+    Ok(requested)
+}
+
+fn env_bool(name: &str, default: bool) -> bool {
+    std::env::var(name)
+        .ok()
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(default)
+}
+
 /// Single KV page storage (dense or quantized).
 #[derive(Debug, Clone)]
 pub enum KvPage {
@@ -336,6 +381,7 @@ pub fn append_to_pages(
     append: &Tensor,
     quantization: KvCacheQuantization,
 ) -> Result<()> {
+    let quantization = resolve_kv_cache_quantization(append.device(), quantization)?;
     if page_size == 0 {
         return Err(Error::InvalidInput(
             "KV page size must be greater than zero".to_string(),
@@ -414,16 +460,34 @@ fn parse_env_positive_usize(name: &str) -> Option<usize> {
 
 fn paged_decode_page_group_size(device: &candle_core::Device, page_count: usize) -> usize {
     let override_pages = parse_env_positive_usize("IZWI_PAGED_DECODE_GROUP_PAGES");
-    paged_decode_page_group_size_policy(device.is_metal(), page_count, override_pages)
+    paged_decode_page_group_size_policy(
+        device.is_metal(),
+        device.is_cuda(),
+        page_count,
+        override_pages,
+    )
 }
 
 fn paged_decode_page_group_size_policy(
     is_metal: bool,
+    is_cuda: bool,
     page_count: usize,
     override_pages: Option<usize>,
 ) -> usize {
     if let Some(override_pages) = override_pages {
         return override_pages.max(1);
+    }
+    if is_cuda {
+        if page_count >= 64 {
+            return 16;
+        }
+        if page_count >= 24 {
+            return 8;
+        }
+        if page_count >= 8 {
+            return 4;
+        }
+        return 1;
     }
     if !is_metal || page_count < 8 {
         return 1;
@@ -564,6 +628,16 @@ pub fn paged_decode_attention(
         )));
     }
     record_decode_attention_path(DecodeAttentionPath::Paged);
+    if q.device().is_cuda() {
+        if let Some(out) = crate::kernels::cuda::try_cuda_paged_decode_attention(
+            q,
+            head_dim,
+            num_heads,
+            num_kv_heads,
+        )? {
+            return Ok(out);
+        }
+    }
     let page_group_size = paged_decode_page_group_size(q.device(), k_pages.len());
     paged_decode_attention_with_group_size(
         q,
@@ -841,19 +915,46 @@ mod tests {
 
     #[test]
     fn test_paged_decode_page_group_policy_scales_on_metal() {
-        assert_eq!(paged_decode_page_group_size_policy(true, 1, None), 1);
-        assert_eq!(paged_decode_page_group_size_policy(true, 7, None), 1);
-        assert_eq!(paged_decode_page_group_size_policy(true, 8, None), 2);
-        assert_eq!(paged_decode_page_group_size_policy(true, 23, None), 2);
-        assert_eq!(paged_decode_page_group_size_policy(true, 24, None), 4);
-        assert_eq!(paged_decode_page_group_size_policy(true, 63, None), 4);
-        assert_eq!(paged_decode_page_group_size_policy(true, 64, None), 8);
+        assert_eq!(paged_decode_page_group_size_policy(true, false, 1, None), 1);
+        assert_eq!(paged_decode_page_group_size_policy(true, false, 7, None), 1);
+        assert_eq!(paged_decode_page_group_size_policy(true, false, 8, None), 2);
+        assert_eq!(paged_decode_page_group_size_policy(true, false, 23, None), 2);
+        assert_eq!(paged_decode_page_group_size_policy(true, false, 24, None), 4);
+        assert_eq!(paged_decode_page_group_size_policy(true, false, 63, None), 4);
+        assert_eq!(paged_decode_page_group_size_policy(true, false, 64, None), 8);
+    }
+
+    #[test]
+    fn test_paged_decode_page_group_policy_scales_on_cuda() {
+        assert_eq!(paged_decode_page_group_size_policy(false, true, 1, None), 1);
+        assert_eq!(paged_decode_page_group_size_policy(false, true, 7, None), 1);
+        assert_eq!(paged_decode_page_group_size_policy(false, true, 8, None), 4);
+        assert_eq!(paged_decode_page_group_size_policy(false, true, 23, None), 4);
+        assert_eq!(paged_decode_page_group_size_policy(false, true, 24, None), 8);
+        assert_eq!(paged_decode_page_group_size_policy(false, true, 63, None), 8);
+        assert_eq!(paged_decode_page_group_size_policy(false, true, 64, None), 16);
     }
 
     #[test]
     fn test_paged_decode_page_group_policy_respects_overrides() {
-        assert_eq!(paged_decode_page_group_size_policy(false, 128, None), 1);
-        assert_eq!(paged_decode_page_group_size_policy(true, 128, Some(3)), 3);
+        assert_eq!(paged_decode_page_group_size_policy(false, false, 128, None), 1);
+        assert_eq!(paged_decode_page_group_size_policy(true, false, 128, Some(3)), 3);
+        assert_eq!(paged_decode_page_group_size_policy(false, true, 128, Some(5)), 5);
+    }
+
+    #[test]
+    fn test_kv_quantization_policy_blocks_implicit_cuda_q4_host_fallback() {
+        assert!(kv_cache_quantization_policy(false, KvCacheQuantization::Q4_0, false).is_ok());
+        assert!(kv_cache_quantization_policy(true, KvCacheQuantization::None, false).is_ok());
+        assert!(kv_cache_quantization_policy(true, KvCacheQuantization::Int8, false).is_ok());
+        assert!(kv_cache_quantization_policy(true, KvCacheQuantization::Q4_0, false).is_err());
+    }
+
+    #[test]
+    fn test_kv_quantization_policy_allows_explicit_cuda_q4_host_fallback() {
+        let selected =
+            kv_cache_quantization_policy(true, KvCacheQuantization::Q4_0, true).unwrap();
+        assert_eq!(selected, KvCacheQuantization::Q4_0);
     }
 
     #[test]

--- a/crates/izwi-core/src/models/shared/telemetry.rs
+++ b/crates/izwi-core/src/models/shared/telemetry.rs
@@ -39,6 +39,15 @@ pub struct KernelPathTelemetrySnapshot {
     pub fused_attention_fallback_metal_sdpa_mask_shape_unsupported_total: u64,
     pub fused_attention_fallback_metal_sdpa_mask_dtype_unsupported_total: u64,
     pub fused_attention_fallback_unsupported_backend_total: u64,
+    pub cuda_kernel_attempts_total: u64,
+    pub cuda_kernel_success_total: u64,
+    pub cuda_kernel_fallback_total: u64,
+    pub cuda_kernel_fallback_not_compiled_total: u64,
+    pub cuda_kernel_fallback_not_cuda_device_total: u64,
+    pub cuda_kernel_fallback_not_implemented_total: u64,
+    pub cuda_kernel_fallback_unsupported_dtype_total: u64,
+    pub cuda_kernel_fallback_unsupported_shape_total: u64,
+    pub cuda_kernel_fallback_capability_missing_total: u64,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -60,6 +69,29 @@ pub enum AttentionFallbackReason {
     MetalSdpaMaskShapeUnsupported,
     MetalSdpaMaskDTypeUnsupported,
     UnsupportedBackend,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CudaKernelFallbackReason {
+    NotCompiled,
+    NotCudaDevice,
+    NotImplemented,
+    UnsupportedDType,
+    UnsupportedShape,
+    CapabilityMissing,
+}
+
+impl CudaKernelFallbackReason {
+    fn as_label(self) -> &'static str {
+        match self {
+            Self::NotCompiled => "not_compiled",
+            Self::NotCudaDevice => "not_cuda_device",
+            Self::NotImplemented => "not_implemented",
+            Self::UnsupportedDType => "unsupported_dtype",
+            Self::UnsupportedShape => "unsupported_shape",
+            Self::CapabilityMissing => "capability_missing",
+        }
+    }
 }
 
 impl AttentionFallbackReason {
@@ -110,11 +142,18 @@ static FUSED_ATTN_FALLBACK_FLASH_DTYPE_MISMATCH_TOTAL: AtomicU64 = AtomicU64::ne
 static FUSED_ATTN_FALLBACK_FLASH_RUNTIME_ERROR_TOTAL: AtomicU64 = AtomicU64::new(0);
 static FUSED_ATTN_FALLBACK_METAL_SDPA_RUNTIME_ERROR_TOTAL: AtomicU64 = AtomicU64::new(0);
 static FUSED_ATTN_FALLBACK_METAL_SDPA_MASK_POLICY_DISABLED_TOTAL: AtomicU64 = AtomicU64::new(0);
-static FUSED_ATTN_FALLBACK_METAL_SDPA_MASK_SHAPE_UNSUPPORTED_TOTAL: AtomicU64 =
-    AtomicU64::new(0);
-static FUSED_ATTN_FALLBACK_METAL_SDPA_MASK_DTYPE_UNSUPPORTED_TOTAL: AtomicU64 =
-    AtomicU64::new(0);
+static FUSED_ATTN_FALLBACK_METAL_SDPA_MASK_SHAPE_UNSUPPORTED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static FUSED_ATTN_FALLBACK_METAL_SDPA_MASK_DTYPE_UNSUPPORTED_TOTAL: AtomicU64 = AtomicU64::new(0);
 static FUSED_ATTN_FALLBACK_UNSUPPORTED_BACKEND_TOTAL: AtomicU64 = AtomicU64::new(0);
+static CUDA_KERNEL_ATTEMPTS_TOTAL: AtomicU64 = AtomicU64::new(0);
+static CUDA_KERNEL_SUCCESS_TOTAL: AtomicU64 = AtomicU64::new(0);
+static CUDA_KERNEL_FALLBACK_TOTAL: AtomicU64 = AtomicU64::new(0);
+static CUDA_KERNEL_FALLBACK_NOT_COMPILED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static CUDA_KERNEL_FALLBACK_NOT_CUDA_DEVICE_TOTAL: AtomicU64 = AtomicU64::new(0);
+static CUDA_KERNEL_FALLBACK_NOT_IMPLEMENTED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static CUDA_KERNEL_FALLBACK_UNSUPPORTED_DTYPE_TOTAL: AtomicU64 = AtomicU64::new(0);
+static CUDA_KERNEL_FALLBACK_UNSUPPORTED_SHAPE_TOTAL: AtomicU64 = AtomicU64::new(0);
+static CUDA_KERNEL_FALLBACK_CAPABILITY_MISSING_TOTAL: AtomicU64 = AtomicU64::new(0);
 
 pub fn record_prefill_token_mode_step() {
     PREFILL_TOKEN_MODE_STEPS_TOTAL.fetch_add(1, Ordering::Relaxed);
@@ -224,6 +263,38 @@ pub fn record_fused_attention_fallback(reason: AttentionFallbackReason) {
     }
 }
 
+pub fn record_cuda_kernel_attempt() {
+    CUDA_KERNEL_ATTEMPTS_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn record_cuda_kernel_success() {
+    CUDA_KERNEL_SUCCESS_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn record_cuda_kernel_fallback(reason: CudaKernelFallbackReason) {
+    CUDA_KERNEL_FALLBACK_TOTAL.fetch_add(1, Ordering::Relaxed);
+    match reason {
+        CudaKernelFallbackReason::NotCompiled => {
+            CUDA_KERNEL_FALLBACK_NOT_COMPILED_TOTAL.fetch_add(1, Ordering::Relaxed);
+        }
+        CudaKernelFallbackReason::NotCudaDevice => {
+            CUDA_KERNEL_FALLBACK_NOT_CUDA_DEVICE_TOTAL.fetch_add(1, Ordering::Relaxed);
+        }
+        CudaKernelFallbackReason::NotImplemented => {
+            CUDA_KERNEL_FALLBACK_NOT_IMPLEMENTED_TOTAL.fetch_add(1, Ordering::Relaxed);
+        }
+        CudaKernelFallbackReason::UnsupportedDType => {
+            CUDA_KERNEL_FALLBACK_UNSUPPORTED_DTYPE_TOTAL.fetch_add(1, Ordering::Relaxed);
+        }
+        CudaKernelFallbackReason::UnsupportedShape => {
+            CUDA_KERNEL_FALLBACK_UNSUPPORTED_SHAPE_TOTAL.fetch_add(1, Ordering::Relaxed);
+        }
+        CudaKernelFallbackReason::CapabilityMissing => {
+            CUDA_KERNEL_FALLBACK_CAPABILITY_MISSING_TOTAL.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
 pub fn snapshot() -> KernelPathTelemetrySnapshot {
     KernelPathTelemetrySnapshot {
         prefill_token_mode_steps_total: PREFILL_TOKEN_MODE_STEPS_TOTAL.load(Ordering::Relaxed),
@@ -274,6 +345,21 @@ pub fn snapshot() -> KernelPathTelemetrySnapshot {
             FUSED_ATTN_FALLBACK_METAL_SDPA_MASK_DTYPE_UNSUPPORTED_TOTAL.load(Ordering::Relaxed),
         fused_attention_fallback_unsupported_backend_total:
             FUSED_ATTN_FALLBACK_UNSUPPORTED_BACKEND_TOTAL.load(Ordering::Relaxed),
+        cuda_kernel_attempts_total: CUDA_KERNEL_ATTEMPTS_TOTAL.load(Ordering::Relaxed),
+        cuda_kernel_success_total: CUDA_KERNEL_SUCCESS_TOTAL.load(Ordering::Relaxed),
+        cuda_kernel_fallback_total: CUDA_KERNEL_FALLBACK_TOTAL.load(Ordering::Relaxed),
+        cuda_kernel_fallback_not_compiled_total: CUDA_KERNEL_FALLBACK_NOT_COMPILED_TOTAL
+            .load(Ordering::Relaxed),
+        cuda_kernel_fallback_not_cuda_device_total: CUDA_KERNEL_FALLBACK_NOT_CUDA_DEVICE_TOTAL
+            .load(Ordering::Relaxed),
+        cuda_kernel_fallback_not_implemented_total: CUDA_KERNEL_FALLBACK_NOT_IMPLEMENTED_TOTAL
+            .load(Ordering::Relaxed),
+        cuda_kernel_fallback_unsupported_dtype_total: CUDA_KERNEL_FALLBACK_UNSUPPORTED_DTYPE_TOTAL
+            .load(Ordering::Relaxed),
+        cuda_kernel_fallback_unsupported_shape_total: CUDA_KERNEL_FALLBACK_UNSUPPORTED_SHAPE_TOTAL
+            .load(Ordering::Relaxed),
+        cuda_kernel_fallback_capability_missing_total:
+            CUDA_KERNEL_FALLBACK_CAPABILITY_MISSING_TOTAL.load(Ordering::Relaxed),
     }
 }
 
@@ -291,6 +377,14 @@ pub fn prometheus() -> String {
         AttentionFallbackReason::MetalSdpaMaskShapeUnsupported,
         AttentionFallbackReason::MetalSdpaMaskDTypeUnsupported,
         AttentionFallbackReason::UnsupportedBackend,
+    ];
+    let cuda_fallback_reasons = [
+        CudaKernelFallbackReason::NotCompiled,
+        CudaKernelFallbackReason::NotCudaDevice,
+        CudaKernelFallbackReason::NotImplemented,
+        CudaKernelFallbackReason::UnsupportedDType,
+        CudaKernelFallbackReason::UnsupportedShape,
+        CudaKernelFallbackReason::CapabilityMissing,
     ];
 
     let mut output = format!(
@@ -312,7 +406,10 @@ pub fn prometheus() -> String {
 # TYPE izwi_kernel_fused_attention_fallback_total counter\nizwi_kernel_fused_attention_fallback_total {}\n\
 # TYPE izwi_kernel_fused_attention_masked_attempts_total counter\nizwi_kernel_fused_attention_masked_attempts_total {}\n\
 # TYPE izwi_kernel_fused_attention_masked_success_total counter\nizwi_kernel_fused_attention_masked_success_total {}\n\
-# TYPE izwi_kernel_fused_attention_masked_fallback_total counter\nizwi_kernel_fused_attention_masked_fallback_total {}\n",
+# TYPE izwi_kernel_fused_attention_masked_fallback_total counter\nizwi_kernel_fused_attention_masked_fallback_total {}\n\
+# TYPE izwi_cuda_kernel_attempts_total counter\nizwi_cuda_kernel_attempts_total {}\n\
+# TYPE izwi_cuda_kernel_success_total counter\nizwi_cuda_kernel_success_total {}\n\
+# TYPE izwi_cuda_kernel_fallback_total counter\nizwi_cuda_kernel_fallback_total {}\n",
         metrics.prefill_token_mode_steps_total,
         metrics.prefill_sequence_spans_total,
         metrics.prefill_sequence_tokens_total,
@@ -332,6 +429,9 @@ pub fn prometheus() -> String {
         metrics.fused_attention_masked_attempts_total,
         metrics.fused_attention_masked_success_total,
         metrics.fused_attention_masked_fallback_total,
+        metrics.cuda_kernel_attempts_total,
+        metrics.cuda_kernel_success_total,
+        metrics.cuda_kernel_fallback_total,
     );
 
     output.push_str("# TYPE izwi_kernel_fused_attention_fallback_reason_total counter\n");
@@ -340,6 +440,14 @@ pub fn prometheus() -> String {
             "izwi_kernel_fused_attention_fallback_reason_total{{reason=\"{}\"}} {}\n",
             reason.as_label(),
             fallback_total_for_reason(reason)
+        ));
+    }
+    output.push_str("# TYPE izwi_cuda_kernel_fallback_reason_total counter\n");
+    for reason in cuda_fallback_reasons {
+        output.push_str(&format!(
+            "izwi_cuda_kernel_fallback_reason_total{{reason=\"{}\"}} {}\n",
+            reason.as_label(),
+            cuda_fallback_total_for_reason(reason)
         ));
     }
 
@@ -384,6 +492,29 @@ fn fallback_total_for_reason(reason: AttentionFallbackReason) -> u64 {
     }
 }
 
+fn cuda_fallback_total_for_reason(reason: CudaKernelFallbackReason) -> u64 {
+    match reason {
+        CudaKernelFallbackReason::NotCompiled => {
+            CUDA_KERNEL_FALLBACK_NOT_COMPILED_TOTAL.load(Ordering::Relaxed)
+        }
+        CudaKernelFallbackReason::NotCudaDevice => {
+            CUDA_KERNEL_FALLBACK_NOT_CUDA_DEVICE_TOTAL.load(Ordering::Relaxed)
+        }
+        CudaKernelFallbackReason::NotImplemented => {
+            CUDA_KERNEL_FALLBACK_NOT_IMPLEMENTED_TOTAL.load(Ordering::Relaxed)
+        }
+        CudaKernelFallbackReason::UnsupportedDType => {
+            CUDA_KERNEL_FALLBACK_UNSUPPORTED_DTYPE_TOTAL.load(Ordering::Relaxed)
+        }
+        CudaKernelFallbackReason::UnsupportedShape => {
+            CUDA_KERNEL_FALLBACK_UNSUPPORTED_SHAPE_TOTAL.load(Ordering::Relaxed)
+        }
+        CudaKernelFallbackReason::CapabilityMissing => {
+            CUDA_KERNEL_FALLBACK_CAPABILITY_MISSING_TOTAL.load(Ordering::Relaxed)
+        }
+    }
+}
+
 #[cfg(test)]
 pub fn reset_for_tests() {
     for counter in [
@@ -417,6 +548,15 @@ pub fn reset_for_tests() {
         &FUSED_ATTN_FALLBACK_METAL_SDPA_MASK_SHAPE_UNSUPPORTED_TOTAL,
         &FUSED_ATTN_FALLBACK_METAL_SDPA_MASK_DTYPE_UNSUPPORTED_TOTAL,
         &FUSED_ATTN_FALLBACK_UNSUPPORTED_BACKEND_TOTAL,
+        &CUDA_KERNEL_ATTEMPTS_TOTAL,
+        &CUDA_KERNEL_SUCCESS_TOTAL,
+        &CUDA_KERNEL_FALLBACK_TOTAL,
+        &CUDA_KERNEL_FALLBACK_NOT_COMPILED_TOTAL,
+        &CUDA_KERNEL_FALLBACK_NOT_CUDA_DEVICE_TOTAL,
+        &CUDA_KERNEL_FALLBACK_NOT_IMPLEMENTED_TOTAL,
+        &CUDA_KERNEL_FALLBACK_UNSUPPORTED_DTYPE_TOTAL,
+        &CUDA_KERNEL_FALLBACK_UNSUPPORTED_SHAPE_TOTAL,
+        &CUDA_KERNEL_FALLBACK_CAPABILITY_MISSING_TOTAL,
     ] {
         counter.store(0, Ordering::Relaxed);
     }

--- a/crates/izwi-core/src/models/shared/weights/mod.rs
+++ b/crates/izwi-core/src/models/shared/weights/mod.rs
@@ -3,3 +3,4 @@
 pub mod gguf;
 pub mod layout;
 pub mod mlx;
+pub mod quantization;

--- a/crates/izwi-core/src/models/shared/weights/quantization.rs
+++ b/crates/izwi-core/src/models/shared/weights/quantization.rs
@@ -1,0 +1,247 @@
+//! Backend-aware quantized weight compatibility policy.
+//!
+//! This module does not load weights by itself. It centralizes the policy used
+//! to decide whether CUDA may use a native/delegated quantized path, an explicit
+//! dense fallback, or must reject an unsafe implicit host fallback.
+
+use candle_core::Device;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuantizedBackend {
+    Cpu,
+    Metal,
+    Cuda,
+}
+
+impl QuantizedBackend {
+    pub fn from_device(device: &Device) -> Self {
+        if device.is_cuda() {
+            Self::Cuda
+        } else if device.is_metal() {
+            Self::Metal
+        } else {
+            Self::Cpu
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuantizedWeightFormat {
+    DenseSafetensors,
+    GgufDense,
+    GgufQ4_0,
+    GgufQ4K,
+    GgufQ5K,
+    GgufQ8_0,
+    GgufOther,
+    MlxAffine,
+    KvCacheInt8,
+    KvCacheQ4_0,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuantizedExecutionMode {
+    ExistingBackendPath,
+    CandleCudaGeneric,
+    DenseDequantFallback,
+    ExplicitHostFallback,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuantizedCompatibilityReason {
+    ExistingCpuOrMetalPolicy,
+    DenseWeights,
+    DelegatedToCandleCuda,
+    CudaDenseFallbackRequired,
+    CudaKernelMissing,
+    ExplicitCudaHostFallback,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QuantizedCompatibility {
+    pub mode: QuantizedExecutionMode,
+    pub reason: QuantizedCompatibilityReason,
+}
+
+impl QuantizedCompatibility {
+    pub const fn new(mode: QuantizedExecutionMode, reason: QuantizedCompatibilityReason) -> Self {
+        Self { mode, reason }
+    }
+
+    pub const fn is_supported(self) -> bool {
+        !matches!(self.mode, QuantizedExecutionMode::Unsupported)
+    }
+}
+
+pub fn quantized_compatibility_for_device(
+    device: &Device,
+    format: QuantizedWeightFormat,
+) -> QuantizedCompatibility {
+    quantized_compatibility(
+        QuantizedBackend::from_device(device),
+        format,
+        cuda_quantized_host_fallback_enabled(),
+    )
+}
+
+pub fn quantized_compatibility(
+    backend: QuantizedBackend,
+    format: QuantizedWeightFormat,
+    explicit_cuda_host_fallback: bool,
+) -> QuantizedCompatibility {
+    if backend != QuantizedBackend::Cuda {
+        return QuantizedCompatibility::new(
+            QuantizedExecutionMode::ExistingBackendPath,
+            QuantizedCompatibilityReason::ExistingCpuOrMetalPolicy,
+        );
+    }
+
+    match format {
+        QuantizedWeightFormat::DenseSafetensors | QuantizedWeightFormat::GgufDense => {
+            QuantizedCompatibility::new(
+                QuantizedExecutionMode::ExistingBackendPath,
+                QuantizedCompatibilityReason::DenseWeights,
+            )
+        }
+        QuantizedWeightFormat::GgufQ4_0
+        | QuantizedWeightFormat::GgufQ4K
+        | QuantizedWeightFormat::GgufQ5K
+        | QuantizedWeightFormat::GgufQ8_0 => QuantizedCompatibility::new(
+            QuantizedExecutionMode::CandleCudaGeneric,
+            QuantizedCompatibilityReason::DelegatedToCandleCuda,
+        ),
+        QuantizedWeightFormat::MlxAffine => QuantizedCompatibility::new(
+            QuantizedExecutionMode::DenseDequantFallback,
+            QuantizedCompatibilityReason::CudaDenseFallbackRequired,
+        ),
+        QuantizedWeightFormat::KvCacheInt8 => QuantizedCompatibility::new(
+            QuantizedExecutionMode::ExistingBackendPath,
+            QuantizedCompatibilityReason::DenseWeights,
+        ),
+        QuantizedWeightFormat::KvCacheQ4_0 if explicit_cuda_host_fallback => {
+            QuantizedCompatibility::new(
+                QuantizedExecutionMode::ExplicitHostFallback,
+                QuantizedCompatibilityReason::ExplicitCudaHostFallback,
+            )
+        }
+        QuantizedWeightFormat::KvCacheQ4_0 | QuantizedWeightFormat::GgufOther => {
+            QuantizedCompatibility::new(
+                QuantizedExecutionMode::Unsupported,
+                QuantizedCompatibilityReason::CudaKernelMissing,
+            )
+        }
+    }
+}
+
+fn cuda_quantized_host_fallback_enabled() -> bool {
+    env_bool("IZWI_CUDA_QUANTIZED_HOST_FALLBACK") || env_bool("IZWI_CUDA_KV_Q4_0_HOST_FALLBACK")
+}
+
+fn env_bool(name: &str) -> bool {
+    std::env::var(name)
+        .ok()
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        quantized_compatibility, QuantizedBackend, QuantizedCompatibilityReason,
+        QuantizedExecutionMode, QuantizedWeightFormat,
+    };
+
+    #[test]
+    fn non_cuda_backends_keep_existing_policy_for_all_formats() {
+        for backend in [QuantizedBackend::Cpu, QuantizedBackend::Metal] {
+            for format in [
+                QuantizedWeightFormat::DenseSafetensors,
+                QuantizedWeightFormat::GgufQ4_0,
+                QuantizedWeightFormat::GgufQ4K,
+                QuantizedWeightFormat::GgufQ5K,
+                QuantizedWeightFormat::GgufQ8_0,
+                QuantizedWeightFormat::MlxAffine,
+                QuantizedWeightFormat::KvCacheInt8,
+                QuantizedWeightFormat::KvCacheQ4_0,
+            ] {
+                let policy = quantized_compatibility(backend, format, false);
+                assert_eq!(policy.mode, QuantizedExecutionMode::ExistingBackendPath);
+                assert_eq!(
+                    policy.reason,
+                    QuantizedCompatibilityReason::ExistingCpuOrMetalPolicy
+                );
+                assert!(policy.is_supported());
+            }
+        }
+    }
+
+    #[test]
+    fn cuda_delegates_known_gguf_quantized_formats_to_candle() {
+        for format in [
+            QuantizedWeightFormat::GgufQ4_0,
+            QuantizedWeightFormat::GgufQ4K,
+            QuantizedWeightFormat::GgufQ5K,
+            QuantizedWeightFormat::GgufQ8_0,
+        ] {
+            let policy = quantized_compatibility(QuantizedBackend::Cuda, format, false);
+            assert_eq!(policy.mode, QuantizedExecutionMode::CandleCudaGeneric);
+            assert_eq!(
+                policy.reason,
+                QuantizedCompatibilityReason::DelegatedToCandleCuda
+            );
+            assert!(policy.is_supported());
+        }
+    }
+
+    #[test]
+    fn cuda_marks_mlx_affine_as_dense_dequant_fallback() {
+        let policy = quantized_compatibility(
+            QuantizedBackend::Cuda,
+            QuantizedWeightFormat::MlxAffine,
+            false,
+        );
+        assert_eq!(policy.mode, QuantizedExecutionMode::DenseDequantFallback);
+        assert_eq!(
+            policy.reason,
+            QuantizedCompatibilityReason::CudaDenseFallbackRequired
+        );
+        assert!(policy.is_supported());
+    }
+
+    #[test]
+    fn cuda_blocks_unknown_and_implicit_q4_kv_fallbacks() {
+        for format in [
+            QuantizedWeightFormat::GgufOther,
+            QuantizedWeightFormat::KvCacheQ4_0,
+        ] {
+            let policy = quantized_compatibility(QuantizedBackend::Cuda, format, false);
+            assert_eq!(policy.mode, QuantizedExecutionMode::Unsupported);
+            assert_eq!(
+                policy.reason,
+                QuantizedCompatibilityReason::CudaKernelMissing
+            );
+            assert!(!policy.is_supported());
+        }
+    }
+
+    #[test]
+    fn cuda_allows_explicit_host_fallback_for_q4_kv_only() {
+        let policy = quantized_compatibility(
+            QuantizedBackend::Cuda,
+            QuantizedWeightFormat::KvCacheQ4_0,
+            true,
+        );
+        assert_eq!(policy.mode, QuantizedExecutionMode::ExplicitHostFallback);
+        assert_eq!(
+            policy.reason,
+            QuantizedCompatibilityReason::ExplicitCudaHostFallback
+        );
+        assert!(policy.is_supported());
+    }
+}


### PR DESCRIPTION
Introduces CUDA capability/dtype policy, kernel dispatch scaffolding, attention/KV/quantization compatibility gates, and Qwen CUDA hook points while preserving CPU/Metal paths.