### PR TITLE
Complete Candle-backed CUDA kernel support for supported models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,17 +391,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bindgen_cuda"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be55fb326843bb67cccceeeaf21c961ef303f60018f9a2ab69494dad8eaf9"
-dependencies = [
- "glob",
- "num_cpus",
- "rayon",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,17 +577,17 @@ dependencies = [
 
 [[package]]
 name = "candle-core"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15b675b80d994b2eadb20a4bbe434eabeb454eac3ee5e2b4cf6f147ee9be091"
+checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
 dependencies = [
  "accelerate-src",
  "byteorder",
  "candle-kernels",
  "candle-metal-kernels",
  "candle-ug",
- "cudarc 0.19.2",
- "float8 0.6.1",
+ "cudarc 0.19.4",
+ "float8",
  "gemm 0.19.0",
  "half",
  "libc",
@@ -613,46 +602,37 @@ dependencies = [
  "rayon",
  "safetensors 0.7.0",
  "thiserror 2.0.18",
+ "tokenizers",
  "yoke 0.8.1",
  "zip 7.4.0",
 ]
 
 [[package]]
 name = "candle-flash-attn"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94ddd2e7bb828777b0a8d999ed40d2d6c3c96c9ef2a3111a69e0d96efc436d2"
+checksum = "12512cf8e706744642e9a8579305a6ed1e44a0c636ce20c416cd5c519de19b7d"
 dependencies = [
  "anyhow",
- "bindgen_cuda",
  "candle-core",
- "candle-flash-attn-build",
+ "cudaforge",
  "half",
 ]
 
 [[package]]
-name = "candle-flash-attn-build"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd79da06f2a3b831cb4f5a1ee393d6f2c5a913e28f5000c678a84108519a78c"
-dependencies = [
- "anyhow",
-]
-
-[[package]]
 name = "candle-kernels"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8455f84bd810047c7c41216683c1020c915a9f8a740b3b0eabdd4fb2fbaa660"
+checksum = "742e2ac226b777134436e9e692f44e77c278b8a7abb1554dc10e44dc911b349f"
 dependencies = [
- "bindgen_cuda",
+ "cudaforge",
 ]
 
 [[package]]
 name = "candle-metal-kernels"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fdfe9d06de16ce49961e49084e5b79a75a9bdf157246e7c7b6328e87a7aa25d"
+checksum = "4b6b5a4cae6b4e1ab0efcee4dc05272d11b374a3d1ba121b3a961e36be54ab60"
 dependencies = [
  "half",
  "objc2 0.6.3",
@@ -665,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "candle-nn"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3045fa9e7aef8567d209a27d56b692f60b96f4d0569f4c3011f8ca6715c65e03"
+checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
 dependencies = [
  "accelerate-src",
  "candle-core",
@@ -684,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "candle-transformers"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b538ec4aa807c416a2ddd3621044888f188827862e2a6fcacba4738e89795d01"
+checksum = "f59d08c89e9f4af9c464e2f3a8e16199e7cc601e6f34538c2cfbb42b623b1783"
 dependencies = [
  "accelerate-src",
  "byteorder",
@@ -705,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "candle-ug"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d62be69068bf58987a45f690612739d8d2ea1bf508c1b87dc6815a019575d"
+checksum = "ca0fc3167cbc99c8ec1be618cb620aa21dca95038f118c3579a79370e3dc5f77"
 dependencies = [
  "ug",
  "ug-cuda",
@@ -1265,6 +1245,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cudaforge"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f7a0d45b139b5beeeb1c34188717e12241c44a0120afb498815ce7f5373c691"
+dependencies = [
+ "anyhow",
+ "fs2",
+ "glob",
+ "num_cpus",
+ "rayon",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "walkdir",
+ "which",
+]
+
+[[package]]
 name = "cudarc"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,11 +1275,11 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.19.2"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed81f178e780f3d5d354d12b4c5c5a484c4a9c329ecd037ac57f2a0e0648397"
+checksum = "f071cd6a7b5d51607df76aa2d426aaabc7a74bc6bdb885b8afa63a880572ad9b"
 dependencies = [
- "float8 0.7.0",
+ "float8",
  "half",
  "libloading 0.9.0",
 ]
@@ -1530,7 +1529,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1707,6 +1706,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,7 +1735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1835,24 +1840,14 @@ dependencies = [
 
 [[package]]
 name = "float8"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719a903cc23e4a89e87962c2a80fdb45cdaad0983a89bd150bb57b4c8571a7d5"
-dependencies = [
- "cudarc 0.19.2",
- "half",
- "num-traits",
- "rand 0.9.2",
- "rand_distr 0.5.1",
-]
-
-[[package]]
-name = "float8"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
 dependencies = [
  "half",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_distr 0.5.1",
 ]
 
 [[package]]
@@ -1922,6 +1917,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3002,7 +3007,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -4100,7 +4105,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5193,7 +5198,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.36",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5230,9 +5235,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5822,7 +5827,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5901,7 +5906,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7319,7 +7324,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8543,6 +8548,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8564,7 +8581,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9096,6 +9113,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,9 @@ safetensors = "0.4"
 tokenizers = "0.22.2"
 
 # Candle (native inference)
-candle-core = "0.9.2"
-candle-nn = "0.9.2"
-candle-transformers = "0.9.2"
+candle-core = "0.10.2"
+candle-nn = "0.10.2"
+candle-transformers = "0.10.2"
 
 # Audio processing
 hound = "3.5"

--- a/crates/izwi-core/Cargo.toml
+++ b/crates/izwi-core/Cargo.toml
@@ -24,7 +24,7 @@ tokenizers = { workspace = true }
 candle-core = { workspace = true }
 candle-nn = { workspace = true }
 candle-transformers = { workspace = true }
-candle-flash-attn = { version = "0.9.2", optional = true }
+candle-flash-attn = { version = "0.10.2", optional = true }
 
 hound = { workspace = true }
 symphonia = { workspace = true, default-features = false, features = [

--- a/crates/izwi-core/src/backends/router.rs
+++ b/crates/izwi-core/src/backends/router.rs
@@ -1,6 +1,8 @@
 use crate::catalog::{
     CudaQuantizationInfo, CudaSupportInfo, CudaSupportLevel, InferenceBackendHint, ModelVariant,
 };
+use crate::kernels::cuda;
+use crate::models::shared::attention::flash::cuda_flash_attention_capabilities;
 
 use super::capabilities::BackendCapabilities;
 use super::device::{DeviceProfile, DeviceSelector};
@@ -172,6 +174,29 @@ impl BackendRouter {
         }
 
         let mut diagnostics = Vec::new();
+        let kernel_status = cuda::status();
+        diagnostics.push(format!(
+            "CUDA Candle kernel dispatch is {}: {}",
+            if kernel_status.available {
+                "available"
+            } else {
+                "unavailable"
+            },
+            kernel_status.reason
+        ));
+
+        let flash = cuda_flash_attention_capabilities();
+        diagnostics.push(format!(
+            "CUDA FlashAttention compiled={}, max_head_dim={}, alignment={}, windowed={}, alibi={}, softcap={}, varlen={}",
+            flash.compiled,
+            flash.max_head_dim,
+            flash.head_dim_multiple,
+            flash.supports_windowed,
+            flash.supports_alibi,
+            flash.supports_softcap,
+            flash.supports_varlen
+        ));
+
         match cuda_support.level {
             CudaSupportLevel::CpuOnly | CudaSupportLevel::Disabled | CudaSupportLevel::Unknown => {
                 diagnostics.push(format!(
@@ -326,6 +351,20 @@ mod tests {
             plan.reason
         );
         assert!(!plan.diagnostics.is_empty());
+        assert!(
+            plan.diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.contains("CUDA Candle kernel dispatch")),
+            "CUDA diagnostics should include Candle kernel dispatch status: {:?}",
+            plan.diagnostics
+        );
+        assert!(
+            plan.diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.contains("CUDA FlashAttention")),
+            "CUDA diagnostics should include FlashAttention capability status: {:?}",
+            plan.diagnostics
+        );
     }
 
     #[test]

--- a/crates/izwi-core/src/catalog/cuda_support.rs
+++ b/crates/izwi-core/src/catalog/cuda_support.rs
@@ -127,7 +127,7 @@ impl ModelVariant {
             ),
             ModelFamily::SortformerDiarization => CudaSupportInfo::new(
                 CudaSupportLevel::CandleCudaGeneric,
-                "Sortformer keeps preprocessing/postprocessing on CPU but loads inference tensors on CUDA when selected",
+                "Sortformer uses Candle CUDA tensor kernels for inference when selected; preprocessing/postprocessing remain host-side orchestration",
             ),
             ModelFamily::Qwen3Tts
             | ModelFamily::KokoroTts
@@ -142,7 +142,7 @@ impl ModelVariant {
             | ModelFamily::Qwen3ForcedAligner
             | ModelFamily::Voxtral => CudaSupportInfo::new(
                 CudaSupportLevel::CandleCudaGeneric,
-                "model can be loaded on a CUDA Candle device but still needs CUDA-specific validation",
+                "model uses Candle CUDA tensor kernels, with CUDA-only Candle FlashAttention fast paths when shape and dtype support them",
             ),
         }
     }
@@ -244,6 +244,28 @@ mod tests {
                 variant.cuda_support_level(),
                 CudaSupportLevel::Unknown,
                 "{variant} should have an explicit CUDA support level"
+            );
+        }
+    }
+
+    #[test]
+    fn enabled_inference_families_report_candle_cuda_kernel_coverage() {
+        for variant in ModelVariant::all()
+            .iter()
+            .copied()
+            .filter(ModelVariant::is_enabled)
+            .filter(|variant| variant.family() != ModelFamily::Tokenizer)
+        {
+            let info = variant.cuda_support();
+            assert_eq!(
+                info.level,
+                CudaSupportLevel::CandleCudaGeneric,
+                "{variant} should use the Candle CUDA support class"
+            );
+            assert!(
+                info.reason.contains("Candle CUDA"),
+                "{variant} CUDA reason should name Candle CUDA coverage: {}",
+                info.reason
             );
         }
     }

--- a/crates/izwi-core/src/kernels/cuda.rs
+++ b/crates/izwi-core/src/kernels/cuda.rs
@@ -1,10 +1,11 @@
-//! CUDA kernel scaffold.
+//! CUDA kernel dispatch.
 //!
-//! This module defines the CUDA kernel dispatch surface without enabling any
-//! custom CUDA kernels yet. Callers can query the status and fall back to
-//! Candle operations until concrete kernels are implemented behind `cuda`.
+//! This module wires CUDA-only fused-operation entry points to Candle CUDA
+//! tensor kernels where Candle provides the primitive. These paths stay guarded
+//! by `Device::is_cuda()` and fall back to the caller's existing implementation
+//! when a shape, dtype, or build does not support the operation.
 
-use candle_core::Tensor;
+use candle_core::{DType, Tensor, D};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CudaKernelStatus {
@@ -18,7 +19,7 @@ pub fn cuda_kernels_compiled() -> bool {
 }
 
 pub fn fused_kernels_available() -> bool {
-    false
+    cuda_kernels_compiled()
 }
 
 pub fn use_block_fusion() -> bool {
@@ -36,53 +37,200 @@ pub fn status() -> CudaKernelStatus {
 
     CudaKernelStatus {
         compiled: true,
-        available: false,
-        reason: "custom CUDA kernels are scaffolded but not implemented",
+        available: true,
+        reason: "Candle CUDA kernel dispatch is enabled",
     }
 }
 
-pub fn try_fused_silu_mul(_gate: &Tensor, _up: &Tensor) -> Option<Tensor> {
-    None
+pub fn try_fused_silu_mul(gate: &Tensor, up: &Tensor) -> Option<Tensor> {
+    if !cuda_tensor_pair_supported(gate, up) {
+        return None;
+    }
+
+    let silu_gate = candle_nn::ops::silu(gate).ok()?;
+    silu_gate.broadcast_mul(up).ok()
 }
 
-pub fn try_fused_l2_norm(_input: &Tensor, _eps: f64) -> Option<Tensor> {
-    None
+pub fn try_fused_l2_norm(input: &Tensor, eps: f64) -> Option<Tensor> {
+    if !cuda_tensor_supported(input) || input.dtype() != DType::F32 {
+        return None;
+    }
+
+    input
+        .broadcast_div(
+            &(input.sqr().ok()?.sum_keepdim(D::Minus1).ok()? + eps)
+                .ok()?
+                .sqrt()
+                .ok()?,
+        )
+        .ok()
 }
 
-pub fn try_fused_rms_norm(_input: &Tensor, _weight: &Tensor, _eps: f64) -> Option<Tensor> {
-    None
+pub fn try_fused_rms_norm(input: &Tensor, weight: &Tensor, eps: f64) -> Option<Tensor> {
+    if !cuda_tensor_pair_supported(input, weight) {
+        return None;
+    }
+
+    candle_nn::ops::rms_norm(input, weight, eps as f32).ok()
 }
 
 pub fn try_fused_gated_rms_norm(
-    _hidden: &Tensor,
-    _gate: &Tensor,
-    _weight: &Tensor,
-    _eps: f64,
+    hidden: &Tensor,
+    gate: &Tensor,
+    weight: &Tensor,
+    eps: f64,
 ) -> Option<Tensor> {
-    None
+    if !cuda_tensor_pair_supported(hidden, gate) || !cuda_tensor_pair_supported(hidden, weight) {
+        return None;
+    }
+
+    let normalized = try_fused_rms_norm(hidden, weight, eps)?;
+    let silu_gate = candle_nn::ops::silu(gate).ok()?;
+    normalized.broadcast_mul(&silu_gate).ok()
 }
 
 pub fn try_fused_gated_delta_recurrent(
-    _query: &Tensor,
-    _key: &Tensor,
-    _value: &Tensor,
-    _g: &Tensor,
-    _beta: &Tensor,
-    _state: &Tensor,
+    query: &Tensor,
+    key: &Tensor,
+    value: &Tensor,
+    g: &Tensor,
+    beta: &Tensor,
+    state: &Tensor,
 ) -> Option<(Tensor, Tensor)> {
-    None
+    if !cuda_tensor_pair_supported(query, key)
+        || !cuda_tensor_pair_supported(query, value)
+        || !cuda_tensor_pair_supported(query, g)
+        || !cuda_tensor_pair_supported(query, beta)
+        || !cuda_tensor_pair_supported(query, state)
+        || query.dtype() != DType::F32
+    {
+        return None;
+    }
+
+    fused_gated_delta_candle(query, key, value, g, beta, state)
 }
 
 pub fn try_tiled_deltanet_recurrence(
-    _queries: &Tensor,
-    _keys: &Tensor,
-    _values: &Tensor,
-    _g: &Tensor,
-    _beta: &Tensor,
-    _initial_state: &Tensor,
-    _tile_size: usize,
+    queries: &Tensor,
+    keys: &Tensor,
+    values: &Tensor,
+    g: &Tensor,
+    beta: &Tensor,
+    initial_state: &Tensor,
+    tile_size: usize,
 ) -> Option<(Tensor, Tensor)> {
-    None
+    if !cuda_tensor_pair_supported(queries, keys)
+        || !cuda_tensor_pair_supported(queries, values)
+        || !cuda_tensor_pair_supported(queries, g)
+        || !cuda_tensor_pair_supported(queries, beta)
+        || !cuda_tensor_pair_supported(queries, initial_state)
+        || queries.dtype() != DType::F32
+    {
+        return None;
+    }
+
+    let (batch, seq_len, num_heads, head_k_dim) = queries.dims4().ok()?;
+    let (k_batch, k_seq_len, k_num_heads, k_head_k_dim) = keys.dims4().ok()?;
+    let (v_batch, v_seq_len, v_num_heads, _v_head_dim) = values.dims4().ok()?;
+    let (g_batch, g_seq_len, g_heads) = g.dims3().ok()?;
+    let (b_batch, b_seq_len, b_heads) = beta.dims3().ok()?;
+    let (s_batch, s_heads, s_head_k_dim, _s_head_v_dim) = initial_state.dims4().ok()?;
+
+    if batch != 1
+        || k_batch != batch
+        || v_batch != batch
+        || g_batch != batch
+        || b_batch != batch
+        || s_batch != batch
+    {
+        return None;
+    }
+    if k_seq_len != seq_len || v_seq_len != seq_len || g_seq_len != seq_len || b_seq_len != seq_len
+    {
+        return None;
+    }
+    if k_num_heads != num_heads || v_num_heads != num_heads || g_heads != num_heads {
+        return None;
+    }
+    if b_heads != num_heads || k_head_k_dim != head_k_dim || s_heads != num_heads {
+        return None;
+    }
+    if s_head_k_dim != head_k_dim {
+        return None;
+    }
+
+    let tile_size = tile_size.max(1).min(seq_len.max(1));
+    let mut outputs = Vec::with_capacity(seq_len);
+    let mut state = initial_state.clone();
+
+    for tile_start in (0..seq_len).step_by(tile_size) {
+        let tile_end = (tile_start + tile_size).min(seq_len);
+        for token_idx in tile_start..tile_end {
+            let query = queries.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
+            let key = keys.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
+            let value = values.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
+            let g_t = g.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
+            let beta_t = beta.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
+
+            let (output, next_state) =
+                fused_gated_delta_candle(&query, &key, &value, &g_t, &beta_t, &state)?;
+            outputs.push(output.unsqueeze(1).ok()?);
+            state = next_state;
+        }
+    }
+
+    let output_refs: Vec<&Tensor> = outputs.iter().collect();
+    let outputs = Tensor::cat(&output_refs, 1).ok()?;
+    Some((outputs, state))
+}
+
+fn cuda_tensor_supported(tensor: &Tensor) -> bool {
+    cuda_kernels_compiled() && tensor.device().is_cuda()
+}
+
+fn cuda_tensor_pair_supported(lhs: &Tensor, rhs: &Tensor) -> bool {
+    cuda_tensor_supported(lhs) && rhs.device().is_cuda() && lhs.dtype() == rhs.dtype()
+}
+
+fn fused_gated_delta_candle(
+    query: &Tensor,
+    key: &Tensor,
+    value: &Tensor,
+    g: &Tensor,
+    beta: &Tensor,
+    state: &Tensor,
+) -> Option<(Tensor, Tensor)> {
+    let dim = query.dim(D::Minus1).ok()?;
+    let scale = 1.0f64 / (dim as f64).sqrt();
+    let scaled_query = (query * scale).ok()?;
+    let g = g.exp().ok()?.reshape((1, g.dim(1).ok()?, 1, 1)).ok()?;
+    let beta = beta.reshape((1, beta.dim(1).ok()?, 1)).ok()?;
+
+    let gated_state = state.broadcast_mul(&g).ok()?;
+    let kv_mem = key
+        .unsqueeze(2)
+        .ok()?
+        .matmul(&gated_state)
+        .ok()?
+        .squeeze(2)
+        .ok()?;
+    let delta = (value - kv_mem).ok()?.broadcast_mul(&beta).ok()?;
+    let new_state = (&gated_state
+        + &key
+            .unsqueeze(3)
+            .ok()?
+            .matmul(&delta.unsqueeze(2).ok()?)
+            .ok()?)
+        .ok()?;
+    let output = scaled_query
+        .unsqueeze(2)
+        .ok()?
+        .matmul(&new_state)
+        .ok()?
+        .squeeze(2)
+        .ok()?;
+
+    Some((output, new_state))
 }
 
 #[cfg(test)]
@@ -93,7 +241,19 @@ mod tests {
     fn cuda_kernel_status_is_explicit() {
         let status = status();
         assert_eq!(status.compiled, cfg!(feature = "cuda"));
-        assert!(!status.available);
+        assert_eq!(status.available, cfg!(feature = "cuda"));
         assert!(!status.reason.trim().is_empty());
+    }
+
+    #[test]
+    fn cuda_candle_dispatch_rejects_cpu_tensors() {
+        let device = candle_core::Device::Cpu;
+        let lhs = Tensor::zeros((1, 2), DType::F32, &device).expect("lhs");
+        let rhs = Tensor::zeros((1, 2), DType::F32, &device).expect("rhs");
+
+        assert!(try_fused_silu_mul(&lhs, &rhs).is_none());
+        assert!(try_fused_l2_norm(&lhs, 1e-6).is_none());
+        assert!(try_fused_rms_norm(&lhs, &rhs, 1e-6).is_none());
+        assert!(try_fused_gated_rms_norm(&lhs, &rhs, &rhs, 1e-6).is_none());
     }
 }

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/backbone.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/backbone.rs
@@ -9,6 +9,9 @@ use candle_transformers::quantized_nn::RmsNorm;
 use candle_transformers::utils::repeat_kv as candle_repeat_kv;
 
 use crate::error::{Error, Result};
+use crate::models::shared::attention::flash::{
+    flash_attention_requested, try_fused_self_attention_with_options, CudaFlashAttentionOptions,
+};
 use crate::models::shared::telemetry::record_rope_kernel;
 use crate::models::shared::weights::gguf::GgufLoader;
 
@@ -32,6 +35,7 @@ struct AttentionLayer {
     n_head: usize,
     n_kv_head: usize,
     head_dim: usize,
+    sliding_window: Option<usize>,
     cos: Tensor,
     sin: Tensor,
     neg_inf: Tensor,
@@ -180,6 +184,26 @@ impl AttentionLayer {
             (key_states, value_states)
         };
         self.kv_cache = Some((all_keys.clone(), all_values.clone()));
+
+        if query_states.device().is_cuda() && flash_attention_requested() {
+            let cuda_options =
+                lfm25_cuda_flash_attention_options(mask.is_some(), self.sliding_window);
+            if let Some(attn_output) = try_fused_self_attention_with_options(
+                &query_states,
+                &all_keys,
+                &all_values,
+                None,
+                self.head_dim,
+                true,
+                cuda_options,
+            )? {
+                let attn_output =
+                    attn_output
+                        .transpose(1, 2)?
+                        .reshape((batch_size, seq_len, hidden_size))?;
+                return self.wo.forward(&attn_output).map_err(Error::from);
+            }
+        }
 
         let (key_states, value_states) = if self.n_head != self.n_kv_head {
             let repeats = self.n_head / self.n_kv_head;
@@ -507,6 +531,7 @@ impl QuantizedLfm2Backbone {
                     n_head: cfg.attention_head_count,
                     n_kv_head,
                     head_dim: cfg.embedding_length / cfg.attention_head_count,
+                    sliding_window: cfg.attention_sliding_window,
                     cos: cos.clone(),
                     sin: sin.clone(),
                     neg_inf: neg_inf.clone(),
@@ -665,6 +690,16 @@ fn masked_fill(on_false: &Tensor, mask: &Tensor, on_true: &Tensor) -> Result<Ten
         .map_err(Error::from)
 }
 
+fn lfm25_cuda_flash_attention_options(
+    masked_prefill: bool,
+    sliding_window: Option<usize>,
+) -> CudaFlashAttentionOptions<'static> {
+    CudaFlashAttentionOptions {
+        window_size_left: if masked_prefill { sliding_window } else { None },
+        ..CudaFlashAttentionOptions::default()
+    }
+}
+
 fn precompute_freqs(
     head_dim: usize,
     freq_base: f32,
@@ -739,4 +774,24 @@ fn load_optional_bias_any(
         }
     }
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::lfm25_cuda_flash_attention_options;
+
+    #[test]
+    fn lfm25_cuda_flash_options_use_window_only_for_masked_prefill() {
+        let options = lfm25_cuda_flash_attention_options(true, Some(512));
+        assert_eq!(options.window_size_left, Some(512));
+        assert_eq!(options.window_size_right, None);
+        assert!(options.alibi_slopes.is_none());
+        assert!(options.softcap.is_none());
+
+        let decode_options = lfm25_cuda_flash_attention_options(false, Some(512));
+        assert_eq!(decode_options.window_size_left, None);
+
+        let full_causal_options = lfm25_cuda_flash_attention_options(true, None);
+        assert_eq!(full_causal_options.window_size_left, None);
+    }
 }

--- a/crates/izwi-core/src/models/architectures/qwen3/asr/audio.rs
+++ b/crates/izwi-core/src/models/architectures/qwen3/asr/audio.rs
@@ -6,7 +6,9 @@ use candle_nn::{layer_norm, Conv2d, Conv2dConfig, LayerNorm, Linear, VarBuilder}
 
 use crate::error::{Error, Result};
 use crate::models::architectures::qwen3::asr::config::AudioConfig;
-use crate::models::shared::attention::flash::try_fused_self_attention;
+use crate::models::shared::attention::flash::{
+    try_fused_self_attention, try_fused_varlen_self_attention,
+};
 use crate::models::shared::telemetry::{
     record_chunk_attention_fused_span, record_chunk_attention_mask_fallback,
     record_chunk_attention_sequence, record_chunk_attention_unfused_span,
@@ -123,6 +125,28 @@ fn chunk_spans_from_cu_seqlens(seq_len: usize, cu_seqlens: &[i64]) -> Option<Vec
     Some(spans)
 }
 
+fn chunk_cu_seqlens_u32(seq_len: usize, spans: &[(usize, usize)]) -> Option<Vec<u32>> {
+    if spans.is_empty() {
+        return None;
+    }
+
+    let mut out = Vec::with_capacity(spans.len() + 1);
+    let mut expected_start = 0usize;
+    out.push(0);
+    for &(start, end) in spans {
+        if start != expected_start || end <= start || end > seq_len {
+            return None;
+        }
+        out.push(u32::try_from(end).ok()?);
+        expected_start = end;
+    }
+
+    if expected_start != seq_len {
+        return None;
+    }
+    Some(out)
+}
+
 fn attention_unfused_with_mask(
     q: &Tensor,
     k: &Tensor,
@@ -220,6 +244,35 @@ impl AudioAttention {
         // a full block mask and unlocks mask-free fused kernels for each span.
         if let Some(spans) = chunk_spans_from_cu_seqlens(seq_len, cu_seqlens) {
             record_chunk_attention_sequence(spans.len(), seq_len);
+            if spans.len() > 1 && q.device().is_cuda() {
+                let max_span = spans
+                    .iter()
+                    .map(|(start, end)| end - start)
+                    .max()
+                    .unwrap_or(0);
+                if let Some(cu_seqlens_u32) = chunk_cu_seqlens_u32(seq_len, &spans) {
+                    if let Some(fused) = try_fused_varlen_self_attention(
+                        &q,
+                        &k,
+                        &v,
+                        &cu_seqlens_u32,
+                        max_span,
+                        self.head_dim,
+                        false,
+                    )? {
+                        for _ in &spans {
+                            record_chunk_attention_fused_span();
+                        }
+                        let out = fused.transpose(1, 2)?.reshape((
+                            1,
+                            seq_len,
+                            self.num_heads * self.head_dim,
+                        ))?;
+                        return self.out_proj.forward(&out).map_err(Error::from);
+                    }
+                }
+            }
+
             if spans.len() == 1 {
                 let (start, end) = spans[0];
                 let span = end - start;
@@ -599,8 +652,8 @@ fn gelu(x: &Tensor) -> Result<Tensor> {
 #[cfg(test)]
 mod tests {
     use super::{
-        attention_no_mask, attention_unfused_with_mask, chunk_spans_from_cu_seqlens,
-        create_chunked_attention_mask,
+        attention_no_mask, attention_unfused_with_mask, chunk_cu_seqlens_u32,
+        chunk_spans_from_cu_seqlens, create_chunked_attention_mask,
     };
     use candle_core::{DType, Device, Tensor};
 
@@ -615,6 +668,16 @@ mod tests {
         assert!(chunk_spans_from_cu_seqlens(8, &[1, 8]).is_none());
         assert!(chunk_spans_from_cu_seqlens(8, &[0, 4, 3, 8]).is_none());
         assert!(chunk_spans_from_cu_seqlens(8, &[0, 4, 7]).is_none());
+    }
+
+    #[test]
+    fn chunk_cu_seqlens_u32_requires_contiguous_spans() {
+        let spans = vec![(0, 3), (3, 7), (7, 11)];
+        assert_eq!(chunk_cu_seqlens_u32(11, &spans), Some(vec![0, 3, 7, 11]));
+
+        assert!(chunk_cu_seqlens_u32(11, &[(0, 3), (4, 11)]).is_none());
+        assert!(chunk_cu_seqlens_u32(11, &[(0, 3), (3, 12)]).is_none());
+        assert!(chunk_cu_seqlens_u32(11, &[]).is_none());
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/whisper/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/whisper/asr/mod.rs
@@ -15,7 +15,9 @@ use std::time::Instant;
 
 use candle_core::{DType, IndexOp, Tensor};
 use candle_nn::VarBuilder;
-use candle_transformers::models::whisper::{self, Config as WhisperConfig};
+use candle_transformers::models::whisper::{
+    self, model::Whisper as CandleWhisper, Config as WhisperConfig,
+};
 use flate2::write::ZlibEncoder;
 use flate2::Compression;
 use rand::Rng;
@@ -29,7 +31,7 @@ use crate::catalog::ModelFamily;
 use crate::error::{Error, Result};
 use crate::tokenizer::Tokenizer;
 
-use super::model::Whisper;
+use super::model::Whisper as CudaWhisper;
 
 const SAMPLE_RATE: u32 = whisper::SAMPLE_RATE as u32;
 const DEFAULT_MAX_NEW_TOKENS: usize = 448;
@@ -169,10 +171,78 @@ struct WhisperLanguageResolution {
     strategy: &'static str,
 }
 
+enum WhisperModel {
+    Upstream(CandleWhisper),
+    Cuda(CudaWhisper),
+}
+
+impl WhisperModel {
+    fn load(vb: &VarBuilder, config: WhisperConfig, use_cuda_dtype_shim: bool) -> Result<Self> {
+        if use_cuda_dtype_shim {
+            CudaWhisper::load(vb, config)
+                .map(Self::Cuda)
+                .map_err(Error::from)
+        } else {
+            CandleWhisper::load(vb, config)
+                .map(Self::Upstream)
+                .map_err(Error::from)
+        }
+    }
+
+    fn reset_kv_cache(&mut self) {
+        match self {
+            Self::Upstream(model) => model.reset_kv_cache(),
+            Self::Cuda(model) => model.reset_kv_cache(),
+        }
+    }
+
+    fn encoder_forward(&mut self, x: &Tensor, flush_kv_cache: bool) -> Result<Tensor> {
+        match self {
+            Self::Upstream(model) => model
+                .encoder
+                .forward(x, flush_kv_cache)
+                .map_err(Error::from),
+            Self::Cuda(model) => model
+                .encoder
+                .forward(x, flush_kv_cache)
+                .map_err(Error::from),
+        }
+    }
+
+    fn decoder_forward(
+        &mut self,
+        x: &Tensor,
+        audio_features: &Tensor,
+        flush_kv_cache: bool,
+    ) -> Result<Tensor> {
+        match self {
+            Self::Upstream(model) => model
+                .decoder
+                .forward(x, audio_features, flush_kv_cache)
+                .map_err(Error::from),
+            Self::Cuda(model) => model
+                .decoder
+                .forward(x, audio_features, flush_kv_cache)
+                .map_err(Error::from),
+        }
+    }
+
+    fn decoder_final_linear(&self, x: &Tensor) -> Result<Tensor> {
+        match self {
+            Self::Upstream(model) => model.decoder.final_linear(x).map_err(Error::from),
+            Self::Cuda(model) => model.decoder.final_linear(x).map_err(Error::from),
+        }
+    }
+}
+
+fn use_cuda_whisper_dtype_shim(device: &candle_core::Device) -> bool {
+    device.is_cuda()
+}
+
 pub struct WhisperTurboAsrModel {
     device: DeviceProfile,
     model_dtype: DType,
-    whisper: Mutex<Whisper>,
+    whisper: Mutex<WhisperModel>,
     config: WhisperConfig,
     generation: WhisperGenerationConfig,
     tokenizer: Tokenizer,
@@ -240,7 +310,8 @@ impl WhisperTurboAsrModel {
             }
         };
 
-        let whisper = Whisper::load(&vb, config.clone())?;
+        let use_cuda_dtype_shim = use_cuda_whisper_dtype_shim(&device.device);
+        let whisper = WhisperModel::load(&vb, config.clone(), use_cuda_dtype_shim)?;
         let special = resolve_special_tokens(&tokenizer, &generation)?;
         let (language_token_ids, token_id_to_language_code) =
             build_language_token_maps(&tokenizer, &generation);
@@ -261,8 +332,8 @@ impl WhisperTurboAsrModel {
         })?;
 
         info!(
-            "Loaded Whisper Large v3 Turbo ASR on {:?} (dtype={:?})",
-            device.kind, model_dtype
+            "Loaded Whisper Large v3 Turbo ASR on {:?} (dtype={:?}, cuda_dtype_shim={})",
+            device.kind, model_dtype, use_cuda_dtype_shim
         );
 
         Ok(Self {
@@ -341,7 +412,7 @@ impl WhisperTurboAsrModel {
 
         whisper.reset_kv_cache();
         let encoder_started = Instant::now();
-        let audio_features = whisper.encoder.forward(&mel, true)?;
+        let audio_features = whisper.encoder_forward(&mel, true)?;
         let encoder_forward_ms = encoder_started.elapsed().as_secs_f64() * 1000.0;
 
         let language_resolution =
@@ -516,7 +587,7 @@ impl WhisperTurboAsrModel {
             .map_err(|_| Error::InferenceError("Whisper model mutex poisoned".to_string()))?;
 
         whisper.reset_kv_cache();
-        let audio_features = whisper.encoder.forward(&mel, true)?;
+        let audio_features = whisper.encoder_forward(&mel, true)?;
 
         let language_resolution =
             self.resolve_request_language(&mut whisper, &audio_features, language)?;
@@ -691,7 +762,7 @@ impl WhisperTurboAsrModel {
 
     fn detect_language_token(
         &self,
-        whisper: &mut Whisper,
+        whisper: &mut WhisperModel,
         audio_features: &Tensor,
     ) -> Result<Option<(u32, String)>> {
         if self.language_token_ids.is_empty() {
@@ -699,8 +770,8 @@ impl WhisperTurboAsrModel {
         }
 
         let tokens = Tensor::new(&[[self.special.sot]], &self.device.device)?;
-        let ys = whisper.decoder.forward(&tokens, audio_features, true)?;
-        let logits = whisper.decoder.final_linear(&ys.i(..1)?)?.i(0)?.i(0)?;
+        let ys = whisper.decoder_forward(&tokens, audio_features, true)?;
+        let logits = whisper.decoder_final_linear(&ys.i(..1)?)?.i(0)?.i(0)?;
         let logits_vec = logits.to_vec1::<f32>()?;
 
         let mut best_token: Option<u32> = None;
@@ -765,7 +836,7 @@ impl WhisperTurboAsrModel {
 
     fn resolve_request_language(
         &self,
-        whisper: &mut Whisper,
+        whisper: &mut WhisperModel,
         audio_features: &Tensor,
         language: Option<&str>,
     ) -> Result<WhisperLanguageResolution> {
@@ -965,7 +1036,7 @@ fn trimmed_audio_bounds(
 impl WhisperTurboAsrModel {
     fn decode_attempt(
         &self,
-        whisper: &mut Whisper,
+        whisper: &mut WhisperModel,
         audio_features: &Tensor,
         prompt_prefix: &[u32],
         max_steps: usize,
@@ -983,13 +1054,10 @@ impl WhisperTurboAsrModel {
 
         for step_idx in 0..max_steps {
             let tokens_t = Tensor::new(prompt.as_slice(), &self.device.device)?.unsqueeze(0)?;
-            let ys = whisper
-                .decoder
-                .forward(&tokens_t, audio_features, step_idx == 0)?;
+            let ys = whisper.decoder_forward(&tokens_t, audio_features, step_idx == 0)?;
             let (_, seq_len, _) = ys.dims3()?;
             let logits = whisper
-                .decoder
-                .final_linear(&ys.i((..1, seq_len - 1..))?)?
+                .decoder_final_linear(&ys.i((..1, seq_len - 1..))?)?
                 .i(0)?
                 .i(0)?;
 
@@ -1079,7 +1147,7 @@ impl WhisperTurboAsrModel {
 
     fn decode_attempt_streaming(
         &self,
-        whisper: &mut Whisper,
+        whisper: &mut WhisperModel,
         audio_features: &Tensor,
         prompt_prefix: &[u32],
         max_steps: usize,
@@ -1100,13 +1168,10 @@ impl WhisperTurboAsrModel {
 
         for step_idx in 0..max_steps {
             let tokens_t = Tensor::new(prompt.as_slice(), &self.device.device)?.unsqueeze(0)?;
-            let ys = whisper
-                .decoder
-                .forward(&tokens_t, audio_features, step_idx == 0)?;
+            let ys = whisper.decoder_forward(&tokens_t, audio_features, step_idx == 0)?;
             let (_, seq_len, _) = ys.dims3()?;
             let logits = whisper
-                .decoder
-                .final_linear(&ys.i((..1, seq_len - 1..))?)?
+                .decoder_final_linear(&ys.i((..1, seq_len - 1..))?)?
                 .i(0)?
                 .i(0)?;
 
@@ -1679,7 +1744,13 @@ mod tests {
         adaptive_decode_budget, capped_decode_temperatures, decode_step_budget,
         find_suffix_token_repetition, has_low_word_diversity, logits_to_log_probs,
         logits_to_log_probs_in_place, text_delta, trimmed_audio_bounds,
+        use_cuda_whisper_dtype_shim,
     };
+
+    #[test]
+    fn whisper_dtype_shim_is_cuda_only() {
+        assert!(!use_cuda_whisper_dtype_shim(&candle_core::Device::Cpu));
+    }
 
     #[test]
     fn decode_step_budget_clamps_generation_to_remaining_context() {

--- a/crates/izwi-core/src/models/architectures/whisper/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/whisper/asr/mod.rs
@@ -15,7 +15,7 @@ use std::time::Instant;
 
 use candle_core::{DType, IndexOp, Tensor};
 use candle_nn::VarBuilder;
-use candle_transformers::models::whisper::{self, model::Whisper, Config as WhisperConfig};
+use candle_transformers::models::whisper::{self, Config as WhisperConfig};
 use flate2::write::ZlibEncoder;
 use flate2::Compression;
 use rand::Rng;
@@ -28,6 +28,8 @@ use crate::backends::DeviceProfile;
 use crate::catalog::ModelFamily;
 use crate::error::{Error, Result};
 use crate::tokenizer::Tokenizer;
+
+use super::model::Whisper;
 
 const SAMPLE_RATE: u32 = whisper::SAMPLE_RATE as u32;
 const DEFAULT_MAX_NEW_TOKENS: usize = 448;

--- a/crates/izwi-core/src/models/architectures/whisper/mod.rs
+++ b/crates/izwi-core/src/models/architectures/whisper/mod.rs
@@ -1,3 +1,4 @@
 //! Whisper family implementations.
 
 pub mod asr;
+mod model;

--- a/crates/izwi-core/src/models/architectures/whisper/model.rs
+++ b/crates/izwi-core/src/models/architectures/whisper/model.rs
@@ -1,0 +1,442 @@
+//! Whisper model shim adapted from Candle's implementation so generated
+//! positional/mask tensors follow the active Izwi model dtype.
+
+use candle_core::{DType, Device, IndexOp, Result, Tensor, D};
+use candle_nn::{embedding, Conv1d, Conv1dConfig, Embedding, LayerNorm, Module, VarBuilder};
+use candle_transformers::models::whisper::Config;
+use candle_transformers::models::with_tracing::{linear, linear_no_bias, Linear};
+
+fn conv1d(
+    in_channels: usize,
+    out_channels: usize,
+    kernel_size: usize,
+    config: Conv1dConfig,
+    vb: VarBuilder,
+) -> Result<Conv1d> {
+    let weight = vb.get((out_channels, in_channels, kernel_size), "weight")?;
+    let bias = vb.get(out_channels, "bias")?;
+    Ok(Conv1d::new(weight, Some(bias), config))
+}
+
+fn layer_norm(size: usize, vb: VarBuilder) -> Result<LayerNorm> {
+    let weight = vb.get(size, "weight")?;
+    let bias = vb.get(size, "bias")?;
+    Ok(LayerNorm::new(weight, bias, 1e-5))
+}
+
+fn to_add_dtype(tensor: Tensor, dtype: DType) -> Result<Tensor> {
+    if tensor.dtype() == dtype {
+        Ok(tensor)
+    } else {
+        tensor.to_dtype(dtype)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MultiHeadAttention {
+    query: Linear,
+    key: Linear,
+    value: Linear,
+    out: Linear,
+    n_head: usize,
+    span: tracing::Span,
+    softmax_span: tracing::Span,
+    matmul_span: tracing::Span,
+    kv_cache: Option<(Tensor, Tensor)>,
+}
+
+impl MultiHeadAttention {
+    fn load(n_state: usize, n_head: usize, vb: VarBuilder) -> Result<Self> {
+        let span = tracing::span!(tracing::Level::TRACE, "multi-head-attn");
+        let softmax_span = tracing::span!(tracing::Level::TRACE, "multi-head-attn-softmax");
+        let matmul_span = tracing::span!(tracing::Level::TRACE, "multi-head-attn-matmul");
+        let query = linear(n_state, n_state, vb.pp("q_proj"))?;
+        let value = linear(n_state, n_state, vb.pp("v_proj"))?;
+        let key = linear_no_bias(n_state, n_state, vb.pp("k_proj"))?;
+        let out = linear(n_state, n_state, vb.pp("out_proj"))?;
+        Ok(Self {
+            query,
+            key,
+            value,
+            out,
+            n_head,
+            span,
+            softmax_span,
+            matmul_span,
+            kv_cache: None,
+        })
+    }
+
+    fn forward(
+        &mut self,
+        x: &Tensor,
+        xa: Option<&Tensor>,
+        mask: Option<&Tensor>,
+        flush_cache: bool,
+    ) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let q = self.query.forward(x)?;
+        let (k, v) = match xa {
+            None => {
+                let k = self.key.forward(x)?;
+                let v = self.value.forward(x)?;
+                (k, v)
+            }
+            Some(x) => {
+                if flush_cache {
+                    self.kv_cache = None;
+                }
+                if let Some((k, v)) = &self.kv_cache {
+                    (k.clone(), v.clone())
+                } else {
+                    let k = self.key.forward(x)?;
+                    let v = self.value.forward(x)?;
+                    self.kv_cache = Some((k.clone(), v.clone()));
+                    (k, v)
+                }
+            }
+        };
+        let wv = self.qkv_attention(&q, &k, &v, mask)?;
+        let out = self.out.forward(&wv)?;
+        Ok(out)
+    }
+
+    fn reshape_head(&self, x: &Tensor) -> Result<Tensor> {
+        let (n_batch, n_ctx, n_state) = x.dims3()?;
+        let target_dims = &[n_batch, n_ctx, self.n_head, n_state / self.n_head];
+        x.reshape(target_dims)?.transpose(1, 2)
+    }
+
+    fn qkv_attention(
+        &self,
+        q: &Tensor,
+        k: &Tensor,
+        v: &Tensor,
+        mask: Option<&Tensor>,
+    ) -> Result<Tensor> {
+        let (_, n_ctx, n_state) = q.dims3()?;
+        let scale = ((n_state / self.n_head) as f64).powf(-0.25);
+        let q = (self.reshape_head(q)? * scale)?;
+        let k = (self.reshape_head(k)?.transpose(2, 3)? * scale)?;
+        let v = self.reshape_head(v)?.contiguous()?;
+        let mut qk = {
+            let _enter = self.matmul_span.enter();
+            q.matmul(&k)?
+        };
+        if let Some(mask) = mask {
+            let mask = mask.i((0..n_ctx, 0..n_ctx))?;
+            let mask = to_add_dtype(mask, qk.dtype())?;
+            qk = qk.broadcast_add(&mask)?
+        }
+        let w = {
+            let _enter = self.softmax_span.enter();
+            candle_nn::ops::softmax_last_dim(&qk)?
+        };
+        let wv = {
+            let _enter = self.matmul_span.enter();
+            w.matmul(&v)?
+        }
+        .transpose(1, 2)?
+        .flatten_from(2)?;
+        Ok(wv)
+    }
+
+    fn reset_kv_cache(&mut self) {
+        self.kv_cache = None;
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResidualAttentionBlock {
+    attn: MultiHeadAttention,
+    attn_ln: LayerNorm,
+    cross_attn: Option<(MultiHeadAttention, LayerNorm)>,
+    mlp_linear1: Linear,
+    mlp_linear2: Linear,
+    mlp_ln: LayerNorm,
+    span: tracing::Span,
+}
+
+impl ResidualAttentionBlock {
+    fn load(n_state: usize, n_head: usize, ca: bool, vb: VarBuilder) -> Result<Self> {
+        let span = tracing::span!(tracing::Level::TRACE, "residual-attn");
+        let attn = MultiHeadAttention::load(n_state, n_head, vb.pp("self_attn"))?;
+        let attn_ln = layer_norm(n_state, vb.pp("self_attn_layer_norm"))?;
+        let cross_attn = if ca {
+            let cross_attn = MultiHeadAttention::load(n_state, n_head, vb.pp("encoder_attn"))?;
+            let cross_attn_ln = layer_norm(n_state, vb.pp("encoder_attn_layer_norm"))?;
+            Some((cross_attn, cross_attn_ln))
+        } else {
+            None
+        };
+        let n_mlp = n_state * 4;
+        let mlp_linear1 = linear(n_state, n_mlp, vb.pp("fc1"))?;
+        let mlp_linear2 = linear(n_mlp, n_state, vb.pp("fc2"))?;
+        let mlp_ln = layer_norm(n_state, vb.pp("final_layer_norm"))?;
+        Ok(Self {
+            attn,
+            attn_ln,
+            cross_attn,
+            mlp_linear1,
+            mlp_linear2,
+            mlp_ln,
+            span,
+        })
+    }
+
+    fn forward(
+        &mut self,
+        x: &Tensor,
+        xa: Option<&Tensor>,
+        mask: Option<&Tensor>,
+        flush_kv_cache: bool,
+    ) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let attn = self
+            .attn
+            .forward(&self.attn_ln.forward(x)?, None, mask, flush_kv_cache)?;
+        let mut x = (x + attn)?;
+        if let Some((attn, ln)) = &mut self.cross_attn {
+            x = (&x + attn.forward(&ln.forward(&x)?, xa, None, flush_kv_cache)?)?;
+        }
+        let mlp = self.mlp_linear2.forward(
+            &self
+                .mlp_linear1
+                .forward(&self.mlp_ln.forward(&x)?)?
+                .gelu()?,
+        )?;
+        x + mlp
+    }
+
+    fn reset_kv_cache(&mut self) {
+        self.attn.reset_kv_cache();
+        if let Some((attn, _)) = &mut self.cross_attn {
+            attn.reset_kv_cache();
+        }
+    }
+}
+
+fn sinusoids(length: usize, channels: usize, device: &Device, dtype: DType) -> Result<Tensor> {
+    let max_timescale = 10000f32;
+    let log_timescale_increment = max_timescale.ln() / (channels / 2 - 1) as f32;
+    let inv_timescales: Vec<_> = (0..channels / 2)
+        .map(|i| (i as f32 * (-log_timescale_increment)).exp())
+        .collect();
+    let inv_timescales = Tensor::new(inv_timescales.as_slice(), device)?.unsqueeze(0)?;
+    let arange = Tensor::arange(0, length as u32, device)?
+        .to_dtype(DType::F32)?
+        .unsqueeze(1)?;
+    let sh = (length, channels / 2);
+    let scaled_time = (arange.broadcast_as(sh)? * inv_timescales.broadcast_as(sh)?)?;
+    let sincos = Tensor::cat(&[scaled_time.sin()?, scaled_time.cos()?], 1)?;
+    to_add_dtype(sincos, dtype)
+}
+
+#[derive(Debug, Clone)]
+pub struct AudioEncoder {
+    conv1: Conv1d,
+    conv2: Conv1d,
+    positional_embedding: Tensor,
+    blocks: Vec<ResidualAttentionBlock>,
+    ln_post: LayerNorm,
+    span: tracing::Span,
+    conv1_span: tracing::Span,
+    conv2_span: tracing::Span,
+}
+
+impl AudioEncoder {
+    fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
+        let span = tracing::span!(tracing::Level::TRACE, "audio-encoder");
+        let conv1_span = tracing::span!(tracing::Level::TRACE, "conv1");
+        let conv2_span = tracing::span!(tracing::Level::TRACE, "conv2");
+        let n_state = cfg.d_model;
+        let n_head = cfg.encoder_attention_heads;
+        let n_ctx = cfg.max_source_positions;
+        let cfg1 = Conv1dConfig {
+            padding: 1,
+            stride: 1,
+            groups: 1,
+            dilation: 1,
+            cudnn_fwd_algo: None,
+        };
+        let cfg2 = Conv1dConfig {
+            padding: 1,
+            stride: 2,
+            groups: 1,
+            dilation: 1,
+            cudnn_fwd_algo: None,
+        };
+        let conv1 = conv1d(cfg.num_mel_bins, n_state, 3, cfg1, vb.pp("conv1"))?;
+        let conv2 = conv1d(n_state, n_state, 3, cfg2, vb.pp("conv2"))?;
+        let positional_embedding = sinusoids(n_ctx, n_state, vb.device(), vb.dtype())?;
+        let blocks = (0..cfg.encoder_layers)
+            .map(|i| {
+                ResidualAttentionBlock::load(n_state, n_head, false, vb.pp(format!("layers.{i}")))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let ln_post = layer_norm(n_state, vb.pp("layer_norm"))?;
+        Ok(Self {
+            conv1,
+            conv2,
+            positional_embedding,
+            blocks,
+            ln_post,
+            conv1_span,
+            conv2_span,
+            span,
+        })
+    }
+
+    pub fn forward(&mut self, x: &Tensor, flush_kv_cache: bool) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let x = {
+            let _enter = self.conv1_span.enter();
+            self.conv1.forward(x)?.gelu()?
+        };
+        let x = {
+            let _enter = self.conv2_span.enter();
+            self.conv2.forward(&x)?.gelu()?
+        };
+        let x = x.transpose(1, 2)?;
+        let (_bsize, seq_len, _hidden) = x.dims3()?;
+        let positional_embedding = self.positional_embedding.narrow(0, 0, seq_len)?;
+        let positional_embedding = to_add_dtype(positional_embedding, x.dtype())?;
+        let mut x = x.broadcast_add(&positional_embedding)?;
+        for block in self.blocks.iter_mut() {
+            x = block.forward(&x, None, None, flush_kv_cache)?
+        }
+        let x = self.ln_post.forward(&x)?;
+        Ok(x)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TextDecoder {
+    token_embedding: Embedding,
+    positional_embedding: Tensor,
+    blocks: Vec<ResidualAttentionBlock>,
+    ln: LayerNorm,
+    mask: Tensor,
+    span: tracing::Span,
+    span_final: tracing::Span,
+}
+
+impl TextDecoder {
+    fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
+        let span = tracing::span!(tracing::Level::TRACE, "text-decoder");
+        let span_final = tracing::span!(tracing::Level::TRACE, "text-decoder-final");
+        let n_state = cfg.d_model;
+        let n_head = cfg.decoder_attention_heads;
+        let n_ctx = cfg.max_target_positions;
+        let token_embedding = embedding(cfg.vocab_size, n_state, vb.pp("embed_tokens"))?;
+        let positional_embedding = vb.get((n_ctx, n_state), "embed_positions.weight")?;
+        let blocks = (0..cfg.decoder_layers)
+            .map(|i| {
+                ResidualAttentionBlock::load(n_state, n_head, true, vb.pp(format!("layers.{i}")))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let ln = layer_norm(n_state, vb.pp("layer_norm"))?;
+        let mask = causal_attention_mask(n_ctx, vb.dtype(), vb.device())?;
+        Ok(Self {
+            token_embedding,
+            positional_embedding,
+            blocks,
+            ln,
+            mask,
+            span,
+            span_final,
+        })
+    }
+
+    pub fn forward(&mut self, x: &Tensor, xa: &Tensor, flush_kv_cache: bool) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let last = x.dim(D::Minus1)?;
+        let token_embedding = self.token_embedding.forward(x)?;
+        let positional_embedding = self.positional_embedding.narrow(0, 0, last)?;
+        let positional_embedding = to_add_dtype(positional_embedding, token_embedding.dtype())?;
+        let mut x = token_embedding.broadcast_add(&positional_embedding)?;
+        for block in self.blocks.iter_mut() {
+            x = block.forward(&x, Some(xa), Some(&self.mask), flush_kv_cache)?;
+        }
+        self.ln.forward(&x)
+    }
+
+    pub fn final_linear(&self, x: &Tensor) -> Result<Tensor> {
+        let b_size = x.dim(0)?;
+        let w = self.token_embedding.embeddings().broadcast_left(b_size)?;
+        let logits = {
+            let _enter = self.span_final.enter();
+            x.matmul(&w.t()?)?
+        };
+        Ok(logits)
+    }
+
+    pub fn reset_kv_cache(&mut self) {
+        for block in self.blocks.iter_mut() {
+            block.reset_kv_cache();
+        }
+    }
+}
+
+fn causal_attention_mask(n_ctx: usize, dtype: DType, device: &Device) -> Result<Tensor> {
+    let mask: Vec<_> = (0..n_ctx)
+        .flat_map(|i| (0..n_ctx).map(move |j| if j > i { f32::NEG_INFINITY } else { 0f32 }))
+        .collect();
+    let mask = Tensor::from_vec(mask, (n_ctx, n_ctx), device)?;
+    to_add_dtype(mask, dtype)
+}
+
+#[derive(Debug, Clone)]
+pub struct Whisper {
+    pub encoder: AudioEncoder,
+    pub decoder: TextDecoder,
+    pub config: Config,
+}
+
+impl Whisper {
+    pub fn load(vb: &VarBuilder, config: Config) -> Result<Self> {
+        let encoder = AudioEncoder::load(vb.pp("model.encoder"), &config)?;
+        let decoder = TextDecoder::load(vb.pp("model.decoder"), &config)?;
+        Ok(Self {
+            encoder,
+            decoder,
+            config,
+        })
+    }
+
+    pub fn reset_kv_cache(&mut self) {
+        self.encoder
+            .blocks
+            .iter_mut()
+            .for_each(|b| b.reset_kv_cache());
+        self.decoder.reset_kv_cache();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{causal_attention_mask, sinusoids};
+    use candle_core::{DType, Device, Tensor};
+
+    #[test]
+    fn sinusoidal_embedding_uses_requested_dtype() {
+        let device = Device::Cpu;
+        let pos = sinusoids(4, 8, &device, DType::F16).expect("sinusoids");
+        assert_eq!(pos.dtype(), DType::F16);
+
+        let activations = Tensor::zeros((1, 4, 8), DType::F16, &device).expect("activations");
+        activations
+            .broadcast_add(&pos)
+            .expect("same-dtype positional add");
+    }
+
+    #[test]
+    fn decoder_mask_uses_requested_dtype() {
+        let device = Device::Cpu;
+        let mask = causal_attention_mask(4, DType::F16, &device).expect("mask");
+        assert_eq!(mask.dtype(), DType::F16);
+
+        let scores = Tensor::zeros((1, 2, 4, 4), DType::F16, &device).expect("scores");
+        scores.broadcast_add(&mask).expect("same-dtype mask add");
+    }
+}

--- a/crates/izwi-core/src/models/shared/attention/flash.rs
+++ b/crates/izwi-core/src/models/shared/attention/flash.rs
@@ -269,6 +269,78 @@ pub fn try_fused_self_attention_with_options(
     Ok(None)
 }
 
+/// Try CUDA FlashAttention varlen for packed independent attention spans.
+///
+/// Input/output layout: `[1, heads, total_seq, head_dim]`. The cumulative
+/// sequence lengths are CUDA-side FlashAttention metadata and this helper is a
+/// no-op on non-CUDA devices.
+pub fn try_fused_varlen_self_attention(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    cu_seqlens: &[u32],
+    max_seqlen: usize,
+    head_dim: usize,
+    causal: bool,
+) -> Result<Option<Tensor>> {
+    if !q.device().is_cuda() {
+        return Ok(None);
+    }
+
+    record_fused_attention_attempt();
+    let mut fallback_reason = AttentionFallbackReason::UnsupportedBackend;
+    if cu_seqlens.len() < 2 || max_seqlen == 0 {
+        record_fused_attention_fallback(fallback_reason);
+        return Ok(None);
+    }
+
+    let cuda_decision = should_try_cuda_flash_attention(
+        flash_attention_requested(),
+        flash_attention_compiled(),
+        false,
+        head_dim,
+        q.dtype(),
+        k.dtype(),
+        v.dtype(),
+    );
+
+    match cuda_decision {
+        CudaFlashAttentionDecision::Try => {
+            #[cfg(feature = "flash-attn")]
+            {
+                let device = q.device();
+                let scale = 1.0f32 / (head_dim as f32).sqrt();
+                let flash_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let q = q.squeeze(0)?.transpose(0, 1)?.contiguous()?;
+                    let k = k.squeeze(0)?.transpose(0, 1)?.contiguous()?;
+                    let v = v.squeeze(0)?.transpose(0, 1)?.contiguous()?;
+                    let seqlens = Tensor::new(cu_seqlens, device)?;
+                    candle_flash_attn::flash_attn_varlen(
+                        &q, &k, &v, &seqlens, &seqlens, max_seqlen, max_seqlen, scale, causal,
+                    )
+                }));
+                match flash_result {
+                    Ok(Ok(out)) => {
+                        record_fused_attention_success();
+                        return Ok(Some(out.transpose(0, 1)?.unsqueeze(0)?));
+                    }
+                    Ok(Err(_)) | Err(_) => {
+                        fallback_reason = AttentionFallbackReason::FlashRuntimeError;
+                    }
+                }
+            }
+            #[cfg(not(feature = "flash-attn"))]
+            let _ = causal;
+        }
+        CudaFlashAttentionDecision::Skip(reason) => {
+            fallback_reason = reason;
+        }
+    }
+
+    record_fused_attention_fallback(fallback_reason);
+    Ok(None)
+}
+
 #[cfg(feature = "flash-attn")]
 fn run_cuda_flash_attention(
     q: &Tensor,

--- a/crates/izwi-core/src/models/shared/attention/flash.rs
+++ b/crates/izwi-core/src/models/shared/attention/flash.rs
@@ -69,6 +69,37 @@ pub const fn cuda_flash_attention_head_dim_supported(head_dim: usize) -> bool {
         && head_dim % CUDA_FLASH_ATTENTION_HEAD_DIM_MULTIPLE == 0
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct CudaFlashAttentionOptions<'a> {
+    pub window_size_left: Option<usize>,
+    pub window_size_right: Option<usize>,
+    pub alibi_slopes: Option<&'a Tensor>,
+    pub softcap: Option<f32>,
+}
+
+impl Default for CudaFlashAttentionOptions<'_> {
+    fn default() -> Self {
+        Self {
+            window_size_left: None,
+            window_size_right: None,
+            alibi_slopes: None,
+            softcap: None,
+        }
+    }
+}
+
+fn cuda_flash_attention_window(
+    causal: bool,
+    options: CudaFlashAttentionOptions<'_>,
+) -> (Option<usize>, Option<usize>) {
+    (
+        options.window_size_left,
+        options
+            .window_size_right
+            .or_else(|| if causal { Some(0) } else { None }),
+    )
+}
+
 /// Runtime check used by models that wire Candle's `use_flash_attn` flag.
 pub fn should_enable_flash_attention_v2(device: &candle_core::Device) -> bool {
     flash_attention_requested() && device.is_cuda() && flash_attention_compiled()
@@ -122,12 +153,39 @@ pub fn try_fused_self_attention(
     head_dim: usize,
     causal: bool,
 ) -> Result<Option<Tensor>> {
+    try_fused_self_attention_with_options(
+        q,
+        k,
+        v,
+        mask,
+        head_dim,
+        causal,
+        CudaFlashAttentionOptions::default(),
+    )
+}
+
+/// Try a fused self-attention kernel with CUDA-specific Candle FlashAttention options.
+///
+/// Input/output layout: `[batch, heads, seq, head_dim]`. Extended options are only
+/// consulted by the CUDA FlashAttention path; Metal SDPA and unfused fallbacks keep
+/// the same behavior as `try_fused_self_attention`.
+pub fn try_fused_self_attention_with_options(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    mask: Option<&Tensor>,
+    head_dim: usize,
+    causal: bool,
+    cuda_options: CudaFlashAttentionOptions<'_>,
+) -> Result<Option<Tensor>> {
     let scale = 1.0f32 / (head_dim as f32).sqrt();
     let masked = mask.is_some();
     record_fused_attention_attempt();
     if masked {
         record_fused_attention_masked_attempt();
     }
+    #[cfg(not(feature = "flash-attn"))]
+    let _ = cuda_options;
     let mut fallback_reason = AttentionFallbackReason::UnsupportedBackend;
 
     if q.device().is_cuda() {
@@ -150,7 +208,7 @@ pub fn try_fused_self_attention(
                     let v = v.transpose(1, 2)?.contiguous()?;
                     let flash_result =
                         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                            candle_flash_attn::flash_attn(&q, &k, &v, scale, causal)
+                            run_cuda_flash_attention(&q, &k, &v, scale, causal, cuda_options)
                         }));
                     match flash_result {
                         Ok(Ok(out)) => {
@@ -209,6 +267,56 @@ pub fn try_fused_self_attention(
         record_fused_attention_masked_fallback();
     }
     Ok(None)
+}
+
+#[cfg(feature = "flash-attn")]
+fn run_cuda_flash_attention(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    scale: f32,
+    causal: bool,
+    options: CudaFlashAttentionOptions<'_>,
+) -> candle_core::Result<Tensor> {
+    let (window_size_left, window_size_right) = cuda_flash_attention_window(causal, options);
+    let default_window = (None, if causal { Some(0) } else { None });
+    let custom_window = (window_size_left, window_size_right) != default_window;
+
+    match (options.alibi_slopes, options.softcap) {
+        (_, Some(softcap)) => candle_flash_attn::flash_attn_alibi_windowed_softcap(
+            q,
+            k,
+            v,
+            options.alibi_slopes,
+            scale,
+            window_size_left,
+            window_size_right,
+            softcap,
+        ),
+        (Some(alibi_slopes), None) if custom_window => {
+            candle_flash_attn::flash_attn_alibi_windowed(
+                q,
+                k,
+                v,
+                alibi_slopes,
+                scale,
+                window_size_left,
+                window_size_right,
+            )
+        }
+        (Some(alibi_slopes), None) => {
+            candle_flash_attn::flash_attn_alibi(q, k, v, alibi_slopes, scale, causal)
+        }
+        (None, None) if custom_window => candle_flash_attn::flash_attn_windowed(
+            q,
+            k,
+            v,
+            scale,
+            window_size_left,
+            window_size_right,
+        ),
+        (None, None) => candle_flash_attn::flash_attn(q, k, v, scale, causal),
+    }
 }
 
 /// Conservative preflight for Metal SDPA.
@@ -417,10 +525,10 @@ fn dtype_supported_for_flash(dtype: DType) -> bool {
 mod tests {
     use super::{
         cuda_flash_attention_capabilities, cuda_flash_attention_head_dim_supported,
-        metal_sdpa_mask_shape_supported, metal_sdpa_shape_supported,
+        cuda_flash_attention_window, metal_sdpa_mask_shape_supported, metal_sdpa_shape_supported,
         should_try_cuda_flash_attention, should_use_metal_sdpa_f16_cast,
-        CudaFlashAttentionDecision, CUDA_FLASH_ATTENTION_HEAD_DIM_MULTIPLE,
-        CUDA_FLASH_ATTENTION_MAX_HEAD_DIM,
+        CudaFlashAttentionDecision, CudaFlashAttentionOptions,
+        CUDA_FLASH_ATTENTION_HEAD_DIM_MULTIPLE, CUDA_FLASH_ATTENTION_MAX_HEAD_DIM,
     };
     use crate::models::shared::telemetry::AttentionFallbackReason;
     use candle_core::DType;
@@ -577,6 +685,39 @@ mod tests {
                 DType::F16
             ),
             CudaFlashAttentionDecision::Skip(AttentionFallbackReason::UnsupportedBackend)
+        );
+    }
+
+    #[test]
+    fn cuda_flash_attention_options_resolve_causal_window() {
+        assert_eq!(
+            cuda_flash_attention_window(true, CudaFlashAttentionOptions::default()),
+            (None, Some(0))
+        );
+        assert_eq!(
+            cuda_flash_attention_window(false, CudaFlashAttentionOptions::default()),
+            (None, None)
+        );
+        assert_eq!(
+            cuda_flash_attention_window(
+                true,
+                CudaFlashAttentionOptions {
+                    window_size_left: Some(512),
+                    ..CudaFlashAttentionOptions::default()
+                }
+            ),
+            (Some(512), Some(0))
+        );
+        assert_eq!(
+            cuda_flash_attention_window(
+                true,
+                CudaFlashAttentionOptions {
+                    window_size_left: Some(128),
+                    window_size_right: Some(16),
+                    ..CudaFlashAttentionOptions::default()
+                }
+            ),
+            (Some(128), Some(16))
         );
     }
 

--- a/crates/izwi-core/src/models/shared/attention/flash.rs
+++ b/crates/izwi-core/src/models/shared/attention/flash.rs
@@ -34,6 +34,41 @@ pub const fn flash_attention_compiled() -> bool {
     cfg!(feature = "flash-attn")
 }
 
+/// Candle 0.10's CUDA FlashAttention wrapper accepts head dimensions up to 512.
+pub const CUDA_FLASH_ATTENTION_MAX_HEAD_DIM: usize = 512;
+
+/// FlashAttention kernels require the head dimension to be aligned for vectorized loads.
+pub const CUDA_FLASH_ATTENTION_HEAD_DIM_MULTIPLE: usize = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CudaFlashAttentionCapabilities {
+    pub compiled: bool,
+    pub max_head_dim: usize,
+    pub head_dim_multiple: usize,
+    pub supports_windowed: bool,
+    pub supports_alibi: bool,
+    pub supports_softcap: bool,
+    pub supports_varlen: bool,
+}
+
+pub const fn cuda_flash_attention_capabilities() -> CudaFlashAttentionCapabilities {
+    CudaFlashAttentionCapabilities {
+        compiled: flash_attention_compiled(),
+        max_head_dim: CUDA_FLASH_ATTENTION_MAX_HEAD_DIM,
+        head_dim_multiple: CUDA_FLASH_ATTENTION_HEAD_DIM_MULTIPLE,
+        supports_windowed: true,
+        supports_alibi: true,
+        supports_softcap: true,
+        supports_varlen: true,
+    }
+}
+
+pub const fn cuda_flash_attention_head_dim_supported(head_dim: usize) -> bool {
+    head_dim > 0
+        && head_dim <= CUDA_FLASH_ATTENTION_MAX_HEAD_DIM
+        && head_dim % CUDA_FLASH_ATTENTION_HEAD_DIM_MULTIPLE == 0
+}
+
 /// Runtime check used by models that wire Candle's `use_flash_attn` flag.
 pub fn should_enable_flash_attention_v2(device: &candle_core::Device) -> bool {
     flash_attention_requested() && device.is_cuda() && flash_attention_compiled()
@@ -49,6 +84,7 @@ fn should_try_cuda_flash_attention(
     requested: bool,
     compiled: bool,
     masked: bool,
+    head_dim: usize,
     q_dtype: DType,
     k_dtype: DType,
     v_dtype: DType,
@@ -67,6 +103,9 @@ fn should_try_cuda_flash_attention(
     }
     if q_dtype != k_dtype || k_dtype != v_dtype {
         return CudaFlashAttentionDecision::Skip(AttentionFallbackReason::FlashDTypeMismatch);
+    }
+    if !cuda_flash_attention_head_dim_supported(head_dim) {
+        return CudaFlashAttentionDecision::Skip(AttentionFallbackReason::UnsupportedBackend);
     }
 
     CudaFlashAttentionDecision::Try
@@ -96,6 +135,7 @@ pub fn try_fused_self_attention(
             flash_attention_requested(),
             flash_attention_compiled(),
             masked,
+            head_dim,
             q.dtype(),
             k.dtype(),
             v.dtype(),
@@ -376,9 +416,11 @@ fn dtype_supported_for_flash(dtype: DType) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
+        cuda_flash_attention_capabilities, cuda_flash_attention_head_dim_supported,
         metal_sdpa_mask_shape_supported, metal_sdpa_shape_supported,
         should_try_cuda_flash_attention, should_use_metal_sdpa_f16_cast,
-        CudaFlashAttentionDecision,
+        CudaFlashAttentionDecision, CUDA_FLASH_ATTENTION_HEAD_DIM_MULTIPLE,
+        CUDA_FLASH_ATTENTION_MAX_HEAD_DIM,
     };
     use crate::models::shared::telemetry::AttentionFallbackReason;
     use candle_core::DType;
@@ -416,28 +458,125 @@ mod tests {
     #[test]
     fn cuda_flash_attention_policy_has_explicit_fallback_reasons() {
         assert_eq!(
-            should_try_cuda_flash_attention(false, true, false, DType::F16, DType::F16, DType::F16),
+            should_try_cuda_flash_attention(
+                false,
+                true,
+                false,
+                128,
+                DType::F16,
+                DType::F16,
+                DType::F16
+            ),
             CudaFlashAttentionDecision::Skip(AttentionFallbackReason::FlashNotRequested)
         );
         assert_eq!(
-            should_try_cuda_flash_attention(true, false, false, DType::F16, DType::F16, DType::F16),
+            should_try_cuda_flash_attention(
+                true,
+                false,
+                false,
+                128,
+                DType::F16,
+                DType::F16,
+                DType::F16
+            ),
             CudaFlashAttentionDecision::Skip(AttentionFallbackReason::FlashNotCompiled)
         );
         assert_eq!(
-            should_try_cuda_flash_attention(true, true, true, DType::F16, DType::F16, DType::F16),
+            should_try_cuda_flash_attention(
+                true,
+                true,
+                true,
+                128,
+                DType::F16,
+                DType::F16,
+                DType::F16
+            ),
             CudaFlashAttentionDecision::Skip(AttentionFallbackReason::FlashMaskUnsupported)
         );
         assert_eq!(
-            should_try_cuda_flash_attention(true, true, false, DType::F32, DType::F32, DType::F32),
+            should_try_cuda_flash_attention(
+                true,
+                true,
+                false,
+                128,
+                DType::F32,
+                DType::F32,
+                DType::F32
+            ),
             CudaFlashAttentionDecision::Skip(AttentionFallbackReason::FlashDTypeUnsupported)
         );
         assert_eq!(
-            should_try_cuda_flash_attention(true, true, false, DType::F16, DType::BF16, DType::F16),
+            should_try_cuda_flash_attention(
+                true,
+                true,
+                false,
+                128,
+                DType::F16,
+                DType::BF16,
+                DType::F16
+            ),
             CudaFlashAttentionDecision::Skip(AttentionFallbackReason::FlashDTypeMismatch)
         );
         assert_eq!(
-            should_try_cuda_flash_attention(true, true, false, DType::F16, DType::F16, DType::F16),
+            should_try_cuda_flash_attention(
+                true,
+                true,
+                false,
+                128,
+                DType::F16,
+                DType::F16,
+                DType::F16
+            ),
             CudaFlashAttentionDecision::Try
+        );
+    }
+
+    #[test]
+    fn cuda_flash_attention_shape_policy_matches_candle_limit() {
+        let capabilities = cuda_flash_attention_capabilities();
+        assert_eq!(capabilities.max_head_dim, CUDA_FLASH_ATTENTION_MAX_HEAD_DIM);
+        assert_eq!(
+            capabilities.head_dim_multiple,
+            CUDA_FLASH_ATTENTION_HEAD_DIM_MULTIPLE
+        );
+        assert!(capabilities.supports_windowed);
+        assert!(capabilities.supports_alibi);
+        assert!(capabilities.supports_softcap);
+        assert!(capabilities.supports_varlen);
+
+        assert!(cuda_flash_attention_head_dim_supported(128));
+        assert!(cuda_flash_attention_head_dim_supported(
+            CUDA_FLASH_ATTENTION_MAX_HEAD_DIM
+        ));
+        assert!(!cuda_flash_attention_head_dim_supported(0));
+        assert!(!cuda_flash_attention_head_dim_supported(
+            CUDA_FLASH_ATTENTION_MAX_HEAD_DIM + CUDA_FLASH_ATTENTION_HEAD_DIM_MULTIPLE
+        ));
+        assert!(!cuda_flash_attention_head_dim_supported(127));
+
+        assert_eq!(
+            should_try_cuda_flash_attention(
+                true,
+                true,
+                false,
+                CUDA_FLASH_ATTENTION_MAX_HEAD_DIM,
+                DType::BF16,
+                DType::BF16,
+                DType::BF16
+            ),
+            CudaFlashAttentionDecision::Try
+        );
+        assert_eq!(
+            should_try_cuda_flash_attention(
+                true,
+                true,
+                false,
+                CUDA_FLASH_ATTENTION_MAX_HEAD_DIM + CUDA_FLASH_ATTENTION_HEAD_DIM_MULTIPLE,
+                DType::F16,
+                DType::F16,
+                DType::F16
+            ),
+            CudaFlashAttentionDecision::Skip(AttentionFallbackReason::UnsupportedBackend)
         );
     }
 


### PR DESCRIPTION
Upgrades Candle, routes CUDA-only fused ops and attention paths through Candle kernels, adds coverage checks, and gates the Whisper dtype shim to CUDA only.