### PR TITLE
Refactor server persistence to SeaORM-backed SQLite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1947,18 +1947,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
 name = "fancy-regex"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2929,15 +2917,6 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
-dependencies = [
- "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
@@ -3729,7 +3708,6 @@ dependencies = [
  "izwi-agent",
  "izwi-core",
  "izwi-hooks",
- "rusqlite",
  "scalar_api_reference",
  "sea-orm",
  "serde",
@@ -6247,20 +6225,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "realfft",
-]
-
-[[package]]
-name = "rusqlite"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
-dependencies = [
- "bitflags 2.10.0",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink 0.9.1",
- "libsqlite3-sys",
- "smallvec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -56,6 +67,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "alloc-no-stdlib"
@@ -248,6 +265,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +417,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +464,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -451,6 +509,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2 0.6.3",
+]
+
+[[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -490,6 +572,28 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -926,6 +1030,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "config"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1082,12 @@ dependencies = [
  "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-random"
@@ -1158,6 +1277,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1376,6 +1504,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,6 +1580,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.114",
+ "unicode-xid",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,6 +1627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1601,6 +1763,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1657,6 +1825,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "embed-resource"
@@ -1745,6 +1916,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1851,6 +2044,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,6 +2134,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,6 +2189,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2659,6 +2880,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2666,7 +2890,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "allocator-api2",
 ]
 
@@ -2676,6 +2900,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2703,11 +2929,20 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2782,12 +3017,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3250,6 +3503,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "inherent"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3467,6 +3731,7 @@ dependencies = [
  "izwi-hooks",
  "rusqlite",
  "scalar_api_reference",
+ "sea-orm",
  "serde",
  "serde_json",
  "tempfile",
@@ -3608,6 +3873,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -3700,9 +3968,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.36.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3763,6 +4031,17 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "serde",
+ "winapi",
+]
 
 [[package]]
 name = "macro_rules_attribute"
@@ -3834,6 +4113,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -4079,6 +4368,19 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -4142,6 +4444,22 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -4634,6 +4952,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4651,7 +4978,7 @@ checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
 dependencies = [
  "android_system_properties",
  "log",
- "nix",
+ "nix 0.30.1",
  "objc2 0.6.3",
  "objc2-foundation 0.3.2",
  "objc2-ui-kit",
@@ -4671,6 +4998,30 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4703,6 +5054,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -4747,6 +5104,15 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -4796,6 +5162,15 @@ checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
 dependencies = [
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "pgvector"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc58e2d255979a31caa7cabfa7aac654af0354220719ab7a68520ae7a91e8c0b"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4945,6 +5320,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4961,6 +5357,16 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
+]
+
+[[package]]
+name = "pluralizer"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3eba432a00a1f6c16f39147847a870e94e2e9b992759b503e330efec778cbe"
+dependencies = [
+ "once_cell",
+ "regex",
 ]
 
 [[package]]
@@ -5101,6 +5507,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.0+spec-1.1.0",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5125,6 +5540,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5137,6 +5574,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5266,6 +5736,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -5548,6 +6024,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5692,6 +6177,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ron"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5704,13 +6218,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsqlite-vfs"
-version = "0.1.0"
+name = "rsa"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "hashbrown 0.16.1",
- "thiserror 2.0.18",
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5727,17 +6251,16 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.38.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags 2.10.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink 0.11.0",
+ "hashlink 0.9.1",
  "libsqlite3-sys",
  "smallvec",
- "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -5782,6 +6305,23 @@ checksum = "3e0698206bcb8882bf2a9ecb4c1e7785db57ff052297085a6efd4fe42302068a"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -6081,6 +6621,136 @@ dependencies = [
 ]
 
 [[package]]
+name = "sea-bae"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f694a6ab48f14bc063cfadff30ab551d3c7e46d8f81836c51989d548f44a2a25"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "sea-orm"
+version = "2.0.0-rc.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b5428ce6a0c8f6b9858df21ad1aa00c2fb94e1c9f344a0436bc855391e5a225"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "bigdecimal",
+ "chrono",
+ "derive_more 2.1.1",
+ "futures-util",
+ "itertools",
+ "log",
+ "mac_address",
+ "ouroboros",
+ "pgvector",
+ "rust_decimal",
+ "sea-orm-macros",
+ "sea-query",
+ "sea-query-sqlx",
+ "sea-schema",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "strum",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "sea-orm-macros"
+version = "2.0.0-rc.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1374d83dd5b43f14dcc90fc726486c556f4db774b680b12b8c680af76e8233"
+dependencies = [
+ "heck 0.5.0",
+ "itertools",
+ "pluralizer",
+ "proc-macro2",
+ "quote",
+ "sea-bae",
+ "syn 2.0.114",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sea-query"
+version = "1.0.0-rc.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04cdb0135c16e829504e93fbe7880513578d56f07aaea152283526590111828"
+dependencies = [
+ "inherent",
+ "ordered-float",
+ "sea-query-derive",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "1.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d88ad44b6ad9788c8b9476b6b91f94c7461d1e19d39cd8ea37838b1e6ff5aa8"
+dependencies = [
+ "darling 0.20.11",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sea-query-sqlx"
+version = "0.8.0-rc.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a04aeecfe00614fece56336fd35dc385bb9ffed0c75660695ba925e42a3991ef"
+dependencies = [
+ "sea-query",
+ "sqlx",
+]
+
+[[package]]
+name = "sea-schema"
+version = "0.17.0-rc.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b363dd21c20fe4d1488819cb2bc7f8d4696c62dd9f39554f97639f54d57dd0ab"
+dependencies = [
+ "async-trait",
+ "sea-query",
+ "sea-query-sqlx",
+ "sea-schema-derive",
+ "sqlx",
+]
+
+[[package]]
+name = "sea-schema-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "security-framework"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6111,7 +6781,7 @@ checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
 dependencies = [
  "bitflags 1.3.2",
  "cssparser",
- "derive_more",
+ "derive_more 0.99.20",
  "fxhash",
  "log",
  "phf 0.8.0",
@@ -6403,10 +7073,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -6431,6 +7117,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -6516,6 +7205,19 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "spm_precompiled"
@@ -6530,15 +7232,195 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlite-wasm-rs"
-version = "0.5.2"
+name = "sqlx"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
 dependencies = [
- "cc",
- "js-sys",
- "rsqlite-vfs",
- "wasm-bindgen",
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink 0.10.0",
+ "indexmap 2.13.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.114",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.10.0",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.10.0",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -6585,10 +7467,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "subtle"
@@ -6999,6 +7898,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -7507,7 +8412,7 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "aho-corasick",
  "compact_str",
  "dary_heap",
@@ -7686,6 +8591,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7707,6 +8621,18 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caee3f6e1c6f2025affe9191e6e6f66ade10b48f36b1a1b3cd92dfe405ffd260"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -8029,6 +8955,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8041,6 +8973,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-normalization-alignments"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8048,6 +8989,12 @@ checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -8311,6 +9258,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8319,6 +9272,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -8569,6 +9523,16 @@ dependencies = [
  "env_home",
  "rustix",
  "winsafe",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]
@@ -9096,6 +10060,9 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"
@@ -9269,6 +10236,15 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/crates/izwi-server/Cargo.toml
+++ b/crates/izwi-server/Cargo.toml
@@ -45,7 +45,15 @@ izwi-agent = { path = "../izwi-agent" }
 
 config = { workspace = true }
 dirs = { workspace = true }
-rusqlite = { version = "0.38.0", features = ["bundled"] }
+rusqlite = { version = "=0.32.1", features = ["bundled"] }
+sea-orm = { version = "=2.0.0-rc.38", default-features = false, features = [
+    "macros",
+    "runtime-tokio",
+    "sqlx-sqlite",
+    "sqlite-use-returning-for-3_35",
+    "with-json",
+    "with-uuid",
+] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 izwi-core = { path = "../izwi-core", default-features = false, features = ["metal", "accelerate"] }

--- a/crates/izwi-server/Cargo.toml
+++ b/crates/izwi-server/Cargo.toml
@@ -45,7 +45,6 @@ izwi-agent = { path = "../izwi-agent" }
 
 config = { workspace = true }
 dirs = { workspace = true }
-rusqlite = { version = "=0.32.1", features = ["bundled"] }
 sea-orm = { version = "=2.0.0-rc.38", default-features = false, features = [
     "macros",
     "runtime-tokio",

--- a/crates/izwi-server/src/chat_store.rs
+++ b/crates/izwi-server/src/chat_store.rs
@@ -1,14 +1,18 @@
 //! Persistent chat thread storage backed by SQLite.
 
-use anyhow::{anyhow, Context};
-use rusqlite::{params, Connection, OptionalExtension, Row};
+use anyhow::{Context, anyhow};
+use sea_orm::sea_query::Expr;
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, DatabaseConnection, DbBackend, EntityTrait, QueryFilter,
+    QueryResult, Set, Statement, TransactionTrait,
+};
 use serde::Serialize;
 use serde_json::Value as JsonValue;
-use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::task;
 
-use crate::{ids::new_uuid, storage_layout};
+use crate::db::StoreDatabase;
+use crate::entity::{chat_messages, chat_threads};
+use crate::ids::new_uuid;
 
 const DEFAULT_THREAD_TITLE: &str = "New chat";
 
@@ -38,98 +42,31 @@ pub struct ChatThreadMessage {
 
 #[derive(Clone)]
 pub struct ChatStore {
-    db_path: PathBuf,
+    db: StoreDatabase,
 }
 
 impl ChatStore {
     pub fn initialize() -> anyhow::Result<Self> {
-        let db_path = storage_layout::resolve_db_path();
-        let media_root = storage_layout::resolve_media_root();
-
-        storage_layout::ensure_storage_dirs(&db_path, &media_root)
-            .context("Failed to prepare chat storage layout")?;
-
-        let conn = storage_layout::open_sqlite_connection(&db_path)
-            .with_context(|| format!("Failed to open chat database: {}", db_path.display()))?;
-        conn.execute_batch(
-            r#"
-            CREATE TABLE IF NOT EXISTS chat_threads (
-                id TEXT PRIMARY KEY,
-                title TEXT NOT NULL,
-                model_id TEXT NULL,
-                created_at INTEGER NOT NULL,
-                updated_at INTEGER NOT NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS chat_messages (
-                id TEXT PRIMARY KEY,
-                thread_id TEXT NOT NULL,
-                role TEXT NOT NULL CHECK(role IN ('system', 'user', 'assistant')),
-                content TEXT NOT NULL,
-                content_parts TEXT NULL,
-                created_at INTEGER NOT NULL,
-                tokens_generated INTEGER NULL,
-                generation_time_ms REAL NULL,
-                FOREIGN KEY(thread_id) REFERENCES chat_threads(id) ON DELETE CASCADE
-            );
-
-            CREATE INDEX IF NOT EXISTS idx_chat_threads_updated_at
-                ON chat_threads(updated_at DESC, created_at DESC);
-            CREATE INDEX IF NOT EXISTS idx_chat_messages_thread_created_at
-                ON chat_messages(thread_id, created_at, id);
-            "#,
-        )
-        .context("Failed to initialize chat database schema")?;
-        ensure_chat_messages_content_parts_column(&conn)?;
-
-        Ok(Self { db_path })
+        Ok(Self {
+            db: StoreDatabase::from_default_path()?,
+        })
     }
 
     pub async fn list_threads(&self) -> anyhow::Result<Vec<ChatThreadSummary>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let mut stmt = conn.prepare(
-                r#"
-                SELECT
-                    t.id,
-                    t.title,
-                    t.model_id,
-                    t.created_at,
-                    t.updated_at,
-                    (
-                        SELECT m.content
-                        FROM chat_messages m
-                        WHERE m.thread_id = t.id
-                        ORDER BY m.created_at DESC, m.id DESC
-                        LIMIT 1
-                    ) AS last_message_preview,
-                    (
-                        SELECT COUNT(1)
-                        FROM chat_messages m
-                        WHERE m.thread_id = t.id
-                    ) AS message_count
-                FROM chat_threads t
-                ORDER BY t.updated_at DESC, t.created_at DESC
-                "#,
-            )?;
-
-            let rows = stmt.query_map([], map_thread_summary)?;
-            let mut threads = Vec::new();
-            for row in rows {
-                threads.push(row?);
-            }
-            Ok(threads)
-        })
-        .await
+        let db = self.db.connection().await?;
+        let rows = db
+            .query_all_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                THREAD_SUMMARY_LIST_SQL.to_string(),
+            ))
+            .await
+            .context("Failed to list chat threads")?;
+        rows.iter().map(map_thread_summary).collect()
     }
 
     pub async fn get_thread(&self, thread_id: String) -> anyhow::Result<Option<ChatThreadSummary>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let thread = fetch_thread_summary(&conn, &thread_id)?;
-            Ok(thread)
-        })
-        .await
+        let db = self.db.connection().await?;
+        fetch_thread_summary(db, &thread_id).await
     }
 
     pub async fn create_thread(
@@ -137,71 +74,53 @@ impl ChatStore {
         title: Option<String>,
         model_id: Option<String>,
     ) -> anyhow::Result<ChatThreadSummary> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let now = now_unix_millis_i64();
-            let thread_id = new_uuid();
-            let resolved_title = sanitize_thread_title(title.as_deref());
+        let db = self.db.connection().await?;
+        let now = now_unix_millis_i64();
+        let thread_id = new_uuid();
+        let resolved_title = sanitize_thread_title(title.as_deref());
 
-            conn.execute(
-                r#"
-                INSERT INTO chat_threads (id, title, model_id, created_at, updated_at)
-                VALUES (?1, ?2, ?3, ?4, ?5)
-                "#,
-                params![thread_id, resolved_title, model_id, now, now],
-            )?;
-
-            Ok(ChatThreadSummary {
-                id: thread_id,
-                title: resolved_title,
-                model_id,
-                created_at: now as u64,
-                updated_at: now as u64,
-                last_message_preview: None,
-                message_count: 0,
-            })
+        chat_threads::Entity::insert(chat_threads::ActiveModel {
+            id: Set(thread_id.clone()),
+            title: Set(resolved_title.clone()),
+            model_id: Set(model_id.clone()),
+            created_at: Set(now),
+            updated_at: Set(now),
         })
+        .exec(db)
         .await
+        .context("Failed to create chat thread")?;
+
+        Ok(ChatThreadSummary {
+            id: thread_id,
+            title: resolved_title,
+            model_id,
+            created_at: now as u64,
+            updated_at: now as u64,
+            last_message_preview: None,
+            message_count: 0,
+        })
     }
 
     pub async fn delete_thread(&self, thread_id: String) -> anyhow::Result<bool> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let deleted_rows =
-                conn.execute("DELETE FROM chat_threads WHERE id = ?1", params![thread_id])?;
-            Ok(deleted_rows > 0)
-        })
-        .await
+        let db = self.db.connection().await?;
+        let result = chat_threads::Entity::delete_by_id(thread_id)
+            .exec(db)
+            .await
+            .context("Failed to delete chat thread")?;
+        Ok(result.rows_affected > 0)
     }
 
     pub async fn list_messages(&self, thread_id: String) -> anyhow::Result<Vec<ChatThreadMessage>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let mut stmt = conn.prepare(
-                r#"
-                SELECT
-                    id,
-                    thread_id,
-                    role,
-                    content,
-                    content_parts,
-                    created_at,
-                    tokens_generated,
-                    generation_time_ms
-                FROM chat_messages
-                WHERE thread_id = ?1
-                ORDER BY created_at ASC, id ASC
-                "#,
-            )?;
-
-            let rows = stmt.query_map(params![thread_id], map_thread_message)?;
-            let mut messages = Vec::new();
-            for row in rows {
-                messages.push(row?);
-            }
-            Ok(messages)
-        })
-        .await
+        let db = self.db.connection().await?;
+        let rows = db
+            .query_all_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                CHAT_MESSAGES_LIST_SQL,
+                vec![thread_id.into()],
+            ))
+            .await
+            .context("Failed to list chat messages")?;
+        rows.iter().map(map_thread_message).collect()
     }
 
     pub async fn update_thread_title(
@@ -209,23 +128,26 @@ impl ChatStore {
         thread_id: String,
         title: String,
     ) -> anyhow::Result<Option<ChatThreadSummary>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let now = now_unix_millis_i64();
-            let resolved_title = sanitize_thread_title(Some(title.as_str()));
+        let db = self.db.connection().await?;
+        let now = now_unix_millis_i64();
+        let resolved_title = sanitize_thread_title(Some(title.as_str()));
 
-            let updated_rows = conn.execute(
-                "UPDATE chat_threads SET title = ?1, updated_at = ?2 WHERE id = ?3",
-                params![resolved_title, now, &thread_id],
-            )?;
+        let result = chat_threads::Entity::update_many()
+            .col_expr(
+                chat_threads::Column::Title,
+                Expr::value(resolved_title.clone()),
+            )
+            .col_expr(chat_threads::Column::UpdatedAt, Expr::value(now))
+            .filter(chat_threads::Column::Id.eq(thread_id.clone()))
+            .exec(db)
+            .await
+            .context("Failed to update chat thread title")?;
 
-            if updated_rows == 0 {
-                return Ok(None);
-            }
+        if result.rows_affected == 0 {
+            return Ok(None);
+        }
 
-            fetch_thread_summary(&conn, &thread_id)
-        })
-        .await
+        fetch_thread_summary(db, &thread_id).await
     }
 
     pub async fn append_message(
@@ -238,183 +160,175 @@ impl ChatStore {
         tokens_generated: Option<usize>,
         generation_time_ms: Option<f64>,
     ) -> anyhow::Result<ChatThreadMessage> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
-
-            let thread_exists = tx
-                .query_row(
-                    "SELECT 1 FROM chat_threads WHERE id = ?1 LIMIT 1",
-                    params![thread_id],
-                    |_| Ok(()),
-                )
-                .optional()?
-                .is_some();
-
-            if !thread_exists {
-                return Err(anyhow!("Thread not found"));
-            }
-
-            let now = now_unix_millis_i64();
-            let message_id = new_uuid();
-            let tokens_i64 = opt_usize_to_i64(tokens_generated)?;
-            let serialized_content_parts = content_parts
-                .as_ref()
-                .map(serde_json::to_string)
-                .transpose()
-                .context("Failed serializing chat message content_parts")?;
-
-            tx.execute(
-                r#"
-                INSERT INTO chat_messages (
-                    id,
-                    thread_id,
-                    role,
-                    content,
-                    content_parts,
-                    created_at,
-                    tokens_generated,
-                    generation_time_ms
-                )
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-                "#,
-                params![
-                    message_id,
-                    thread_id,
-                    role,
-                    content,
-                    serialized_content_parts,
-                    now,
-                    tokens_i64,
-                    generation_time_ms
-                ],
-            )?;
-
-            tx.execute(
-                "UPDATE chat_threads SET updated_at = ?1, model_id = ?2 WHERE id = ?3",
-                params![now, model_id, thread_id],
-            )?;
-
-            tx.commit()?;
-
-            Ok(ChatThreadMessage {
-                id: message_id,
-                thread_id,
-                role,
-                content,
-                content_parts,
-                created_at: now as u64,
-                tokens_generated,
-                generation_time_ms,
-            })
-        })
-        .await
-    }
-
-    async fn run_blocking<F, T>(&self, task_fn: F) -> anyhow::Result<T>
-    where
-        F: FnOnce(PathBuf) -> anyhow::Result<T> + Send + 'static,
-        T: Send + 'static,
-    {
-        let db_path = self.db_path.clone();
-        task::spawn_blocking(move || task_fn(db_path))
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
             .await
-            .map_err(|err| anyhow!("Chat storage worker failed: {err}"))?
+            .context("Failed to start chat message transaction")?;
+
+        let thread_exists = chat_threads::Entity::find_by_id(thread_id.clone())
+            .one(&tx)
+            .await
+            .context("Failed to load chat thread")?
+            .is_some();
+
+        if !thread_exists {
+            return Err(anyhow!("Thread not found"));
+        }
+
+        let now = now_unix_millis_i64();
+        let message_id = new_uuid();
+        let tokens_i64 = opt_usize_to_i64(tokens_generated)?;
+        let serialized_content_parts = content_parts
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .context("Failed serializing chat message content_parts")?;
+
+        chat_messages::Entity::insert(chat_messages::ActiveModel {
+            id: Set(message_id.clone()),
+            thread_id: Set(thread_id.clone()),
+            role: Set(role.clone()),
+            content: Set(content.clone()),
+            content_parts: Set(serialized_content_parts),
+            created_at: Set(now),
+            tokens_generated: Set(tokens_i64),
+            generation_time_ms: Set(generation_time_ms),
+        })
+        .exec(&tx)
+        .await
+        .context("Failed to append chat message")?;
+
+        chat_threads::Entity::update_many()
+            .col_expr(chat_threads::Column::UpdatedAt, Expr::value(now))
+            .col_expr(chat_threads::Column::ModelId, Expr::value(model_id.clone()))
+            .filter(chat_threads::Column::Id.eq(thread_id.clone()))
+            .exec(&tx)
+            .await
+            .context("Failed to update chat thread metadata")?;
+
+        tx.commit()
+            .await
+            .context("Failed to commit chat message transaction")?;
+
+        Ok(ChatThreadMessage {
+            id: message_id,
+            thread_id,
+            role,
+            content,
+            content_parts,
+            created_at: now as u64,
+            tokens_generated,
+            generation_time_ms,
+        })
     }
 }
 
-fn fetch_thread_summary(
-    conn: &Connection,
+const THREAD_SUMMARY_LIST_SQL: &str = r#"
+    SELECT
+        t.id,
+        t.title,
+        t.model_id,
+        t.created_at,
+        t.updated_at,
+        (
+            SELECT m.content
+            FROM chat_messages m
+            WHERE m.thread_id = t.id
+            ORDER BY m.created_at DESC, m.id DESC
+            LIMIT 1
+        ) AS last_message_preview,
+        (
+            SELECT COUNT(1)
+            FROM chat_messages m
+            WHERE m.thread_id = t.id
+        ) AS message_count
+    FROM chat_threads t
+    ORDER BY t.updated_at DESC, t.created_at DESC
+"#;
+
+const THREAD_SUMMARY_BY_ID_SQL: &str = r#"
+    SELECT
+        t.id,
+        t.title,
+        t.model_id,
+        t.created_at,
+        t.updated_at,
+        (
+            SELECT m.content
+            FROM chat_messages m
+            WHERE m.thread_id = t.id
+            ORDER BY m.created_at DESC, m.id DESC
+            LIMIT 1
+        ) AS last_message_preview,
+        (
+            SELECT COUNT(1)
+            FROM chat_messages m
+            WHERE m.thread_id = t.id
+        ) AS message_count
+    FROM chat_threads t
+    WHERE t.id = ?1
+"#;
+
+const CHAT_MESSAGES_LIST_SQL: &str = r#"
+    SELECT
+        id,
+        thread_id,
+        role,
+        content,
+        content_parts,
+        created_at,
+        tokens_generated,
+        generation_time_ms
+    FROM chat_messages
+    WHERE thread_id = ?1
+    ORDER BY created_at ASC, id ASC
+"#;
+
+async fn fetch_thread_summary(
+    db: &DatabaseConnection,
     thread_id: &str,
 ) -> anyhow::Result<Option<ChatThreadSummary>> {
-    let thread = conn
-        .query_row(
-            r#"
-            SELECT
-                t.id,
-                t.title,
-                t.model_id,
-                t.created_at,
-                t.updated_at,
-                (
-                    SELECT m.content
-                    FROM chat_messages m
-                    WHERE m.thread_id = t.id
-                    ORDER BY m.created_at DESC, m.id DESC
-                    LIMIT 1
-                ) AS last_message_preview,
-                (
-                    SELECT COUNT(1)
-                    FROM chat_messages m
-                    WHERE m.thread_id = t.id
-                ) AS message_count
-            FROM chat_threads t
-            WHERE t.id = ?1
-            "#,
-            params![thread_id],
-            map_thread_summary,
-        )
-        .optional()?;
-    Ok(thread)
+    let row = db
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            THREAD_SUMMARY_BY_ID_SQL,
+            vec![thread_id.into()],
+        ))
+        .await
+        .context("Failed to load chat thread summary")?;
+    row.as_ref().map(map_thread_summary).transpose()
 }
 
-fn map_thread_summary(row: &Row<'_>) -> rusqlite::Result<ChatThreadSummary> {
-    let message_count_raw: i64 = row.get(6)?;
+fn map_thread_summary(row: &QueryResult) -> anyhow::Result<ChatThreadSummary> {
+    let message_count_raw: i64 = row.try_get_by_index(6)?;
     Ok(ChatThreadSummary {
-        id: row.get(0)?,
-        title: row.get(1)?,
-        model_id: row.get(2)?,
-        created_at: i64_to_u64(row.get(3)?),
-        updated_at: i64_to_u64(row.get(4)?),
-        last_message_preview: row.get(5)?,
+        id: row.try_get_by_index(0)?,
+        title: row.try_get_by_index(1)?,
+        model_id: row.try_get_by_index(2)?,
+        created_at: i64_to_u64(row.try_get_by_index(3)?),
+        updated_at: i64_to_u64(row.try_get_by_index(4)?),
+        last_message_preview: row.try_get_by_index(5)?,
         message_count: i64_to_usize(message_count_raw),
     })
 }
 
-fn map_thread_message(row: &Row<'_>) -> rusqlite::Result<ChatThreadMessage> {
-    let content_parts_raw: Option<String> = row.get(4)?;
+fn map_thread_message(row: &QueryResult) -> anyhow::Result<ChatThreadMessage> {
+    let content_parts_raw: Option<String> = row.try_get_by_index(4)?;
     let content_parts = content_parts_raw
         .as_deref()
         .and_then(|raw| serde_json::from_str::<Vec<JsonValue>>(raw).ok());
-    let tokens_generated_raw: Option<i64> = row.get(6)?;
+    let tokens_generated_raw: Option<i64> = row.try_get_by_index(6)?;
     Ok(ChatThreadMessage {
-        id: row.get(0)?,
-        thread_id: row.get(1)?,
-        role: row.get(2)?,
-        content: row.get(3)?,
+        id: row.try_get_by_index(0)?,
+        thread_id: row.try_get_by_index(1)?,
+        role: row.try_get_by_index(2)?,
+        content: row.try_get_by_index(3)?,
         content_parts,
-        created_at: i64_to_u64(row.get(5)?),
+        created_at: i64_to_u64(row.try_get_by_index(5)?),
         tokens_generated: tokens_generated_raw.map(i64_to_usize),
-        generation_time_ms: row.get(7)?,
+        generation_time_ms: row.try_get_by_index(7)?,
     })
-}
-
-fn ensure_chat_messages_content_parts_column(conn: &Connection) -> anyhow::Result<()> {
-    let mut stmt = conn
-        .prepare("PRAGMA table_info(chat_messages)")
-        .context("Failed to inspect chat_messages schema")?;
-    let mut rows = stmt
-        .query([])
-        .context("Failed to query chat_messages schema info")?;
-
-    while let Some(row) = rows
-        .next()
-        .context("Failed reading chat_messages schema row")?
-    {
-        let name: String = row
-            .get(1)
-            .context("Failed reading chat_messages column name")?;
-        if name == "content_parts" {
-            return Ok(());
-        }
-    }
-
-    conn.execute(
-        "ALTER TABLE chat_messages ADD COLUMN content_parts TEXT NULL",
-        [],
-    )
-    .context("Failed adding chat_messages.content_parts column")?;
-    Ok(())
 }
 
 fn now_unix_millis_i64() -> i64 {
@@ -461,11 +375,7 @@ fn opt_usize_to_i64(value: Option<usize>) -> anyhow::Result<Option<i64>> {
 }
 
 fn i64_to_u64(value: i64) -> u64 {
-    if value.is_negative() {
-        0
-    } else {
-        value as u64
-    }
+    if value.is_negative() { 0 } else { value as u64 }
 }
 
 fn i64_to_usize(value: i64) -> usize {
@@ -473,5 +383,153 @@ fn i64_to_usize(value: i64) -> usize {
         0
     } else {
         value as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::env_lock;
+    use serde_json::json;
+    use std::future::Future;
+    use tempfile::TempDir;
+
+    async fn with_env_lock<T>(action: impl Future<Output = T>) -> T {
+        let _guard = env_lock();
+        action.await
+    }
+
+    fn setup_store() -> (TempDir, ChatStore) {
+        let temp_dir = tempfile::tempdir().expect("temp dir should create");
+        let db_path = temp_dir.path().join("izwi.sqlite3");
+        let media_root = temp_dir.path().join("media");
+
+        std::env::set_var("IZWI_DB_PATH", &db_path);
+        std::env::set_var("IZWI_MEDIA_DIR", &media_root);
+
+        let store = ChatStore::initialize().expect("store should init");
+        (temp_dir, store)
+    }
+
+    fn clear_env() {
+        std::env::remove_var("IZWI_DB_PATH");
+        std::env::remove_var("IZWI_MEDIA_DIR");
+    }
+
+    #[tokio::test]
+    async fn persists_threads_messages_and_content_parts() {
+        with_env_lock(async {
+            let (_temp, store) = setup_store();
+            assert!(
+                store
+                    .list_threads()
+                    .await
+                    .expect("threads should list")
+                    .is_empty()
+            );
+
+            let thread = store
+                .create_thread(
+                    Some("  A   thread title  ".to_string()),
+                    Some("qwen".to_string()),
+                )
+                .await
+                .expect("thread should create");
+            assert_eq!(thread.title, "A thread title");
+            assert_eq!(thread.message_count, 0);
+
+            let content_parts = vec![json!({"type": "text", "text": "hello"})];
+            let user_message = store
+                .append_message(
+                    thread.id.clone(),
+                    "user".to_string(),
+                    "hello".to_string(),
+                    Some(content_parts.clone()),
+                    Some("qwen-updated".to_string()),
+                    None,
+                    None,
+                )
+                .await
+                .expect("user message should append");
+            assert_eq!(user_message.content_parts, Some(content_parts.clone()));
+
+            let assistant_message = store
+                .append_message(
+                    thread.id.clone(),
+                    "assistant".to_string(),
+                    "world".to_string(),
+                    None,
+                    Some("qwen-updated".to_string()),
+                    Some(42),
+                    Some(12.5),
+                )
+                .await
+                .expect("assistant message should append");
+            assert_eq!(assistant_message.tokens_generated, Some(42));
+
+            let messages = store
+                .list_messages(thread.id.clone())
+                .await
+                .expect("messages should list");
+            assert_eq!(messages.len(), 2);
+            assert_eq!(messages[0].id, user_message.id);
+            assert_eq!(messages[0].content_parts, Some(content_parts));
+            assert_eq!(messages[1].id, assistant_message.id);
+            assert_eq!(messages[1].generation_time_ms, Some(12.5));
+
+            let summary = store
+                .get_thread(thread.id.clone())
+                .await
+                .expect("thread should load")
+                .expect("thread should exist");
+            assert_eq!(summary.model_id.as_deref(), Some("qwen-updated"));
+            assert_eq!(summary.last_message_preview.as_deref(), Some("world"));
+            assert_eq!(summary.message_count, 2);
+
+            let updated = store
+                .update_thread_title(thread.id.clone(), "Renamed".to_string())
+                .await
+                .expect("title should update")
+                .expect("thread should exist");
+            assert_eq!(updated.title, "Renamed");
+
+            assert!(
+                store
+                    .delete_thread(thread.id.clone())
+                    .await
+                    .expect("thread should delete")
+            );
+            assert!(
+                store
+                    .list_messages(thread.id)
+                    .await
+                    .expect("messages should list")
+                    .is_empty()
+            );
+            clear_env();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn append_message_requires_existing_thread() {
+        with_env_lock(async {
+            let (_temp, store) = setup_store();
+            let err = store
+                .append_message(
+                    "missing".to_string(),
+                    "user".to_string(),
+                    "hello".to_string(),
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .expect_err("missing thread should fail");
+            assert!(err.to_string().contains("Thread not found"));
+            clear_env();
+        })
+        .await;
     }
 }

--- a/crates/izwi-server/src/db/migrator.rs
+++ b/crates/izwi-server/src/db/migrator.rs
@@ -1,9 +1,555 @@
-use sea_orm::DatabaseConnection;
+use crate::voice_defaults::{
+    DEFAULT_VOICE_AGENT_SYSTEM_PROMPT, DEFAULT_VOICE_PROFILE_ID, DEFAULT_VOICE_PROFILE_NAME,
+};
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub struct Migrator;
 
 impl Migrator {
-    pub async fn up(_db: &DatabaseConnection) -> anyhow::Result<()> {
+    pub async fn up(db: &DatabaseConnection) -> anyhow::Result<()> {
+        for statement in BASELINE_SCHEMA {
+            db.execute_unprepared(statement).await?;
+        }
+
+        for column in COMPATIBILITY_COLUMNS {
+            ensure_column(db, column).await?;
+        }
+
+        ensure_default_voice_profile(db).await?;
         Ok(())
     }
+}
+
+struct CompatibilityColumn {
+    table: &'static str,
+    column: &'static str,
+    definition: &'static str,
+}
+
+const BASELINE_SCHEMA: &[&str] = &[
+    r#"
+    CREATE TABLE IF NOT EXISTS chat_threads (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        model_id TEXT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+    );
+    "#,
+    r#"
+    CREATE TABLE IF NOT EXISTS chat_messages (
+        id TEXT PRIMARY KEY,
+        thread_id TEXT NOT NULL,
+        role TEXT NOT NULL CHECK(role IN ('system', 'user', 'assistant')),
+        content TEXT NOT NULL,
+        content_parts TEXT NULL,
+        created_at INTEGER NOT NULL,
+        tokens_generated INTEGER NULL,
+        generation_time_ms REAL NULL,
+        FOREIGN KEY(thread_id) REFERENCES chat_threads(id) ON DELETE CASCADE
+    );
+    "#,
+    "CREATE INDEX IF NOT EXISTS idx_chat_threads_updated_at ON chat_threads(updated_at DESC, created_at DESC);",
+    "CREATE INDEX IF NOT EXISTS idx_chat_messages_thread_created_at ON chat_messages(thread_id, created_at, id);",
+    r#"
+    CREATE TABLE IF NOT EXISTS voice_profiles (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        system_prompt TEXT NOT NULL,
+        observational_memory_enabled INTEGER NOT NULL DEFAULT 1,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+    );
+    "#,
+    r#"
+    CREATE TABLE IF NOT EXISTS voice_sessions (
+        id TEXT PRIMARY KEY,
+        profile_id TEXT NOT NULL,
+        mode TEXT NOT NULL CHECK(mode IN ('modular', 'unified')),
+        system_prompt TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        ended_at INTEGER NULL,
+        FOREIGN KEY(profile_id) REFERENCES voice_profiles(id) ON DELETE CASCADE
+    );
+    "#,
+    r#"
+    CREATE TABLE IF NOT EXISTS voice_turns (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        utterance_id TEXT NOT NULL,
+        utterance_seq INTEGER NOT NULL,
+        mode TEXT NOT NULL CHECK(mode IN ('modular', 'unified')),
+        status TEXT NOT NULL CHECK(status IN ('processing', 'ok', 'error', 'timeout', 'interrupted', 'no_input')),
+        status_reason TEXT NULL,
+        vad_end_reason TEXT NULL,
+        user_text TEXT NULL,
+        assistant_text TEXT NULL,
+        assistant_raw_text TEXT NULL,
+        language TEXT NULL,
+        audio_duration_secs REAL NULL,
+        asr_model_id TEXT NULL,
+        text_model_id TEXT NULL,
+        tts_model_id TEXT NULL,
+        s2s_model_id TEXT NULL,
+        speaker TEXT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        FOREIGN KEY(session_id) REFERENCES voice_sessions(id) ON DELETE CASCADE
+    );
+    "#,
+    "CREATE INDEX IF NOT EXISTS idx_voice_sessions_updated_at ON voice_sessions(updated_at DESC, created_at DESC);",
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_voice_turns_session_utterance ON voice_turns(session_id, utterance_seq);",
+    "CREATE INDEX IF NOT EXISTS idx_voice_turns_session_created_at ON voice_turns(session_id, created_at ASC, id ASC);",
+    r#"
+    CREATE TABLE IF NOT EXISTS voice_observations (
+        id TEXT PRIMARY KEY,
+        profile_id TEXT NOT NULL,
+        category TEXT NOT NULL,
+        summary TEXT NOT NULL,
+        canonical_summary TEXT NOT NULL,
+        confidence REAL NOT NULL,
+        source_turn_id TEXT NULL,
+        source_user_text TEXT NULL,
+        source_assistant_text TEXT NULL,
+        times_seen INTEGER NOT NULL DEFAULT 1,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        forgotten_at INTEGER NULL,
+        FOREIGN KEY(profile_id) REFERENCES voice_profiles(id) ON DELETE CASCADE
+    );
+    "#,
+    "CREATE INDEX IF NOT EXISTS idx_voice_observations_profile_updated_at ON voice_observations(profile_id, updated_at DESC, created_at DESC);",
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_voice_observations_profile_canonical_active ON voice_observations(profile_id, canonical_summary) WHERE forgotten_at IS NULL;",
+    r#"
+    CREATE TABLE IF NOT EXISTS onboarding_state (
+        id TEXT PRIMARY KEY,
+        completed_at INTEGER NULL,
+        analytics_opt_in INTEGER NOT NULL DEFAULT 0
+    );
+    "#,
+    r#"
+    CREATE TABLE IF NOT EXISTS transcription_records (
+        id TEXT PRIMARY KEY,
+        created_at INTEGER NOT NULL,
+        model_id TEXT NULL,
+        aligner_model_id TEXT NULL,
+        language TEXT NULL,
+        processing_status TEXT NOT NULL DEFAULT 'ready',
+        processing_error TEXT NULL,
+        duration_secs REAL NULL,
+        processing_time_ms REAL NOT NULL,
+        rtf REAL NULL,
+        audio_mime_type TEXT NOT NULL,
+        audio_filename TEXT NULL,
+        audio_storage_path TEXT NOT NULL,
+        transcription TEXT NOT NULL,
+        segments_json TEXT NOT NULL DEFAULT '[]',
+        words_json TEXT NOT NULL DEFAULT '[]',
+        summary_status TEXT NOT NULL DEFAULT 'not_requested',
+        summary_model_id TEXT NULL,
+        summary_text TEXT NULL,
+        summary_error TEXT NULL,
+        summary_updated_at INTEGER NULL
+    );
+    "#,
+    "CREATE INDEX IF NOT EXISTS idx_transcription_records_created_at ON transcription_records(created_at DESC);",
+    r#"
+    CREATE TABLE IF NOT EXISTS diarization_records (
+        id TEXT PRIMARY KEY,
+        created_at INTEGER NOT NULL,
+        model_id TEXT NULL,
+        asr_model_id TEXT NULL,
+        aligner_model_id TEXT NULL,
+        llm_model_id TEXT NULL,
+        processing_status TEXT NOT NULL DEFAULT 'ready',
+        processing_error TEXT NULL,
+        min_speakers INTEGER NULL,
+        max_speakers INTEGER NULL,
+        min_speech_duration_ms REAL NULL,
+        min_silence_duration_ms REAL NULL,
+        enable_llm_refinement INTEGER NOT NULL,
+        processing_time_ms REAL NOT NULL,
+        duration_secs REAL NULL,
+        rtf REAL NULL,
+        speaker_count INTEGER NOT NULL,
+        alignment_coverage REAL NULL,
+        unattributed_words INTEGER NOT NULL,
+        llm_refined INTEGER NOT NULL,
+        asr_text TEXT NOT NULL,
+        raw_transcript TEXT NOT NULL,
+        transcript TEXT NOT NULL,
+        summary_status TEXT NOT NULL DEFAULT 'not_requested',
+        summary_model_id TEXT NULL,
+        summary_text TEXT NULL,
+        summary_error TEXT NULL,
+        summary_updated_at INTEGER NULL,
+        segments_json TEXT NOT NULL,
+        words_json TEXT NOT NULL,
+        utterances_json TEXT NOT NULL,
+        speaker_name_overrides_json TEXT NOT NULL DEFAULT '{}',
+        audio_mime_type TEXT NOT NULL,
+        audio_filename TEXT NULL,
+        audio_storage_path TEXT NOT NULL
+    );
+    "#,
+    "CREATE INDEX IF NOT EXISTS idx_diarization_records_created_at ON diarization_records(created_at DESC);",
+    r#"
+    CREATE TABLE IF NOT EXISTS speech_history_records (
+        id TEXT PRIMARY KEY,
+        created_at INTEGER NOT NULL,
+        route_kind TEXT NOT NULL,
+        processing_status TEXT NOT NULL DEFAULT 'ready',
+        processing_error TEXT NULL,
+        model_id TEXT NULL,
+        speaker TEXT NULL,
+        language TEXT NULL,
+        saved_voice_id TEXT NULL,
+        speed REAL NULL,
+        input_text TEXT NOT NULL,
+        voice_description TEXT NULL,
+        reference_text TEXT NULL,
+        generation_time_ms REAL NOT NULL,
+        audio_duration_secs REAL NULL,
+        rtf REAL NULL,
+        tokens_generated INTEGER NULL,
+        audio_mime_type TEXT NOT NULL,
+        audio_filename TEXT NULL,
+        audio_storage_path TEXT NOT NULL
+    );
+    "#,
+    "CREATE INDEX IF NOT EXISTS idx_speech_history_route_created_at ON speech_history_records(route_kind, created_at DESC);",
+    r#"
+    CREATE TABLE IF NOT EXISTS saved_voices (
+        id TEXT PRIMARY KEY,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        name TEXT NOT NULL COLLATE NOCASE,
+        reference_text TEXT NOT NULL,
+        audio_mime_type TEXT NOT NULL,
+        audio_filename TEXT NULL,
+        audio_storage_path TEXT NOT NULL,
+        source_route_kind TEXT NULL,
+        source_record_id TEXT NULL
+    );
+    "#,
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_saved_voices_name_nocase ON saved_voices(name COLLATE NOCASE);",
+    "CREATE INDEX IF NOT EXISTS idx_saved_voices_updated_at ON saved_voices(updated_at DESC, created_at DESC);",
+    r#"
+    CREATE TABLE IF NOT EXISTS studio_projects (
+        id TEXT PRIMARY KEY,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        name TEXT NOT NULL,
+        source_filename TEXT NULL,
+        source_text TEXT NOT NULL,
+        model_id TEXT NULL,
+        voice_mode TEXT NOT NULL,
+        speaker TEXT NULL,
+        saved_voice_id TEXT NULL,
+        speed REAL NULL
+    );
+    "#,
+    r#"
+    CREATE TABLE IF NOT EXISTS studio_project_segments (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        position INTEGER NOT NULL,
+        text TEXT NOT NULL,
+        model_id TEXT NULL,
+        voice_mode TEXT NULL,
+        speaker TEXT NULL,
+        saved_voice_id TEXT NULL,
+        speech_record_id TEXT NULL,
+        updated_at INTEGER NOT NULL,
+        FOREIGN KEY(project_id) REFERENCES studio_projects(id) ON DELETE CASCADE
+    );
+    "#,
+    r#"
+    CREATE TABLE IF NOT EXISTS studio_project_folders (
+        id TEXT PRIMARY KEY,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        name TEXT NOT NULL,
+        parent_id TEXT NULL,
+        sort_order INTEGER NOT NULL DEFAULT 0
+    );
+    "#,
+    r#"
+    CREATE TABLE IF NOT EXISTS studio_project_meta (
+        project_id TEXT PRIMARY KEY,
+        folder_id TEXT NULL,
+        tags_json TEXT NOT NULL DEFAULT '[]',
+        default_export_format TEXT NOT NULL DEFAULT 'wav',
+        last_render_job_id TEXT NULL,
+        last_rendered_at INTEGER NULL,
+        FOREIGN KEY(project_id) REFERENCES studio_projects(id) ON DELETE CASCADE,
+        FOREIGN KEY(folder_id) REFERENCES studio_project_folders(id) ON DELETE SET NULL
+    );
+    "#,
+    r#"
+    CREATE TABLE IF NOT EXISTS studio_project_pronunciations (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        source_text TEXT NOT NULL,
+        replacement_text TEXT NOT NULL,
+        locale TEXT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        FOREIGN KEY(project_id) REFERENCES studio_projects(id) ON DELETE CASCADE
+    );
+    "#,
+    r#"
+    CREATE TABLE IF NOT EXISTS studio_project_snapshots (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        label TEXT NULL,
+        project_json TEXT NOT NULL,
+        FOREIGN KEY(project_id) REFERENCES studio_projects(id) ON DELETE CASCADE
+    );
+    "#,
+    r#"
+    CREATE TABLE IF NOT EXISTS studio_project_render_jobs (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        status TEXT NOT NULL,
+        error_message TEXT NULL,
+        queued_segment_ids_json TEXT NOT NULL DEFAULT '[]',
+        FOREIGN KEY(project_id) REFERENCES studio_projects(id) ON DELETE CASCADE
+    );
+    "#,
+    "CREATE INDEX IF NOT EXISTS idx_studio_projects_updated_at ON studio_projects(updated_at DESC, id DESC);",
+    "CREATE INDEX IF NOT EXISTS idx_studio_project_segments_project_position ON studio_project_segments(project_id, position ASC);",
+    "CREATE INDEX IF NOT EXISTS idx_studio_project_folders_parent ON studio_project_folders(parent_id, sort_order ASC, updated_at DESC);",
+    "CREATE INDEX IF NOT EXISTS idx_studio_project_pronunciations_project ON studio_project_pronunciations(project_id, updated_at DESC, id DESC);",
+    "CREATE INDEX IF NOT EXISTS idx_studio_project_snapshots_project ON studio_project_snapshots(project_id, created_at DESC, id DESC);",
+    "CREATE INDEX IF NOT EXISTS idx_studio_project_render_jobs_project ON studio_project_render_jobs(project_id, created_at DESC, id DESC);",
+];
+
+const COMPATIBILITY_COLUMNS: &[CompatibilityColumn] = &[
+    CompatibilityColumn {
+        table: "chat_messages",
+        column: "content_parts",
+        definition: "TEXT NULL",
+    },
+    CompatibilityColumn {
+        table: "onboarding_state",
+        column: "analytics_opt_in",
+        definition: "INTEGER NOT NULL DEFAULT 0",
+    },
+    CompatibilityColumn {
+        table: "transcription_records",
+        column: "aligner_model_id",
+        definition: "TEXT NULL",
+    },
+    CompatibilityColumn {
+        table: "transcription_records",
+        column: "processing_status",
+        definition: "TEXT NOT NULL DEFAULT 'ready'",
+    },
+    CompatibilityColumn {
+        table: "transcription_records",
+        column: "processing_error",
+        definition: "TEXT NULL",
+    },
+    CompatibilityColumn {
+        table: "transcription_records",
+        column: "segments_json",
+        definition: "TEXT NOT NULL DEFAULT '[]'",
+    },
+    CompatibilityColumn {
+        table: "transcription_records",
+        column: "words_json",
+        definition: "TEXT NOT NULL DEFAULT '[]'",
+    },
+    CompatibilityColumn {
+        table: "transcription_records",
+        column: "summary_status",
+        definition: "TEXT NOT NULL DEFAULT 'not_requested'",
+    },
+    CompatibilityColumn {
+        table: "transcription_records",
+        column: "summary_model_id",
+        definition: "TEXT NULL",
+    },
+    CompatibilityColumn {
+        table: "transcription_records",
+        column: "summary_text",
+        definition: "TEXT NULL",
+    },
+    CompatibilityColumn {
+        table: "transcription_records",
+        column: "summary_error",
+        definition: "TEXT NULL",
+    },
+    CompatibilityColumn {
+        table: "transcription_records",
+        column: "summary_updated_at",
+        definition: "INTEGER NULL",
+    },
+    CompatibilityColumn {
+        table: "speech_history_records",
+        column: "saved_voice_id",
+        definition: "TEXT NULL",
+    },
+    CompatibilityColumn {
+        table: "speech_history_records",
+        column: "speed",
+        definition: "REAL NULL",
+    },
+    CompatibilityColumn {
+        table: "speech_history_records",
+        column: "processing_status",
+        definition: "TEXT NOT NULL DEFAULT 'ready'",
+    },
+    CompatibilityColumn {
+        table: "speech_history_records",
+        column: "processing_error",
+        definition: "TEXT NULL",
+    },
+    CompatibilityColumn {
+        table: "diarization_records",
+        column: "speaker_name_overrides_json",
+        definition: "TEXT NOT NULL DEFAULT '{}'",
+    },
+    CompatibilityColumn {
+        table: "diarization_records",
+        column: "processing_status",
+        definition: "TEXT NOT NULL DEFAULT 'ready'",
+    },
+    CompatibilityColumn {
+        table: "diarization_records",
+        column: "processing_error",
+        definition: "TEXT NULL",
+    },
+    CompatibilityColumn {
+        table: "diarization_records",
+        column: "summary_status",
+        definition: "TEXT NOT NULL DEFAULT 'not_requested'",
+    },
+    CompatibilityColumn {
+        table: "diarization_records",
+        column: "summary_model_id",
+        definition: "TEXT NULL",
+    },
+    CompatibilityColumn {
+        table: "diarization_records",
+        column: "summary_text",
+        definition: "TEXT NULL",
+    },
+    CompatibilityColumn {
+        table: "diarization_records",
+        column: "summary_error",
+        definition: "TEXT NULL",
+    },
+    CompatibilityColumn {
+        table: "diarization_records",
+        column: "summary_updated_at",
+        definition: "INTEGER NULL",
+    },
+    CompatibilityColumn {
+        table: "studio_project_segments",
+        column: "model_id",
+        definition: "TEXT NULL",
+    },
+    CompatibilityColumn {
+        table: "studio_project_segments",
+        column: "voice_mode",
+        definition: "TEXT NULL",
+    },
+    CompatibilityColumn {
+        table: "studio_project_segments",
+        column: "speaker",
+        definition: "TEXT NULL",
+    },
+    CompatibilityColumn {
+        table: "studio_project_segments",
+        column: "saved_voice_id",
+        definition: "TEXT NULL",
+    },
+];
+
+async fn ensure_column(
+    db: &DatabaseConnection,
+    column: &CompatibilityColumn,
+) -> anyhow::Result<()> {
+    if table_has_column(db, column.table, column.column).await? {
+        return Ok(());
+    }
+    db.execute_unprepared(&format!(
+        "ALTER TABLE {} ADD COLUMN {} {}",
+        column.table, column.column, column.definition
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn table_has_column(
+    db: &DatabaseConnection,
+    table: &str,
+    target: &str,
+) -> anyhow::Result<bool> {
+    let rows = db
+        .query_all_raw(Statement::from_string(
+            DbBackend::Sqlite,
+            format!("PRAGMA table_info({table})"),
+        ))
+        .await?;
+    for row in rows {
+        let name: String = row.try_get_by_index(1)?;
+        if name == target {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+async fn ensure_default_voice_profile(db: &DatabaseConnection) -> anyhow::Result<()> {
+    let exists = db
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT 1 FROM voice_profiles WHERE id = ?1 LIMIT 1",
+            vec![DEFAULT_VOICE_PROFILE_ID.into()],
+        ))
+        .await?
+        .is_some();
+    if exists {
+        return Ok(());
+    }
+
+    let now = current_timestamp_millis();
+    db.execute_raw(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        r#"
+        INSERT INTO voice_profiles (
+            id,
+            name,
+            system_prompt,
+            observational_memory_enabled,
+            created_at,
+            updated_at
+        )
+        VALUES (?1, ?2, ?3, 1, ?4, ?4)
+        "#,
+        vec![
+            DEFAULT_VOICE_PROFILE_ID.into(),
+            DEFAULT_VOICE_PROFILE_NAME.into(),
+            DEFAULT_VOICE_AGENT_SYSTEM_PROMPT.into(),
+            now.into(),
+        ],
+    ))
+    .await?;
+
+    Ok(())
+}
+
+fn current_timestamp_millis() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
 }

--- a/crates/izwi-server/src/db/migrator.rs
+++ b/crates/izwi-server/src/db/migrator.rs
@@ -1,0 +1,9 @@
+use sea_orm::DatabaseConnection;
+
+pub struct Migrator;
+
+impl Migrator {
+    pub async fn up(_db: &DatabaseConnection) -> anyhow::Result<()> {
+        Ok(())
+    }
+}

--- a/crates/izwi-server/src/db/mod.rs
+++ b/crates/izwi-server/src/db/mod.rs
@@ -3,4 +3,4 @@
 pub mod migrator;
 pub mod sqlite;
 
-pub use sqlite::initialize_default;
+pub use sqlite::{StoreDatabase, initialize_default};

--- a/crates/izwi-server/src/db/mod.rs
+++ b/crates/izwi-server/src/db/mod.rs
@@ -1,0 +1,6 @@
+//! SeaORM-backed database initialization.
+
+pub mod migrator;
+pub mod sqlite;
+
+pub use sqlite::initialize_default;

--- a/crates/izwi-server/src/db/sqlite.rs
+++ b/crates/izwi-server/src/db/sqlite.rs
@@ -1,8 +1,10 @@
 use crate::{db::migrator::Migrator, storage_layout};
 use anyhow::Context;
-use sea_orm::{sqlx::sqlite::SqliteJournalMode, ConnectOptions, Database, DatabaseConnection};
-use std::path::Path;
+use sea_orm::{ConnectOptions, Database, DatabaseConnection, sqlx::sqlite::SqliteJournalMode};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::OnceCell;
 
 const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(3);
 const SQLITE_MAX_CONNECTIONS: u32 = 5;
@@ -46,6 +48,42 @@ pub async fn connect_path(db_path: &Path) -> anyhow::Result<DatabaseConnection> 
             db_path.display()
         )
     })
+}
+
+#[derive(Clone)]
+pub struct StoreDatabase {
+    db_path: PathBuf,
+    connection: Arc<OnceCell<DatabaseConnection>>,
+}
+
+impl StoreDatabase {
+    pub fn from_default_path() -> anyhow::Result<Self> {
+        let db_path = storage_layout::resolve_db_path();
+        let media_root = storage_layout::resolve_media_root();
+        storage_layout::ensure_storage_dirs(&db_path, &media_root)
+            .context("Failed to prepare storage layout for SeaORM store")?;
+        Ok(Self::new(db_path))
+    }
+
+    pub fn new(db_path: PathBuf) -> Self {
+        Self {
+            db_path,
+            connection: Arc::new(OnceCell::new()),
+        }
+    }
+
+    pub async fn connection(&self) -> anyhow::Result<&DatabaseConnection> {
+        let db_path = self.db_path.clone();
+        self.connection
+            .get_or_try_init(|| async move {
+                let db = connect_path(&db_path).await?;
+                Migrator::up(&db)
+                    .await
+                    .context("Failed to run SQLite migrations for SeaORM store")?;
+                Ok(db)
+            })
+            .await
+    }
 }
 
 fn sqlite_url(db_path: &Path) -> String {

--- a/crates/izwi-server/src/db/sqlite.rs
+++ b/crates/izwi-server/src/db/sqlite.rs
@@ -1,0 +1,109 @@
+use crate::{db::migrator::Migrator, storage_layout};
+use anyhow::Context;
+use sea_orm::{
+    sqlx::sqlite::SqliteJournalMode, ConnectOptions, Database, DatabaseConnection,
+};
+use std::path::Path;
+use std::time::Duration;
+
+const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(3);
+const SQLITE_MAX_CONNECTIONS: u32 = 5;
+
+pub async fn initialize_default() -> anyhow::Result<DatabaseConnection> {
+    let db = connect_default().await?;
+    Migrator::up(&db)
+        .await
+        .context("Failed to run SQLite migrations")?;
+    Ok(db)
+}
+
+pub async fn connect_default() -> anyhow::Result<DatabaseConnection> {
+    let db_path = storage_layout::resolve_db_path();
+    let media_root = storage_layout::resolve_media_root();
+    storage_layout::ensure_storage_dirs(&db_path, &media_root)
+        .context("Failed to prepare storage layout for SeaORM")?;
+
+    connect_path(&db_path).await
+}
+
+pub async fn connect_path(db_path: &Path) -> anyhow::Result<DatabaseConnection> {
+    let mut options = ConnectOptions::new(sqlite_url(db_path));
+    options
+        .max_connections(SQLITE_MAX_CONNECTIONS)
+        .min_connections(1)
+        .connect_timeout(SQLITE_BUSY_TIMEOUT)
+        .acquire_timeout(SQLITE_BUSY_TIMEOUT)
+        .sqlx_logging(false)
+        .map_sqlx_sqlite_opts(|options| {
+            options
+                .create_if_missing(true)
+                .busy_timeout(SQLITE_BUSY_TIMEOUT)
+                .foreign_keys(true)
+                .journal_mode(SqliteJournalMode::Wal)
+        });
+
+    Database::connect(options)
+        .await
+        .with_context(|| format!("Unable to open SeaORM SQLite database at {}", db_path.display()))
+}
+
+fn sqlite_url(db_path: &Path) -> String {
+    let path = db_path.to_string_lossy();
+    let escaped = path
+        .replace('%', "%25")
+        .replace('?', "%3F")
+        .replace('#', "%23");
+    format!("sqlite://{escaped}?mode=rwc")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::env_lock;
+    use sea_orm::{ConnectionTrait, DbBackend, Statement};
+
+    #[tokio::test]
+    async fn default_connection_preserves_sqlite_pragmas() {
+        let _guard = env_lock();
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("seaorm.sqlite3");
+        let media_dir = temp_dir.path().join("media");
+        std::env::set_var("IZWI_DB_PATH", &db_path);
+        std::env::set_var("IZWI_MEDIA_DIR", &media_dir);
+
+        let db = initialize_default().await.expect("database initializes");
+        assert_eq!(db.get_database_backend(), DbBackend::Sqlite);
+
+        let foreign_keys = query_i64_pragma(&db, "PRAGMA foreign_keys")
+            .await
+            .expect("foreign_keys pragma");
+        assert_eq!(foreign_keys, 1);
+
+        let journal_mode = query_string_pragma(&db, "PRAGMA journal_mode")
+            .await
+            .expect("journal_mode pragma");
+        assert_eq!(journal_mode.to_ascii_lowercase(), "wal");
+
+        assert!(db_path.exists());
+        assert!(media_dir.exists());
+
+        std::env::remove_var("IZWI_DB_PATH");
+        std::env::remove_var("IZWI_MEDIA_DIR");
+    }
+
+    async fn query_i64_pragma(db: &DatabaseConnection, sql: &str) -> anyhow::Result<i64> {
+        let row = db
+            .query_one_raw(Statement::from_string(DbBackend::Sqlite, sql.to_string()))
+            .await?
+            .context("pragma returned no row")?;
+        Ok(row.try_get_by_index(0)?)
+    }
+
+    async fn query_string_pragma(db: &DatabaseConnection, sql: &str) -> anyhow::Result<String> {
+        let row = db
+            .query_one_raw(Statement::from_string(DbBackend::Sqlite, sql.to_string()))
+            .await?
+            .context("pragma returned no row")?;
+        Ok(row.try_get_by_index(0)?)
+    }
+}

--- a/crates/izwi-server/src/db/sqlite.rs
+++ b/crates/izwi-server/src/db/sqlite.rs
@@ -1,8 +1,6 @@
 use crate::{db::migrator::Migrator, storage_layout};
 use anyhow::Context;
-use sea_orm::{
-    sqlx::sqlite::SqliteJournalMode, ConnectOptions, Database, DatabaseConnection,
-};
+use sea_orm::{sqlx::sqlite::SqliteJournalMode, ConnectOptions, Database, DatabaseConnection};
 use std::path::Path;
 use std::time::Duration;
 
@@ -42,9 +40,12 @@ pub async fn connect_path(db_path: &Path) -> anyhow::Result<DatabaseConnection> 
                 .journal_mode(SqliteJournalMode::Wal)
         });
 
-    Database::connect(options)
-        .await
-        .with_context(|| format!("Unable to open SeaORM SQLite database at {}", db_path.display()))
+    Database::connect(options).await.with_context(|| {
+        format!(
+            "Unable to open SeaORM SQLite database at {}",
+            db_path.display()
+        )
+    })
 }
 
 fn sqlite_url(db_path: &Path) -> String {
@@ -60,7 +61,9 @@ fn sqlite_url(db_path: &Path) -> String {
 mod tests {
     use super::*;
     use crate::test_support::env_lock;
+    use crate::voice_defaults::DEFAULT_VOICE_PROFILE_ID;
     use sea_orm::{ConnectionTrait, DbBackend, Statement};
+    use std::collections::BTreeSet;
 
     #[tokio::test]
     async fn default_connection_preserves_sqlite_pragmas() {
@@ -91,11 +94,57 @@ mod tests {
         std::env::remove_var("IZWI_MEDIA_DIR");
     }
 
+    #[tokio::test]
+    async fn migrations_create_schema_and_backfill_compatibility_columns() {
+        let _guard = env_lock();
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("legacy.sqlite3");
+        let media_dir = temp_dir.path().join("media");
+        std::env::set_var("IZWI_DB_PATH", &db_path);
+        std::env::set_var("IZWI_MEDIA_DIR", &media_dir);
+
+        {
+            let db = connect_path(&db_path).await.expect("legacy db opens");
+            db.execute_unprepared(LEGACY_COMPAT_SCHEMA)
+                .await
+                .expect("legacy schema created");
+        }
+
+        let db = initialize_default().await.expect("database initializes");
+        let tables = user_tables(&db).await.expect("table list");
+        for table in EXPECTED_TABLES {
+            assert!(tables.contains(*table), "{table} table exists");
+        }
+
+        for (table, column) in EXPECTED_COMPAT_COLUMNS {
+            let columns = table_columns(&db, table).await.expect("table columns");
+            assert!(
+                columns.contains(*column),
+                "{table}.{column} compatibility column exists"
+            );
+        }
+
+        let default_profiles = query_i64_scalar(
+            &db,
+            &format!("SELECT COUNT(*) FROM voice_profiles WHERE id = '{DEFAULT_VOICE_PROFILE_ID}'"),
+        )
+        .await
+        .expect("default profile count");
+        assert_eq!(default_profiles, 1);
+
+        std::env::remove_var("IZWI_DB_PATH");
+        std::env::remove_var("IZWI_MEDIA_DIR");
+    }
+
     async fn query_i64_pragma(db: &DatabaseConnection, sql: &str) -> anyhow::Result<i64> {
+        query_i64_scalar(db, sql).await
+    }
+
+    async fn query_i64_scalar(db: &DatabaseConnection, sql: &str) -> anyhow::Result<i64> {
         let row = db
             .query_one_raw(Statement::from_string(DbBackend::Sqlite, sql.to_string()))
             .await?
-            .context("pragma returned no row")?;
+            .context("query returned no row")?;
         Ok(row.try_get_by_index(0)?)
     }
 
@@ -106,4 +155,201 @@ mod tests {
             .context("pragma returned no row")?;
         Ok(row.try_get_by_index(0)?)
     }
+
+    async fn user_tables(db: &DatabaseConnection) -> anyhow::Result<BTreeSet<String>> {
+        let rows = db
+            .query_all_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+                    .to_string(),
+            ))
+            .await?;
+        let mut tables = BTreeSet::new();
+        for row in rows {
+            tables.insert(row.try_get_by_index::<String>(0)?);
+        }
+        Ok(tables)
+    }
+
+    async fn table_columns(
+        db: &DatabaseConnection,
+        table: &str,
+    ) -> anyhow::Result<BTreeSet<String>> {
+        let rows = db
+            .query_all_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                format!("PRAGMA table_info({table})"),
+            ))
+            .await?;
+        let mut columns = BTreeSet::new();
+        for row in rows {
+            columns.insert(row.try_get_by_index::<String>(1)?);
+        }
+        Ok(columns)
+    }
+
+    const EXPECTED_TABLES: &[&str] = &[
+        "chat_threads",
+        "chat_messages",
+        "voice_profiles",
+        "voice_sessions",
+        "voice_turns",
+        "voice_observations",
+        "onboarding_state",
+        "transcription_records",
+        "diarization_records",
+        "speech_history_records",
+        "saved_voices",
+        "studio_projects",
+        "studio_project_segments",
+        "studio_project_folders",
+        "studio_project_meta",
+        "studio_project_pronunciations",
+        "studio_project_snapshots",
+        "studio_project_render_jobs",
+    ];
+
+    const EXPECTED_COMPAT_COLUMNS: &[(&str, &str)] = &[
+        ("chat_messages", "content_parts"),
+        ("onboarding_state", "analytics_opt_in"),
+        ("transcription_records", "aligner_model_id"),
+        ("transcription_records", "processing_status"),
+        ("transcription_records", "processing_error"),
+        ("transcription_records", "segments_json"),
+        ("transcription_records", "words_json"),
+        ("transcription_records", "summary_status"),
+        ("transcription_records", "summary_model_id"),
+        ("transcription_records", "summary_text"),
+        ("transcription_records", "summary_error"),
+        ("transcription_records", "summary_updated_at"),
+        ("speech_history_records", "saved_voice_id"),
+        ("speech_history_records", "speed"),
+        ("speech_history_records", "processing_status"),
+        ("speech_history_records", "processing_error"),
+        ("diarization_records", "speaker_name_overrides_json"),
+        ("diarization_records", "processing_status"),
+        ("diarization_records", "processing_error"),
+        ("diarization_records", "summary_status"),
+        ("diarization_records", "summary_model_id"),
+        ("diarization_records", "summary_text"),
+        ("diarization_records", "summary_error"),
+        ("diarization_records", "summary_updated_at"),
+        ("studio_project_segments", "model_id"),
+        ("studio_project_segments", "voice_mode"),
+        ("studio_project_segments", "speaker"),
+        ("studio_project_segments", "saved_voice_id"),
+    ];
+
+    const LEGACY_COMPAT_SCHEMA: &str = r#"
+        CREATE TABLE chat_threads (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            model_id TEXT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+        );
+
+        CREATE TABLE chat_messages (
+            id TEXT PRIMARY KEY,
+            thread_id TEXT NOT NULL,
+            role TEXT NOT NULL CHECK(role IN ('system', 'user', 'assistant')),
+            content TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            tokens_generated INTEGER NULL,
+            generation_time_ms REAL NULL,
+            FOREIGN KEY(thread_id) REFERENCES chat_threads(id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE onboarding_state (
+            id TEXT PRIMARY KEY,
+            completed_at INTEGER NULL
+        );
+
+        CREATE TABLE transcription_records (
+            id TEXT PRIMARY KEY,
+            created_at INTEGER NOT NULL,
+            model_id TEXT NULL,
+            language TEXT NULL,
+            duration_secs REAL NULL,
+            processing_time_ms REAL NOT NULL,
+            rtf REAL NULL,
+            audio_mime_type TEXT NOT NULL,
+            audio_filename TEXT NULL,
+            audio_storage_path TEXT NOT NULL,
+            transcription TEXT NOT NULL
+        );
+
+        CREATE TABLE speech_history_records (
+            id TEXT PRIMARY KEY,
+            created_at INTEGER NOT NULL,
+            route_kind TEXT NOT NULL,
+            model_id TEXT NULL,
+            speaker TEXT NULL,
+            language TEXT NULL,
+            input_text TEXT NOT NULL,
+            voice_description TEXT NULL,
+            reference_text TEXT NULL,
+            generation_time_ms REAL NOT NULL,
+            audio_duration_secs REAL NULL,
+            rtf REAL NULL,
+            tokens_generated INTEGER NULL,
+            audio_mime_type TEXT NOT NULL,
+            audio_filename TEXT NULL,
+            audio_storage_path TEXT NOT NULL
+        );
+
+        CREATE TABLE diarization_records (
+            id TEXT PRIMARY KEY,
+            created_at INTEGER NOT NULL,
+            model_id TEXT NULL,
+            asr_model_id TEXT NULL,
+            aligner_model_id TEXT NULL,
+            llm_model_id TEXT NULL,
+            min_speakers INTEGER NULL,
+            max_speakers INTEGER NULL,
+            min_speech_duration_ms REAL NULL,
+            min_silence_duration_ms REAL NULL,
+            enable_llm_refinement INTEGER NOT NULL,
+            processing_time_ms REAL NOT NULL,
+            duration_secs REAL NULL,
+            rtf REAL NULL,
+            speaker_count INTEGER NOT NULL,
+            alignment_coverage REAL NULL,
+            unattributed_words INTEGER NOT NULL,
+            llm_refined INTEGER NOT NULL,
+            asr_text TEXT NOT NULL,
+            raw_transcript TEXT NOT NULL,
+            transcript TEXT NOT NULL,
+            segments_json TEXT NOT NULL,
+            words_json TEXT NOT NULL,
+            utterances_json TEXT NOT NULL,
+            audio_mime_type TEXT NOT NULL,
+            audio_filename TEXT NULL,
+            audio_storage_path TEXT NOT NULL
+        );
+
+        CREATE TABLE studio_projects (
+            id TEXT PRIMARY KEY,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            source_filename TEXT NULL,
+            source_text TEXT NOT NULL,
+            model_id TEXT NULL,
+            voice_mode TEXT NOT NULL,
+            speaker TEXT NULL,
+            saved_voice_id TEXT NULL,
+            speed REAL NULL
+        );
+
+        CREATE TABLE studio_project_segments (
+            id TEXT PRIMARY KEY,
+            project_id TEXT NOT NULL,
+            position INTEGER NOT NULL,
+            text TEXT NOT NULL,
+            speech_record_id TEXT NULL,
+            updated_at INTEGER NOT NULL,
+            FOREIGN KEY(project_id) REFERENCES studio_projects(id) ON DELETE CASCADE
+        );
+    "#;
 }

--- a/crates/izwi-server/src/diarization_store.rs
+++ b/crates/izwi-server/src/diarization_store.rs
@@ -1,14 +1,18 @@
 //! Persistent diarization history storage backed by SQLite.
 
-use anyhow::{anyhow, Context};
-use rusqlite::{params, Connection, OptionalExtension, Row};
+use anyhow::{Context, anyhow};
+use sea_orm::sea_query::Expr;
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, QueryFilter, QueryResult, Set, Statement,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::task;
 
 use crate::{
+    db::StoreDatabase,
+    entity::diarization_records,
     ids::new_uuid,
     storage_layout::{self, MediaGroup},
 };
@@ -248,7 +252,7 @@ pub struct CompleteDiarizationRecord {
 
 #[derive(Clone)]
 pub struct DiarizationStore {
-    db_path: PathBuf,
+    db: StoreDatabase,
     media_root: PathBuf,
 }
 
@@ -264,66 +268,8 @@ impl DiarizationStore {
         storage_layout::ensure_storage_dirs(&db_path, &media_root)
             .context("Failed to prepare diarization storage layout")?;
 
-        let conn = storage_layout::open_sqlite_connection(&db_path).with_context(|| {
-            format!("Failed to open diarization database: {}", db_path.display())
-        })?;
-
-        conn.execute_batch(
-            r#"
-            CREATE TABLE IF NOT EXISTS diarization_records (
-                id TEXT PRIMARY KEY,
-                created_at INTEGER NOT NULL,
-                model_id TEXT NULL,
-                asr_model_id TEXT NULL,
-                aligner_model_id TEXT NULL,
-                llm_model_id TEXT NULL,
-                processing_status TEXT NOT NULL DEFAULT 'ready',
-                processing_error TEXT NULL,
-                min_speakers INTEGER NULL,
-                max_speakers INTEGER NULL,
-                min_speech_duration_ms REAL NULL,
-                min_silence_duration_ms REAL NULL,
-                enable_llm_refinement INTEGER NOT NULL,
-                processing_time_ms REAL NOT NULL,
-                duration_secs REAL NULL,
-                rtf REAL NULL,
-                speaker_count INTEGER NOT NULL,
-                alignment_coverage REAL NULL,
-                unattributed_words INTEGER NOT NULL,
-                llm_refined INTEGER NOT NULL,
-                asr_text TEXT NOT NULL,
-                raw_transcript TEXT NOT NULL,
-                transcript TEXT NOT NULL,
-                summary_status TEXT NOT NULL DEFAULT 'not_requested',
-                summary_model_id TEXT NULL,
-                summary_text TEXT NULL,
-                summary_error TEXT NULL,
-                summary_updated_at INTEGER NULL,
-                segments_json TEXT NOT NULL,
-                words_json TEXT NOT NULL,
-                utterances_json TEXT NOT NULL,
-                speaker_name_overrides_json TEXT NOT NULL DEFAULT '{}',
-                audio_mime_type TEXT NOT NULL,
-                audio_filename TEXT NULL,
-                audio_storage_path TEXT NOT NULL
-            );
-
-            CREATE INDEX IF NOT EXISTS idx_diarization_records_created_at
-                ON diarization_records(created_at DESC);
-            "#,
-        )
-        .context("Failed to initialize diarization database schema")?;
-        ensure_diarization_records_speaker_name_overrides_column(&conn)?;
-        ensure_diarization_records_processing_status_column(&conn)?;
-        ensure_diarization_records_processing_error_column(&conn)?;
-        ensure_diarization_records_summary_status_column(&conn)?;
-        ensure_diarization_records_summary_model_id_column(&conn)?;
-        ensure_diarization_records_summary_text_column(&conn)?;
-        ensure_diarization_records_summary_error_column(&conn)?;
-        ensure_diarization_records_summary_updated_at_column(&conn)?;
-
         Ok(Self {
-            db_path,
+            db: StoreDatabase::new(db_path),
             media_root,
         })
     }
@@ -336,455 +282,255 @@ impl DiarizationStore {
         Vec<DiarizationRecordSummary>,
         Option<DiarizationRecordListCursor>,
     )> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let list_limit = i64::try_from(limit.clamp(1, 500).max(1)).unwrap_or(200);
-            let mut records = Vec::new();
-            let fetch_limit = list_limit.saturating_add(1);
+        let db = self.db.connection().await?;
+        let list_limit = i64::try_from(limit.clamp(1, 500).max(1)).unwrap_or(200);
+        let fetch_limit = list_limit.saturating_add(1);
 
-            if let Some(cursor) = cursor {
-                let cursor_created_at = i64::try_from(cursor.created_at).unwrap_or(i64::MAX);
-                let mut stmt = conn.prepare(
-                    r#"
-                    SELECT
-                        id,
-                        created_at,
-                        model_id,
-                        processing_status,
-                        processing_error,
-                        speaker_count,
-                        utterances_json,
-                        speaker_name_overrides_json,
-                        duration_secs,
-                        processing_time_ms,
-                        rtf,
-                        audio_mime_type,
-                        audio_filename,
-                        transcript,
-                        summary_status,
-                        summary_text
-                    FROM diarization_records
-                    WHERE created_at < ?1 OR (created_at = ?1 AND id < ?2)
-                    ORDER BY created_at DESC, id DESC
-                    LIMIT ?3
-                    "#,
-                )?;
+        let rows = if let Some(cursor) = cursor {
+            let cursor_created_at = i64::try_from(cursor.created_at).unwrap_or(i64::MAX);
+            db.query_all_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                DIARIZATION_PAGE_AFTER_CURSOR_SQL,
+                vec![
+                    cursor_created_at.into(),
+                    cursor.id.into(),
+                    fetch_limit.into(),
+                ],
+            ))
+            .await
+        } else {
+            db.query_all_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                DIARIZATION_PAGE_SQL,
+                vec![fetch_limit.into()],
+            ))
+            .await
+        }
+        .context("Failed to list diarization records")?;
 
-                let rows =
-                    stmt.query_map(params![cursor_created_at, cursor.id, fetch_limit], |row| {
-                        let speaker_count = row
-                            .get::<_, Option<i64>>(5)?
-                            .and_then(i64_to_usize)
-                            .unwrap_or(0);
-                        let utterances: Vec<DiarizationUtteranceRecord> =
-                            parse_json_vec(row.get(6)?);
-                        let speaker_name_overrides = parse_json_map(row.get(7)?);
-                        let transcript: String = row.get(13)?;
-                        let summary_status =
-                            parse_summary_status(row.get::<_, Option<String>>(14)?);
-                        let summary_text: Option<String> = row.get(15)?;
-                        Ok(DiarizationRecordSummary {
-                            id: row.get(0)?,
-                            created_at: i64_to_u64(row.get(1)?),
-                            model_id: row.get(2)?,
-                            processing_status: parse_processing_status(row.get(3)?),
-                            processing_error: row.get(4)?,
-                            speaker_count,
-                            corrected_speaker_count: corrected_speaker_count_from_parts(
-                                speaker_count,
-                                &[],
-                                &[],
-                                &utterances,
-                                &speaker_name_overrides,
-                            ),
-                            speaker_name_override_count: speaker_name_overrides.len(),
-                            duration_secs: row.get(8)?,
-                            processing_time_ms: row.get(9)?,
-                            rtf: row.get(10)?,
-                            audio_mime_type: row.get(11)?,
-                            audio_filename: row.get(12)?,
-                            transcript_preview: transcript_preview_with_utterances(
-                                &utterances,
-                                &speaker_name_overrides,
-                                transcript.as_str(),
-                            ),
-                            transcript_chars: transcript.chars().count(),
-                            summary_status,
-                            summary_preview: summary_preview(summary_text.as_deref()),
-                            summary_chars: summary_text
-                                .as_ref()
-                                .map(|text| text.chars().count())
-                                .unwrap_or(0),
-                        })
-                    })?;
+        let mut records = rows
+            .iter()
+            .map(map_diarization_summary)
+            .collect::<anyhow::Result<Vec<_>>>()?;
 
-                for row in rows {
-                    records.push(row?);
-                }
-            } else {
-                let mut stmt = conn.prepare(
-                    r#"
-                    SELECT
-                        id,
-                        created_at,
-                        model_id,
-                        processing_status,
-                        processing_error,
-                        speaker_count,
-                        utterances_json,
-                        speaker_name_overrides_json,
-                        duration_secs,
-                        processing_time_ms,
-                        rtf,
-                        audio_mime_type,
-                        audio_filename,
-                        transcript,
-                        summary_status,
-                        summary_text
-                    FROM diarization_records
-                    ORDER BY created_at DESC, id DESC
-                    LIMIT ?1
-                    "#,
-                )?;
+        let page_limit = usize::try_from(list_limit).unwrap_or(200);
+        let has_more = records.len() > page_limit;
+        if has_more {
+            records.truncate(page_limit);
+        }
+        let next_cursor = if has_more {
+            records.last().map(|record| DiarizationRecordListCursor {
+                created_at: record.created_at,
+                id: record.id.clone(),
+            })
+        } else {
+            None
+        };
 
-                let rows = stmt.query_map(params![fetch_limit], |row| {
-                    let speaker_count = row
-                        .get::<_, Option<i64>>(5)?
-                        .and_then(i64_to_usize)
-                        .unwrap_or(0);
-                    let utterances: Vec<DiarizationUtteranceRecord> = parse_json_vec(row.get(6)?);
-                    let speaker_name_overrides = parse_json_map(row.get(7)?);
-                    let transcript: String = row.get(13)?;
-                    let summary_status = parse_summary_status(row.get::<_, Option<String>>(14)?);
-                    let summary_text: Option<String> = row.get(15)?;
-                    Ok(DiarizationRecordSummary {
-                        id: row.get(0)?,
-                        created_at: i64_to_u64(row.get(1)?),
-                        model_id: row.get(2)?,
-                        processing_status: parse_processing_status(row.get(3)?),
-                        processing_error: row.get(4)?,
-                        speaker_count,
-                        corrected_speaker_count: corrected_speaker_count_from_parts(
-                            speaker_count,
-                            &[],
-                            &[],
-                            &utterances,
-                            &speaker_name_overrides,
-                        ),
-                        speaker_name_override_count: speaker_name_overrides.len(),
-                        duration_secs: row.get(8)?,
-                        processing_time_ms: row.get(9)?,
-                        rtf: row.get(10)?,
-                        audio_mime_type: row.get(11)?,
-                        audio_filename: row.get(12)?,
-                        transcript_preview: transcript_preview_with_utterances(
-                            &utterances,
-                            &speaker_name_overrides,
-                            transcript.as_str(),
-                        ),
-                        transcript_chars: transcript.chars().count(),
-                        summary_status,
-                        summary_preview: summary_preview(summary_text.as_deref()),
-                        summary_chars: summary_text
-                            .as_ref()
-                            .map(|text| text.chars().count())
-                            .unwrap_or(0),
-                    })
-                })?;
-
-                for row in rows {
-                    records.push(row?);
-                }
-            }
-
-            let page_limit = usize::try_from(list_limit).unwrap_or(200);
-            let has_more = records.len() > page_limit;
-            if has_more {
-                records.truncate(page_limit);
-            }
-            let next_cursor = if has_more {
-                records.last().map(|record| DiarizationRecordListCursor {
-                    created_at: record.created_at,
-                    id: record.id.clone(),
-                })
-            } else {
-                None
-            };
-
-            Ok((records, next_cursor))
-        })
-        .await
+        Ok((records, next_cursor))
     }
 
     pub async fn get_record(&self, record_id: String) -> anyhow::Result<Option<DiarizationRecord>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let record = fetch_record_without_audio(&conn, &record_id)?;
-            Ok(record)
-        })
-        .await
+        let db = self.db.connection().await?;
+        fetch_record_without_audio(db, &record_id).await
     }
 
     pub async fn get_audio(
         &self,
         record_id: String,
     ) -> anyhow::Result<Option<StoredDiarizationAudio>> {
-        let media_root = self.media_root.clone();
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let audio = conn
-                .query_row(
-                    r#"
-                    SELECT audio_storage_path, audio_mime_type, audio_filename
-                    FROM diarization_records
-                    WHERE id = ?1
-                    "#,
-                    params![record_id],
-                    |row| {
-                        Ok((
-                            row.get::<_, String>(0)?,
-                            row.get::<_, String>(1)?,
-                            row.get::<_, Option<String>>(2)?,
-                        ))
-                    },
-                )
-                .optional()?;
-            let Some((audio_storage_path, audio_mime_type, audio_filename)) = audio else {
-                return Ok(None);
-            };
+        let db = self.db.connection().await?;
+        let audio = db
+            .query_one_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                r#"
+                SELECT audio_storage_path, audio_mime_type, audio_filename
+                FROM diarization_records
+                WHERE id = ?1
+                "#,
+                vec![record_id.into()],
+            ))
+            .await
+            .context("Failed to load diarization audio metadata")?;
+        let Some(row) = audio else {
+            return Ok(None);
+        };
 
-            let audio_bytes =
-                storage_layout::read_media_file(&media_root, audio_storage_path.as_str())?;
+        let audio_storage_path: String = row.try_get_by_index(0)?;
+        let audio_mime_type: String = row.try_get_by_index(1)?;
+        let audio_filename: Option<String> = row.try_get_by_index(2)?;
+        let audio_bytes =
+            storage_layout::read_media_file(&self.media_root, audio_storage_path.as_str())?;
 
-            Ok(Some(StoredDiarizationAudio {
-                audio_bytes,
-                audio_mime_type,
-                audio_filename,
-            }))
-        })
-        .await
+        Ok(Some(StoredDiarizationAudio {
+            audio_bytes,
+            audio_mime_type,
+            audio_filename,
+        }))
     }
 
     pub async fn create_record(
         &self,
         record: NewDiarizationRecord,
     ) -> anyhow::Result<DiarizationRecord> {
-        let media_root = self.media_root.clone();
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let now = now_unix_millis_i64();
-            let record_id = new_uuid();
+        let db = self.db.connection().await?;
+        let now = now_unix_millis_i64();
+        let record_id = new_uuid();
 
-            let model_id = sanitize_optional_text(record.model_id.as_deref(), 160);
-            let asr_model_id = sanitize_optional_text(record.asr_model_id.as_deref(), 160);
-            let aligner_model_id = sanitize_optional_text(record.aligner_model_id.as_deref(), 160);
-            let llm_model_id = sanitize_optional_text(record.llm_model_id.as_deref(), 160);
-            let processing_error =
-                sanitize_optional_text(record.processing_error.as_deref(), 1_000);
-            let processing_status =
-                normalize_processing_status(record.processing_status, processing_error.as_deref());
-            let min_speakers = record
-                .min_speakers
-                .and_then(|value| i64::try_from(value).ok());
-            let max_speakers = record
-                .max_speakers
-                .and_then(|value| i64::try_from(value).ok());
-            let min_speech_duration_ms = record
-                .min_speech_duration_ms
-                .filter(|value| value.is_finite() && *value >= 0.0);
-            let min_silence_duration_ms = record
-                .min_silence_duration_ms
-                .filter(|value| value.is_finite() && *value >= 0.0);
-            let processing_time_ms = if record.processing_time_ms.is_finite() {
-                record.processing_time_ms.max(0.0)
+        let model_id = sanitize_optional_text(record.model_id.as_deref(), 160);
+        let asr_model_id = sanitize_optional_text(record.asr_model_id.as_deref(), 160);
+        let aligner_model_id = sanitize_optional_text(record.aligner_model_id.as_deref(), 160);
+        let llm_model_id = sanitize_optional_text(record.llm_model_id.as_deref(), 160);
+        let processing_error = sanitize_optional_text(record.processing_error.as_deref(), 1_000);
+        let processing_status =
+            normalize_processing_status(record.processing_status, processing_error.as_deref());
+        let min_speakers = record
+            .min_speakers
+            .and_then(|value| i64::try_from(value).ok());
+        let max_speakers = record
+            .max_speakers
+            .and_then(|value| i64::try_from(value).ok());
+        let min_speech_duration_ms = record
+            .min_speech_duration_ms
+            .filter(|value| value.is_finite() && *value >= 0.0);
+        let min_silence_duration_ms = record
+            .min_silence_duration_ms
+            .filter(|value| value.is_finite() && *value >= 0.0);
+        let processing_time_ms = if record.processing_time_ms.is_finite() {
+            record.processing_time_ms.max(0.0)
+        } else {
+            0.0
+        };
+        let duration_secs = record
+            .duration_secs
+            .filter(|value| value.is_finite() && *value >= 0.0);
+        let rtf = record
+            .rtf
+            .filter(|value| value.is_finite() && *value >= 0.0);
+        let speaker_count = i64::try_from(record.speaker_count).unwrap_or(0);
+        let alignment_coverage = record
+            .alignment_coverage
+            .filter(|value| value.is_finite() && *value >= 0.0);
+        let unattributed_words = i64::try_from(record.unattributed_words).unwrap_or(0);
+        let asr_text = sanitize_required_text(record.asr_text.as_str(), 40_000);
+        let raw_transcript = sanitize_required_text(record.raw_transcript.as_str(), 100_000);
+        let transcript = sanitize_required_text(record.transcript.as_str(), 100_000);
+        let summary_model_id = sanitize_optional_text(record.summary_model_id.as_deref(), 160);
+        let summary_text = sanitize_optional_text(record.summary_text.as_deref(), 20_000);
+        let summary_error = sanitize_optional_text(record.summary_error.as_deref(), 1_000);
+        let summary_status = normalize_summary_status(
+            record.summary_status,
+            summary_text.as_deref(),
+            summary_error.as_deref(),
+        );
+        let summary_updated_at = normalize_optional_timestamp_i64(record.summary_updated_at)
+            .or_else(|| {
+                if summary_status == DiarizationSummaryStatus::NotRequested {
+                    None
+                } else {
+                    Some(now)
+                }
+            });
+        let speaker_name_overrides = sanitize_speaker_name_overrides(
+            &record.speaker_name_overrides,
+            &raw_speaker_labels_from_parts(&record.segments, &record.words, &record.utterances),
+        )?;
+        let audio_mime_type = sanitize_audio_mime_type(record.audio_mime_type.as_str());
+        let audio_filename = sanitize_optional_text(record.audio_filename.as_deref(), 260);
+
+        if record.audio_bytes.is_empty() {
+            return Err(anyhow!("Audio payload cannot be empty"));
+        }
+
+        let audio_storage_path = storage_layout::persist_audio_file(
+            &self.media_root,
+            MediaGroup::Uploads,
+            "diarization",
+            &record_id,
+            audio_filename.as_deref(),
+            audio_mime_type.as_str(),
+            &record.audio_bytes,
+        )?;
+
+        let segments_json =
+            serde_json::to_string(&record.segments).context("Failed serializing segments")?;
+        let words_json =
+            serde_json::to_string(&record.words).context("Failed serializing words")?;
+        let utterances_json =
+            serde_json::to_string(&record.utterances).context("Failed serializing utterances")?;
+        let speaker_name_overrides_json = serde_json::to_string(&speaker_name_overrides)
+            .context("Failed serializing speaker name overrides")?;
+
+        if let Err(err) = diarization_records::Entity::insert(diarization_records::ActiveModel {
+            id: Set(record_id.clone()),
+            created_at: Set(now),
+            model_id: Set(model_id),
+            asr_model_id: Set(asr_model_id),
+            aligner_model_id: Set(aligner_model_id),
+            llm_model_id: Set(llm_model_id),
+            processing_status: Set(processing_status.as_db_value().to_string()),
+            processing_error: Set(processing_error),
+            min_speakers: Set(min_speakers),
+            max_speakers: Set(max_speakers),
+            min_speech_duration_ms: Set(min_speech_duration_ms),
+            min_silence_duration_ms: Set(min_silence_duration_ms),
+            enable_llm_refinement: Set(if record.enable_llm_refinement {
+                1_i64
             } else {
-                0.0
-            };
-            let duration_secs = record
-                .duration_secs
-                .filter(|value| value.is_finite() && *value >= 0.0);
-            let rtf = record
-                .rtf
-                .filter(|value| value.is_finite() && *value >= 0.0);
-            let speaker_count = i64::try_from(record.speaker_count).unwrap_or(0);
-            let alignment_coverage = record
-                .alignment_coverage
-                .filter(|value| value.is_finite() && *value >= 0.0);
-            let unattributed_words = i64::try_from(record.unattributed_words).unwrap_or(0);
-            let asr_text = sanitize_required_text(record.asr_text.as_str(), 40_000);
-            let raw_transcript = sanitize_required_text(record.raw_transcript.as_str(), 100_000);
-            let transcript = sanitize_required_text(record.transcript.as_str(), 100_000);
-            let summary_model_id = sanitize_optional_text(record.summary_model_id.as_deref(), 160);
-            let summary_text = sanitize_optional_text(record.summary_text.as_deref(), 20_000);
-            let summary_error = sanitize_optional_text(record.summary_error.as_deref(), 1_000);
-            let summary_status = normalize_summary_status(
-                record.summary_status,
-                summary_text.as_deref(),
-                summary_error.as_deref(),
-            );
-            let summary_updated_at = normalize_optional_timestamp_i64(record.summary_updated_at)
-                .or_else(|| {
-                    if summary_status == DiarizationSummaryStatus::NotRequested {
-                        None
-                    } else {
-                        Some(now)
-                    }
-                });
-            let speaker_name_overrides = sanitize_speaker_name_overrides(
-                &record.speaker_name_overrides,
-                &raw_speaker_labels_from_parts(&record.segments, &record.words, &record.utterances),
-            )?;
-            let audio_mime_type = sanitize_audio_mime_type(record.audio_mime_type.as_str());
-            let audio_filename = sanitize_optional_text(record.audio_filename.as_deref(), 260);
-
-            if record.audio_bytes.is_empty() {
-                return Err(anyhow!("Audio payload cannot be empty"));
-            }
-
-            let audio_storage_path = storage_layout::persist_audio_file(
-                &media_root,
-                MediaGroup::Uploads,
-                "diarization",
-                &record_id,
-                audio_filename.as_deref(),
-                audio_mime_type.as_str(),
-                &record.audio_bytes,
-            )?;
-
-            let segments_json =
-                serde_json::to_string(&record.segments).context("Failed serializing segments")?;
-            let words_json =
-                serde_json::to_string(&record.words).context("Failed serializing words")?;
-            let utterances_json = serde_json::to_string(&record.utterances)
-                .context("Failed serializing utterances")?;
-            let speaker_name_overrides_json = serde_json::to_string(&speaker_name_overrides)
-                .context("Failed serializing speaker name overrides")?;
-
-            if let Err(err) = conn.execute(
-                r#"
-                INSERT INTO diarization_records (
-                    id,
-                    created_at,
-                    model_id,
-                    asr_model_id,
-                    aligner_model_id,
-                    llm_model_id,
-                    processing_status,
-                    processing_error,
-                    min_speakers,
-                    max_speakers,
-                    min_speech_duration_ms,
-                    min_silence_duration_ms,
-                    enable_llm_refinement,
-                    processing_time_ms,
-                    duration_secs,
-                    rtf,
-                    speaker_count,
-                    alignment_coverage,
-                    unattributed_words,
-                    llm_refined,
-                    asr_text,
-                    raw_transcript,
-                    transcript,
-                    summary_status,
-                    summary_model_id,
-                    summary_text,
-                    summary_error,
-                    summary_updated_at,
-                    segments_json,
-                    words_json,
-                    utterances_json,
-                    speaker_name_overrides_json,
-                    audio_mime_type,
-                    audio_filename,
-                    audio_storage_path
-                )
-                VALUES (
-                    ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15,
-                    ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29,
-                    ?30, ?31, ?32, ?33, ?34, ?35
-                )
-                "#,
-                params![
-                    &record_id,
-                    now,
-                    model_id,
-                    asr_model_id,
-                    aligner_model_id,
-                    llm_model_id,
-                    processing_status.as_db_value(),
-                    processing_error,
-                    min_speakers,
-                    max_speakers,
-                    min_speech_duration_ms,
-                    min_silence_duration_ms,
-                    if record.enable_llm_refinement {
-                        1_i64
-                    } else {
-                        0_i64
-                    },
-                    processing_time_ms,
-                    duration_secs,
-                    rtf,
-                    speaker_count,
-                    alignment_coverage,
-                    unattributed_words,
-                    if record.llm_refined { 1_i64 } else { 0_i64 },
-                    asr_text,
-                    raw_transcript,
-                    transcript,
-                    summary_status.as_db_value(),
-                    summary_model_id,
-                    summary_text,
-                    summary_error,
-                    summary_updated_at,
-                    segments_json,
-                    words_json,
-                    utterances_json,
-                    speaker_name_overrides_json,
-                    audio_mime_type,
-                    audio_filename,
-                    audio_storage_path
-                ],
-            ) {
-                let _ = storage_layout::delete_media_file(
-                    &media_root,
-                    Some(audio_storage_path.as_str()),
-                );
-                return Err(err).context("Failed to insert diarization record");
-            }
-
-            let created = fetch_record_without_audio(&conn, &record_id)?
-                .ok_or_else(|| anyhow!("Failed to fetch created diarization record"))?;
-            Ok(created)
+                0_i64
+            }),
+            processing_time_ms: Set(processing_time_ms),
+            duration_secs: Set(duration_secs),
+            rtf: Set(rtf),
+            speaker_count: Set(speaker_count),
+            alignment_coverage: Set(alignment_coverage),
+            unattributed_words: Set(unattributed_words),
+            llm_refined: Set(if record.llm_refined { 1_i64 } else { 0_i64 }),
+            asr_text: Set(asr_text),
+            raw_transcript: Set(raw_transcript),
+            transcript: Set(transcript),
+            summary_status: Set(summary_status.as_db_value().to_string()),
+            summary_model_id: Set(summary_model_id),
+            summary_text: Set(summary_text),
+            summary_error: Set(summary_error),
+            summary_updated_at: Set(summary_updated_at),
+            segments_json: Set(segments_json),
+            words_json: Set(words_json),
+            utterances_json: Set(utterances_json),
+            speaker_name_overrides_json: Set(speaker_name_overrides_json),
+            audio_mime_type: Set(audio_mime_type),
+            audio_filename: Set(audio_filename),
+            audio_storage_path: Set(audio_storage_path.clone()),
         })
+        .exec(db)
         .await
+        {
+            let _ = storage_layout::delete_media_file(
+                &self.media_root,
+                Some(audio_storage_path.as_str()),
+            );
+            return Err(err).context("Failed to insert diarization record");
+        }
+
+        fetch_record_without_audio(db, &record_id)
+            .await?
+            .ok_or_else(|| anyhow!("Failed to fetch created diarization record"))
     }
 
     pub async fn delete_record(&self, record_id: String) -> anyhow::Result<bool> {
-        let media_root = self.media_root.clone();
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let audio_storage_path = conn
-                .query_row(
-                    "SELECT audio_storage_path FROM diarization_records WHERE id = ?1",
-                    params![&record_id],
-                    |row| row.get::<_, Option<String>>(0),
-                )
-                .optional()?
-                .flatten();
-            let changed = conn.execute(
-                "DELETE FROM diarization_records WHERE id = ?1",
-                params![record_id],
-            )?;
+        let db = self.db.connection().await?;
+        let audio_storage_path = fetch_audio_storage_path(db, &record_id).await?.flatten();
+        let result = diarization_records::Entity::delete_many()
+            .filter(diarization_records::Column::Id.eq(record_id))
+            .exec(db)
+            .await
+            .context("Failed to delete diarization record")?;
 
-            if changed > 0 {
-                storage_layout::delete_media_file(&media_root, audio_storage_path.as_deref())?;
-            }
+        if result.rows_affected > 0 {
+            storage_layout::delete_media_file(&self.media_root, audio_storage_path.as_deref())?;
+        }
 
-            Ok(changed > 0)
-        })
-        .await
+        Ok(result.rows_affected > 0)
     }
 
     pub async fn update_speaker_name_overrides(
@@ -792,37 +538,34 @@ impl DiarizationStore {
         record_id: String,
         speaker_name_overrides: BTreeMap<String, String>,
     ) -> anyhow::Result<Option<DiarizationRecord>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let existing = fetch_record_without_audio(&conn, &record_id)?;
-            let Some(existing) = existing else {
-                return Ok(None);
-            };
+        let db = self.db.connection().await?;
+        let existing = fetch_record_without_audio(db, &record_id).await?;
+        let Some(existing) = existing else {
+            return Ok(None);
+        };
 
-            let sanitized_overrides = sanitize_speaker_name_overrides(
-                &speaker_name_overrides,
-                &raw_speaker_labels_from_parts(
-                    &existing.segments,
-                    &existing.words,
-                    &existing.utterances,
-                ),
-            )?;
-            let speaker_name_overrides_json = serde_json::to_string(&sanitized_overrides)
-                .context("Failed serializing speaker name overrides")?;
+        let sanitized_overrides = sanitize_speaker_name_overrides(
+            &speaker_name_overrides,
+            &raw_speaker_labels_from_parts(
+                &existing.segments,
+                &existing.words,
+                &existing.utterances,
+            ),
+        )?;
+        let speaker_name_overrides_json = serde_json::to_string(&sanitized_overrides)
+            .context("Failed serializing speaker name overrides")?;
 
-            conn.execute(
-                r#"
-                UPDATE diarization_records
-                SET speaker_name_overrides_json = ?2
-                WHERE id = ?1
-                "#,
-                params![record_id, speaker_name_overrides_json],
+        diarization_records::Entity::update_many()
+            .col_expr(
+                diarization_records::Column::SpeakerNameOverridesJson,
+                Expr::value(speaker_name_overrides_json),
             )
+            .filter(diarization_records::Column::Id.eq(record_id))
+            .exec(db)
+            .await
             .context("Failed updating speaker name overrides")?;
 
-            fetch_record_without_audio(&conn, &existing.id)
-        })
-        .await
+        fetch_record_without_audio(db, &existing.id).await
     }
 
     pub async fn update_summary(
@@ -830,55 +573,57 @@ impl DiarizationStore {
         record_id: String,
         update: UpdateDiarizationSummary,
     ) -> anyhow::Result<Option<DiarizationRecord>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let now = now_unix_millis_i64();
+        let db = self.db.connection().await?;
+        let now = now_unix_millis_i64();
 
-            let summary_model_id = sanitize_optional_text(update.model_id.as_deref(), 160);
-            let summary_text = sanitize_optional_text(update.text.as_deref(), 20_000);
-            let summary_error = sanitize_optional_text(update.error.as_deref(), 1_000);
-            let summary_status = normalize_summary_status(
-                update.status,
-                summary_text.as_deref(),
-                summary_error.as_deref(),
-            );
-            let summary_updated_at =
-                normalize_optional_timestamp_i64(update.updated_at).or_else(|| {
-                    if summary_status == DiarizationSummaryStatus::NotRequested {
-                        None
-                    } else {
-                        Some(now)
-                    }
-                });
+        let summary_model_id = sanitize_optional_text(update.model_id.as_deref(), 160);
+        let summary_text = sanitize_optional_text(update.text.as_deref(), 20_000);
+        let summary_error = sanitize_optional_text(update.error.as_deref(), 1_000);
+        let summary_status = normalize_summary_status(
+            update.status,
+            summary_text.as_deref(),
+            summary_error.as_deref(),
+        );
+        let summary_updated_at =
+            normalize_optional_timestamp_i64(update.updated_at).or_else(|| {
+                if summary_status == DiarizationSummaryStatus::NotRequested {
+                    None
+                } else {
+                    Some(now)
+                }
+            });
 
-            let changed = conn.execute(
-                r#"
-                UPDATE diarization_records
-                SET
-                    summary_status = ?2,
-                    summary_model_id = ?3,
-                    summary_text = ?4,
-                    summary_error = ?5,
-                    summary_updated_at = ?6
-                WHERE id = ?1
-                "#,
-                params![
-                    record_id,
-                    summary_status.as_db_value(),
-                    summary_model_id,
-                    summary_text,
-                    summary_error,
-                    summary_updated_at,
-                ],
-            )?;
+        let result = diarization_records::Entity::update_many()
+            .col_expr(
+                diarization_records::Column::SummaryStatus,
+                Expr::value(summary_status.as_db_value()),
+            )
+            .col_expr(
+                diarization_records::Column::SummaryModelId,
+                Expr::value(summary_model_id),
+            )
+            .col_expr(
+                diarization_records::Column::SummaryText,
+                Expr::value(summary_text),
+            )
+            .col_expr(
+                diarization_records::Column::SummaryError,
+                Expr::value(summary_error),
+            )
+            .col_expr(
+                diarization_records::Column::SummaryUpdatedAt,
+                Expr::value(summary_updated_at),
+            )
+            .filter(diarization_records::Column::Id.eq(record_id.clone()))
+            .exec(db)
+            .await
+            .context("Failed updating diarization summary")?;
 
-            if changed == 0 {
-                return Ok(None);
-            }
+        if result.rows_affected == 0 {
+            return Ok(None);
+        }
 
-            fetch_record_without_audio(&conn, &record_id)
-        })
-        .await
+        fetch_record_without_audio(db, &record_id).await
     }
 
     pub async fn update_processing_status(
@@ -887,30 +632,29 @@ impl DiarizationStore {
         status: DiarizationProcessingStatus,
         error: Option<String>,
     ) -> anyhow::Result<Option<DiarizationRecord>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let processing_error = sanitize_optional_text(error.as_deref(), 1_000);
-            let processing_status =
-                normalize_processing_status(status, processing_error.as_deref());
+        let db = self.db.connection().await?;
+        let processing_error = sanitize_optional_text(error.as_deref(), 1_000);
+        let processing_status = normalize_processing_status(status, processing_error.as_deref());
 
-            let changed = conn.execute(
-                r#"
-                UPDATE diarization_records
-                SET
-                    processing_status = ?2,
-                    processing_error = ?3
-                WHERE id = ?1
-                "#,
-                params![record_id, processing_status.as_db_value(), processing_error,],
-            )?;
+        let result = diarization_records::Entity::update_many()
+            .col_expr(
+                diarization_records::Column::ProcessingStatus,
+                Expr::value(processing_status.as_db_value()),
+            )
+            .col_expr(
+                diarization_records::Column::ProcessingError,
+                Expr::value(processing_error),
+            )
+            .filter(diarization_records::Column::Id.eq(record_id.clone()))
+            .exec(db)
+            .await
+            .context("Failed updating diarization processing status")?;
 
-            if changed == 0 {
-                return Ok(None);
-            }
+        if result.rows_affected == 0 {
+            return Ok(None);
+        }
 
-            fetch_record_without_audio(&conn, &record_id)
-        })
-        .await
+        fetch_record_without_audio(db, &record_id).await
     }
 
     pub async fn complete_record(
@@ -918,220 +662,369 @@ impl DiarizationStore {
         record_id: String,
         record: CompleteDiarizationRecord,
     ) -> anyhow::Result<Option<DiarizationRecord>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
+        let db = self.db.connection().await?;
 
-            let model_id = sanitize_optional_text(record.model_id.as_deref(), 160);
-            let asr_model_id = sanitize_optional_text(record.asr_model_id.as_deref(), 160);
-            let aligner_model_id = sanitize_optional_text(record.aligner_model_id.as_deref(), 160);
-            let llm_model_id = sanitize_optional_text(record.llm_model_id.as_deref(), 160);
-            let min_speakers = record
-                .min_speakers
-                .and_then(|value| i64::try_from(value).ok());
-            let max_speakers = record
-                .max_speakers
-                .and_then(|value| i64::try_from(value).ok());
-            let min_speech_duration_ms = record
-                .min_speech_duration_ms
-                .filter(|value| value.is_finite() && *value >= 0.0);
-            let min_silence_duration_ms = record
-                .min_silence_duration_ms
-                .filter(|value| value.is_finite() && *value >= 0.0);
-            let processing_time_ms = if record.processing_time_ms.is_finite() {
-                record.processing_time_ms.max(0.0)
-            } else {
-                0.0
-            };
-            let duration_secs = record
-                .duration_secs
-                .filter(|value| value.is_finite() && *value >= 0.0);
-            let rtf = record
-                .rtf
-                .filter(|value| value.is_finite() && *value >= 0.0);
-            let speaker_count = i64::try_from(record.speaker_count).unwrap_or(0);
-            let alignment_coverage = record
-                .alignment_coverage
-                .filter(|value| value.is_finite() && *value >= 0.0);
-            let unattributed_words = i64::try_from(record.unattributed_words).unwrap_or(0);
-            let asr_text = sanitize_required_text(record.asr_text.as_str(), 40_000);
-            let raw_transcript = sanitize_required_text(record.raw_transcript.as_str(), 100_000);
-            let transcript = sanitize_required_text(record.transcript.as_str(), 100_000);
-            let segments_json =
-                serde_json::to_string(&record.segments).context("Failed serializing segments")?;
-            let words_json =
-                serde_json::to_string(&record.words).context("Failed serializing words")?;
-            let utterances_json = serde_json::to_string(&record.utterances)
-                .context("Failed serializing utterances")?;
-            let summary_model_id = sanitize_optional_text(record.summary_model_id.as_deref(), 160);
-            let summary_text = sanitize_optional_text(record.summary_text.as_deref(), 20_000);
-            let summary_error = sanitize_optional_text(record.summary_error.as_deref(), 1_000);
-            let summary_status = normalize_summary_status(
-                record.summary_status,
-                summary_text.as_deref(),
-                summary_error.as_deref(),
-            );
-            let summary_updated_at = normalize_optional_timestamp_i64(record.summary_updated_at);
+        let model_id = sanitize_optional_text(record.model_id.as_deref(), 160);
+        let asr_model_id = sanitize_optional_text(record.asr_model_id.as_deref(), 160);
+        let aligner_model_id = sanitize_optional_text(record.aligner_model_id.as_deref(), 160);
+        let llm_model_id = sanitize_optional_text(record.llm_model_id.as_deref(), 160);
+        let min_speakers = record
+            .min_speakers
+            .and_then(|value| i64::try_from(value).ok());
+        let max_speakers = record
+            .max_speakers
+            .and_then(|value| i64::try_from(value).ok());
+        let min_speech_duration_ms = record
+            .min_speech_duration_ms
+            .filter(|value| value.is_finite() && *value >= 0.0);
+        let min_silence_duration_ms = record
+            .min_silence_duration_ms
+            .filter(|value| value.is_finite() && *value >= 0.0);
+        let processing_time_ms = if record.processing_time_ms.is_finite() {
+            record.processing_time_ms.max(0.0)
+        } else {
+            0.0
+        };
+        let duration_secs = record
+            .duration_secs
+            .filter(|value| value.is_finite() && *value >= 0.0);
+        let rtf = record
+            .rtf
+            .filter(|value| value.is_finite() && *value >= 0.0);
+        let speaker_count = i64::try_from(record.speaker_count).unwrap_or(0);
+        let alignment_coverage = record
+            .alignment_coverage
+            .filter(|value| value.is_finite() && *value >= 0.0);
+        let unattributed_words = i64::try_from(record.unattributed_words).unwrap_or(0);
+        let asr_text = sanitize_required_text(record.asr_text.as_str(), 40_000);
+        let raw_transcript = sanitize_required_text(record.raw_transcript.as_str(), 100_000);
+        let transcript = sanitize_required_text(record.transcript.as_str(), 100_000);
+        let segments_json =
+            serde_json::to_string(&record.segments).context("Failed serializing segments")?;
+        let words_json =
+            serde_json::to_string(&record.words).context("Failed serializing words")?;
+        let utterances_json =
+            serde_json::to_string(&record.utterances).context("Failed serializing utterances")?;
+        let summary_model_id = sanitize_optional_text(record.summary_model_id.as_deref(), 160);
+        let summary_text = sanitize_optional_text(record.summary_text.as_deref(), 20_000);
+        let summary_error = sanitize_optional_text(record.summary_error.as_deref(), 1_000);
+        let summary_status = normalize_summary_status(
+            record.summary_status,
+            summary_text.as_deref(),
+            summary_error.as_deref(),
+        );
+        let summary_updated_at = normalize_optional_timestamp_i64(record.summary_updated_at);
 
-            let changed = conn.execute(
-                r#"
-                UPDATE diarization_records
-                SET
-                    model_id = ?2,
-                    asr_model_id = ?3,
-                    aligner_model_id = ?4,
-                    llm_model_id = ?5,
-                    processing_status = ?6,
-                    processing_error = NULL,
-                    min_speakers = ?7,
-                    max_speakers = ?8,
-                    min_speech_duration_ms = ?9,
-                    min_silence_duration_ms = ?10,
-                    enable_llm_refinement = ?11,
-                    processing_time_ms = ?12,
-                    duration_secs = ?13,
-                    rtf = ?14,
-                    speaker_count = ?15,
-                    alignment_coverage = ?16,
-                    unattributed_words = ?17,
-                    llm_refined = ?18,
-                    asr_text = ?19,
-                    raw_transcript = ?20,
-                    transcript = ?21,
-                    summary_status = ?22,
-                    summary_model_id = ?23,
-                    summary_text = ?24,
-                    summary_error = ?25,
-                    summary_updated_at = ?26,
-                    segments_json = ?27,
-                    words_json = ?28,
-                    utterances_json = ?29
-                WHERE id = ?1 AND processing_status IN ('pending', 'processing')
-                "#,
-                params![
-                    record_id,
-                    model_id,
-                    asr_model_id,
-                    aligner_model_id,
-                    llm_model_id,
-                    DiarizationProcessingStatus::Ready.as_db_value(),
-                    min_speakers,
-                    max_speakers,
-                    min_speech_duration_ms,
-                    min_silence_duration_ms,
-                    if record.enable_llm_refinement {
-                        1_i64
-                    } else {
-                        0_i64
-                    },
-                    processing_time_ms,
-                    duration_secs,
-                    rtf,
-                    speaker_count,
-                    alignment_coverage,
-                    unattributed_words,
-                    if record.llm_refined { 1_i64 } else { 0_i64 },
-                    asr_text,
-                    raw_transcript,
-                    transcript,
-                    summary_status.as_db_value(),
-                    summary_model_id,
-                    summary_text,
-                    summary_error,
-                    summary_updated_at,
-                    segments_json,
-                    words_json,
-                    utterances_json,
-                ],
-            )?;
-
-            if changed == 0 {
-                return Ok(None);
-            }
-
-            fetch_record_without_audio(&conn, &record_id)
-        })
-        .await
-    }
-
-    async fn run_blocking<F, T>(&self, task_fn: F) -> anyhow::Result<T>
-    where
-        F: FnOnce(PathBuf) -> anyhow::Result<T> + Send + 'static,
-        T: Send + 'static,
-    {
-        let db_path = self.db_path.clone();
-        task::spawn_blocking(move || task_fn(db_path))
+        let result = diarization_records::Entity::update_many()
+            .col_expr(diarization_records::Column::ModelId, Expr::value(model_id))
+            .col_expr(
+                diarization_records::Column::AsrModelId,
+                Expr::value(asr_model_id),
+            )
+            .col_expr(
+                diarization_records::Column::AlignerModelId,
+                Expr::value(aligner_model_id),
+            )
+            .col_expr(
+                diarization_records::Column::LlmModelId,
+                Expr::value(llm_model_id),
+            )
+            .col_expr(
+                diarization_records::Column::ProcessingStatus,
+                Expr::value(DiarizationProcessingStatus::Ready.as_db_value()),
+            )
+            .col_expr(
+                diarization_records::Column::ProcessingError,
+                Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                diarization_records::Column::MinSpeakers,
+                Expr::value(min_speakers),
+            )
+            .col_expr(
+                diarization_records::Column::MaxSpeakers,
+                Expr::value(max_speakers),
+            )
+            .col_expr(
+                diarization_records::Column::MinSpeechDurationMs,
+                Expr::value(min_speech_duration_ms),
+            )
+            .col_expr(
+                diarization_records::Column::MinSilenceDurationMs,
+                Expr::value(min_silence_duration_ms),
+            )
+            .col_expr(
+                diarization_records::Column::EnableLlmRefinement,
+                Expr::value(if record.enable_llm_refinement {
+                    1_i64
+                } else {
+                    0_i64
+                }),
+            )
+            .col_expr(
+                diarization_records::Column::ProcessingTimeMs,
+                Expr::value(processing_time_ms),
+            )
+            .col_expr(
+                diarization_records::Column::DurationSecs,
+                Expr::value(duration_secs),
+            )
+            .col_expr(diarization_records::Column::Rtf, Expr::value(rtf))
+            .col_expr(
+                diarization_records::Column::SpeakerCount,
+                Expr::value(speaker_count),
+            )
+            .col_expr(
+                diarization_records::Column::AlignmentCoverage,
+                Expr::value(alignment_coverage),
+            )
+            .col_expr(
+                diarization_records::Column::UnattributedWords,
+                Expr::value(unattributed_words),
+            )
+            .col_expr(
+                diarization_records::Column::LlmRefined,
+                Expr::value(if record.llm_refined { 1_i64 } else { 0_i64 }),
+            )
+            .col_expr(diarization_records::Column::AsrText, Expr::value(asr_text))
+            .col_expr(
+                diarization_records::Column::RawTranscript,
+                Expr::value(raw_transcript),
+            )
+            .col_expr(
+                diarization_records::Column::Transcript,
+                Expr::value(transcript),
+            )
+            .col_expr(
+                diarization_records::Column::SummaryStatus,
+                Expr::value(summary_status.as_db_value()),
+            )
+            .col_expr(
+                diarization_records::Column::SummaryModelId,
+                Expr::value(summary_model_id),
+            )
+            .col_expr(
+                diarization_records::Column::SummaryText,
+                Expr::value(summary_text),
+            )
+            .col_expr(
+                diarization_records::Column::SummaryError,
+                Expr::value(summary_error),
+            )
+            .col_expr(
+                diarization_records::Column::SummaryUpdatedAt,
+                Expr::value(summary_updated_at),
+            )
+            .col_expr(
+                diarization_records::Column::SegmentsJson,
+                Expr::value(segments_json),
+            )
+            .col_expr(
+                diarization_records::Column::WordsJson,
+                Expr::value(words_json),
+            )
+            .col_expr(
+                diarization_records::Column::UtterancesJson,
+                Expr::value(utterances_json),
+            )
+            .filter(diarization_records::Column::Id.eq(record_id.clone()))
+            .filter(
+                diarization_records::Column::ProcessingStatus
+                    .is_in(["pending".to_string(), "processing".to_string()]),
+            )
+            .exec(db)
             .await
-            .map_err(|err| anyhow!("Diarization storage worker failed: {err}"))?
+            .context("Failed to complete diarization record")?;
+
+        if result.rows_affected == 0 {
+            return Ok(None);
+        }
+
+        fetch_record_without_audio(db, &record_id).await
     }
 }
 
-fn fetch_record_without_audio(
-    conn: &Connection,
+const DIARIZATION_PAGE_SQL: &str = r#"
+    SELECT
+        id,
+        created_at,
+        model_id,
+        processing_status,
+        processing_error,
+        speaker_count,
+        utterances_json,
+        speaker_name_overrides_json,
+        duration_secs,
+        processing_time_ms,
+        rtf,
+        audio_mime_type,
+        audio_filename,
+        transcript,
+        summary_status,
+        summary_text
+    FROM diarization_records
+    ORDER BY created_at DESC, id DESC
+    LIMIT ?1
+"#;
+
+const DIARIZATION_PAGE_AFTER_CURSOR_SQL: &str = r#"
+    SELECT
+        id,
+        created_at,
+        model_id,
+        processing_status,
+        processing_error,
+        speaker_count,
+        utterances_json,
+        speaker_name_overrides_json,
+        duration_secs,
+        processing_time_ms,
+        rtf,
+        audio_mime_type,
+        audio_filename,
+        transcript,
+        summary_status,
+        summary_text
+    FROM diarization_records
+    WHERE created_at < ?1 OR (created_at = ?1 AND id < ?2)
+    ORDER BY created_at DESC, id DESC
+    LIMIT ?3
+"#;
+
+const DIARIZATION_RECORD_COLUMNS: &str = r#"
+    id,
+    created_at,
+    model_id,
+    asr_model_id,
+    aligner_model_id,
+    llm_model_id,
+    processing_status,
+    processing_error,
+    min_speakers,
+    max_speakers,
+    min_speech_duration_ms,
+    min_silence_duration_ms,
+    enable_llm_refinement,
+    processing_time_ms,
+    duration_secs,
+    rtf,
+    speaker_count,
+    alignment_coverage,
+    unattributed_words,
+    llm_refined,
+    asr_text,
+    raw_transcript,
+    transcript,
+    summary_status,
+    summary_model_id,
+    summary_text,
+    summary_error,
+    summary_updated_at,
+    segments_json,
+    words_json,
+    utterances_json,
+    speaker_name_overrides_json,
+    audio_mime_type,
+    audio_filename
+"#;
+
+async fn fetch_record_without_audio(
+    db: &sea_orm::DatabaseConnection,
     record_id: &str,
 ) -> anyhow::Result<Option<DiarizationRecord>> {
-    let record = conn
-        .query_row(
-            r#"
-            SELECT
-                id,
-                created_at,
-                model_id,
-                asr_model_id,
-                aligner_model_id,
-                llm_model_id,
-                processing_status,
-                processing_error,
-                min_speakers,
-                max_speakers,
-                min_speech_duration_ms,
-                min_silence_duration_ms,
-                enable_llm_refinement,
-                processing_time_ms,
-                duration_secs,
-                rtf,
-                speaker_count,
-                alignment_coverage,
-                unattributed_words,
-                llm_refined,
-                asr_text,
-                raw_transcript,
-                transcript,
-                summary_status,
-                summary_model_id,
-                summary_text,
-                summary_error,
-                summary_updated_at,
-                segments_json,
-                words_json,
-                utterances_json,
-                speaker_name_overrides_json,
-                audio_mime_type,
-                audio_filename
-            FROM diarization_records
-            WHERE id = ?1
-            "#,
-            params![record_id],
-            map_diarization_record,
-        )
-        .optional()?;
-    Ok(record)
+    let row = db
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            format!("SELECT {DIARIZATION_RECORD_COLUMNS} FROM diarization_records WHERE id = ?1"),
+            vec![record_id.into()],
+        ))
+        .await
+        .context("Failed to load diarization record")?;
+    row.as_ref().map(map_diarization_record).transpose()
 }
 
-fn map_diarization_record(row: &Row<'_>) -> rusqlite::Result<DiarizationRecord> {
-    let min_speakers = row.get::<_, Option<i64>>(8)?.and_then(i64_to_usize);
-    let max_speakers = row.get::<_, Option<i64>>(9)?.and_then(i64_to_usize);
+async fn fetch_audio_storage_path(
+    db: &sea_orm::DatabaseConnection,
+    record_id: &str,
+) -> anyhow::Result<Option<Option<String>>> {
+    let row = db
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT audio_storage_path FROM diarization_records WHERE id = ?1",
+            vec![record_id.into()],
+        ))
+        .await
+        .context("Failed to load diarization media path")?;
+    row.map(|row| row.try_get_by_index::<Option<String>>(0))
+        .transpose()
+        .map_err(Into::into)
+}
+
+fn map_diarization_summary(row: &QueryResult) -> anyhow::Result<DiarizationRecordSummary> {
     let speaker_count = row
-        .get::<_, Option<i64>>(16)?
+        .try_get_by_index::<Option<i64>>(5)?
+        .and_then(i64_to_usize)
+        .unwrap_or(0);
+    let utterances: Vec<DiarizationUtteranceRecord> = parse_json_vec(row.try_get_by_index(6)?);
+    let speaker_name_overrides = parse_json_map(row.try_get_by_index(7)?);
+    let transcript: String = row.try_get_by_index(13)?;
+    let summary_status = parse_summary_status(row.try_get_by_index(14)?);
+    let summary_text: Option<String> = row.try_get_by_index(15)?;
+
+    Ok(DiarizationRecordSummary {
+        id: row.try_get_by_index(0)?,
+        created_at: i64_to_u64(row.try_get_by_index(1)?),
+        model_id: row.try_get_by_index(2)?,
+        processing_status: parse_processing_status(row.try_get_by_index(3)?),
+        processing_error: row.try_get_by_index(4)?,
+        speaker_count,
+        corrected_speaker_count: corrected_speaker_count_from_parts(
+            speaker_count,
+            &[],
+            &[],
+            &utterances,
+            &speaker_name_overrides,
+        ),
+        speaker_name_override_count: speaker_name_overrides.len(),
+        duration_secs: row.try_get_by_index(8)?,
+        processing_time_ms: row.try_get_by_index(9)?,
+        rtf: row.try_get_by_index(10)?,
+        audio_mime_type: row.try_get_by_index(11)?,
+        audio_filename: row.try_get_by_index(12)?,
+        transcript_preview: transcript_preview_with_utterances(
+            &utterances,
+            &speaker_name_overrides,
+            transcript.as_str(),
+        ),
+        transcript_chars: transcript.chars().count(),
+        summary_status,
+        summary_preview: summary_preview(summary_text.as_deref()),
+        summary_chars: summary_text
+            .as_ref()
+            .map(|text| text.chars().count())
+            .unwrap_or(0),
+    })
+}
+
+fn map_diarization_record(row: &QueryResult) -> anyhow::Result<DiarizationRecord> {
+    let min_speakers = row
+        .try_get_by_index::<Option<i64>>(8)?
+        .and_then(i64_to_usize);
+    let max_speakers = row
+        .try_get_by_index::<Option<i64>>(9)?
+        .and_then(i64_to_usize);
+    let speaker_count = row
+        .try_get_by_index::<Option<i64>>(16)?
         .and_then(i64_to_usize)
         .unwrap_or(0);
     let unattributed_words = row
-        .get::<_, Option<i64>>(18)?
+        .try_get_by_index::<Option<i64>>(18)?
         .and_then(i64_to_usize)
         .unwrap_or(0);
-    let segments_raw: String = row.get(28)?;
-    let words_raw: String = row.get(29)?;
-    let utterances_raw: String = row.get(30)?;
-    let speaker_name_overrides = parse_json_map(row.get(31)?);
+    let segments_raw: String = row.try_get_by_index(28)?;
+    let words_raw: String = row.try_get_by_index(29)?;
+    let utterances_raw: String = row.try_get_by_index(30)?;
+    let speaker_name_overrides = parse_json_map(row.try_get_by_index(31)?);
     let segments: Vec<DiarizationSegmentRecord> = parse_json_vec(Some(segments_raw));
     let words: Vec<DiarizationWordRecord> = parse_json_vec(Some(words_raw));
     let utterances: Vec<DiarizationUtteranceRecord> = parse_json_vec(Some(utterances_raw));
@@ -1144,41 +1037,41 @@ fn map_diarization_record(row: &Row<'_>) -> rusqlite::Result<DiarizationRecord> 
     );
 
     Ok(DiarizationRecord {
-        id: row.get(0)?,
-        created_at: i64_to_u64(row.get(1)?),
-        model_id: row.get(2)?,
-        asr_model_id: row.get(3)?,
-        aligner_model_id: row.get(4)?,
-        llm_model_id: row.get(5)?,
-        processing_status: parse_processing_status(row.get(6)?),
-        processing_error: row.get(7)?,
+        id: row.try_get_by_index(0)?,
+        created_at: i64_to_u64(row.try_get_by_index(1)?),
+        model_id: row.try_get_by_index(2)?,
+        asr_model_id: row.try_get_by_index(3)?,
+        aligner_model_id: row.try_get_by_index(4)?,
+        llm_model_id: row.try_get_by_index(5)?,
+        processing_status: parse_processing_status(row.try_get_by_index(6)?),
+        processing_error: row.try_get_by_index(7)?,
         min_speakers,
         max_speakers,
-        min_speech_duration_ms: row.get(10)?,
-        min_silence_duration_ms: row.get(11)?,
-        enable_llm_refinement: row.get::<_, i64>(12)? > 0,
-        processing_time_ms: row.get(13)?,
-        duration_secs: row.get(14)?,
-        rtf: row.get(15)?,
+        min_speech_duration_ms: row.try_get_by_index(10)?,
+        min_silence_duration_ms: row.try_get_by_index(11)?,
+        enable_llm_refinement: row.try_get_by_index::<i64>(12)? > 0,
+        processing_time_ms: row.try_get_by_index(13)?,
+        duration_secs: row.try_get_by_index(14)?,
+        rtf: row.try_get_by_index(15)?,
         speaker_count,
         corrected_speaker_count,
-        alignment_coverage: row.get(17)?,
+        alignment_coverage: row.try_get_by_index(17)?,
         unattributed_words,
-        llm_refined: row.get::<_, i64>(19)? > 0,
-        asr_text: row.get(20)?,
-        raw_transcript: row.get(21)?,
-        transcript: row.get(22)?,
-        summary_status: parse_summary_status(row.get(23)?),
-        summary_model_id: row.get(24)?,
-        summary_text: row.get(25)?,
-        summary_error: row.get(26)?,
-        summary_updated_at: row.get::<_, Option<i64>>(27)?.map(i64_to_u64),
+        llm_refined: row.try_get_by_index::<i64>(19)? > 0,
+        asr_text: row.try_get_by_index(20)?,
+        raw_transcript: row.try_get_by_index(21)?,
+        transcript: row.try_get_by_index(22)?,
+        summary_status: parse_summary_status(row.try_get_by_index(23)?),
+        summary_model_id: row.try_get_by_index(24)?,
+        summary_text: row.try_get_by_index(25)?,
+        summary_error: row.try_get_by_index(26)?,
+        summary_updated_at: row.try_get_by_index::<Option<i64>>(27)?.map(i64_to_u64),
         segments,
         words,
         utterances,
         speaker_name_overrides,
-        audio_mime_type: row.get(32)?,
-        audio_filename: row.get(33)?,
+        audio_mime_type: row.try_get_by_index(32)?,
+        audio_filename: row.try_get_by_index(33)?,
     })
 }
 
@@ -1343,135 +1236,6 @@ fn normalize_optional_timestamp_i64(value: Option<u64>) -> Option<i64> {
     value.and_then(|raw| i64::try_from(raw).ok())
 }
 
-fn ensure_diarization_records_speaker_name_overrides_column(
-    conn: &Connection,
-) -> anyhow::Result<()> {
-    if diarization_records_has_column(conn, "speaker_name_overrides_json")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE diarization_records ADD COLUMN speaker_name_overrides_json TEXT NOT NULL DEFAULT '{}'",
-        [],
-    )
-    .context("Failed adding diarization_records.speaker_name_overrides_json column")?;
-    Ok(())
-}
-
-fn ensure_diarization_records_processing_status_column(conn: &Connection) -> anyhow::Result<()> {
-    if diarization_records_has_column(conn, "processing_status")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE diarization_records ADD COLUMN processing_status TEXT NOT NULL DEFAULT 'ready'",
-        [],
-    )
-    .context("Failed adding diarization_records.processing_status column")?;
-    Ok(())
-}
-
-fn ensure_diarization_records_processing_error_column(conn: &Connection) -> anyhow::Result<()> {
-    if diarization_records_has_column(conn, "processing_error")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE diarization_records ADD COLUMN processing_error TEXT NULL",
-        [],
-    )
-    .context("Failed adding diarization_records.processing_error column")?;
-    Ok(())
-}
-
-fn ensure_diarization_records_summary_status_column(conn: &Connection) -> anyhow::Result<()> {
-    if diarization_records_has_column(conn, "summary_status")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE diarization_records ADD COLUMN summary_status TEXT NOT NULL DEFAULT 'not_requested'",
-        [],
-    )
-    .context("Failed adding diarization_records.summary_status column")?;
-    Ok(())
-}
-
-fn ensure_diarization_records_summary_model_id_column(conn: &Connection) -> anyhow::Result<()> {
-    if diarization_records_has_column(conn, "summary_model_id")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE diarization_records ADD COLUMN summary_model_id TEXT NULL",
-        [],
-    )
-    .context("Failed adding diarization_records.summary_model_id column")?;
-    Ok(())
-}
-
-fn ensure_diarization_records_summary_text_column(conn: &Connection) -> anyhow::Result<()> {
-    if diarization_records_has_column(conn, "summary_text")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE diarization_records ADD COLUMN summary_text TEXT NULL",
-        [],
-    )
-    .context("Failed adding diarization_records.summary_text column")?;
-    Ok(())
-}
-
-fn ensure_diarization_records_summary_error_column(conn: &Connection) -> anyhow::Result<()> {
-    if diarization_records_has_column(conn, "summary_error")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE diarization_records ADD COLUMN summary_error TEXT NULL",
-        [],
-    )
-    .context("Failed adding diarization_records.summary_error column")?;
-    Ok(())
-}
-
-fn ensure_diarization_records_summary_updated_at_column(conn: &Connection) -> anyhow::Result<()> {
-    if diarization_records_has_column(conn, "summary_updated_at")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE diarization_records ADD COLUMN summary_updated_at INTEGER NULL",
-        [],
-    )
-    .context("Failed adding diarization_records.summary_updated_at column")?;
-    Ok(())
-}
-
-fn diarization_records_has_column(conn: &Connection, target: &str) -> anyhow::Result<bool> {
-    let mut stmt = conn
-        .prepare("PRAGMA table_info(diarization_records)")
-        .context("Failed to inspect diarization_records schema")?;
-    let mut rows = stmt
-        .query([])
-        .context("Failed to query diarization_records schema info")?;
-
-    while let Some(row) = rows
-        .next()
-        .context("Failed reading diarization_records schema row")?
-    {
-        let name: String = row
-            .get(1)
-            .context("Failed reading diarization_records column name")?;
-        if name == target {
-            return Ok(true);
-        }
-    }
-
-    Ok(false)
-}
-
 fn resolve_speaker_label(
     raw_label: &str,
     speaker_name_overrides: &BTreeMap<String, String>,
@@ -1583,11 +1347,7 @@ fn now_unix_millis_i64() -> i64 {
 }
 
 fn i64_to_u64(value: i64) -> u64 {
-    if value.is_negative() {
-        0
-    } else {
-        value as u64
-    }
+    if value.is_negative() { 0 } else { value as u64 }
 }
 
 fn i64_to_usize(value: i64) -> Option<usize> {
@@ -1838,9 +1598,10 @@ mod tests {
             .await
             .expect_err("unknown speaker should fail");
 
-        assert!(err
-            .to_string()
-            .contains("Unknown diarization speaker label"));
+        assert!(
+            err.to_string()
+                .contains("Unknown diarization speaker label")
+        );
         std::fs::remove_dir_all(root).expect("test temp dir should be removable");
     }
 
@@ -1892,10 +1653,7 @@ mod tests {
         );
 
         let completed = store
-            .complete_record(
-                created.id.clone(),
-                sample_complete_record(),
-            )
+            .complete_record(created.id.clone(), sample_complete_record())
             .await
             .expect("completion should succeed")
             .expect("record should exist");
@@ -1949,7 +1707,10 @@ mod tests {
             .await
             .expect("cancel status update should succeed")
             .expect("record should exist");
-        assert_eq!(cancelled.processing_status, DiarizationProcessingStatus::Failed);
+        assert_eq!(
+            cancelled.processing_status,
+            DiarizationProcessingStatus::Failed
+        );
 
         let completion = store
             .complete_record(created.id.clone(), sample_complete_record())
@@ -1965,8 +1726,14 @@ mod tests {
             .await
             .expect("record lookup should succeed")
             .expect("record should exist");
-        assert_eq!(current.processing_status, DiarizationProcessingStatus::Failed);
-        assert_eq!(current.processing_error.as_deref(), Some("Cancelled by user."));
+        assert_eq!(
+            current.processing_status,
+            DiarizationProcessingStatus::Failed
+        );
+        assert_eq!(
+            current.processing_error.as_deref(),
+            Some("Cancelled by user.")
+        );
 
         std::fs::remove_dir_all(root).expect("test temp dir should be removable");
     }

--- a/crates/izwi-server/src/entity/mod.rs
+++ b/crates/izwi-server/src/entity/mod.rs
@@ -1,0 +1,392 @@
+#![allow(dead_code)]
+
+use sea_orm::entity::prelude::*;
+
+macro_rules! empty_relation {
+    () => {
+        #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+        pub enum Relation {}
+
+        impl ActiveModelBehavior for ActiveModel {}
+    };
+}
+
+pub mod chat_threads {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "chat_threads")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub title: String,
+        pub model_id: Option<String>,
+        pub created_at: i64,
+        pub updated_at: i64,
+    }
+    empty_relation!();
+}
+
+pub mod chat_messages {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "chat_messages")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub thread_id: String,
+        pub role: String,
+        pub content: String,
+        pub content_parts: Option<String>,
+        pub created_at: i64,
+        pub tokens_generated: Option<i64>,
+        pub generation_time_ms: Option<f64>,
+    }
+    empty_relation!();
+}
+
+pub mod voice_profiles {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "voice_profiles")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub name: String,
+        pub system_prompt: String,
+        pub observational_memory_enabled: i64,
+        pub created_at: i64,
+        pub updated_at: i64,
+    }
+    empty_relation!();
+}
+
+pub mod voice_sessions {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "voice_sessions")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub profile_id: String,
+        pub mode: String,
+        pub system_prompt: String,
+        pub created_at: i64,
+        pub updated_at: i64,
+        pub ended_at: Option<i64>,
+    }
+    empty_relation!();
+}
+
+pub mod voice_turns {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "voice_turns")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub session_id: String,
+        pub utterance_id: String,
+        pub utterance_seq: i64,
+        pub mode: String,
+        pub status: String,
+        pub status_reason: Option<String>,
+        pub vad_end_reason: Option<String>,
+        pub user_text: Option<String>,
+        pub assistant_text: Option<String>,
+        pub assistant_raw_text: Option<String>,
+        pub language: Option<String>,
+        pub audio_duration_secs: Option<f64>,
+        pub asr_model_id: Option<String>,
+        pub text_model_id: Option<String>,
+        pub tts_model_id: Option<String>,
+        pub s2s_model_id: Option<String>,
+        pub speaker: Option<String>,
+        pub created_at: i64,
+        pub updated_at: i64,
+    }
+    empty_relation!();
+}
+
+pub mod voice_observations {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "voice_observations")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub profile_id: String,
+        pub category: String,
+        pub summary: String,
+        pub canonical_summary: String,
+        pub confidence: f64,
+        pub source_turn_id: Option<String>,
+        pub source_user_text: Option<String>,
+        pub source_assistant_text: Option<String>,
+        pub times_seen: i64,
+        pub created_at: i64,
+        pub updated_at: i64,
+        pub forgotten_at: Option<i64>,
+    }
+    empty_relation!();
+}
+
+pub mod onboarding_state {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "onboarding_state")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub completed_at: Option<i64>,
+        pub analytics_opt_in: i64,
+    }
+    empty_relation!();
+}
+
+pub mod transcription_records {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "transcription_records")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub created_at: i64,
+        pub model_id: Option<String>,
+        pub aligner_model_id: Option<String>,
+        pub language: Option<String>,
+        pub processing_status: String,
+        pub processing_error: Option<String>,
+        pub duration_secs: Option<f64>,
+        pub processing_time_ms: f64,
+        pub rtf: Option<f64>,
+        pub audio_mime_type: String,
+        pub audio_filename: Option<String>,
+        pub audio_storage_path: String,
+        pub transcription: String,
+        pub segments_json: String,
+        pub words_json: String,
+        pub summary_status: String,
+        pub summary_model_id: Option<String>,
+        pub summary_text: Option<String>,
+        pub summary_error: Option<String>,
+        pub summary_updated_at: Option<i64>,
+    }
+    empty_relation!();
+}
+
+pub mod diarization_records {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "diarization_records")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub created_at: i64,
+        pub model_id: Option<String>,
+        pub asr_model_id: Option<String>,
+        pub aligner_model_id: Option<String>,
+        pub llm_model_id: Option<String>,
+        pub processing_status: String,
+        pub processing_error: Option<String>,
+        pub min_speakers: Option<i64>,
+        pub max_speakers: Option<i64>,
+        pub min_speech_duration_ms: Option<f64>,
+        pub min_silence_duration_ms: Option<f64>,
+        pub enable_llm_refinement: i64,
+        pub processing_time_ms: f64,
+        pub duration_secs: Option<f64>,
+        pub rtf: Option<f64>,
+        pub speaker_count: i64,
+        pub alignment_coverage: Option<f64>,
+        pub unattributed_words: i64,
+        pub llm_refined: i64,
+        pub asr_text: String,
+        pub raw_transcript: String,
+        pub transcript: String,
+        pub summary_status: String,
+        pub summary_model_id: Option<String>,
+        pub summary_text: Option<String>,
+        pub summary_error: Option<String>,
+        pub summary_updated_at: Option<i64>,
+        pub segments_json: String,
+        pub words_json: String,
+        pub utterances_json: String,
+        pub speaker_name_overrides_json: String,
+        pub audio_mime_type: String,
+        pub audio_filename: Option<String>,
+        pub audio_storage_path: String,
+    }
+    empty_relation!();
+}
+
+pub mod speech_history_records {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "speech_history_records")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub created_at: i64,
+        pub route_kind: String,
+        pub processing_status: String,
+        pub processing_error: Option<String>,
+        pub model_id: Option<String>,
+        pub speaker: Option<String>,
+        pub language: Option<String>,
+        pub saved_voice_id: Option<String>,
+        pub speed: Option<f64>,
+        pub input_text: String,
+        pub voice_description: Option<String>,
+        pub reference_text: Option<String>,
+        pub generation_time_ms: f64,
+        pub audio_duration_secs: Option<f64>,
+        pub rtf: Option<f64>,
+        pub tokens_generated: Option<i64>,
+        pub audio_mime_type: String,
+        pub audio_filename: Option<String>,
+        pub audio_storage_path: String,
+    }
+    empty_relation!();
+}
+
+pub mod saved_voices {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "saved_voices")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub created_at: i64,
+        pub updated_at: i64,
+        pub name: String,
+        pub reference_text: String,
+        pub audio_mime_type: String,
+        pub audio_filename: Option<String>,
+        pub audio_storage_path: String,
+        pub source_route_kind: Option<String>,
+        pub source_record_id: Option<String>,
+    }
+    empty_relation!();
+}
+
+pub mod studio_projects {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "studio_projects")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub created_at: i64,
+        pub updated_at: i64,
+        pub name: String,
+        pub source_filename: Option<String>,
+        pub source_text: String,
+        pub model_id: Option<String>,
+        pub voice_mode: String,
+        pub speaker: Option<String>,
+        pub saved_voice_id: Option<String>,
+        pub speed: Option<f64>,
+    }
+    empty_relation!();
+}
+
+pub mod studio_project_segments {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "studio_project_segments")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub project_id: String,
+        pub position: i64,
+        pub text: String,
+        pub model_id: Option<String>,
+        pub voice_mode: Option<String>,
+        pub speaker: Option<String>,
+        pub saved_voice_id: Option<String>,
+        pub speech_record_id: Option<String>,
+        pub updated_at: i64,
+    }
+    empty_relation!();
+}
+
+pub mod studio_project_folders {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "studio_project_folders")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub created_at: i64,
+        pub updated_at: i64,
+        pub name: String,
+        pub parent_id: Option<String>,
+        pub sort_order: i64,
+    }
+    empty_relation!();
+}
+
+pub mod studio_project_meta {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "studio_project_meta")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub project_id: String,
+        pub folder_id: Option<String>,
+        pub tags_json: String,
+        pub default_export_format: String,
+        pub last_render_job_id: Option<String>,
+        pub last_rendered_at: Option<i64>,
+    }
+    empty_relation!();
+}
+
+pub mod studio_project_pronunciations {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "studio_project_pronunciations")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub project_id: String,
+        pub source_text: String,
+        pub replacement_text: String,
+        pub locale: Option<String>,
+        pub created_at: i64,
+        pub updated_at: i64,
+    }
+    empty_relation!();
+}
+
+pub mod studio_project_snapshots {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "studio_project_snapshots")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub project_id: String,
+        pub created_at: i64,
+        pub label: Option<String>,
+        pub project_json: String,
+    }
+    empty_relation!();
+}
+
+pub mod studio_project_render_jobs {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "studio_project_render_jobs")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub project_id: String,
+        pub created_at: i64,
+        pub updated_at: i64,
+        pub status: String,
+        pub error_message: Option<String>,
+        pub queued_segment_ids_json: String,
+    }
+    empty_relation!();
+}

--- a/crates/izwi-server/src/lib.rs
+++ b/crates/izwi-server/src/lib.rs
@@ -13,6 +13,7 @@ mod app;
 mod chat_store;
 mod db;
 mod diarization_store;
+mod entity;
 mod error;
 mod ids;
 mod logging;

--- a/crates/izwi-server/src/lib.rs
+++ b/crates/izwi-server/src/lib.rs
@@ -11,6 +11,7 @@ use tracing::{info, warn};
 mod api;
 mod app;
 mod chat_store;
+mod db;
 mod diarization_store;
 mod error;
 mod ids;
@@ -109,6 +110,7 @@ async fn run_with_args(args: ServerArgs, enterprise_hooks: EnterpriseHooks) -> a
 
     // Create runtime service
     let runtime = RuntimeService::new(config)?;
+    db::initialize_default().await?;
     let state = AppState::with_enterprise_hooks(runtime, &serve_config, enterprise_hooks)?;
     let mut startup_warnings = preload_configured_models(&state).await;
     startup_warnings.extend(warmup_preloaded_asr_models(&state).await);

--- a/crates/izwi-server/src/onboarding_store.rs
+++ b/crates/izwi-server/src/onboarding_store.rs
@@ -1,13 +1,13 @@
 //! Persistent first-run onboarding state backed by SQLite.
 
 use anyhow::Context;
-use rusqlite::{params, OptionalExtension};
+use sea_orm::sea_query::OnConflict;
+use sea_orm::{DatabaseConnection, EntityTrait, Set};
 use serde::Serialize;
-use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::task;
 
-use crate::storage_layout;
+use crate::db::StoreDatabase;
+use crate::entity::onboarding_state;
 
 const ONBOARDING_STATE_ID: &str = "default";
 
@@ -20,129 +20,95 @@ pub struct OnboardingState {
 
 #[derive(Clone)]
 pub struct OnboardingStore {
-    db_path: PathBuf,
+    db: StoreDatabase,
 }
 
 impl OnboardingStore {
     pub fn initialize() -> anyhow::Result<Self> {
-        let db_path = storage_layout::resolve_db_path();
-        let media_root = storage_layout::resolve_media_root();
-
-        storage_layout::ensure_storage_dirs(&db_path, &media_root)
-            .context("Failed to prepare onboarding storage layout")?;
-
-        let conn = storage_layout::open_sqlite_connection(&db_path).with_context(|| {
-            format!("Failed to open onboarding database: {}", db_path.display())
-        })?;
-
-        conn.execute_batch(
-            r#"
-            CREATE TABLE IF NOT EXISTS onboarding_state (
-                id TEXT PRIMARY KEY,
-                completed_at INTEGER NULL,
-                analytics_opt_in INTEGER NOT NULL DEFAULT 0
-            );
-            "#,
-        )
-        .context("Failed to initialize onboarding database schema")?;
-        ensure_onboarding_state_analytics_opt_in_column(&conn)?;
-
-        Ok(Self { db_path })
+        Ok(Self {
+            db: StoreDatabase::from_default_path()?,
+        })
     }
 
     pub async fn get_state(&self) -> anyhow::Result<OnboardingState> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            read_state_from_conn(&conn)
-        })
-        .await
+        let db = self.db.connection().await?;
+        read_state(db).await
     }
 
     pub async fn mark_completed(&self) -> anyhow::Result<OnboardingState> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let completed_at = current_timestamp();
+        let db = self.db.connection().await?;
+        let completed_at = current_timestamp();
+        let state = onboarding_state::ActiveModel {
+            id: Set(ONBOARDING_STATE_ID.to_string()),
+            completed_at: Set(Some(completed_at as i64)),
+            ..Default::default()
+        };
 
-            conn.execute(
-                r#"
-                INSERT INTO onboarding_state (id, completed_at)
-                VALUES (?1, ?2)
-                ON CONFLICT(id) DO UPDATE SET completed_at = excluded.completed_at
-                "#,
-                params![ONBOARDING_STATE_ID, completed_at as i64],
-            )?;
+        onboarding_state::Entity::insert(state)
+            .on_conflict(
+                OnConflict::column(onboarding_state::Column::Id)
+                    .update_column(onboarding_state::Column::CompletedAt)
+                    .to_owned(),
+            )
+            .exec(db)
+            .await
+            .context("Failed to mark onboarding completed")?;
 
-            read_state_from_conn(&conn)
-        })
-        .await
+        read_state(db).await
     }
 
     pub async fn set_analytics_opt_in(
         &self,
         analytics_opt_in: bool,
     ) -> anyhow::Result<OnboardingState> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let analytics_opt_in_int = bool_to_i64(analytics_opt_in);
+        let db = self.db.connection().await?;
+        let state = onboarding_state::ActiveModel {
+            id: Set(ONBOARDING_STATE_ID.to_string()),
+            analytics_opt_in: Set(bool_to_i64(analytics_opt_in)),
+            ..Default::default()
+        };
 
-            conn.execute(
-                r#"
-                INSERT INTO onboarding_state (id, completed_at, analytics_opt_in)
-                VALUES (?1, NULL, ?2)
-                ON CONFLICT(id) DO UPDATE SET analytics_opt_in = excluded.analytics_opt_in
-                "#,
-                params![ONBOARDING_STATE_ID, analytics_opt_in_int],
-            )?;
-
-            read_state_from_conn(&conn)
-        })
-        .await
-    }
-
-    async fn run_blocking<F, T>(&self, task_fn: F) -> anyhow::Result<T>
-    where
-        F: FnOnce(PathBuf) -> anyhow::Result<T> + Send + 'static,
-        T: Send + 'static,
-    {
-        let db_path = self.db_path.clone();
-        task::spawn_blocking(move || task_fn(db_path))
+        onboarding_state::Entity::insert(state)
+            .on_conflict(
+                OnConflict::column(onboarding_state::Column::Id)
+                    .update_column(onboarding_state::Column::AnalyticsOptIn)
+                    .to_owned(),
+            )
+            .exec(db)
             .await
-            .context("Onboarding store task failed")?
+            .context("Failed to update onboarding analytics preference")?;
+
+        read_state(db).await
     }
 }
 
-fn read_state_from_conn(conn: &rusqlite::Connection) -> anyhow::Result<OnboardingState> {
-    let row = conn
-        .query_row(
-            r#"
-            SELECT completed_at, analytics_opt_in
-            FROM onboarding_state
-            WHERE id = ?1
-            "#,
-            params![ONBOARDING_STATE_ID],
-            |row| {
-                let completed_at: Option<i64> = row.get(0)?;
-                let analytics_opt_in: i64 = row.get(1)?;
-                Ok((completed_at, analytics_opt_in))
-            },
-        )
-        .optional()?;
+async fn read_state(db: &DatabaseConnection) -> anyhow::Result<OnboardingState> {
+    let model = onboarding_state::Entity::find_by_id(ONBOARDING_STATE_ID.to_string())
+        .one(db)
+        .await
+        .context("Failed to load onboarding state")?;
+    Ok(model_to_state(model))
+}
 
-    let (completed_at_raw, analytics_opt_in_raw) = row.unwrap_or((None, 0));
-    let completed_at = completed_at_raw.and_then(i64_to_u64);
-    Ok(OnboardingState {
+fn model_to_state(model: Option<onboarding_state::Model>) -> OnboardingState {
+    let Some(model) = model else {
+        return OnboardingState {
+            completed: false,
+            completed_at: None,
+            analytics_opt_in: false,
+        };
+    };
+
+    let completed_at = model.completed_at.and_then(i64_to_u64);
+    OnboardingState {
         completed: completed_at.is_some(),
         completed_at,
-        analytics_opt_in: i64_to_bool(analytics_opt_in_raw),
-    })
+        analytics_opt_in: i64_to_bool(model.analytics_opt_in),
+    }
 }
 
 fn i64_to_u64(value: i64) -> Option<u64> {
-    if value > 0 {
-        Some(value as u64)
-    } else {
-        None
-    }
+    if value > 0 { Some(value as u64) } else { None }
 }
 
 fn current_timestamp() -> u64 {
@@ -153,54 +119,11 @@ fn current_timestamp() -> u64 {
 }
 
 fn bool_to_i64(value: bool) -> i64 {
-    if value {
-        1
-    } else {
-        0
-    }
+    if value { 1 } else { 0 }
 }
 
 fn i64_to_bool(value: i64) -> bool {
     value > 0
-}
-
-fn ensure_onboarding_state_analytics_opt_in_column(
-    conn: &rusqlite::Connection,
-) -> anyhow::Result<()> {
-    if onboarding_state_has_column(conn, "analytics_opt_in")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE onboarding_state ADD COLUMN analytics_opt_in INTEGER NOT NULL DEFAULT 0",
-        [],
-    )
-    .context("Failed adding onboarding_state.analytics_opt_in column")?;
-
-    Ok(())
-}
-
-fn onboarding_state_has_column(conn: &rusqlite::Connection, target: &str) -> anyhow::Result<bool> {
-    let mut stmt = conn
-        .prepare("PRAGMA table_info(onboarding_state)")
-        .context("Failed to inspect onboarding_state schema")?;
-    let mut rows = stmt
-        .query([])
-        .context("Failed to query onboarding_state schema info")?;
-
-    while let Some(row) = rows
-        .next()
-        .context("Failed reading onboarding_state schema row")?
-    {
-        let name: String = row
-            .get(1)
-            .context("Failed reading onboarding_state column name")?;
-        if name == target {
-            return Ok(true);
-        }
-    }
-
-    Ok(false)
 }
 
 #[cfg(test)]

--- a/crates/izwi-server/src/saved_voice_store.rs
+++ b/crates/izwi-server/src/saved_voice_store.rs
@@ -1,13 +1,14 @@
 //! Persistent saved voice storage backed by SQLite.
 
-use anyhow::{anyhow, Context};
-use rusqlite::{params, Connection, OptionalExtension, Row};
+use anyhow::{Context, anyhow};
+use sea_orm::{ConnectionTrait, DbBackend, EntityTrait, QueryResult, Set, Statement};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::task;
 
 use crate::{
+    db::StoreDatabase,
+    entity::saved_voices,
     ids::new_uuid,
     storage_layout::{self, MediaGroup},
 };
@@ -92,7 +93,7 @@ pub struct NewSavedVoice {
 
 #[derive(Clone)]
 pub struct SavedVoiceStore {
-    db_path: PathBuf,
+    db: StoreDatabase,
     media_root: PathBuf,
 }
 
@@ -104,36 +105,8 @@ impl SavedVoiceStore {
         storage_layout::ensure_storage_dirs(&db_path, &media_root)
             .context("Failed to prepare saved voice storage layout")?;
 
-        let conn = storage_layout::open_sqlite_connection(&db_path).with_context(|| {
-            format!("Failed to open saved voice database: {}", db_path.display())
-        })?;
-
-        conn.execute_batch(
-            r#"
-            CREATE TABLE IF NOT EXISTS saved_voices (
-                id TEXT PRIMARY KEY,
-                created_at INTEGER NOT NULL,
-                updated_at INTEGER NOT NULL,
-                name TEXT NOT NULL COLLATE NOCASE,
-                reference_text TEXT NOT NULL,
-                audio_mime_type TEXT NOT NULL,
-                audio_filename TEXT NULL,
-                audio_storage_path TEXT NOT NULL,
-                source_route_kind TEXT NULL,
-                source_record_id TEXT NULL
-            );
-
-            CREATE UNIQUE INDEX IF NOT EXISTS idx_saved_voices_name_nocase
-                ON saved_voices(name COLLATE NOCASE);
-
-            CREATE INDEX IF NOT EXISTS idx_saved_voices_updated_at
-                ON saved_voices(updated_at DESC, created_at DESC);
-            "#,
-        )
-        .context("Failed to initialize saved voice database schema")?;
-
         Ok(Self {
-            db_path,
+            db: StoreDatabase::new(db_path),
             media_root,
         })
     }
@@ -143,316 +116,278 @@ impl SavedVoiceStore {
         limit: usize,
         cursor: Option<SavedVoiceListCursor>,
     ) -> anyhow::Result<(Vec<SavedVoiceSummary>, Option<SavedVoiceListCursor>)> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let list_limit = i64::try_from(limit.clamp(1, 2000).max(1)).unwrap_or(500);
-            let page_size = usize::try_from(list_limit).unwrap_or(500);
-            let fetch_limit = list_limit.saturating_add(1);
+        let db = self.db.connection().await?;
+        let list_limit = i64::try_from(limit.clamp(1, 2000).max(1)).unwrap_or(500);
+        let page_size = usize::try_from(list_limit).unwrap_or(500);
+        let fetch_limit = list_limit.saturating_add(1);
 
-            let mut records = Vec::new();
-            if let Some(cursor) = cursor {
-                let cursor_updated_at = i64::try_from(cursor.updated_at).unwrap_or(i64::MAX);
-                let cursor_created_at = i64::try_from(cursor.created_at).unwrap_or(i64::MAX);
-                let mut stmt = conn.prepare(
-                    r#"
-                    SELECT
-                        id,
-                        created_at,
-                        updated_at,
-                        name,
-                        reference_text,
-                        audio_mime_type,
-                        audio_filename,
-                        source_route_kind,
-                        source_record_id
-                    FROM saved_voices
-                    WHERE
-                        updated_at < ?1
-                        OR (
-                            updated_at = ?1
-                            AND (
-                                created_at < ?2
-                                OR (created_at = ?2 AND id < ?3)
-                            )
-                        )
-                    ORDER BY updated_at DESC, created_at DESC, id DESC
-                    LIMIT ?4
-                    "#,
-                )?;
+        let rows = if let Some(cursor) = cursor {
+            let cursor_updated_at = i64::try_from(cursor.updated_at).unwrap_or(i64::MAX);
+            let cursor_created_at = i64::try_from(cursor.created_at).unwrap_or(i64::MAX);
+            db.query_all_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                SAVED_VOICE_PAGE_AFTER_CURSOR_SQL,
+                vec![
+                    cursor_updated_at.into(),
+                    cursor_created_at.into(),
+                    cursor.id.into(),
+                    fetch_limit.into(),
+                ],
+            ))
+            .await
+        } else {
+            db.query_all_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                SAVED_VOICE_PAGE_SQL,
+                vec![fetch_limit.into()],
+            ))
+            .await
+        }
+        .context("Failed to list saved voices")?;
 
-                let rows = stmt.query_map(
-                    params![cursor_updated_at, cursor_created_at, cursor.id, fetch_limit],
-                    map_saved_voice_summary,
-                )?;
-                for row in rows {
-                    records.push(row?);
-                }
-            } else {
-                let mut stmt = conn.prepare(
-                    r#"
-                    SELECT
-                        id,
-                        created_at,
-                        updated_at,
-                        name,
-                        reference_text,
-                        audio_mime_type,
-                        audio_filename,
-                        source_route_kind,
-                        source_record_id
-                    FROM saved_voices
-                    ORDER BY updated_at DESC, created_at DESC, id DESC
-                    LIMIT ?1
-                    "#,
-                )?;
+        let mut records = rows
+            .iter()
+            .map(map_saved_voice_summary)
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let has_more = records.len() > page_size;
+        if has_more {
+            records.truncate(page_size);
+        }
 
-                let rows = stmt.query_map(params![fetch_limit], map_saved_voice_summary)?;
-                for row in rows {
-                    records.push(row?);
-                }
-            }
+        let next_cursor = if has_more {
+            records.last().map(|record| SavedVoiceListCursor {
+                updated_at: record.updated_at,
+                created_at: record.created_at,
+                id: record.id.clone(),
+            })
+        } else {
+            None
+        };
 
-            let has_more = records.len() > page_size;
-            if has_more {
-                records.truncate(page_size);
-            }
-
-            let next_cursor = if has_more {
-                records.last().map(|record| SavedVoiceListCursor {
-                    updated_at: record.updated_at,
-                    created_at: record.created_at,
-                    id: record.id.clone(),
-                })
-            } else {
-                None
-            };
-
-            Ok((records, next_cursor))
-        })
-        .await
+        Ok((records, next_cursor))
     }
 
     pub async fn get_voice(&self, voice_id: String) -> anyhow::Result<Option<SavedVoice>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            fetch_voice_without_audio(&conn, &voice_id)
-        })
-        .await
+        let db = self.db.connection().await?;
+        fetch_voice_without_audio(db, &voice_id).await
     }
 
     pub async fn get_audio(
         &self,
         voice_id: String,
     ) -> anyhow::Result<Option<StoredSavedVoiceAudio>> {
-        let media_root = self.media_root.clone();
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let audio = conn
-                .query_row(
-                    r#"
-                    SELECT audio_storage_path, audio_mime_type, audio_filename
-                    FROM saved_voices
-                    WHERE id = ?1
-                    "#,
-                    params![voice_id],
-                    |row| {
-                        Ok((
-                            row.get::<_, String>(0)?,
-                            row.get::<_, String>(1)?,
-                            row.get::<_, Option<String>>(2)?,
-                        ))
-                    },
-                )
-                .optional()?;
+        let db = self.db.connection().await?;
+        let audio = db
+            .query_one_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                r#"
+                SELECT audio_storage_path, audio_mime_type, audio_filename
+                FROM saved_voices
+                WHERE id = ?1
+                "#,
+                vec![voice_id.into()],
+            ))
+            .await
+            .context("Failed to load saved voice audio metadata")?;
 
-            let Some((audio_storage_path, audio_mime_type, audio_filename)) = audio else {
-                return Ok(None);
-            };
+        let Some(row) = audio else {
+            return Ok(None);
+        };
 
-            let audio_bytes =
-                storage_layout::read_media_file(&media_root, audio_storage_path.as_str())?;
+        let audio_storage_path: String = row.try_get_by_index(0)?;
+        let audio_mime_type: String = row.try_get_by_index(1)?;
+        let audio_filename: Option<String> = row.try_get_by_index(2)?;
+        let audio_bytes =
+            storage_layout::read_media_file(&self.media_root, audio_storage_path.as_str())?;
 
-            Ok(Some(StoredSavedVoiceAudio {
-                audio_bytes,
-                audio_mime_type,
-                audio_filename,
-            }))
-        })
-        .await
+        Ok(Some(StoredSavedVoiceAudio {
+            audio_bytes,
+            audio_mime_type,
+            audio_filename,
+        }))
     }
 
     pub async fn create_voice(&self, voice: NewSavedVoice) -> anyhow::Result<SavedVoice> {
-        let media_root = self.media_root.clone();
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
+        let db = self.db.connection().await?;
+        let now = now_unix_millis_i64();
+        let voice_id = new_uuid();
+        let name = sanitize_required_text(voice.name.as_str(), 120, "name")?;
+        let reference_text =
+            sanitize_required_text(voice.reference_text.as_str(), 4_000, "reference_text")?;
+        let audio_mime_type = sanitize_audio_mime_type(voice.audio_mime_type.as_str());
+        let audio_filename = sanitize_optional_text(voice.audio_filename.as_deref(), 260);
+        let source_route_kind = voice
+            .source_route_kind
+            .map(|kind| kind.as_db_value().to_string());
+        let source_record_id = sanitize_optional_text(voice.source_record_id.as_deref(), 200);
 
-            let now = now_unix_millis_i64();
-            let voice_id = new_uuid();
+        if voice.audio_bytes.is_empty() {
+            return Err(anyhow!("Audio payload cannot be empty"));
+        }
 
-            let name = sanitize_required_text(voice.name.as_str(), 120, "name")?;
-            let reference_text =
-                sanitize_required_text(voice.reference_text.as_str(), 4_000, "reference_text")?;
-            let audio_mime_type = sanitize_audio_mime_type(voice.audio_mime_type.as_str());
-            let audio_filename = sanitize_optional_text(voice.audio_filename.as_deref(), 260);
-            let source_route_kind = voice
-                .source_route_kind
-                .map(SavedVoiceSourceRouteKind::as_db_value);
-            let source_record_id = sanitize_optional_text(voice.source_record_id.as_deref(), 200);
+        let audio_storage_path = storage_layout::persist_audio_file(
+            &self.media_root,
+            MediaGroup::Generated,
+            "voices",
+            &voice_id,
+            audio_filename.as_deref(),
+            audio_mime_type.as_str(),
+            &voice.audio_bytes,
+        )?;
 
-            if voice.audio_bytes.is_empty() {
-                return Err(anyhow!("Audio payload cannot be empty"));
-            }
-
-            let audio_storage_path = storage_layout::persist_audio_file(
-                &media_root,
-                MediaGroup::Generated,
-                "voices",
-                &voice_id,
-                audio_filename.as_deref(),
-                audio_mime_type.as_str(),
-                &voice.audio_bytes,
-            )?;
-
-            if let Err(err) = conn.execute(
-                r#"
-                INSERT INTO saved_voices (
-                    id,
-                    created_at,
-                    updated_at,
-                    name,
-                    reference_text,
-                    audio_mime_type,
-                    audio_filename,
-                    audio_storage_path,
-                    source_route_kind,
-                    source_record_id
-                )
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
-                "#,
-                params![
-                    &voice_id,
-                    now,
-                    now,
-                    name,
-                    reference_text,
-                    audio_mime_type,
-                    audio_filename,
-                    audio_storage_path,
-                    source_route_kind,
-                    source_record_id,
-                ],
-            ) {
-                let _ = storage_layout::delete_media_file(
-                    &media_root,
-                    Some(audio_storage_path.as_str()),
-                );
-                return Err(err).context("Failed to insert saved voice");
-            }
-
-            fetch_voice_without_audio(&conn, &voice_id)?
-                .ok_or_else(|| anyhow!("Failed to fetch created saved voice"))
+        if let Err(err) = saved_voices::Entity::insert(saved_voices::ActiveModel {
+            id: Set(voice_id.clone()),
+            created_at: Set(now),
+            updated_at: Set(now),
+            name: Set(name),
+            reference_text: Set(reference_text),
+            audio_mime_type: Set(audio_mime_type),
+            audio_filename: Set(audio_filename),
+            audio_storage_path: Set(audio_storage_path.clone()),
+            source_route_kind: Set(source_route_kind),
+            source_record_id: Set(source_record_id),
         })
+        .exec(db)
         .await
+        {
+            let _ = storage_layout::delete_media_file(&self.media_root, Some(&audio_storage_path));
+            return Err(err).context("Failed to insert saved voice");
+        }
+
+        fetch_voice_without_audio(db, &voice_id)
+            .await?
+            .ok_or_else(|| anyhow!("Failed to fetch created saved voice"))
     }
 
     pub async fn delete_voice(&self, voice_id: String) -> anyhow::Result<bool> {
-        let media_root = self.media_root.clone();
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let audio_storage_path = conn
-                .query_row(
-                    "SELECT audio_storage_path FROM saved_voices WHERE id = ?1",
-                    params![&voice_id],
-                    |row| row.get::<_, Option<String>>(0),
-                )
-                .optional()?
-                .flatten();
-
-            let changed =
-                conn.execute("DELETE FROM saved_voices WHERE id = ?1", params![voice_id])?;
-
-            if changed > 0 {
-                storage_layout::delete_media_file(&media_root, audio_storage_path.as_deref())?;
-            }
-
-            Ok(changed > 0)
-        })
-        .await
-    }
-
-    async fn run_blocking<F, T>(&self, task_fn: F) -> anyhow::Result<T>
-    where
-        F: FnOnce(PathBuf) -> anyhow::Result<T> + Send + 'static,
-        T: Send + 'static,
-    {
-        let db_path = self.db_path.clone();
-        task::spawn_blocking(move || task_fn(db_path))
+        let db = self.db.connection().await?;
+        let audio_storage_path = db
+            .query_one_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                "SELECT audio_storage_path FROM saved_voices WHERE id = ?1",
+                vec![voice_id.clone().into()],
+            ))
             .await
-            .map_err(|err| anyhow!("Saved voice storage worker failed: {err}"))?
+            .context("Failed to load saved voice media path")?
+            .map(|row| row.try_get_by_index::<Option<String>>(0))
+            .transpose()?
+            .flatten();
+
+        let result = saved_voices::Entity::delete_by_id(voice_id)
+            .exec(db)
+            .await
+            .context("Failed to delete saved voice")?;
+
+        if result.rows_affected > 0 {
+            storage_layout::delete_media_file(&self.media_root, audio_storage_path.as_deref())?;
+        }
+
+        Ok(result.rows_affected > 0)
     }
 }
 
-fn fetch_voice_without_audio(
-    conn: &Connection,
+const SAVED_VOICE_COLUMNS: &str = r#"
+    id,
+    created_at,
+    updated_at,
+    name,
+    reference_text,
+    audio_mime_type,
+    audio_filename,
+    source_route_kind,
+    source_record_id
+"#;
+
+const SAVED_VOICE_PAGE_SQL: &str = r#"
+    SELECT
+        id,
+        created_at,
+        updated_at,
+        name,
+        reference_text,
+        audio_mime_type,
+        audio_filename,
+        source_route_kind,
+        source_record_id
+    FROM saved_voices
+    ORDER BY updated_at DESC, created_at DESC, id DESC
+    LIMIT ?1
+"#;
+
+const SAVED_VOICE_PAGE_AFTER_CURSOR_SQL: &str = r#"
+    SELECT
+        id,
+        created_at,
+        updated_at,
+        name,
+        reference_text,
+        audio_mime_type,
+        audio_filename,
+        source_route_kind,
+        source_record_id
+    FROM saved_voices
+    WHERE
+        updated_at < ?1
+        OR (
+            updated_at = ?1
+            AND (
+                created_at < ?2
+                OR (created_at = ?2 AND id < ?3)
+            )
+        )
+    ORDER BY updated_at DESC, created_at DESC, id DESC
+    LIMIT ?4
+"#;
+
+async fn fetch_voice_without_audio(
+    db: &sea_orm::DatabaseConnection,
     voice_id: &str,
 ) -> anyhow::Result<Option<SavedVoice>> {
-    let voice = conn
-        .query_row(
-            r#"
-            SELECT
-                id,
-                created_at,
-                updated_at,
-                name,
-                reference_text,
-                audio_mime_type,
-                audio_filename,
-                source_route_kind,
-                source_record_id
-            FROM saved_voices
-            WHERE id = ?1
-            "#,
-            params![voice_id],
-            map_saved_voice,
-        )
-        .optional()?;
-    Ok(voice)
+    let row = db
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            format!("SELECT {SAVED_VOICE_COLUMNS} FROM saved_voices WHERE id = ?1"),
+            vec![voice_id.into()],
+        ))
+        .await
+        .context("Failed to load saved voice")?;
+    row.as_ref().map(map_saved_voice).transpose()
 }
 
-fn map_saved_voice(row: &Row<'_>) -> rusqlite::Result<SavedVoice> {
-    let source_route_raw: Option<String> = row.get(7)?;
+fn map_saved_voice(row: &QueryResult) -> anyhow::Result<SavedVoice> {
+    let source_route_raw: Option<String> = row.try_get_by_index(7)?;
     Ok(SavedVoice {
-        id: row.get(0)?,
-        created_at: i64_to_u64(row.get(1)?),
-        updated_at: i64_to_u64(row.get(2)?),
-        name: row.get(3)?,
-        reference_text: row.get(4)?,
-        audio_mime_type: row.get(5)?,
-        audio_filename: row.get(6)?,
+        id: row.try_get_by_index(0)?,
+        created_at: i64_to_u64(row.try_get_by_index(1)?),
+        updated_at: i64_to_u64(row.try_get_by_index(2)?),
+        name: row.try_get_by_index(3)?,
+        reference_text: row.try_get_by_index(4)?,
+        audio_mime_type: row.try_get_by_index(5)?,
+        audio_filename: row.try_get_by_index(6)?,
         source_route_kind: source_route_raw
             .as_deref()
             .and_then(SavedVoiceSourceRouteKind::from_db_value),
-        source_record_id: row.get(8)?,
+        source_record_id: row.try_get_by_index(8)?,
     })
 }
 
-fn map_saved_voice_summary(row: &Row<'_>) -> rusqlite::Result<SavedVoiceSummary> {
-    let reference_text: String = row.get(4)?;
-    let source_route_raw: Option<String> = row.get(7)?;
+fn map_saved_voice_summary(row: &QueryResult) -> anyhow::Result<SavedVoiceSummary> {
+    let reference_text: String = row.try_get_by_index(4)?;
+    let source_route_raw: Option<String> = row.try_get_by_index(7)?;
 
     Ok(SavedVoiceSummary {
-        id: row.get(0)?,
-        created_at: i64_to_u64(row.get(1)?),
-        updated_at: i64_to_u64(row.get(2)?),
-        name: row.get(3)?,
+        id: row.try_get_by_index(0)?,
+        created_at: i64_to_u64(row.try_get_by_index(1)?),
+        updated_at: i64_to_u64(row.try_get_by_index(2)?),
+        name: row.try_get_by_index(3)?,
         reference_text_preview: reference_text_preview(reference_text.as_str()),
         reference_text_chars: reference_text.chars().count(),
-        audio_mime_type: row.get(5)?,
-        audio_filename: row.get(6)?,
+        audio_mime_type: row.try_get_by_index(5)?,
+        audio_filename: row.try_get_by_index(6)?,
         source_route_kind: source_route_raw
             .as_deref()
             .and_then(SavedVoiceSourceRouteKind::from_db_value),
-        source_record_id: row.get(8)?,
+        source_record_id: row.try_get_by_index(8)?,
     })
 }
 
@@ -519,14 +454,87 @@ fn now_unix_millis_i64() -> i64 {
 }
 
 fn i64_to_u64(value: i64) -> u64 {
-    if value.is_negative() {
-        0
-    } else {
-        value as u64
-    }
+    if value.is_negative() { 0 } else { value as u64 }
 }
 
 #[allow(dead_code)]
 pub const fn default_list_limit() -> usize {
     DEFAULT_LIST_LIMIT
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::env_lock;
+
+    fn setup_store() -> (tempfile::TempDir, SavedVoiceStore) {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("saved-voices.sqlite3");
+        let media_dir = temp_dir.path().join("media");
+        std::env::set_var("IZWI_DB_PATH", &db_path);
+        std::env::set_var("IZWI_MEDIA_DIR", &media_dir);
+        let store = SavedVoiceStore::initialize().expect("store");
+        (temp_dir, store)
+    }
+
+    fn clear_env() {
+        std::env::remove_var("IZWI_DB_PATH");
+        std::env::remove_var("IZWI_MEDIA_DIR");
+    }
+
+    #[tokio::test]
+    async fn creates_lists_reads_audio_and_deletes_voice() {
+        let _guard = env_lock();
+        let (_temp, store) = setup_store();
+
+        let created = store
+            .create_voice(NewSavedVoice {
+                name: "  Demo Voice ".to_string(),
+                reference_text: " A calm reference sample ".to_string(),
+                audio_mime_type: "audio/wav".to_string(),
+                audio_filename: Some("demo.wav".to_string()),
+                audio_bytes: vec![1, 2, 3, 4],
+                source_route_kind: Some(SavedVoiceSourceRouteKind::VoiceCloning),
+                source_record_id: Some("speech-1".to_string()),
+            })
+            .await
+            .expect("voice should create");
+
+        assert_eq!(created.name, "Demo Voice");
+        assert_eq!(
+            created.source_route_kind,
+            Some(SavedVoiceSourceRouteKind::VoiceCloning)
+        );
+
+        let audio = store
+            .get_audio(created.id.clone())
+            .await
+            .expect("audio should load")
+            .expect("audio should exist");
+        assert_eq!(audio.audio_bytes, vec![1, 2, 3, 4]);
+
+        let (voices, cursor) = store
+            .list_voices_page(10, None)
+            .await
+            .expect("voices should list");
+        assert!(cursor.is_none());
+        assert_eq!(voices.len(), 1);
+        assert_eq!(voices[0].name, "Demo Voice");
+
+        assert!(
+            store
+                .delete_voice(created.id.clone())
+                .await
+                .expect("voice should delete")
+        );
+        assert!(
+            store
+                .get_voice(created.id)
+                .await
+                .expect("voice lookup should succeed")
+                .is_none()
+        );
+
+        clear_env();
+    }
 }

--- a/crates/izwi-server/src/speech_history_store.rs
+++ b/crates/izwi-server/src/speech_history_store.rs
@@ -1,13 +1,17 @@
 //! Persistent speech generation history storage backed by SQLite.
 
-use anyhow::{anyhow, Context};
-use rusqlite::{params, Connection, OptionalExtension, Row};
+use anyhow::{Context, anyhow};
+use sea_orm::sea_query::Expr;
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, QueryFilter, QueryResult, Set, Statement,
+};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::task;
 
 use crate::{
+    db::StoreDatabase,
+    entity::speech_history_records,
     ids::new_uuid,
     storage_layout::{self, MediaGroup},
 };
@@ -178,7 +182,7 @@ pub struct CompleteSpeechHistoryRecord {
 
 #[derive(Clone)]
 pub struct SpeechHistoryStore {
-    db_path: PathBuf,
+    db: StoreDatabase,
     media_root: PathBuf,
 }
 
@@ -190,51 +194,8 @@ impl SpeechHistoryStore {
         storage_layout::ensure_storage_dirs(&db_path, &media_root)
             .context("Failed to prepare speech history storage layout")?;
 
-        let conn = storage_layout::open_sqlite_connection(&db_path).with_context(|| {
-            format!(
-                "Failed to open speech history database: {}",
-                db_path.display()
-            )
-        })?;
-
-        conn.execute_batch(
-            r#"
-            CREATE TABLE IF NOT EXISTS speech_history_records (
-                id TEXT PRIMARY KEY,
-                created_at INTEGER NOT NULL,
-                route_kind TEXT NOT NULL,
-                processing_status TEXT NOT NULL DEFAULT 'ready',
-                processing_error TEXT NULL,
-                model_id TEXT NULL,
-                speaker TEXT NULL,
-                language TEXT NULL,
-                saved_voice_id TEXT NULL,
-                speed REAL NULL,
-                input_text TEXT NOT NULL,
-                voice_description TEXT NULL,
-                reference_text TEXT NULL,
-                generation_time_ms REAL NOT NULL,
-                audio_duration_secs REAL NULL,
-                rtf REAL NULL,
-                tokens_generated INTEGER NULL,
-                audio_mime_type TEXT NOT NULL,
-                audio_filename TEXT NULL,
-                audio_storage_path TEXT NOT NULL
-            );
-
-            CREATE INDEX IF NOT EXISTS idx_speech_history_route_created_at
-                ON speech_history_records(route_kind, created_at DESC);
-            "#,
-        )
-        .context("Failed to initialize speech history database schema")?;
-
-        ensure_speech_history_records_saved_voice_id_column(&conn)?;
-        ensure_speech_history_records_speed_column(&conn)?;
-        ensure_speech_history_records_processing_status_column(&conn)?;
-        ensure_speech_history_records_processing_error_column(&conn)?;
-
         Ok(Self {
-            db_path,
+            db: StoreDatabase::new(db_path),
             media_root,
         })
     }
@@ -248,170 +209,53 @@ impl SpeechHistoryStore {
         Vec<SpeechHistoryRecordSummary>,
         Option<SpeechHistoryRecordListCursor>,
     )> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let list_limit = i64::try_from(limit.clamp(1, 500).max(1)).unwrap_or(200);
-            let mut records = Vec::new();
-            let fetch_limit = list_limit.saturating_add(1);
+        let db = self.db.connection().await?;
+        let list_limit = i64::try_from(limit.clamp(1, 500).max(1)).unwrap_or(200);
+        let fetch_limit = list_limit.saturating_add(1);
 
-            if let Some(cursor) = cursor {
-                let cursor_created_at = i64::try_from(cursor.created_at).unwrap_or(i64::MAX);
-                let mut stmt = conn.prepare(
-                    r#"
-                    SELECT
-                        id,
-                        created_at,
-                        route_kind,
-                        processing_status,
-                        processing_error,
-                        model_id,
-                        speaker,
-                        language,
-                        saved_voice_id,
-                        speed,
-                        input_text,
-                        generation_time_ms,
-                        audio_duration_secs,
-                        rtf,
-                        tokens_generated,
-                        audio_mime_type,
-                        audio_filename
-                    FROM speech_history_records
-                    WHERE route_kind = ?1
-                        AND (created_at < ?2 OR (created_at = ?2 AND id < ?3))
-                    ORDER BY created_at DESC, id DESC
-                    LIMIT ?4
-                    "#,
-                )?;
+        let rows = if let Some(cursor) = cursor {
+            let cursor_created_at = i64::try_from(cursor.created_at).unwrap_or(i64::MAX);
+            db.query_all_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                SPEECH_HISTORY_PAGE_AFTER_CURSOR_SQL,
+                vec![
+                    route_kind.as_db_value().into(),
+                    cursor_created_at.into(),
+                    cursor.id.into(),
+                    fetch_limit.into(),
+                ],
+            ))
+            .await
+        } else {
+            db.query_all_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                SPEECH_HISTORY_PAGE_SQL,
+                vec![route_kind.as_db_value().into(), fetch_limit.into()],
+            ))
+            .await
+        }
+        .context("Failed to list speech history records")?;
 
-                let rows = stmt.query_map(
-                    params![
-                        route_kind.as_db_value(),
-                        cursor_created_at,
-                        cursor.id,
-                        fetch_limit
-                    ],
-                    |row| {
-                        let input_text: String = row.get(10)?;
-                        let route_raw: String = row.get(2)?;
-                        let route_kind = SpeechRouteKind::from_db_value(route_raw.as_str())
-                            .unwrap_or(SpeechRouteKind::TextToSpeech);
-                        let processing_status_raw: String = row.get(3)?;
-                        Ok(SpeechHistoryRecordSummary {
-                            id: row.get(0)?,
-                            created_at: i64_to_u64(row.get(1)?),
-                            route_kind,
-                            processing_status: SpeechHistoryProcessingStatus::from_db_value(
-                                processing_status_raw.as_str(),
-                            )
-                            .unwrap_or_default(),
-                            processing_error: row.get(4)?,
-                            model_id: row.get(5)?,
-                            speaker: row.get(6)?,
-                            language: row.get(7)?,
-                            saved_voice_id: row.get(8)?,
-                            speed: row.get(9)?,
-                            input_preview: input_preview(input_text.as_str()),
-                            input_chars: input_text.chars().count(),
-                            generation_time_ms: row.get(11)?,
-                            audio_duration_secs: row.get(12)?,
-                            rtf: row.get(13)?,
-                            tokens_generated: row
-                                .get::<_, Option<i64>>(14)?
-                                .and_then(|value| i64_to_usize(value)),
-                            audio_mime_type: row.get(15)?,
-                            audio_filename: row.get(16)?,
-                        })
-                    },
-                )?;
+        let mut records = rows
+            .iter()
+            .map(map_speech_history_summary)
+            .collect::<anyhow::Result<Vec<_>>>()?;
 
-                for row in rows {
-                    records.push(row?);
-                }
-            } else {
-                let mut stmt = conn.prepare(
-                    r#"
-                    SELECT
-                        id,
-                        created_at,
-                        route_kind,
-                        processing_status,
-                        processing_error,
-                        model_id,
-                        speaker,
-                        language,
-                        saved_voice_id,
-                        speed,
-                        input_text,
-                        generation_time_ms,
-                        audio_duration_secs,
-                        rtf,
-                        tokens_generated,
-                        audio_mime_type,
-                        audio_filename
-                    FROM speech_history_records
-                    WHERE route_kind = ?1
-                    ORDER BY created_at DESC, id DESC
-                    LIMIT ?2
-                    "#,
-                )?;
+        let page_limit = usize::try_from(list_limit).unwrap_or(200);
+        let has_more = records.len() > page_limit;
+        if has_more {
+            records.truncate(page_limit);
+        }
+        let next_cursor = if has_more {
+            records.last().map(|record| SpeechHistoryRecordListCursor {
+                created_at: record.created_at,
+                id: record.id.clone(),
+            })
+        } else {
+            None
+        };
 
-                let rows =
-                    stmt.query_map(params![route_kind.as_db_value(), fetch_limit], |row| {
-                        let input_text: String = row.get(10)?;
-                        let route_raw: String = row.get(2)?;
-                        let route_kind = SpeechRouteKind::from_db_value(route_raw.as_str())
-                            .unwrap_or(SpeechRouteKind::TextToSpeech);
-                        let processing_status_raw: String = row.get(3)?;
-                        Ok(SpeechHistoryRecordSummary {
-                            id: row.get(0)?,
-                            created_at: i64_to_u64(row.get(1)?),
-                            route_kind,
-                            processing_status: SpeechHistoryProcessingStatus::from_db_value(
-                                processing_status_raw.as_str(),
-                            )
-                            .unwrap_or_default(),
-                            processing_error: row.get(4)?,
-                            model_id: row.get(5)?,
-                            speaker: row.get(6)?,
-                            language: row.get(7)?,
-                            saved_voice_id: row.get(8)?,
-                            speed: row.get(9)?,
-                            input_preview: input_preview(input_text.as_str()),
-                            input_chars: input_text.chars().count(),
-                            generation_time_ms: row.get(11)?,
-                            audio_duration_secs: row.get(12)?,
-                            rtf: row.get(13)?,
-                            tokens_generated: row
-                                .get::<_, Option<i64>>(14)?
-                                .and_then(|value| i64_to_usize(value)),
-                            audio_mime_type: row.get(15)?,
-                            audio_filename: row.get(16)?,
-                        })
-                    })?;
-
-                for row in rows {
-                    records.push(row?);
-                }
-            }
-
-            let page_limit = usize::try_from(list_limit).unwrap_or(200);
-            let has_more = records.len() > page_limit;
-            if has_more {
-                records.truncate(page_limit);
-            }
-            let next_cursor = if has_more {
-                records.last().map(|record| SpeechHistoryRecordListCursor {
-                    created_at: record.created_at,
-                    id: record.id.clone(),
-                })
-            } else {
-                None
-            };
-
-            Ok((records, next_cursor))
-        })
-        .await
+        Ok((records, next_cursor))
     }
 
     pub async fn get_record(
@@ -419,12 +263,8 @@ impl SpeechHistoryStore {
         route_kind: SpeechRouteKind,
         record_id: String,
     ) -> anyhow::Result<Option<SpeechHistoryRecord>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let record = fetch_record_without_audio(&conn, route_kind, &record_id)?;
-            Ok(record)
-        })
-        .await
+        let db = self.db.connection().await?;
+        fetch_record_without_audio(db, route_kind, &record_id).await
     }
 
     pub async fn get_audio(
@@ -432,191 +272,135 @@ impl SpeechHistoryStore {
         route_kind: SpeechRouteKind,
         record_id: String,
     ) -> anyhow::Result<Option<StoredSpeechAudio>> {
-        let media_root = self.media_root.clone();
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let audio = conn
-                .query_row(
-                    r#"
-                    SELECT audio_storage_path, audio_mime_type, audio_filename
-                    FROM speech_history_records
-                    WHERE route_kind = ?1 AND id = ?2
-                    "#,
-                    params![route_kind.as_db_value(), record_id],
-                    |row| {
-                        Ok((
-                            row.get::<_, Option<String>>(0)?,
-                            row.get::<_, String>(1)?,
-                            row.get::<_, Option<String>>(2)?,
-                        ))
-                    },
-                )
-                .optional()?;
-            let Some((audio_storage_path, audio_mime_type, audio_filename)) = audio else {
-                return Ok(None);
-            };
-            let Some(audio_storage_path) = sanitize_media_path(audio_storage_path.as_deref())
-            else {
-                return Ok(None);
-            };
+        let db = self.db.connection().await?;
+        let audio = db
+            .query_one_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                r#"
+                SELECT audio_storage_path, audio_mime_type, audio_filename
+                FROM speech_history_records
+                WHERE route_kind = ?1 AND id = ?2
+                "#,
+                vec![route_kind.as_db_value().into(), record_id.into()],
+            ))
+            .await
+            .context("Failed to load speech history audio metadata")?;
+        let Some(row) = audio else {
+            return Ok(None);
+        };
 
-            let audio_bytes =
-                storage_layout::read_media_file(&media_root, audio_storage_path.as_str())?;
+        let audio_storage_path: Option<String> = row.try_get_by_index(0)?;
+        let audio_mime_type: String = row.try_get_by_index(1)?;
+        let audio_filename: Option<String> = row.try_get_by_index(2)?;
+        let Some(audio_storage_path) = sanitize_media_path(audio_storage_path.as_deref()) else {
+            return Ok(None);
+        };
 
-            Ok(Some(StoredSpeechAudio {
-                audio_bytes,
-                audio_mime_type,
-                audio_filename,
-            }))
-        })
-        .await
+        let audio_bytes =
+            storage_layout::read_media_file(&self.media_root, audio_storage_path.as_str())?;
+
+        Ok(Some(StoredSpeechAudio {
+            audio_bytes,
+            audio_mime_type,
+            audio_filename,
+        }))
     }
 
     pub async fn create_record(
         &self,
         record: NewSpeechHistoryRecord,
     ) -> anyhow::Result<SpeechHistoryRecord> {
-        let media_root = self.media_root.clone();
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let now = now_unix_millis_i64();
-            let record_id = new_uuid();
+        let db = self.db.connection().await?;
+        let now = now_unix_millis_i64();
+        let record_id = new_uuid();
+        let route_kind = record.route_kind;
+        let processing_status = record.processing_status;
+        let processing_error = sanitize_optional_text(record.processing_error.as_deref(), 1_200);
+        let model_id = sanitize_optional_text(record.model_id.as_deref(), 160);
+        let speaker = sanitize_optional_text(record.speaker.as_deref(), 120);
+        let language = sanitize_optional_text(record.language.as_deref(), 80);
+        let saved_voice_id = sanitize_optional_text(record.saved_voice_id.as_deref(), 160);
+        let speed = record
+            .speed
+            .filter(|value| value.is_finite() && *value > 0.0);
+        let input_text = sanitize_required_text(record.input_text.as_str(), 20_000);
+        let voice_description = sanitize_optional_text(record.voice_description.as_deref(), 2_000);
+        let reference_text = sanitize_optional_text(record.reference_text.as_deref(), 2_000);
+        let generation_time_ms = if record.generation_time_ms.is_finite() {
+            record.generation_time_ms.max(0.0)
+        } else {
+            0.0
+        };
+        let audio_duration_secs = record
+            .audio_duration_secs
+            .filter(|value| value.is_finite() && *value >= 0.0);
+        let rtf = record
+            .rtf
+            .filter(|value| value.is_finite() && *value >= 0.0);
+        let tokens_generated = record
+            .tokens_generated
+            .filter(|value| *value > 0)
+            .and_then(|value| i64::try_from(value).ok());
+        let audio_mime_type = sanitize_audio_mime_type(record.audio_mime_type.as_str());
+        let audio_filename = sanitize_optional_text(record.audio_filename.as_deref(), 260);
 
-            let processing_status = record.processing_status;
-            let processing_error =
-                sanitize_optional_text(record.processing_error.as_deref(), 1_200);
-            let model_id = sanitize_optional_text(record.model_id.as_deref(), 160);
-            let speaker = sanitize_optional_text(record.speaker.as_deref(), 120);
-            let language = sanitize_optional_text(record.language.as_deref(), 80);
-            let saved_voice_id = sanitize_optional_text(record.saved_voice_id.as_deref(), 160);
-            let speed = record
-                .speed
-                .filter(|value| value.is_finite() && *value > 0.0);
-            let input_text = sanitize_required_text(record.input_text.as_str(), 20_000);
-            let voice_description =
-                sanitize_optional_text(record.voice_description.as_deref(), 2_000);
-            let reference_text = sanitize_optional_text(record.reference_text.as_deref(), 2_000);
-            let generation_time_ms = if record.generation_time_ms.is_finite() {
-                record.generation_time_ms.max(0.0)
-            } else {
-                0.0
-            };
-            let audio_duration_secs = record
-                .audio_duration_secs
-                .filter(|value| value.is_finite() && *value >= 0.0);
-            let rtf = record
-                .rtf
-                .filter(|value| value.is_finite() && *value >= 0.0);
-            let tokens_generated = record
-                .tokens_generated
-                .filter(|value| *value > 0)
-                .and_then(|value| i64::try_from(value).ok());
-            let audio_mime_type = sanitize_audio_mime_type(record.audio_mime_type.as_str());
-            let audio_filename = sanitize_optional_text(record.audio_filename.as_deref(), 260);
+        let has_audio_payload = !record.audio_bytes.is_empty();
+        if !has_audio_payload && processing_status == SpeechHistoryProcessingStatus::Ready {
+            return Err(anyhow!(
+                "Audio payload cannot be empty for ready speech history records",
+            ));
+        }
 
-            let has_audio_payload = !record.audio_bytes.is_empty();
-            if !has_audio_payload && processing_status == SpeechHistoryProcessingStatus::Ready {
-                return Err(anyhow!(
-                    "Audio payload cannot be empty for ready speech history records",
-                ));
+        let audio_storage_path = if has_audio_payload {
+            let namespace = format!("speech/{}", route_kind.as_db_value());
+            Some(storage_layout::persist_audio_file(
+                &self.media_root,
+                MediaGroup::Generated,
+                namespace.as_str(),
+                &record_id,
+                audio_filename.as_deref(),
+                audio_mime_type.as_str(),
+                &record.audio_bytes,
+            )?)
+        } else {
+            None
+        };
+
+        if let Err(err) =
+            speech_history_records::Entity::insert(speech_history_records::ActiveModel {
+                id: Set(record_id.clone()),
+                created_at: Set(now),
+                route_kind: Set(route_kind.as_db_value().to_string()),
+                processing_status: Set(processing_status.as_db_value().to_string()),
+                processing_error: Set(processing_error),
+                model_id: Set(model_id),
+                speaker: Set(speaker),
+                language: Set(language),
+                saved_voice_id: Set(saved_voice_id),
+                speed: Set(speed),
+                input_text: Set(input_text),
+                voice_description: Set(voice_description),
+                reference_text: Set(reference_text),
+                generation_time_ms: Set(generation_time_ms),
+                audio_duration_secs: Set(audio_duration_secs),
+                rtf: Set(rtf),
+                tokens_generated: Set(tokens_generated),
+                audio_mime_type: Set(audio_mime_type),
+                audio_filename: Set(audio_filename),
+                audio_storage_path: Set(audio_storage_path.clone().unwrap_or_default()),
+            })
+            .exec(db)
+            .await
+        {
+            if let Some(path) = audio_storage_path.as_deref() {
+                let _ = storage_layout::delete_media_file(&self.media_root, Some(path));
             }
+            return Err(err).context("Failed to insert speech history record");
+        }
 
-            let audio_storage_path = if has_audio_payload {
-                let namespace = format!("speech/{}", record.route_kind.as_db_value());
-                Some(storage_layout::persist_audio_file(
-                    &media_root,
-                    MediaGroup::Generated,
-                    namespace.as_str(),
-                    &record_id,
-                    audio_filename.as_deref(),
-                    audio_mime_type.as_str(),
-                    &record.audio_bytes,
-                )?)
-            } else {
-                None
-            };
-
-            if let Err(err) = conn.execute(
-                r#"
-                INSERT INTO speech_history_records (
-                    id,
-                    created_at,
-                    route_kind,
-                    processing_status,
-                    processing_error,
-                    model_id,
-                    speaker,
-                    language,
-                    saved_voice_id,
-                    speed,
-                    input_text,
-                    voice_description,
-                    reference_text,
-                    generation_time_ms,
-                    audio_duration_secs,
-                    rtf,
-                    tokens_generated,
-                    audio_mime_type,
-                    audio_filename,
-                    audio_storage_path
-                )
-                VALUES (
-                    ?1,
-                    ?2,
-                    ?3,
-                    ?4,
-                    ?5,
-                    ?6,
-                    ?7,
-                    ?8,
-                    ?9,
-                    ?10,
-                    ?11,
-                    ?12,
-                    ?13,
-                    ?14,
-                    ?15,
-                    ?16,
-                    ?17,
-                    ?18,
-                    ?19,
-                    ?20
-                )
-                "#,
-                params![
-                    &record_id,
-                    now,
-                    record.route_kind.as_db_value(),
-                    processing_status.as_db_value(),
-                    processing_error,
-                    model_id,
-                    speaker,
-                    language,
-                    saved_voice_id,
-                    speed,
-                    input_text,
-                    voice_description,
-                    reference_text,
-                    generation_time_ms,
-                    audio_duration_secs,
-                    rtf,
-                    tokens_generated,
-                    audio_mime_type,
-                    audio_filename,
-                    audio_storage_path.clone().unwrap_or_default(),
-                ],
-            ) {
-                if let Some(path) = audio_storage_path.as_deref() {
-                    let _ = storage_layout::delete_media_file(&media_root, Some(path));
-                }
-                return Err(err).context("Failed to insert speech history record");
-            }
-
-            let created = fetch_record_without_audio(&conn, record.route_kind, &record_id)?
-                .ok_or_else(|| anyhow!("Failed to fetch created speech history record"))?;
-            Ok(created)
-        })
-        .await
+        fetch_record_without_audio(db, route_kind, &record_id)
+            .await?
+            .ok_or_else(|| anyhow!("Failed to fetch created speech history record"))
     }
 
     pub async fn update_processing_status(
@@ -626,28 +410,24 @@ impl SpeechHistoryStore {
         status: SpeechHistoryProcessingStatus,
         processing_error: Option<String>,
     ) -> anyhow::Result<Option<SpeechHistoryRecord>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let sanitized_error = sanitize_optional_text(processing_error.as_deref(), 1_200);
-            conn.execute(
-                r#"
-                UPDATE speech_history_records
-                SET processing_status = ?3,
-                    processing_error = ?4
-                WHERE route_kind = ?1 AND id = ?2
-                "#,
-                params![
-                    route_kind.as_db_value(),
-                    &record_id,
-                    status.as_db_value(),
-                    sanitized_error,
-                ],
-            )?;
+        let db = self.db.connection().await?;
+        let sanitized_error = sanitize_optional_text(processing_error.as_deref(), 1_200);
+        speech_history_records::Entity::update_many()
+            .col_expr(
+                speech_history_records::Column::ProcessingStatus,
+                Expr::value(status.as_db_value()),
+            )
+            .col_expr(
+                speech_history_records::Column::ProcessingError,
+                Expr::value(sanitized_error),
+            )
+            .filter(speech_history_records::Column::RouteKind.eq(route_kind.as_db_value()))
+            .filter(speech_history_records::Column::Id.eq(record_id.clone()))
+            .exec(db)
+            .await
+            .context("Failed to update speech history processing status")?;
 
-            let updated = fetch_record_without_audio(&conn, route_kind, &record_id)?;
-            Ok(updated)
-        })
-        .await
+        fetch_record_without_audio(db, route_kind, &record_id).await
     }
 
     pub async fn complete_record(
@@ -656,129 +436,139 @@ impl SpeechHistoryStore {
         record_id: String,
         record: CompleteSpeechHistoryRecord,
     ) -> anyhow::Result<Option<SpeechHistoryRecord>> {
-        let media_root = self.media_root.clone();
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let model_id = sanitize_optional_text(record.model_id.as_deref(), 160);
-            let speaker = sanitize_optional_text(record.speaker.as_deref(), 120);
-            let language = sanitize_optional_text(record.language.as_deref(), 80);
-            let saved_voice_id = sanitize_optional_text(record.saved_voice_id.as_deref(), 160);
-            let speed = record
-                .speed
-                .filter(|value| value.is_finite() && *value > 0.0);
-            let input_text = sanitize_required_text(record.input_text.as_str(), 20_000);
-            let voice_description =
-                sanitize_optional_text(record.voice_description.as_deref(), 2_000);
-            let reference_text = sanitize_optional_text(record.reference_text.as_deref(), 2_000);
-            let generation_time_ms = if record.generation_time_ms.is_finite() {
-                record.generation_time_ms.max(0.0)
-            } else {
-                0.0
-            };
-            let audio_duration_secs = record
-                .audio_duration_secs
-                .filter(|value| value.is_finite() && *value >= 0.0);
-            let rtf = record
-                .rtf
-                .filter(|value| value.is_finite() && *value >= 0.0);
-            let tokens_generated = record
-                .tokens_generated
-                .filter(|value| *value > 0)
-                .and_then(|value| i64::try_from(value).ok());
-            let audio_mime_type = sanitize_audio_mime_type(record.audio_mime_type.as_str());
-            let audio_filename = sanitize_optional_text(record.audio_filename.as_deref(), 260);
+        let db = self.db.connection().await?;
+        let model_id = sanitize_optional_text(record.model_id.as_deref(), 160);
+        let speaker = sanitize_optional_text(record.speaker.as_deref(), 120);
+        let language = sanitize_optional_text(record.language.as_deref(), 80);
+        let saved_voice_id = sanitize_optional_text(record.saved_voice_id.as_deref(), 160);
+        let speed = record
+            .speed
+            .filter(|value| value.is_finite() && *value > 0.0);
+        let input_text = sanitize_required_text(record.input_text.as_str(), 20_000);
+        let voice_description = sanitize_optional_text(record.voice_description.as_deref(), 2_000);
+        let reference_text = sanitize_optional_text(record.reference_text.as_deref(), 2_000);
+        let generation_time_ms = if record.generation_time_ms.is_finite() {
+            record.generation_time_ms.max(0.0)
+        } else {
+            0.0
+        };
+        let audio_duration_secs = record
+            .audio_duration_secs
+            .filter(|value| value.is_finite() && *value >= 0.0);
+        let rtf = record
+            .rtf
+            .filter(|value| value.is_finite() && *value >= 0.0);
+        let tokens_generated = record
+            .tokens_generated
+            .filter(|value| *value > 0)
+            .and_then(|value| i64::try_from(value).ok());
+        let audio_mime_type = sanitize_audio_mime_type(record.audio_mime_type.as_str());
+        let audio_filename = sanitize_optional_text(record.audio_filename.as_deref(), 260);
 
-            if record.audio_bytes.is_empty() {
-                return Err(anyhow!(
-                    "Audio payload cannot be empty when completing speech history records",
-                ));
-            }
+        if record.audio_bytes.is_empty() {
+            return Err(anyhow!(
+                "Audio payload cannot be empty when completing speech history records",
+            ));
+        }
 
-            let namespace = format!("speech/{}", route_kind.as_db_value());
-            let next_audio_storage_path = storage_layout::persist_audio_file(
-                &media_root,
-                MediaGroup::Generated,
-                namespace.as_str(),
-                &record_id,
-                audio_filename.as_deref(),
-                audio_mime_type.as_str(),
-                &record.audio_bytes,
-            )?;
+        let namespace = format!("speech/{}", route_kind.as_db_value());
+        let next_audio_storage_path = storage_layout::persist_audio_file(
+            &self.media_root,
+            MediaGroup::Generated,
+            namespace.as_str(),
+            &record_id,
+            audio_filename.as_deref(),
+            audio_mime_type.as_str(),
+            &record.audio_bytes,
+        )?;
 
-            let previous_audio_storage_path = conn
-                .query_row(
-                    r#"
-                    SELECT audio_storage_path
-                    FROM speech_history_records
-                    WHERE route_kind = ?1 AND id = ?2
-                    "#,
-                    params![route_kind.as_db_value(), &record_id],
-                    |row| row.get::<_, Option<String>>(0),
-                )
-                .optional()?
-                .flatten();
+        let previous_audio_storage_path = fetch_audio_storage_path(db, route_kind, &record_id)
+            .await?
+            .flatten();
 
-            let changed = conn.execute(
-                r#"
-                UPDATE speech_history_records
-                SET processing_status = ?3,
-                    processing_error = NULL,
-                    model_id = ?4,
-                    speaker = ?5,
-                    language = ?6,
-                    saved_voice_id = ?7,
-                    speed = ?8,
-                    input_text = ?9,
-                    voice_description = ?10,
-                    reference_text = ?11,
-                    generation_time_ms = ?12,
-                    audio_duration_secs = ?13,
-                    rtf = ?14,
-                    tokens_generated = ?15,
-                    audio_mime_type = ?16,
-                    audio_filename = ?17,
-                    audio_storage_path = ?18
-                WHERE route_kind = ?1 AND id = ?2
-                "#,
-                params![
-                    route_kind.as_db_value(),
-                    &record_id,
-                    SpeechHistoryProcessingStatus::Ready.as_db_value(),
-                    model_id,
-                    speaker,
-                    language,
-                    saved_voice_id,
-                    speed,
-                    input_text,
-                    voice_description,
-                    reference_text,
-                    generation_time_ms,
-                    audio_duration_secs,
-                    rtf,
-                    tokens_generated,
-                    audio_mime_type,
-                    audio_filename,
-                    next_audio_storage_path.as_str(),
-                ],
-            )?;
+        let result = speech_history_records::Entity::update_many()
+            .col_expr(
+                speech_history_records::Column::ProcessingStatus,
+                Expr::value(SpeechHistoryProcessingStatus::Ready.as_db_value()),
+            )
+            .col_expr(
+                speech_history_records::Column::ProcessingError,
+                Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                speech_history_records::Column::ModelId,
+                Expr::value(model_id),
+            )
+            .col_expr(
+                speech_history_records::Column::Speaker,
+                Expr::value(speaker),
+            )
+            .col_expr(
+                speech_history_records::Column::Language,
+                Expr::value(language),
+            )
+            .col_expr(
+                speech_history_records::Column::SavedVoiceId,
+                Expr::value(saved_voice_id),
+            )
+            .col_expr(speech_history_records::Column::Speed, Expr::value(speed))
+            .col_expr(
+                speech_history_records::Column::InputText,
+                Expr::value(input_text),
+            )
+            .col_expr(
+                speech_history_records::Column::VoiceDescription,
+                Expr::value(voice_description),
+            )
+            .col_expr(
+                speech_history_records::Column::ReferenceText,
+                Expr::value(reference_text),
+            )
+            .col_expr(
+                speech_history_records::Column::GenerationTimeMs,
+                Expr::value(generation_time_ms),
+            )
+            .col_expr(
+                speech_history_records::Column::AudioDurationSecs,
+                Expr::value(audio_duration_secs),
+            )
+            .col_expr(speech_history_records::Column::Rtf, Expr::value(rtf))
+            .col_expr(
+                speech_history_records::Column::TokensGenerated,
+                Expr::value(tokens_generated),
+            )
+            .col_expr(
+                speech_history_records::Column::AudioMimeType,
+                Expr::value(audio_mime_type),
+            )
+            .col_expr(
+                speech_history_records::Column::AudioFilename,
+                Expr::value(audio_filename),
+            )
+            .col_expr(
+                speech_history_records::Column::AudioStoragePath,
+                Expr::value(next_audio_storage_path.clone()),
+            )
+            .filter(speech_history_records::Column::RouteKind.eq(route_kind.as_db_value()))
+            .filter(speech_history_records::Column::Id.eq(record_id.clone()))
+            .exec(db)
+            .await
+            .context("Failed to complete speech history record")?;
 
-            if changed == 0 {
-                let _ = storage_layout::delete_media_file(
-                    &media_root,
-                    Some(next_audio_storage_path.as_str()),
-                );
-                return Ok(None);
-            }
+        if result.rows_affected == 0 {
+            let _ = storage_layout::delete_media_file(
+                &self.media_root,
+                Some(next_audio_storage_path.as_str()),
+            );
+            return Ok(None);
+        }
 
-            if let Some(previous_path) = sanitize_media_path(previous_audio_storage_path.as_deref())
-            {
-                let _ =
-                    storage_layout::delete_media_file(&media_root, Some(previous_path.as_str()));
-            }
+        if let Some(previous_path) = sanitize_media_path(previous_audio_storage_path.as_deref()) {
+            let _ =
+                storage_layout::delete_media_file(&self.media_root, Some(previous_path.as_str()));
+        }
 
-            fetch_record_without_audio(&conn, route_kind, &record_id)
-        })
-        .await
+        fetch_record_without_audio(db, route_kind, &record_id).await
     }
 
     pub async fn delete_record(
@@ -786,192 +576,201 @@ impl SpeechHistoryStore {
         route_kind: SpeechRouteKind,
         record_id: String,
     ) -> anyhow::Result<bool> {
-        let media_root = self.media_root.clone();
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let audio_storage_path = conn
-                .query_row(
-                    "SELECT audio_storage_path FROM speech_history_records WHERE route_kind = ?1 AND id = ?2",
-                    params![route_kind.as_db_value(), &record_id],
-                    |row| row.get::<_, Option<String>>(0),
-                )
-                .optional()?
-                .flatten();
-            let changed = conn.execute(
-                "DELETE FROM speech_history_records WHERE route_kind = ?1 AND id = ?2",
-                params![route_kind.as_db_value(), record_id],
-            )?;
-
-            if changed > 0 {
-                let normalized_audio_path = sanitize_media_path(audio_storage_path.as_deref());
-                storage_layout::delete_media_file(
-                    &media_root,
-                    normalized_audio_path.as_deref(),
-                )?;
-            }
-
-            Ok(changed > 0)
-        })
-        .await
-    }
-
-    async fn run_blocking<F, T>(&self, task_fn: F) -> anyhow::Result<T>
-    where
-        F: FnOnce(PathBuf) -> anyhow::Result<T> + Send + 'static,
-        T: Send + 'static,
-    {
-        let db_path = self.db_path.clone();
-        task::spawn_blocking(move || task_fn(db_path))
+        let db = self.db.connection().await?;
+        let audio_storage_path = fetch_audio_storage_path(db, route_kind, &record_id)
+            .await?
+            .flatten();
+        let result = speech_history_records::Entity::delete_many()
+            .filter(speech_history_records::Column::RouteKind.eq(route_kind.as_db_value()))
+            .filter(speech_history_records::Column::Id.eq(record_id))
+            .exec(db)
             .await
-            .map_err(|err| anyhow!("Speech history storage worker failed: {err}"))?
+            .context("Failed to delete speech history record")?;
+
+        if result.rows_affected > 0 {
+            let normalized_audio_path = sanitize_media_path(audio_storage_path.as_deref());
+            storage_layout::delete_media_file(&self.media_root, normalized_audio_path.as_deref())?;
+        }
+
+        Ok(result.rows_affected > 0)
     }
 }
 
-fn fetch_record_without_audio(
-    conn: &Connection,
+const SPEECH_HISTORY_PAGE_SQL: &str = r#"
+    SELECT
+        id,
+        created_at,
+        route_kind,
+        processing_status,
+        processing_error,
+        model_id,
+        speaker,
+        language,
+        saved_voice_id,
+        speed,
+        input_text,
+        generation_time_ms,
+        audio_duration_secs,
+        rtf,
+        tokens_generated,
+        audio_mime_type,
+        audio_filename
+    FROM speech_history_records
+    WHERE route_kind = ?1
+    ORDER BY created_at DESC, id DESC
+    LIMIT ?2
+"#;
+
+const SPEECH_HISTORY_PAGE_AFTER_CURSOR_SQL: &str = r#"
+    SELECT
+        id,
+        created_at,
+        route_kind,
+        processing_status,
+        processing_error,
+        model_id,
+        speaker,
+        language,
+        saved_voice_id,
+        speed,
+        input_text,
+        generation_time_ms,
+        audio_duration_secs,
+        rtf,
+        tokens_generated,
+        audio_mime_type,
+        audio_filename
+    FROM speech_history_records
+    WHERE route_kind = ?1
+        AND (created_at < ?2 OR (created_at = ?2 AND id < ?3))
+    ORDER BY created_at DESC, id DESC
+    LIMIT ?4
+"#;
+
+const SPEECH_HISTORY_RECORD_COLUMNS: &str = r#"
+    id,
+    created_at,
+    route_kind,
+    processing_status,
+    processing_error,
+    model_id,
+    speaker,
+    language,
+    saved_voice_id,
+    speed,
+    input_text,
+    voice_description,
+    reference_text,
+    generation_time_ms,
+    audio_duration_secs,
+    rtf,
+    tokens_generated,
+    audio_mime_type,
+    audio_filename
+"#;
+
+async fn fetch_record_without_audio(
+    db: &sea_orm::DatabaseConnection,
     route_kind: SpeechRouteKind,
     record_id: &str,
 ) -> anyhow::Result<Option<SpeechHistoryRecord>> {
-    let record = conn
-        .query_row(
-            r#"
-            SELECT
-                id,
-                created_at,
-                route_kind,
-                processing_status,
-                processing_error,
-                model_id,
-                speaker,
-                language,
-                saved_voice_id,
-                speed,
-                input_text,
-                voice_description,
-                reference_text,
-                generation_time_ms,
-                audio_duration_secs,
-                rtf,
-                tokens_generated,
-                audio_mime_type,
-                audio_filename
-            FROM speech_history_records
-            WHERE route_kind = ?1 AND id = ?2
-            "#,
-            params![route_kind.as_db_value(), record_id],
-            map_speech_history_record,
-        )
-        .optional()?;
-    Ok(record)
+    let row = db
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            format!(
+                "SELECT {SPEECH_HISTORY_RECORD_COLUMNS} FROM speech_history_records WHERE route_kind = ?1 AND id = ?2"
+            ),
+            vec![route_kind.as_db_value().into(), record_id.into()],
+        ))
+        .await
+        .context("Failed to load speech history record")?;
+    row.as_ref().map(map_speech_history_record).transpose()
 }
 
-fn map_speech_history_record(row: &Row<'_>) -> rusqlite::Result<SpeechHistoryRecord> {
-    let route_raw: String = row.get(2)?;
+async fn fetch_audio_storage_path(
+    db: &sea_orm::DatabaseConnection,
+    route_kind: SpeechRouteKind,
+    record_id: &str,
+) -> anyhow::Result<Option<Option<String>>> {
+    let row = db
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT audio_storage_path FROM speech_history_records WHERE route_kind = ?1 AND id = ?2",
+            vec![route_kind.as_db_value().into(), record_id.into()],
+        ))
+        .await
+        .context("Failed to load speech history media path")?;
+    row.map(|row| row.try_get_by_index::<Option<String>>(0))
+        .transpose()
+        .map_err(Into::into)
+}
+
+fn map_speech_history_summary(row: &QueryResult) -> anyhow::Result<SpeechHistoryRecordSummary> {
+    let input_text: String = row.try_get_by_index(10)?;
+    let route_raw: String = row.try_get_by_index(2)?;
     let route_kind =
         SpeechRouteKind::from_db_value(route_raw.as_str()).unwrap_or(SpeechRouteKind::TextToSpeech);
-    let processing_status_raw: String = row.get(3)?;
+    let processing_status_raw: String = row.try_get_by_index(3)?;
 
-    Ok(SpeechHistoryRecord {
-        id: row.get(0)?,
-        created_at: i64_to_u64(row.get(1)?),
+    Ok(SpeechHistoryRecordSummary {
+        id: row.try_get_by_index(0)?,
+        created_at: i64_to_u64(row.try_get_by_index(1)?),
         route_kind,
         processing_status: SpeechHistoryProcessingStatus::from_db_value(
             processing_status_raw.as_str(),
         )
         .unwrap_or_default(),
-        processing_error: row.get(4)?,
-        model_id: row.get(5)?,
-        speaker: row.get(6)?,
-        language: row.get(7)?,
-        saved_voice_id: row.get(8)?,
-        speed: row.get(9)?,
-        input_text: row.get(10)?,
-        voice_description: row.get(11)?,
-        reference_text: row.get(12)?,
-        generation_time_ms: row.get(13)?,
-        audio_duration_secs: row.get(14)?,
-        rtf: row.get(15)?,
+        processing_error: row.try_get_by_index(4)?,
+        model_id: row.try_get_by_index(5)?,
+        speaker: row.try_get_by_index(6)?,
+        language: row.try_get_by_index(7)?,
+        saved_voice_id: row.try_get_by_index(8)?,
+        speed: row.try_get_by_index(9)?,
+        input_preview: input_preview(input_text.as_str()),
+        input_chars: input_text.chars().count(),
+        generation_time_ms: row.try_get_by_index(11)?,
+        audio_duration_secs: row.try_get_by_index(12)?,
+        rtf: row.try_get_by_index(13)?,
         tokens_generated: row
-            .get::<_, Option<i64>>(16)?
-            .and_then(|value| i64_to_usize(value)),
-        audio_mime_type: row.get(17)?,
-        audio_filename: row.get(18)?,
+            .try_get_by_index::<Option<i64>>(14)?
+            .and_then(i64_to_usize),
+        audio_mime_type: row.try_get_by_index(15)?,
+        audio_filename: row.try_get_by_index(16)?,
     })
 }
 
-fn ensure_speech_history_records_saved_voice_id_column(conn: &Connection) -> anyhow::Result<()> {
-    if speech_history_records_has_column(conn, "saved_voice_id")? {
-        return Ok(());
-    }
+fn map_speech_history_record(row: &QueryResult) -> anyhow::Result<SpeechHistoryRecord> {
+    let route_raw: String = row.try_get_by_index(2)?;
+    let route_kind =
+        SpeechRouteKind::from_db_value(route_raw.as_str()).unwrap_or(SpeechRouteKind::TextToSpeech);
+    let processing_status_raw: String = row.try_get_by_index(3)?;
 
-    conn.execute(
-        "ALTER TABLE speech_history_records ADD COLUMN saved_voice_id TEXT NULL",
-        [],
-    )
-    .context("Failed adding speech_history_records.saved_voice_id column")?;
-    Ok(())
-}
-
-fn ensure_speech_history_records_speed_column(conn: &Connection) -> anyhow::Result<()> {
-    if speech_history_records_has_column(conn, "speed")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE speech_history_records ADD COLUMN speed REAL NULL",
-        [],
-    )
-    .context("Failed adding speech_history_records.speed column")?;
-    Ok(())
-}
-
-fn ensure_speech_history_records_processing_status_column(conn: &Connection) -> anyhow::Result<()> {
-    if speech_history_records_has_column(conn, "processing_status")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE speech_history_records ADD COLUMN processing_status TEXT NOT NULL DEFAULT 'ready'",
-        [],
-    )
-    .context("Failed adding speech_history_records.processing_status column")?;
-    Ok(())
-}
-
-fn ensure_speech_history_records_processing_error_column(conn: &Connection) -> anyhow::Result<()> {
-    if speech_history_records_has_column(conn, "processing_error")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE speech_history_records ADD COLUMN processing_error TEXT NULL",
-        [],
-    )
-    .context("Failed adding speech_history_records.processing_error column")?;
-    Ok(())
-}
-
-fn speech_history_records_has_column(conn: &Connection, target: &str) -> anyhow::Result<bool> {
-    let mut stmt = conn
-        .prepare("PRAGMA table_info(speech_history_records)")
-        .context("Failed to inspect speech_history_records schema")?;
-    let mut rows = stmt
-        .query([])
-        .context("Failed to query speech_history_records schema info")?;
-
-    while let Some(row) = rows
-        .next()
-        .context("Failed reading speech_history_records schema row")?
-    {
-        let name: String = row
-            .get(1)
-            .context("Failed reading speech_history_records column name")?;
-        if name == target {
-            return Ok(true);
-        }
-    }
-
-    Ok(false)
+    Ok(SpeechHistoryRecord {
+        id: row.try_get_by_index(0)?,
+        created_at: i64_to_u64(row.try_get_by_index(1)?),
+        route_kind,
+        processing_status: SpeechHistoryProcessingStatus::from_db_value(
+            processing_status_raw.as_str(),
+        )
+        .unwrap_or_default(),
+        processing_error: row.try_get_by_index(4)?,
+        model_id: row.try_get_by_index(5)?,
+        speaker: row.try_get_by_index(6)?,
+        language: row.try_get_by_index(7)?,
+        saved_voice_id: row.try_get_by_index(8)?,
+        speed: row.try_get_by_index(9)?,
+        input_text: row.try_get_by_index(10)?,
+        voice_description: row.try_get_by_index(11)?,
+        reference_text: row.try_get_by_index(12)?,
+        generation_time_ms: row.try_get_by_index(13)?,
+        audio_duration_secs: row.try_get_by_index(14)?,
+        rtf: row.try_get_by_index(15)?,
+        tokens_generated: row
+            .try_get_by_index::<Option<i64>>(16)?
+            .and_then(i64_to_usize),
+        audio_mime_type: row.try_get_by_index(17)?,
+        audio_filename: row.try_get_by_index(18)?,
+    })
 }
 
 fn input_preview(content: &str) -> String {
@@ -1044,11 +843,7 @@ fn now_unix_millis_i64() -> i64 {
 }
 
 fn i64_to_u64(value: i64) -> u64 {
-    if value.is_negative() {
-        0
-    } else {
-        value as u64
-    }
+    if value.is_negative() { 0 } else { value as u64 }
 }
 
 fn i64_to_usize(value: i64) -> Option<usize> {
@@ -1062,4 +857,173 @@ fn i64_to_usize(value: i64) -> Option<usize> {
 #[allow(dead_code)]
 pub const fn default_list_limit() -> usize {
     DEFAULT_LIST_LIMIT
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::env_lock;
+
+    fn setup_store() -> (tempfile::TempDir, SpeechHistoryStore) {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("speech-history.sqlite3");
+        let media_dir = temp_dir.path().join("media");
+        std::env::set_var("IZWI_DB_PATH", &db_path);
+        std::env::set_var("IZWI_MEDIA_DIR", &media_dir);
+        let store = SpeechHistoryStore::initialize().expect("store");
+        (temp_dir, store)
+    }
+
+    fn clear_env() {
+        std::env::remove_var("IZWI_DB_PATH");
+        std::env::remove_var("IZWI_MEDIA_DIR");
+    }
+
+    fn ready_record() -> NewSpeechHistoryRecord {
+        NewSpeechHistoryRecord {
+            route_kind: SpeechRouteKind::TextToSpeech,
+            processing_status: SpeechHistoryProcessingStatus::Ready,
+            processing_error: None,
+            model_id: Some("model-a".to_string()),
+            speaker: Some("Serena".to_string()),
+            language: Some("en".to_string()),
+            saved_voice_id: None,
+            speed: Some(1.0),
+            input_text: "Hello world".to_string(),
+            voice_description: None,
+            reference_text: None,
+            generation_time_ms: 20.0,
+            audio_duration_secs: Some(1.5),
+            rtf: Some(0.2),
+            tokens_generated: Some(12),
+            audio_mime_type: "audio/wav".to_string(),
+            audio_filename: Some("hello.wav".to_string()),
+            audio_bytes: vec![5, 6, 7],
+        }
+    }
+
+    #[tokio::test]
+    async fn creates_lists_reads_audio_updates_status_and_deletes_record() {
+        let _guard = env_lock();
+        let (_temp, store) = setup_store();
+
+        let created = store
+            .create_record(ready_record())
+            .await
+            .expect("record should create");
+        assert_eq!(
+            created.processing_status,
+            SpeechHistoryProcessingStatus::Ready
+        );
+
+        let audio = store
+            .get_audio(SpeechRouteKind::TextToSpeech, created.id.clone())
+            .await
+            .expect("audio should load")
+            .expect("audio should exist");
+        assert_eq!(audio.audio_bytes, vec![5, 6, 7]);
+
+        let (records, cursor) = store
+            .list_records_page(SpeechRouteKind::TextToSpeech, 10, None)
+            .await
+            .expect("records should list");
+        assert!(cursor.is_none());
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].input_preview, "Hello world");
+
+        let failed = store
+            .update_processing_status(
+                SpeechRouteKind::TextToSpeech,
+                created.id.clone(),
+                SpeechHistoryProcessingStatus::Failed,
+                Some("boom".to_string()),
+            )
+            .await
+            .expect("status should update")
+            .expect("record should exist");
+        assert_eq!(
+            failed.processing_status,
+            SpeechHistoryProcessingStatus::Failed
+        );
+        assert_eq!(failed.processing_error.as_deref(), Some("boom"));
+
+        assert!(
+            store
+                .delete_record(SpeechRouteKind::TextToSpeech, created.id.clone())
+                .await
+                .expect("record should delete")
+        );
+        assert!(
+            store
+                .get_record(SpeechRouteKind::TextToSpeech, created.id)
+                .await
+                .expect("record lookup should succeed")
+                .is_none()
+        );
+
+        clear_env();
+    }
+
+    #[tokio::test]
+    async fn completes_pending_record_with_audio() {
+        let _guard = env_lock();
+        let (_temp, store) = setup_store();
+
+        let pending = store
+            .create_record(NewSpeechHistoryRecord {
+                processing_status: SpeechHistoryProcessingStatus::Pending,
+                audio_bytes: Vec::new(),
+                audio_filename: None,
+                ..ready_record()
+            })
+            .await
+            .expect("pending record should create");
+        assert!(
+            store
+                .get_audio(SpeechRouteKind::TextToSpeech, pending.id.clone())
+                .await
+                .expect("audio lookup should succeed")
+                .is_none()
+        );
+
+        let completed = store
+            .complete_record(
+                SpeechRouteKind::TextToSpeech,
+                pending.id.clone(),
+                CompleteSpeechHistoryRecord {
+                    model_id: Some("model-b".to_string()),
+                    speaker: Some("Alex".to_string()),
+                    language: Some("en".to_string()),
+                    saved_voice_id: Some("voice-1".to_string()),
+                    speed: Some(0.9),
+                    input_text: "Completed text".to_string(),
+                    voice_description: None,
+                    reference_text: None,
+                    generation_time_ms: 30.0,
+                    audio_duration_secs: Some(2.0),
+                    rtf: Some(0.3),
+                    tokens_generated: Some(18),
+                    audio_mime_type: "audio/wav".to_string(),
+                    audio_filename: Some("completed.wav".to_string()),
+                    audio_bytes: vec![8, 9],
+                },
+            )
+            .await
+            .expect("record should complete")
+            .expect("record should exist");
+        assert_eq!(
+            completed.processing_status,
+            SpeechHistoryProcessingStatus::Ready
+        );
+        assert_eq!(completed.input_text, "Completed text");
+
+        let audio = store
+            .get_audio(SpeechRouteKind::TextToSpeech, pending.id)
+            .await
+            .expect("audio should load")
+            .expect("audio should exist");
+        assert_eq!(audio.audio_bytes, vec![8, 9]);
+
+        clear_env();
+    }
 }

--- a/crates/izwi-server/src/storage_layout.rs
+++ b/crates/izwi-server/src/storage_layout.rs
@@ -1,9 +1,7 @@
 //! Shared storage layout and filesystem helpers for server persistence.
 
 use anyhow::{anyhow, Context};
-use rusqlite::Connection;
 use std::path::{Component, Path, PathBuf};
-use std::time::Duration;
 
 const APP_NAME_DIR: &str = "izwi";
 const DEFAULT_DB_FILENAME: &str = "izwi.sqlite3";
@@ -69,18 +67,6 @@ pub fn ensure_storage_dirs(db_path: &Path, media_root: &Path) -> anyhow::Result<
     }
 
     Ok(())
-}
-
-pub fn open_sqlite_connection(path: &Path) -> anyhow::Result<Connection> {
-    let conn = Connection::open(path)
-        .with_context(|| format!("Unable to open SQLite database at {}", path.display()))?;
-    conn.busy_timeout(Duration::from_secs(3))
-        .context("Failed to configure SQLite busy timeout")?;
-    conn.pragma_update(None, "journal_mode", "WAL")
-        .context("Failed to enable SQLite WAL journal mode")?;
-    conn.pragma_update(None, "foreign_keys", "ON")
-        .context("Failed to enable SQLite foreign key constraints")?;
-    Ok(conn)
 }
 
 pub fn persist_audio_file(

--- a/crates/izwi-server/src/studio_project_store.rs
+++ b/crates/izwi-server/src/studio_project_store.rs
@@ -1,13 +1,16 @@
 //! Persistent text-to-speech project storage backed by SQLite.
 
-use anyhow::Context;
-use rusqlite::{params, Connection, OptionalExtension, Row};
+use anyhow::{Context, anyhow};
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DbBackend, QueryResult, Statement, TransactionTrait, Value,
+};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::task;
 
 use crate::{
+    db::StoreDatabase,
     ids::new_uuid,
     storage_layout::{self},
 };
@@ -278,7 +281,7 @@ pub struct UpdateStudioProjectRenderJobRecord {
 
 #[derive(Clone)]
 pub struct StudioProjectStore {
-    db_path: PathBuf,
+    db: StoreDatabase,
 }
 
 impl StudioProjectStore {
@@ -293,113 +296,9 @@ impl StudioProjectStore {
         storage_layout::ensure_storage_dirs(&db_path, &media_root)
             .context("Failed to prepare Studio project storage layout")?;
 
-        let conn = storage_layout::open_sqlite_connection(&db_path).with_context(|| {
-            format!(
-                "Failed to open Studio project database: {}",
-                db_path.display()
-            )
-        })?;
-
-        conn.execute_batch(
-            r#"
-            CREATE TABLE IF NOT EXISTS studio_projects (
-                id TEXT PRIMARY KEY,
-                created_at INTEGER NOT NULL,
-                updated_at INTEGER NOT NULL,
-                name TEXT NOT NULL,
-                source_filename TEXT NULL,
-                source_text TEXT NOT NULL,
-                model_id TEXT NULL,
-                voice_mode TEXT NOT NULL,
-                speaker TEXT NULL,
-                saved_voice_id TEXT NULL,
-                speed REAL NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS studio_project_segments (
-                id TEXT PRIMARY KEY,
-                project_id TEXT NOT NULL,
-                position INTEGER NOT NULL,
-                text TEXT NOT NULL,
-                model_id TEXT NULL,
-                voice_mode TEXT NULL,
-                speaker TEXT NULL,
-                saved_voice_id TEXT NULL,
-                speech_record_id TEXT NULL,
-                updated_at INTEGER NOT NULL,
-                FOREIGN KEY(project_id) REFERENCES studio_projects(id) ON DELETE CASCADE
-            );
-
-            CREATE TABLE IF NOT EXISTS studio_project_folders (
-                id TEXT PRIMARY KEY,
-                created_at INTEGER NOT NULL,
-                updated_at INTEGER NOT NULL,
-                name TEXT NOT NULL,
-                parent_id TEXT NULL,
-                sort_order INTEGER NOT NULL DEFAULT 0
-            );
-
-            CREATE TABLE IF NOT EXISTS studio_project_meta (
-                project_id TEXT PRIMARY KEY,
-                folder_id TEXT NULL,
-                tags_json TEXT NOT NULL DEFAULT '[]',
-                default_export_format TEXT NOT NULL DEFAULT 'wav',
-                last_render_job_id TEXT NULL,
-                last_rendered_at INTEGER NULL,
-                FOREIGN KEY(project_id) REFERENCES studio_projects(id) ON DELETE CASCADE,
-                FOREIGN KEY(folder_id) REFERENCES studio_project_folders(id) ON DELETE SET NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS studio_project_pronunciations (
-                id TEXT PRIMARY KEY,
-                project_id TEXT NOT NULL,
-                source_text TEXT NOT NULL,
-                replacement_text TEXT NOT NULL,
-                locale TEXT NULL,
-                created_at INTEGER NOT NULL,
-                updated_at INTEGER NOT NULL,
-                FOREIGN KEY(project_id) REFERENCES studio_projects(id) ON DELETE CASCADE
-            );
-
-            CREATE TABLE IF NOT EXISTS studio_project_snapshots (
-                id TEXT PRIMARY KEY,
-                project_id TEXT NOT NULL,
-                created_at INTEGER NOT NULL,
-                label TEXT NULL,
-                project_json TEXT NOT NULL,
-                FOREIGN KEY(project_id) REFERENCES studio_projects(id) ON DELETE CASCADE
-            );
-
-            CREATE TABLE IF NOT EXISTS studio_project_render_jobs (
-                id TEXT PRIMARY KEY,
-                project_id TEXT NOT NULL,
-                created_at INTEGER NOT NULL,
-                updated_at INTEGER NOT NULL,
-                status TEXT NOT NULL,
-                error_message TEXT NULL,
-                queued_segment_ids_json TEXT NOT NULL DEFAULT '[]',
-                FOREIGN KEY(project_id) REFERENCES studio_projects(id) ON DELETE CASCADE
-            );
-
-            CREATE INDEX IF NOT EXISTS idx_studio_projects_updated_at
-                ON studio_projects(updated_at DESC, id DESC);
-            CREATE INDEX IF NOT EXISTS idx_studio_project_segments_project_position
-                ON studio_project_segments(project_id, position ASC);
-            CREATE INDEX IF NOT EXISTS idx_studio_project_folders_parent
-                ON studio_project_folders(parent_id, sort_order ASC, updated_at DESC);
-            CREATE INDEX IF NOT EXISTS idx_studio_project_pronunciations_project
-                ON studio_project_pronunciations(project_id, updated_at DESC, id DESC);
-            CREATE INDEX IF NOT EXISTS idx_studio_project_snapshots_project
-                ON studio_project_snapshots(project_id, created_at DESC, id DESC);
-            CREATE INDEX IF NOT EXISTS idx_studio_project_render_jobs_project
-                ON studio_project_render_jobs(project_id, created_at DESC, id DESC);
-            "#,
-        )
-        .context("Failed to initialize Studio project database schema")?;
-
-        ensure_studio_project_segment_settings_columns(&conn)?;
-
-        Ok(Self { db_path })
+        Ok(Self {
+            db: StoreDatabase::new(db_path),
+        })
     }
 
     pub async fn list_projects_page(
@@ -407,206 +306,149 @@ impl StudioProjectStore {
         limit: usize,
         cursor: Option<StudioProjectListCursor>,
     ) -> anyhow::Result<(Vec<StudioProjectSummary>, Option<StudioProjectListCursor>)> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let list_limit = i64::try_from(limit.clamp(1, 200).max(1)).unwrap_or(100);
-            let page_size = usize::try_from(list_limit).unwrap_or(100);
-            let fetch_limit = list_limit.saturating_add(1);
+        let db = self.db.connection().await?;
+        let list_limit = i64::try_from(limit.clamp(1, 200).max(1)).unwrap_or(100);
+        let page_size = usize::try_from(list_limit).unwrap_or(100);
+        let fetch_limit = list_limit.saturating_add(1);
 
-            let mut projects = Vec::new();
-            if let Some(cursor) = cursor {
-                let cursor_updated_at = i64::try_from(cursor.updated_at).unwrap_or(i64::MAX);
-                let mut stmt = conn.prepare(
-                    r#"
-                    SELECT
-                        p.id,
-                        p.created_at,
-                        p.updated_at,
-                        p.name,
-                        p.source_filename,
-                        p.model_id,
-                        p.voice_mode,
-                        p.speaker,
-                        p.saved_voice_id,
-                        p.speed,
-                        COUNT(s.id) AS segment_count,
-                        COALESCE(SUM(CASE WHEN s.speech_record_id IS NOT NULL THEN 1 ELSE 0 END), 0) AS rendered_segment_count,
-                        COALESCE(SUM(LENGTH(s.text)), 0) AS total_chars
-                    FROM studio_projects p
-                    LEFT JOIN studio_project_segments s ON s.project_id = p.id
-                    WHERE p.updated_at < ?1 OR (p.updated_at = ?1 AND p.id < ?2)
-                    GROUP BY
-                        p.id,
-                        p.created_at,
-                        p.updated_at,
-                        p.name,
-                        p.source_filename,
-                        p.model_id,
-                        p.voice_mode,
-                        p.speaker,
-                        p.saved_voice_id,
-                        p.speed
-                    ORDER BY p.updated_at DESC, p.id DESC
-                    LIMIT ?3
-                    "#,
-                )?;
+        let rows = if let Some(cursor) = cursor {
+            let cursor_updated_at = i64::try_from(cursor.updated_at).unwrap_or(i64::MAX);
+            query_all(
+                db,
+                STUDIO_PROJECT_PAGE_AFTER_CURSOR_SQL,
+                vec![
+                    cursor_updated_at.into(),
+                    cursor.id.into(),
+                    fetch_limit.into(),
+                ],
+                "Failed to list Studio projects page after cursor",
+            )
+            .await?
+        } else {
+            query_all(
+                db,
+                STUDIO_PROJECT_PAGE_SQL,
+                vec![fetch_limit.into()],
+                "Failed to list Studio projects page",
+            )
+            .await?
+        };
 
-                let rows = stmt.query_map(
-                    params![cursor_updated_at, cursor.id, fetch_limit],
-                    map_project_summary_row,
-                )?;
-                for row in rows {
-                    projects.push(row?);
-                }
-            } else {
-                let mut stmt = conn.prepare(
-                    r#"
-                    SELECT
-                        p.id,
-                        p.created_at,
-                        p.updated_at,
-                        p.name,
-                        p.source_filename,
-                        p.model_id,
-                        p.voice_mode,
-                        p.speaker,
-                        p.saved_voice_id,
-                        p.speed,
-                        COUNT(s.id) AS segment_count,
-                        COALESCE(SUM(CASE WHEN s.speech_record_id IS NOT NULL THEN 1 ELSE 0 END), 0) AS rendered_segment_count,
-                        COALESCE(SUM(LENGTH(s.text)), 0) AS total_chars
-                    FROM studio_projects p
-                    LEFT JOIN studio_project_segments s ON s.project_id = p.id
-                    GROUP BY
-                        p.id,
-                        p.created_at,
-                        p.updated_at,
-                        p.name,
-                        p.source_filename,
-                        p.model_id,
-                        p.voice_mode,
-                        p.speaker,
-                        p.saved_voice_id,
-                        p.speed
-                    ORDER BY p.updated_at DESC, p.id DESC
-                    LIMIT ?1
-                    "#,
-                )?;
+        let mut projects = rows
+            .iter()
+            .map(map_project_summary_row)
+            .collect::<anyhow::Result<Vec<_>>>()?;
 
-                let rows = stmt.query_map(params![fetch_limit], map_project_summary_row)?;
-                for row in rows {
-                    projects.push(row?);
-                }
-            }
+        let has_more = projects.len() > page_size;
+        if has_more {
+            projects.truncate(page_size);
+        }
 
-            let has_more = projects.len() > page_size;
-            if has_more {
-                projects.truncate(page_size);
-            }
+        let next_cursor = if has_more {
+            projects.last().map(|project| StudioProjectListCursor {
+                updated_at: project.updated_at,
+                id: project.id.clone(),
+            })
+        } else {
+            None
+        };
 
-            let next_cursor = if has_more {
-                projects.last().map(|project| StudioProjectListCursor {
-                    updated_at: project.updated_at,
-                    id: project.id.clone(),
-                })
-            } else {
-                None
-            };
-
-            Ok((projects, next_cursor))
-        })
-        .await
+        Ok((projects, next_cursor))
     }
 
     pub async fn get_project(
         &self,
         project_id: String,
     ) -> anyhow::Result<Option<StudioProjectRecord>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            fetch_project(&conn, &project_id)
-        })
-        .await
+        let db = self.db.connection().await?;
+        fetch_project(db, &project_id).await
     }
 
     pub async fn create_project(
         &self,
         record: NewStudioProjectRecord,
     ) -> anyhow::Result<StudioProjectRecord> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start Studio project create transaction")?;
+        let now = now_unix_millis_i64();
+        let project_id = new_uuid();
 
-            let now = now_unix_millis_i64();
-            let project_id = new_uuid();
+        execute(
+            &tx,
+            r#"
+            INSERT INTO studio_projects (
+                id,
+                created_at,
+                updated_at,
+                name,
+                source_filename,
+                source_text,
+                model_id,
+                voice_mode,
+                speaker,
+                saved_voice_id,
+                speed
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+            "#,
+            vec![
+                project_id.clone().into(),
+                now.into(),
+                now.into(),
+                record.name.into(),
+                record.source_filename.into(),
+                record.source_text.into(),
+                record.model_id.into(),
+                record.voice_mode.as_db_value().into(),
+                record.speaker.into(),
+                record.saved_voice_id.into(),
+                record.speed.into(),
+            ],
+            "Failed to create Studio project",
+        )
+        .await?;
 
-            tx.execute(
+        for segment in record.segments {
+            execute(
+                &tx,
                 r#"
-                INSERT INTO studio_projects (
+                INSERT INTO studio_project_segments (
                     id,
-                    created_at,
-                    updated_at,
-                    name,
-                    source_filename,
-                    source_text,
+                    project_id,
+                    position,
+                    text,
                     model_id,
                     voice_mode,
                     speaker,
                     saved_voice_id,
-                    speed
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+                    speech_record_id,
+                    updated_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, ?9)
                 "#,
-                params![
-                    project_id,
-                    now,
-                    now,
-                    record.name,
-                    record.source_filename,
-                    record.source_text,
-                    record.model_id,
-                    record.voice_mode.as_db_value(),
-                    record.speaker,
-                    record.saved_voice_id,
-                    record.speed,
+                vec![
+                    new_uuid().into(),
+                    project_id.clone().into(),
+                    usize_to_i64(segment.position).into(),
+                    segment.text.into(),
+                    segment.model_id.into(),
+                    segment.voice_mode.map(|value| value.as_db_value()).into(),
+                    segment.speaker.into(),
+                    segment.saved_voice_id.into(),
+                    now.into(),
                 ],
-            )?;
+                "Failed to create Studio project segment",
+            )
+            .await?;
+        }
 
-            for segment in record.segments {
-                let segment_id = new_uuid();
-                tx.execute(
-                    r#"
-                    INSERT INTO studio_project_segments (
-                        id,
-                        project_id,
-                        position,
-                        text,
-                        model_id,
-                        voice_mode,
-                        speaker,
-                        saved_voice_id,
-                        speech_record_id,
-                        updated_at
-                    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, ?9)
-                    "#,
-                    params![
-                        segment_id,
-                        project_id,
-                        usize_to_i64(segment.position),
-                        segment.text,
-                        segment.model_id,
-                        segment.voice_mode.map(|value| value.as_db_value()),
-                        segment.speaker,
-                        segment.saved_voice_id,
-                        now,
-                    ],
-                )?;
-            }
-
-            tx.commit()?;
-            fetch_project(&conn, &project_id)?
-                .ok_or_else(|| anyhow::anyhow!("Created Studio project was not found"))
-        })
-        .await
+        tx.commit()
+            .await
+            .context("Failed to commit Studio project create transaction")?;
+        fetch_project(db, &project_id)
+            .await?
+            .ok_or_else(|| anyhow!("Created Studio project was not found"))
     }
 
     pub async fn update_project(
@@ -614,80 +456,87 @@ impl StudioProjectStore {
         project_id: String,
         update: UpdateStudioProjectRecord,
     ) -> anyhow::Result<Option<StudioProjectRecord>> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start Studio project update transaction")?;
 
-            let current = tx
-                .query_row(
-                    r#"
-                    SELECT
-                        name,
-                        model_id,
-                        voice_mode,
-                        speaker,
-                        saved_voice_id,
-                        speed
-                    FROM studio_projects
-                    WHERE id = ?1
-                    "#,
-                    params![project_id.as_str()],
-                    |row| {
-                        let voice_mode_raw: String = row.get(2)?;
-                        Ok((
-                            row.get::<_, String>(0)?,
-                            row.get::<_, Option<String>>(1)?,
-                            StudioProjectVoiceMode::from_db_value(voice_mode_raw.as_str())
-                                .unwrap_or(StudioProjectVoiceMode::BuiltIn),
-                            row.get::<_, Option<String>>(3)?,
-                            row.get::<_, Option<String>>(4)?,
-                            row.get::<_, Option<f64>>(5)?,
-                        ))
-                    },
-                )
-                .optional()?;
-
-            let Some((name, model_id, voice_mode, speaker, saved_voice_id, speed)) = current else {
-                return Ok(None);
-            };
-
-            let next_name = update.name.unwrap_or(name);
-            let next_model_id = update.model_id.or(model_id);
-            let next_voice_mode = update.voice_mode.unwrap_or(voice_mode);
-            let next_speaker = update.speaker.unwrap_or(speaker);
-            let next_saved_voice_id = update.saved_voice_id.unwrap_or(saved_voice_id);
-            let next_speed = update.speed.unwrap_or(speed);
-            let now = now_unix_millis_i64();
-
-            tx.execute(
-                r#"
-                UPDATE studio_projects
-                SET
-                    updated_at = ?2,
-                    name = ?3,
-                    model_id = ?4,
-                    voice_mode = ?5,
-                    speaker = ?6,
-                    saved_voice_id = ?7,
-                    speed = ?8
-                WHERE id = ?1
-                "#,
-                params![
-                    project_id.as_str(),
-                    now,
-                    next_name,
-                    next_model_id,
-                    next_voice_mode.as_db_value(),
-                    next_speaker,
-                    next_saved_voice_id,
-                    next_speed,
-                ],
-            )?;
-
-            tx.commit()?;
-            fetch_project(&conn, &project_id)
+        let current = query_one(
+            &tx,
+            r#"
+            SELECT
+                name,
+                model_id,
+                voice_mode,
+                speaker,
+                saved_voice_id,
+                speed
+            FROM studio_projects
+            WHERE id = ?1
+            "#,
+            vec![project_id.clone().into()],
+            "Failed to load Studio project for update",
+        )
+        .await?
+        .map(|row| {
+            let voice_mode_raw: String = row.try_get_by_index(2)?;
+            Ok::<_, anyhow::Error>((
+                row.try_get_by_index::<String>(0)?,
+                row.try_get_by_index::<Option<String>>(1)?,
+                StudioProjectVoiceMode::from_db_value(voice_mode_raw.as_str())
+                    .unwrap_or(StudioProjectVoiceMode::BuiltIn),
+                row.try_get_by_index::<Option<String>>(3)?,
+                row.try_get_by_index::<Option<String>>(4)?,
+                row.try_get_by_index::<Option<f64>>(5)?,
+            ))
         })
-        .await
+        .transpose()?;
+
+        let Some((name, model_id, voice_mode, speaker, saved_voice_id, speed)) = current else {
+            return Ok(None);
+        };
+
+        let next_name = update.name.unwrap_or(name);
+        let next_model_id = update.model_id.or(model_id);
+        let next_voice_mode = update.voice_mode.unwrap_or(voice_mode);
+        let next_speaker = update.speaker.unwrap_or(speaker);
+        let next_saved_voice_id = update.saved_voice_id.unwrap_or(saved_voice_id);
+        let next_speed = update.speed.unwrap_or(speed);
+        let now = now_unix_millis_i64();
+
+        execute(
+            &tx,
+            r#"
+            UPDATE studio_projects
+            SET
+                updated_at = ?2,
+                name = ?3,
+                model_id = ?4,
+                voice_mode = ?5,
+                speaker = ?6,
+                saved_voice_id = ?7,
+                speed = ?8
+            WHERE id = ?1
+            "#,
+            vec![
+                project_id.clone().into(),
+                now.into(),
+                next_name.into(),
+                next_model_id.into(),
+                next_voice_mode.as_db_value().into(),
+                next_speaker.into(),
+                next_saved_voice_id.into(),
+                next_speed.into(),
+            ],
+            "Failed to update Studio project",
+        )
+        .await?;
+
+        tx.commit()
+            .await
+            .context("Failed to commit Studio project update transaction")?;
+        fetch_project(db, &project_id).await
     }
 
     pub async fn update_segment_text(
@@ -696,34 +545,43 @@ impl StudioProjectStore {
         segment_id: String,
         text: String,
     ) -> anyhow::Result<Option<StudioProjectRecord>> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
-            let now = now_unix_millis_i64();
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start Studio segment text transaction")?;
+        let now = now_unix_millis_i64();
 
-            let updated = tx.execute(
-                r#"
-                UPDATE studio_project_segments
-                SET
-                    text = ?3,
-                    speech_record_id = NULL,
-                    updated_at = ?4
-                WHERE project_id = ?1 AND id = ?2
-                "#,
-                params![project_id.as_str(), segment_id.as_str(), text, now],
-            )?;
+        let updated = execute(
+            &tx,
+            r#"
+            UPDATE studio_project_segments
+            SET
+                text = ?3,
+                speech_record_id = NULL,
+                updated_at = ?4
+            WHERE project_id = ?1 AND id = ?2
+            "#,
+            vec![
+                project_id.clone().into(),
+                segment_id.into(),
+                text.into(),
+                now.into(),
+            ],
+            "Failed to update Studio segment text",
+        )
+        .await?;
 
-            if updated == 0 {
-                tx.rollback()?;
-                return Ok(None);
-            }
+        if updated == 0 {
+            return Ok(None);
+        }
 
-            sync_project_source_text(&tx, project_id.as_str())?;
-            touch_project(&tx, project_id.as_str(), now)?;
-            tx.commit()?;
-            fetch_project(&conn, &project_id)
-        })
-        .await
+        sync_project_source_text(&tx, &project_id).await?;
+        touch_project(&tx, &project_id, now).await?;
+        tx.commit()
+            .await
+            .context("Failed to commit Studio segment text transaction")?;
+        fetch_project(db, &project_id).await
     }
 
     pub async fn update_segment_settings(
@@ -735,44 +593,48 @@ impl StudioProjectStore {
         speaker: Option<String>,
         saved_voice_id: Option<String>,
     ) -> anyhow::Result<Option<StudioProjectRecord>> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
-            let now = now_unix_millis_i64();
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start Studio segment settings transaction")?;
+        let now = now_unix_millis_i64();
 
-            let updated = tx.execute(
-                r#"
-                UPDATE studio_project_segments
-                SET
-                    model_id = ?3,
-                    voice_mode = ?4,
-                    speaker = ?5,
-                    saved_voice_id = ?6,
-                    speech_record_id = NULL,
-                    updated_at = ?7
-                WHERE project_id = ?1 AND id = ?2
-                "#,
-                params![
-                    project_id.as_str(),
-                    segment_id.as_str(),
-                    model_id,
-                    voice_mode.as_db_value(),
-                    speaker,
-                    saved_voice_id,
-                    now,
-                ],
-            )?;
+        let updated = execute(
+            &tx,
+            r#"
+            UPDATE studio_project_segments
+            SET
+                model_id = ?3,
+                voice_mode = ?4,
+                speaker = ?5,
+                saved_voice_id = ?6,
+                speech_record_id = NULL,
+                updated_at = ?7
+            WHERE project_id = ?1 AND id = ?2
+            "#,
+            vec![
+                project_id.clone().into(),
+                segment_id.into(),
+                model_id.into(),
+                voice_mode.as_db_value().into(),
+                speaker.into(),
+                saved_voice_id.into(),
+                now.into(),
+            ],
+            "Failed to update Studio segment settings",
+        )
+        .await?;
 
-            if updated == 0 {
-                tx.rollback()?;
-                return Ok(None);
-            }
+        if updated == 0 {
+            return Ok(None);
+        }
 
-            touch_project(&tx, project_id.as_str(), now)?;
-            tx.commit()?;
-            fetch_project(&conn, &project_id)
-        })
-        .await
+        touch_project(&tx, &project_id, now).await?;
+        tx.commit()
+            .await
+            .context("Failed to commit Studio segment settings transaction")?;
+        fetch_project(db, &project_id).await
     }
 
     pub async fn update_segment_text_and_settings(
@@ -785,47 +647,51 @@ impl StudioProjectStore {
         speaker: Option<String>,
         saved_voice_id: Option<String>,
     ) -> anyhow::Result<Option<StudioProjectRecord>> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
-            let now = now_unix_millis_i64();
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start Studio segment text/settings transaction")?;
+        let now = now_unix_millis_i64();
 
-            let updated = tx.execute(
-                r#"
-                UPDATE studio_project_segments
-                SET
-                    text = ?3,
-                    model_id = ?4,
-                    voice_mode = ?5,
-                    speaker = ?6,
-                    saved_voice_id = ?7,
-                    speech_record_id = NULL,
-                    updated_at = ?8
-                WHERE project_id = ?1 AND id = ?2
-                "#,
-                params![
-                    project_id.as_str(),
-                    segment_id.as_str(),
-                    text,
-                    model_id,
-                    voice_mode.as_db_value(),
-                    speaker,
-                    saved_voice_id,
-                    now,
-                ],
-            )?;
+        let updated = execute(
+            &tx,
+            r#"
+            UPDATE studio_project_segments
+            SET
+                text = ?3,
+                model_id = ?4,
+                voice_mode = ?5,
+                speaker = ?6,
+                saved_voice_id = ?7,
+                speech_record_id = NULL,
+                updated_at = ?8
+            WHERE project_id = ?1 AND id = ?2
+            "#,
+            vec![
+                project_id.clone().into(),
+                segment_id.into(),
+                text.into(),
+                model_id.into(),
+                voice_mode.as_db_value().into(),
+                speaker.into(),
+                saved_voice_id.into(),
+                now.into(),
+            ],
+            "Failed to update Studio segment text/settings",
+        )
+        .await?;
 
-            if updated == 0 {
-                tx.rollback()?;
-                return Ok(None);
-            }
+        if updated == 0 {
+            return Ok(None);
+        }
 
-            sync_project_source_text(&tx, project_id.as_str())?;
-            touch_project(&tx, project_id.as_str(), now)?;
-            tx.commit()?;
-            fetch_project(&conn, &project_id)
-        })
-        .await
+        sync_project_source_text(&tx, &project_id).await?;
+        touch_project(&tx, &project_id, now).await?;
+        tx.commit()
+            .await
+            .context("Failed to commit Studio segment text/settings transaction")?;
+        fetch_project(db, &project_id).await
     }
 
     pub async fn insert_segment(
@@ -834,192 +700,205 @@ impl StudioProjectStore {
         after_segment_id: Option<String>,
         text: String,
     ) -> anyhow::Result<Option<StudioProjectRecord>> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
-            let now = now_unix_millis_i64();
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start Studio segment insert transaction")?;
+        let now = now_unix_millis_i64();
 
-            let project_state = tx
-                .query_row(
-                    r#"
-                    SELECT
-                        model_id,
-                        voice_mode,
-                        speaker,
-                        saved_voice_id
-                    FROM studio_projects
-                    WHERE id = ?1
-                    "#,
-                    params![project_id.as_str()],
-                    |row| {
-                        let voice_mode_raw = row.get::<_, String>(1)?;
-                        let voice_mode =
-                            StudioProjectVoiceMode::from_db_value(voice_mode_raw.as_str())
-                                .unwrap_or(StudioProjectVoiceMode::BuiltIn);
-                        Ok((
-                            row.get::<_, Option<String>>(0)?,
-                            voice_mode,
-                            row.get::<_, Option<String>>(2)?,
-                            row.get::<_, Option<String>>(3)?,
-                        ))
-                    },
-                )
-                .optional()?;
+        let project_state = query_one(
+            &tx,
+            r#"
+            SELECT
+                model_id,
+                voice_mode,
+                speaker,
+                saved_voice_id
+            FROM studio_projects
+            WHERE id = ?1
+            "#,
+            vec![project_id.clone().into()],
+            "Failed to load Studio project segment defaults",
+        )
+        .await?
+        .map(|row| {
+            let voice_mode_raw: String = row.try_get_by_index(1)?;
+            Ok::<_, anyhow::Error>((
+                row.try_get_by_index::<Option<String>>(0)?,
+                StudioProjectVoiceMode::from_db_value(voice_mode_raw.as_str())
+                    .unwrap_or(StudioProjectVoiceMode::BuiltIn),
+                row.try_get_by_index::<Option<String>>(2)?,
+                row.try_get_by_index::<Option<String>>(3)?,
+            ))
+        })
+        .transpose()?;
 
-            let Some((
-                project_model_id,
-                project_voice_mode,
-                project_speaker,
-                project_saved_voice_id,
-            )) = project_state
-            else {
-                tx.rollback()?;
-                return Ok(None);
-            };
+        let Some((project_model_id, project_voice_mode, project_speaker, project_saved_voice_id)) =
+            project_state
+        else {
+            return Ok(None);
+        };
 
-            let (
-                insert_position,
-                inherited_model_id,
-                inherited_voice_mode,
-                inherited_speaker,
-                inherited_saved_voice_id,
-            ) = if let Some(anchor_segment_id) = after_segment_id {
-                let anchor_state = tx
-                    .query_row(
-                        r#"
-                            SELECT
-                                position,
-                                model_id,
-                                voice_mode,
-                                speaker,
-                                saved_voice_id
-                            FROM studio_project_segments
-                            WHERE project_id = ?1 AND id = ?2
-                            "#,
-                        params![project_id.as_str(), anchor_segment_id.as_str()],
-                        |row| {
-                            let voice_mode_raw: Option<String> = row.get(2)?;
-                            Ok((
-                                row.get::<_, i64>(0)?,
-                                row.get::<_, Option<String>>(1)?,
-                                voice_mode_raw
-                                    .as_deref()
-                                    .and_then(StudioProjectVoiceMode::from_db_value),
-                                row.get::<_, Option<String>>(3)?,
-                                row.get::<_, Option<String>>(4)?,
-                            ))
-                        },
-                    )
-                    .optional()?;
-
-                let Some((
-                    anchor_position,
-                    anchor_model_id,
-                    anchor_voice_mode,
-                    anchor_speaker,
-                    anchor_saved_voice_id,
-                )) = anchor_state
-                else {
-                    tx.rollback()?;
-                    return Ok(None);
-                };
-
-                let resolved_voice_mode = anchor_voice_mode.unwrap_or(project_voice_mode);
-                let resolved_speaker = match resolved_voice_mode {
-                    StudioProjectVoiceMode::BuiltIn => {
-                        anchor_speaker.or_else(|| project_speaker.clone())
-                    }
-                    StudioProjectVoiceMode::Saved => None,
-                };
-                let resolved_saved_voice_id = match resolved_voice_mode {
-                    StudioProjectVoiceMode::BuiltIn => None,
-                    StudioProjectVoiceMode::Saved => {
-                        anchor_saved_voice_id.or_else(|| project_saved_voice_id.clone())
-                    }
-                };
-
-                (
-                    anchor_position + 1,
-                    anchor_model_id.or_else(|| project_model_id.clone()),
-                    resolved_voice_mode,
-                    resolved_speaker,
-                    resolved_saved_voice_id,
-                )
-            } else {
-                let tail_position = tx
-                    .query_row(
-                        r#"
-                            SELECT MAX(position)
-                            FROM studio_project_segments
-                            WHERE project_id = ?1
-                            "#,
-                        params![project_id.as_str()],
-                        |row| row.get::<_, Option<i64>>(0),
-                    )?
-                    .map(|value| value + 1)
-                    .unwrap_or(0);
-                let resolved_speaker = match project_voice_mode {
-                    StudioProjectVoiceMode::BuiltIn => project_speaker.clone(),
-                    StudioProjectVoiceMode::Saved => None,
-                };
-                let resolved_saved_voice_id = match project_voice_mode {
-                    StudioProjectVoiceMode::BuiltIn => None,
-                    StudioProjectVoiceMode::Saved => project_saved_voice_id.clone(),
-                };
-
-                (
-                    tail_position,
-                    project_model_id,
-                    project_voice_mode,
-                    resolved_speaker,
-                    resolved_saved_voice_id,
-                )
-            };
-
-            tx.execute(
+        let (
+            insert_position,
+            inherited_model_id,
+            inherited_voice_mode,
+            inherited_speaker,
+            inherited_saved_voice_id,
+        ): (
+            i64,
+            Option<String>,
+            StudioProjectVoiceMode,
+            Option<String>,
+            Option<String>,
+        ) = if let Some(anchor_segment_id) = after_segment_id {
+            let anchor_state = query_one(
+                &tx,
                 r#"
-                UPDATE studio_project_segments
-                SET position = position + 1
-                WHERE project_id = ?1 AND position >= ?2
-                "#,
-                params![project_id.as_str(), insert_position],
-            )?;
-
-            let new_segment_id = new_uuid();
-            tx.execute(
-                r#"
-                INSERT INTO studio_project_segments (
-                    id,
-                    project_id,
+                SELECT
                     position,
-                    text,
                     model_id,
                     voice_mode,
                     speaker,
-                    saved_voice_id,
-                    speech_record_id,
-                    updated_at
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, ?9)
+                    saved_voice_id
+                FROM studio_project_segments
+                WHERE project_id = ?1 AND id = ?2
                 "#,
-                params![
-                    new_segment_id,
-                    project_id.as_str(),
-                    insert_position,
-                    text,
-                    inherited_model_id,
-                    inherited_voice_mode.as_db_value(),
-                    inherited_speaker,
-                    inherited_saved_voice_id,
-                    now
-                ],
-            )?;
+                vec![project_id.clone().into(), anchor_segment_id.into()],
+                "Failed to load Studio segment insert anchor",
+            )
+            .await?
+            .map(|row| {
+                let voice_mode_raw: Option<String> = row.try_get_by_index(2)?;
+                Ok::<_, anyhow::Error>((
+                    row.try_get_by_index::<i64>(0)?,
+                    row.try_get_by_index::<Option<String>>(1)?,
+                    voice_mode_raw
+                        .as_deref()
+                        .and_then(StudioProjectVoiceMode::from_db_value),
+                    row.try_get_by_index::<Option<String>>(3)?,
+                    row.try_get_by_index::<Option<String>>(4)?,
+                ))
+            })
+            .transpose()?;
 
-            sync_project_source_text(&tx, project_id.as_str())?;
-            touch_project(&tx, project_id.as_str(), now)?;
-            tx.commit()?;
-            fetch_project(&conn, &project_id)
-        })
-        .await
+            let Some((
+                anchor_position,
+                anchor_model_id,
+                anchor_voice_mode,
+                anchor_speaker,
+                anchor_saved_voice_id,
+            )) = anchor_state
+            else {
+                return Ok(None);
+            };
+
+            let resolved_voice_mode = anchor_voice_mode.unwrap_or(project_voice_mode);
+            let resolved_speaker = match resolved_voice_mode {
+                StudioProjectVoiceMode::BuiltIn => {
+                    anchor_speaker.or_else(|| project_speaker.clone())
+                }
+                StudioProjectVoiceMode::Saved => None,
+            };
+            let resolved_saved_voice_id = match resolved_voice_mode {
+                StudioProjectVoiceMode::BuiltIn => None,
+                StudioProjectVoiceMode::Saved => {
+                    anchor_saved_voice_id.or_else(|| project_saved_voice_id.clone())
+                }
+            };
+
+            (
+                anchor_position + 1,
+                anchor_model_id.or_else(|| project_model_id.clone()),
+                resolved_voice_mode,
+                resolved_speaker,
+                resolved_saved_voice_id,
+            )
+        } else {
+            let tail_position: i64 = query_one(
+                &tx,
+                r#"
+                SELECT MAX(position)
+                FROM studio_project_segments
+                WHERE project_id = ?1
+                "#,
+                vec![project_id.clone().into()],
+                "Failed to load Studio segment tail position",
+            )
+            .await?
+            .map(|row| row.try_get_by_index::<Option<i64>>(0))
+            .transpose()?
+            .flatten()
+            .map(|value| value + 1)
+            .unwrap_or(0);
+            let resolved_speaker = match project_voice_mode {
+                StudioProjectVoiceMode::BuiltIn => project_speaker.clone(),
+                StudioProjectVoiceMode::Saved => None,
+            };
+            let resolved_saved_voice_id = match project_voice_mode {
+                StudioProjectVoiceMode::BuiltIn => None,
+                StudioProjectVoiceMode::Saved => project_saved_voice_id.clone(),
+            };
+
+            (
+                tail_position,
+                project_model_id,
+                project_voice_mode,
+                resolved_speaker,
+                resolved_saved_voice_id,
+            )
+        };
+
+        execute(
+            &tx,
+            r#"
+            UPDATE studio_project_segments
+            SET position = position + 1
+            WHERE project_id = ?1 AND position >= ?2
+            "#,
+            vec![project_id.clone().into(), insert_position.into()],
+            "Failed to shift Studio segments for insert",
+        )
+        .await?;
+
+        execute(
+            &tx,
+            r#"
+            INSERT INTO studio_project_segments (
+                id,
+                project_id,
+                position,
+                text,
+                model_id,
+                voice_mode,
+                speaker,
+                saved_voice_id,
+                speech_record_id,
+                updated_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, ?9)
+            "#,
+            vec![
+                new_uuid().into(),
+                project_id.clone().into(),
+                insert_position.into(),
+                text.into(),
+                inherited_model_id.into(),
+                inherited_voice_mode.as_db_value().into(),
+                inherited_speaker.into(),
+                inherited_saved_voice_id.into(),
+                now.into(),
+            ],
+            "Failed to insert Studio segment",
+        )
+        .await?;
+
+        sync_project_source_text(&tx, &project_id).await?;
+        touch_project(&tx, &project_id, now).await?;
+        tx.commit()
+            .await
+            .context("Failed to commit Studio segment insert transaction")?;
+        fetch_project(db, &project_id).await
     }
 
     pub async fn split_segment(
@@ -1029,68 +908,898 @@ impl StudioProjectStore {
         before_text: String,
         after_text: String,
     ) -> anyhow::Result<Option<StudioProjectRecord>> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
-            let now = now_unix_millis_i64();
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start Studio segment split transaction")?;
+        let now = now_unix_millis_i64();
 
-            let segment_state = tx
-                .query_row(
-                    r#"
-                    SELECT
-                        position,
-                        model_id,
-                        voice_mode,
-                        speaker,
-                        saved_voice_id
-                    FROM studio_project_segments
-                    WHERE project_id = ?1 AND id = ?2
-                    "#,
-                    params![project_id.as_str(), segment_id.as_str()],
-                    |row| {
-                        let voice_mode_raw: Option<String> = row.get(2)?;
-                        Ok((
-                            row.get::<_, i64>(0)?,
-                            row.get::<_, Option<String>>(1)?,
-                            voice_mode_raw
-                                .as_deref()
-                                .and_then(StudioProjectVoiceMode::from_db_value),
-                            row.get::<_, Option<String>>(3)?,
-                            row.get::<_, Option<String>>(4)?,
-                        ))
-                    },
-                )
-                .optional()?;
+        let segment_state = query_one(
+            &tx,
+            r#"
+            SELECT
+                position,
+                model_id,
+                voice_mode,
+                speaker,
+                saved_voice_id
+            FROM studio_project_segments
+            WHERE project_id = ?1 AND id = ?2
+            "#,
+            vec![project_id.clone().into(), segment_id.clone().into()],
+            "Failed to load Studio segment for split",
+        )
+        .await?
+        .map(|row| {
+            let voice_mode_raw: Option<String> = row.try_get_by_index(2)?;
+            Ok::<_, anyhow::Error>((
+                row.try_get_by_index::<i64>(0)?,
+                row.try_get_by_index::<Option<String>>(1)?,
+                voice_mode_raw
+                    .as_deref()
+                    .and_then(StudioProjectVoiceMode::from_db_value),
+                row.try_get_by_index::<Option<String>>(3)?,
+                row.try_get_by_index::<Option<String>>(4)?,
+            ))
+        })
+        .transpose()?;
 
-            let Some((position, model_id, voice_mode, speaker, saved_voice_id)) = segment_state
-            else {
-                tx.rollback()?;
-                return Ok(None);
-            };
+        let Some((position, model_id, voice_mode, speaker, saved_voice_id)) = segment_state else {
+            return Ok(None);
+        };
 
-            tx.execute(
+        execute(
+            &tx,
+            r#"
+            UPDATE studio_project_segments
+            SET position = position + 1
+            WHERE project_id = ?1 AND position > ?2
+            "#,
+            vec![project_id.clone().into(), position.into()],
+            "Failed to shift Studio segments for split",
+        )
+        .await?;
+
+        execute(
+            &tx,
+            r#"
+            UPDATE studio_project_segments
+            SET
+                text = ?3,
+                speech_record_id = NULL,
+                updated_at = ?4
+            WHERE project_id = ?1 AND id = ?2
+            "#,
+            vec![
+                project_id.clone().into(),
+                segment_id.into(),
+                before_text.into(),
+                now.into(),
+            ],
+            "Failed to update Studio split segment",
+        )
+        .await?;
+
+        execute(
+            &tx,
+            r#"
+            INSERT INTO studio_project_segments (
+                id,
+                project_id,
+                position,
+                text,
+                model_id,
+                voice_mode,
+                speaker,
+                saved_voice_id,
+                speech_record_id,
+                updated_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, ?9)
+            "#,
+            vec![
+                new_uuid().into(),
+                project_id.clone().into(),
+                (position + 1).into(),
+                after_text.into(),
+                model_id.into(),
+                voice_mode.map(|value| value.as_db_value()).into(),
+                speaker.into(),
+                saved_voice_id.into(),
+                now.into(),
+            ],
+            "Failed to insert Studio split segment",
+        )
+        .await?;
+
+        sync_project_source_text(&tx, &project_id).await?;
+        touch_project(&tx, &project_id, now).await?;
+        tx.commit()
+            .await
+            .context("Failed to commit Studio segment split transaction")?;
+        fetch_project(db, &project_id).await
+    }
+
+    pub async fn delete_segment(
+        &self,
+        project_id: String,
+        segment_id: String,
+    ) -> anyhow::Result<Option<StudioProjectRecord>> {
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start Studio segment delete transaction")?;
+        let now = now_unix_millis_i64();
+
+        let position = query_one(
+            &tx,
+            r#"
+            SELECT position
+            FROM studio_project_segments
+            WHERE project_id = ?1 AND id = ?2
+            "#,
+            vec![project_id.clone().into(), segment_id.clone().into()],
+            "Failed to load Studio segment position for delete",
+        )
+        .await?
+        .map(|row| row.try_get_by_index::<i64>(0))
+        .transpose()?;
+
+        let Some(position) = position else {
+            return Ok(None);
+        };
+
+        let deleted = execute(
+            &tx,
+            r#"
+            DELETE FROM studio_project_segments
+            WHERE project_id = ?1 AND id = ?2
+            "#,
+            vec![project_id.clone().into(), segment_id.into()],
+            "Failed to delete Studio segment",
+        )
+        .await?;
+
+        if deleted == 0 {
+            return Ok(None);
+        }
+
+        execute(
+            &tx,
+            r#"
+            UPDATE studio_project_segments
+            SET position = position - 1
+            WHERE project_id = ?1 AND position > ?2
+            "#,
+            vec![project_id.clone().into(), position.into()],
+            "Failed to compact Studio segments after delete",
+        )
+        .await?;
+
+        sync_project_source_text(&tx, &project_id).await?;
+        touch_project(&tx, &project_id, now).await?;
+        tx.commit()
+            .await
+            .context("Failed to commit Studio segment delete transaction")?;
+        fetch_project(db, &project_id).await
+    }
+
+    pub async fn merge_segment_with_next(
+        &self,
+        project_id: String,
+        segment_id: String,
+    ) -> anyhow::Result<Option<StudioProjectRecord>> {
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start Studio segment merge transaction")?;
+        let now = now_unix_millis_i64();
+
+        let current = query_one(
+            &tx,
+            r#"
+            SELECT id, position, text
+            FROM studio_project_segments
+            WHERE project_id = ?1 AND id = ?2
+            "#,
+            vec![project_id.clone().into(), segment_id.into()],
+            "Failed to load Studio segment for merge",
+        )
+        .await?
+        .map(|row| {
+            Ok::<_, anyhow::Error>((
+                row.try_get_by_index::<String>(0)?,
+                row.try_get_by_index::<i64>(1)?,
+                row.try_get_by_index::<String>(2)?,
+            ))
+        })
+        .transpose()?;
+        let Some((current_id, current_position, current_text)) = current else {
+            return Ok(None);
+        };
+
+        let next = query_one(
+            &tx,
+            r#"
+            SELECT id, position, text
+            FROM studio_project_segments
+            WHERE project_id = ?1 AND position = ?2
+            "#,
+            vec![project_id.clone().into(), (current_position + 1).into()],
+            "Failed to load next Studio segment for merge",
+        )
+        .await?
+        .map(|row| {
+            Ok::<_, anyhow::Error>((
+                row.try_get_by_index::<String>(0)?,
+                row.try_get_by_index::<i64>(1)?,
+                row.try_get_by_index::<String>(2)?,
+            ))
+        })
+        .transpose()?;
+        let Some((next_id, next_position, next_text)) = next else {
+            return Ok(None);
+        };
+
+        let merged_text = format!("{}\n\n{}", current_text.trim(), next_text.trim())
+            .trim()
+            .to_string();
+        execute(
+            &tx,
+            r#"
+            UPDATE studio_project_segments
+            SET
+                text = ?3,
+                speech_record_id = NULL,
+                updated_at = ?4
+            WHERE project_id = ?1 AND id = ?2
+            "#,
+            vec![
+                project_id.clone().into(),
+                current_id.into(),
+                merged_text.into(),
+                now.into(),
+            ],
+            "Failed to update merged Studio segment",
+        )
+        .await?;
+
+        execute(
+            &tx,
+            r#"
+            DELETE FROM studio_project_segments
+            WHERE project_id = ?1 AND id = ?2
+            "#,
+            vec![project_id.clone().into(), next_id.into()],
+            "Failed to delete merged Studio segment",
+        )
+        .await?;
+
+        execute(
+            &tx,
+            r#"
+            UPDATE studio_project_segments
+            SET position = position - 1
+            WHERE project_id = ?1 AND position > ?2
+            "#,
+            vec![project_id.clone().into(), next_position.into()],
+            "Failed to compact Studio segments after merge",
+        )
+        .await?;
+
+        sync_project_source_text(&tx, &project_id).await?;
+        touch_project(&tx, &project_id, now).await?;
+        tx.commit()
+            .await
+            .context("Failed to commit Studio segment merge transaction")?;
+        fetch_project(db, &project_id).await
+    }
+
+    pub async fn reorder_segments(
+        &self,
+        project_id: String,
+        ordered_segment_ids: Vec<String>,
+    ) -> anyhow::Result<Option<StudioProjectRecord>> {
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start Studio segment reorder transaction")?;
+
+        let rows = query_all(
+            &tx,
+            r#"
+            SELECT id
+            FROM studio_project_segments
+            WHERE project_id = ?1
+            ORDER BY position ASC, id ASC
+            "#,
+            vec![project_id.clone().into()],
+            "Failed to list Studio segments for reorder",
+        )
+        .await?;
+        let existing_ids = rows
+            .iter()
+            .map(|row| row.try_get_by_index::<String>(0).map_err(Into::into))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        if existing_ids.is_empty() {
+            return Ok(None);
+        }
+        if ordered_segment_ids.len() != existing_ids.len() {
+            anyhow::bail!("Reorder request must include every project segment exactly once.");
+        }
+
+        let existing_set = existing_ids.iter().collect::<HashSet<_>>();
+        let requested_set = ordered_segment_ids.iter().collect::<HashSet<_>>();
+        if existing_set != requested_set {
+            anyhow::bail!("Reorder request contains unknown or missing segment ids.");
+        }
+
+        let now = now_unix_millis_i64();
+        for (position, segment_id) in ordered_segment_ids.iter().enumerate() {
+            execute(
+                &tx,
                 r#"
                 UPDATE studio_project_segments
-                SET position = position + 1
-                WHERE project_id = ?1 AND position > ?2
-                "#,
-                params![project_id.as_str(), position],
-            )?;
-
-            tx.execute(
-                r#"
-                UPDATE studio_project_segments
-                SET
-                    text = ?3,
-                    speech_record_id = NULL,
-                    updated_at = ?4
+                SET position = ?3, updated_at = ?4, speech_record_id = NULL
                 WHERE project_id = ?1 AND id = ?2
                 "#,
-                params![project_id.as_str(), segment_id.as_str(), before_text, now],
-            )?;
+                vec![
+                    project_id.clone().into(),
+                    segment_id.clone().into(),
+                    usize_to_i64(position).into(),
+                    now.into(),
+                ],
+                "Failed to update Studio segment position",
+            )
+            .await?;
+        }
 
-            let next_segment_id = new_uuid();
-            tx.execute(
+        sync_project_source_text(&tx, &project_id).await?;
+        touch_project(&tx, &project_id, now).await?;
+        tx.commit()
+            .await
+            .context("Failed to commit Studio segment reorder transaction")?;
+        fetch_project(db, &project_id).await
+    }
+
+    pub async fn delete_segments(
+        &self,
+        project_id: String,
+        segment_ids: Vec<String>,
+    ) -> anyhow::Result<Option<StudioProjectRecord>> {
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start Studio segment batch delete transaction")?;
+        let rows = query_all(
+            &tx,
+            r#"
+            SELECT id, position
+            FROM studio_project_segments
+            WHERE project_id = ?1
+            ORDER BY position ASC, id ASC
+            "#,
+            vec![project_id.clone().into()],
+            "Failed to list Studio segments for batch delete",
+        )
+        .await?;
+        let existing = rows
+            .iter()
+            .map(|row| {
+                Ok::<_, anyhow::Error>((
+                    row.try_get_by_index::<String>(0)?,
+                    row.try_get_by_index::<i64>(1)?,
+                ))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        if existing.is_empty() {
+            return Ok(None);
+        }
+
+        let remove_set = segment_ids.into_iter().collect::<HashSet<_>>();
+        if remove_set.is_empty() {
+            tx.rollback()
+                .await
+                .context("Failed to roll back empty Studio segment delete transaction")?;
+            return fetch_project(db, &project_id).await;
+        }
+
+        let remaining_count = existing
+            .iter()
+            .filter(|(id, _)| !remove_set.contains(id))
+            .count();
+        if remaining_count == 0 {
+            anyhow::bail!("A project must keep at least one segment.");
+        }
+
+        for (segment_id, _) in &existing {
+            if remove_set.contains(segment_id) {
+                execute(
+                    &tx,
+                    r#"
+                    DELETE FROM studio_project_segments
+                    WHERE project_id = ?1 AND id = ?2
+                    "#,
+                    vec![project_id.clone().into(), segment_id.clone().into()],
+                    "Failed to delete Studio segment in batch",
+                )
+                .await?;
+            }
+        }
+
+        let mut new_position = 0usize;
+        for (segment_id, _) in existing {
+            if remove_set.contains(segment_id.as_str()) {
+                continue;
+            }
+            execute(
+                &tx,
+                r#"
+                UPDATE studio_project_segments
+                SET position = ?3
+                WHERE project_id = ?1 AND id = ?2
+                "#,
+                vec![
+                    project_id.clone().into(),
+                    segment_id.into(),
+                    usize_to_i64(new_position).into(),
+                ],
+                "Failed to compact Studio segment positions",
+            )
+            .await?;
+            new_position += 1;
+        }
+
+        let now = now_unix_millis_i64();
+        sync_project_source_text(&tx, &project_id).await?;
+        touch_project(&tx, &project_id, now).await?;
+        tx.commit()
+            .await
+            .context("Failed to commit Studio segment batch delete transaction")?;
+        fetch_project(db, &project_id).await
+    }
+
+    pub async fn attach_segment_record(
+        &self,
+        project_id: String,
+        segment_id: String,
+        speech_record_id: String,
+    ) -> anyhow::Result<Option<StudioProjectRecord>> {
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start Studio segment attach transaction")?;
+        let now = now_unix_millis_i64();
+
+        let updated = execute(
+            &tx,
+            r#"
+            UPDATE studio_project_segments
+            SET
+                speech_record_id = ?3,
+                updated_at = ?4
+            WHERE project_id = ?1 AND id = ?2
+            "#,
+            vec![
+                project_id.clone().into(),
+                segment_id.into(),
+                speech_record_id.into(),
+                now.into(),
+            ],
+            "Failed to attach speech record to Studio segment",
+        )
+        .await?;
+
+        if updated == 0 {
+            return Ok(None);
+        }
+
+        touch_project(&tx, &project_id, now).await?;
+        tx.commit()
+            .await
+            .context("Failed to commit Studio segment attach transaction")?;
+        fetch_project(db, &project_id).await
+    }
+
+    pub async fn delete_project(&self, project_id: String) -> anyhow::Result<bool> {
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start Studio project delete transaction")?;
+        execute(
+            &tx,
+            "DELETE FROM studio_project_segments WHERE project_id = ?1",
+            vec![project_id.clone().into()],
+            "Failed to delete Studio project segments",
+        )
+        .await?;
+        let deleted = execute(
+            &tx,
+            "DELETE FROM studio_projects WHERE id = ?1",
+            vec![project_id.into()],
+            "Failed to delete Studio project",
+        )
+        .await?;
+        tx.commit()
+            .await
+            .context("Failed to commit Studio project delete transaction")?;
+        Ok(deleted > 0)
+    }
+
+    pub async fn list_folders(&self) -> anyhow::Result<Vec<StudioProjectFolderRecord>> {
+        let db = self.db.connection().await?;
+        let rows = query_all(
+            db,
+            r#"
+            SELECT id, created_at, updated_at, name, parent_id, sort_order
+            FROM studio_project_folders
+            ORDER BY
+                CASE WHEN parent_id IS NULL THEN 0 ELSE 1 END ASC,
+                parent_id ASC,
+                sort_order ASC,
+                updated_at DESC,
+                id DESC
+            "#,
+            vec![],
+            "Failed to list Studio project folders",
+        )
+        .await?;
+        rows.iter().map(map_folder_row).collect()
+    }
+
+    pub async fn create_folder(
+        &self,
+        record: NewStudioProjectFolderRecord,
+    ) -> anyhow::Result<StudioProjectFolderRecord> {
+        let db = self.db.connection().await?;
+        let now = now_unix_millis_i64();
+        let id = new_uuid();
+        execute(
+            db,
+            r#"
+            INSERT INTO studio_project_folders (id, created_at, updated_at, name, parent_id, sort_order)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            "#,
+            vec![
+                id.clone().into(),
+                now.into(),
+                now.into(),
+                record.name.into(),
+                record.parent_id.into(),
+                record.sort_order.unwrap_or(0).into(),
+            ],
+            "Failed to create Studio project folder",
+        )
+        .await?;
+        fetch_folder(db, &id)
+            .await?
+            .ok_or_else(|| anyhow!("Created Studio project folder was not found"))
+    }
+
+    pub async fn get_project_meta(
+        &self,
+        project_id: String,
+    ) -> anyhow::Result<Option<StudioProjectMetaRecord>> {
+        let db = self.db.connection().await?;
+        fetch_project_meta(db, &project_id).await
+    }
+
+    pub async fn upsert_project_meta(
+        &self,
+        project_id: String,
+        update: UpsertStudioProjectMetaRecord,
+    ) -> anyhow::Result<Option<StudioProjectMetaRecord>> {
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start Studio project metadata transaction")?;
+        let exists = project_exists(&tx, &project_id).await?;
+        if !exists {
+            return Ok(None);
+        }
+
+        let current = query_one(
+            &tx,
+            r#"
+            SELECT folder_id, tags_json, default_export_format, last_render_job_id, last_rendered_at
+            FROM studio_project_meta
+            WHERE project_id = ?1
+            "#,
+            vec![project_id.clone().into()],
+            "Failed to load Studio project metadata",
+        )
+        .await?
+        .map(|row| {
+            Ok::<_, anyhow::Error>((
+                row.try_get_by_index::<Option<String>>(0)?,
+                row.try_get_by_index::<Option<String>>(1)?,
+                row.try_get_by_index::<Option<String>>(2)?,
+                row.try_get_by_index::<Option<String>>(3)?,
+                row.try_get_by_index::<Option<i64>>(4)?,
+            ))
+        })
+        .transpose()?;
+
+        let default_current_export = current
+            .as_ref()
+            .and_then(|(_, _, format, _, _)| format.as_deref())
+            .and_then(StudioProjectExportFormat::from_db_value)
+            .unwrap_or(StudioProjectExportFormat::Wav);
+        let next_folder_id = update.folder_id.unwrap_or_else(|| {
+            current
+                .as_ref()
+                .and_then(|(folder_id, _, _, _, _)| folder_id.clone())
+        });
+        let next_tags = update.tags.unwrap_or_else(|| {
+            current
+                .as_ref()
+                .and_then(|(_, tags_json, _, _, _)| tags_json.clone())
+                .map(|raw| parse_json_string_vec(Some(raw)))
+                .unwrap_or_default()
+        });
+        let next_export = update
+            .default_export_format
+            .unwrap_or(default_current_export);
+        let next_last_render_job_id = update.last_render_job_id.unwrap_or_else(|| {
+            current
+                .as_ref()
+                .and_then(|(_, _, _, last_render_job_id, _)| last_render_job_id.clone())
+        });
+        let next_last_rendered_at = update.last_rendered_at.unwrap_or_else(|| {
+            current
+                .as_ref()
+                .and_then(|(_, _, _, _, last_rendered_at)| *last_rendered_at)
+                .map(i64_to_u64)
+        });
+        let next_last_rendered_at_i64 =
+            next_last_rendered_at.and_then(|value| i64::try_from(value).ok());
+
+        execute(
+            &tx,
+            r#"
+            INSERT INTO studio_project_meta (
+                project_id,
+                folder_id,
+                tags_json,
+                default_export_format,
+                last_render_job_id,
+                last_rendered_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            ON CONFLICT(project_id) DO UPDATE SET
+                folder_id = excluded.folder_id,
+                tags_json = excluded.tags_json,
+                default_export_format = excluded.default_export_format,
+                last_render_job_id = excluded.last_render_job_id,
+                last_rendered_at = excluded.last_rendered_at
+            "#,
+            vec![
+                project_id.clone().into(),
+                next_folder_id.into(),
+                encode_json_string_vec(next_tags.as_slice()).into(),
+                next_export.as_db_value().into(),
+                next_last_render_job_id.into(),
+                next_last_rendered_at_i64.into(),
+            ],
+            "Failed to upsert Studio project metadata",
+        )
+        .await?;
+
+        tx.commit()
+            .await
+            .context("Failed to commit Studio project metadata transaction")?;
+        fetch_project_meta(db, &project_id).await
+    }
+
+    pub async fn list_project_pronunciations(
+        &self,
+        project_id: String,
+    ) -> anyhow::Result<Vec<StudioProjectPronunciationRecord>> {
+        let db = self.db.connection().await?;
+        let rows = query_all(
+            db,
+            r#"
+            SELECT id, project_id, source_text, replacement_text, locale, created_at, updated_at
+            FROM studio_project_pronunciations
+            WHERE project_id = ?1
+            ORDER BY updated_at DESC, id DESC
+            "#,
+            vec![project_id.into()],
+            "Failed to list Studio project pronunciations",
+        )
+        .await?;
+        rows.iter().map(map_pronunciation_row).collect()
+    }
+
+    pub async fn create_project_pronunciation(
+        &self,
+        project_id: String,
+        record: NewStudioProjectPronunciationRecord,
+    ) -> anyhow::Result<Option<StudioProjectPronunciationRecord>> {
+        let db = self.db.connection().await?;
+        if !project_exists(db, &project_id).await? {
+            return Ok(None);
+        }
+
+        let now = now_unix_millis_i64();
+        let id = new_uuid();
+        execute(
+            db,
+            r#"
+            INSERT INTO studio_project_pronunciations (
+                id, project_id, source_text, replacement_text, locale, created_at, updated_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            "#,
+            vec![
+                id.clone().into(),
+                project_id.into(),
+                record.source_text.into(),
+                record.replacement_text.into(),
+                record.locale.into(),
+                now.into(),
+                now.into(),
+            ],
+            "Failed to create Studio project pronunciation",
+        )
+        .await?;
+
+        fetch_project_pronunciation(db, &id).await
+    }
+
+    pub async fn delete_project_pronunciation(
+        &self,
+        project_id: String,
+        pronunciation_id: String,
+    ) -> anyhow::Result<bool> {
+        let db = self.db.connection().await?;
+        let deleted = execute(
+            db,
+            r#"
+            DELETE FROM studio_project_pronunciations
+            WHERE project_id = ?1 AND id = ?2
+            "#,
+            vec![project_id.into(), pronunciation_id.into()],
+            "Failed to delete Studio project pronunciation",
+        )
+        .await?;
+        Ok(deleted > 0)
+    }
+
+    pub async fn list_project_snapshots(
+        &self,
+        project_id: String,
+    ) -> anyhow::Result<Vec<StudioProjectSnapshotRecord>> {
+        let db = self.db.connection().await?;
+        let rows = query_all(
+            db,
+            STUDIO_PROJECT_SNAPSHOTS_SQL,
+            vec![project_id.into()],
+            "Failed to list Studio project snapshots",
+        )
+        .await?;
+        rows.iter().map(map_snapshot_row).collect()
+    }
+
+    pub async fn create_project_snapshot(
+        &self,
+        project_id: String,
+        record: NewStudioProjectSnapshotRecord,
+    ) -> anyhow::Result<Option<StudioProjectSnapshotRecord>> {
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start Studio project snapshot transaction")?;
+        let Some(project) = fetch_project(&tx, &project_id).await? else {
+            return Ok(None);
+        };
+        let payload = serde_json::to_string(&project)
+            .context("Failed to serialize project snapshot payload")?;
+        let now = now_unix_millis_i64();
+        let snapshot_id = new_uuid();
+        execute(
+            &tx,
+            r#"
+            INSERT INTO studio_project_snapshots (id, project_id, created_at, label, project_json)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            "#,
+            vec![
+                snapshot_id.clone().into(),
+                project_id.into(),
+                now.into(),
+                record.label.into(),
+                payload.into(),
+            ],
+            "Failed to create Studio project snapshot",
+        )
+        .await?;
+        tx.commit()
+            .await
+            .context("Failed to commit Studio project snapshot transaction")?;
+
+        fetch_snapshot(db, &snapshot_id).await
+    }
+
+    pub async fn restore_project_snapshot(
+        &self,
+        project_id: String,
+        snapshot_id: String,
+    ) -> anyhow::Result<Option<StudioProjectRecord>> {
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start Studio project snapshot restore transaction")?;
+        let snapshot_json = query_one(
+            &tx,
+            r#"
+            SELECT project_json
+            FROM studio_project_snapshots
+            WHERE id = ?1 AND project_id = ?2
+            "#,
+            vec![snapshot_id.into(), project_id.clone().into()],
+            "Failed to load Studio project snapshot payload",
+        )
+        .await?
+        .map(|row| row.try_get_by_index::<String>(0))
+        .transpose()?;
+        let Some(snapshot_json) = snapshot_json else {
+            return Ok(None);
+        };
+
+        let snapshot: StudioProjectRecord = serde_json::from_str(snapshot_json.as_str())
+            .context("Failed to decode project snapshot payload")?;
+        let now = now_unix_millis_i64();
+        execute(
+            &tx,
+            r#"
+            UPDATE studio_projects
+            SET
+                updated_at = ?2,
+                name = ?3,
+                source_filename = ?4,
+                source_text = ?5,
+                model_id = ?6,
+                voice_mode = ?7,
+                speaker = ?8,
+                saved_voice_id = ?9,
+                speed = ?10
+            WHERE id = ?1
+            "#,
+            vec![
+                project_id.clone().into(),
+                now.into(),
+                snapshot.name.into(),
+                snapshot.source_filename.into(),
+                snapshot.source_text.into(),
+                snapshot.model_id.into(),
+                snapshot.voice_mode.as_db_value().into(),
+                snapshot.speaker.into(),
+                snapshot.saved_voice_id.into(),
+                snapshot.speed.into(),
+            ],
+            "Failed to restore Studio project snapshot project row",
+        )
+        .await?;
+
+        execute(
+            &tx,
+            "DELETE FROM studio_project_segments WHERE project_id = ?1",
+            vec![project_id.clone().into()],
+            "Failed to clear Studio project segments for snapshot restore",
+        )
+        .await?;
+        for segment in snapshot.segments {
+            execute(
+                &tx,
                 r#"
                 INSERT INTO studio_project_segments (
                     id,
@@ -1103,877 +1812,44 @@ impl StudioProjectStore {
                     saved_voice_id,
                     speech_record_id,
                     updated_at
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, ?9)
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
                 "#,
-                params![
-                    next_segment_id,
-                    project_id.as_str(),
-                    position + 1,
-                    after_text,
-                    model_id,
-                    voice_mode.map(|value| value.as_db_value()),
-                    speaker,
-                    saved_voice_id,
-                    now
+                vec![
+                    segment.id.into(),
+                    project_id.clone().into(),
+                    usize_to_i64(segment.position).into(),
+                    segment.text.into(),
+                    segment.model_id.into(),
+                    segment.voice_mode.map(|value| value.as_db_value()).into(),
+                    segment.speaker.into(),
+                    segment.saved_voice_id.into(),
+                    segment.speech_record_id.into(),
+                    now.into(),
                 ],
-            )?;
-
-            sync_project_source_text(&tx, project_id.as_str())?;
-            touch_project(&tx, project_id.as_str(), now)?;
-            tx.commit()?;
-            fetch_project(&conn, &project_id)
-        })
-        .await
-    }
-
-    pub async fn delete_segment(
-        &self,
-        project_id: String,
-        segment_id: String,
-    ) -> anyhow::Result<Option<StudioProjectRecord>> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
-            let now = now_unix_millis_i64();
-
-            let position = tx
-                .query_row(
-                    r#"
-                    SELECT position
-                    FROM studio_project_segments
-                    WHERE project_id = ?1 AND id = ?2
-                    "#,
-                    params![project_id.as_str(), segment_id.as_str()],
-                    |row| row.get::<_, i64>(0),
-                )
-                .optional()?;
-
-            let Some(position) = position else {
-                tx.rollback()?;
-                return Ok(None);
-            };
-
-            let deleted = tx.execute(
-                r#"
-                DELETE FROM studio_project_segments
-                WHERE project_id = ?1 AND id = ?2
-                "#,
-                params![project_id.as_str(), segment_id.as_str()],
-            )?;
-
-            if deleted == 0 {
-                tx.rollback()?;
-                return Ok(None);
-            }
-
-            tx.execute(
-                r#"
-                UPDATE studio_project_segments
-                SET position = position - 1
-                WHERE project_id = ?1 AND position > ?2
-                "#,
-                params![project_id.as_str(), position],
-            )?;
-
-            sync_project_source_text(&tx, project_id.as_str())?;
-            touch_project(&tx, project_id.as_str(), now)?;
-            tx.commit()?;
-            fetch_project(&conn, &project_id)
-        })
-        .await
-    }
-
-    pub async fn merge_segment_with_next(
-        &self,
-        project_id: String,
-        segment_id: String,
-    ) -> anyhow::Result<Option<StudioProjectRecord>> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
-            let now = now_unix_millis_i64();
-
-            let current = tx
-                .query_row(
-                    r#"
-                    SELECT id, position, text
-                    FROM studio_project_segments
-                    WHERE project_id = ?1 AND id = ?2
-                    "#,
-                    params![project_id.as_str(), segment_id.as_str()],
-                    |row| {
-                        Ok((
-                            row.get::<_, String>(0)?,
-                            row.get::<_, i64>(1)?,
-                            row.get::<_, String>(2)?,
-                        ))
-                    },
-                )
-                .optional()?;
-            let Some((current_id, current_position, current_text)) = current else {
-                tx.rollback()?;
-                return Ok(None);
-            };
-
-            let next = tx
-                .query_row(
-                    r#"
-                    SELECT id, position, text
-                    FROM studio_project_segments
-                    WHERE project_id = ?1 AND position = ?2
-                    "#,
-                    params![project_id.as_str(), current_position + 1],
-                    |row| {
-                        Ok((
-                            row.get::<_, String>(0)?,
-                            row.get::<_, i64>(1)?,
-                            row.get::<_, String>(2)?,
-                        ))
-                    },
-                )
-                .optional()?;
-            let Some((next_id, next_position, next_text)) = next else {
-                tx.rollback()?;
-                return Ok(None);
-            };
-
-            let merged_text = format!("{}\n\n{}", current_text.trim(), next_text.trim())
-                .trim()
-                .to_string();
-            tx.execute(
-                r#"
-                UPDATE studio_project_segments
-                SET
-                    text = ?3,
-                    speech_record_id = NULL,
-                    updated_at = ?4
-                WHERE project_id = ?1 AND id = ?2
-                "#,
-                params![project_id.as_str(), current_id.as_str(), merged_text, now],
-            )?;
-
-            tx.execute(
-                r#"
-                DELETE FROM studio_project_segments
-                WHERE project_id = ?1 AND id = ?2
-                "#,
-                params![project_id.as_str(), next_id.as_str()],
-            )?;
-
-            tx.execute(
-                r#"
-                UPDATE studio_project_segments
-                SET position = position - 1
-                WHERE project_id = ?1 AND position > ?2
-                "#,
-                params![project_id.as_str(), next_position],
-            )?;
-
-            sync_project_source_text(&tx, project_id.as_str())?;
-            touch_project(&tx, project_id.as_str(), now)?;
-            tx.commit()?;
-            fetch_project(&conn, &project_id)
-        })
-        .await
-    }
-
-    pub async fn reorder_segments(
-        &self,
-        project_id: String,
-        ordered_segment_ids: Vec<String>,
-    ) -> anyhow::Result<Option<StudioProjectRecord>> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
-
-            let existing_ids = {
-                let mut stmt = tx.prepare(
-                    r#"
-                    SELECT id
-                    FROM studio_project_segments
-                    WHERE project_id = ?1
-                    ORDER BY position ASC, id ASC
-                    "#,
-                )?;
-                let rows =
-                    stmt.query_map(params![project_id.as_str()], |row| row.get::<_, String>(0))?;
-                let mut ids = Vec::new();
-                for row in rows {
-                    ids.push(row?);
-                }
-                ids
-            };
-            if existing_ids.is_empty() {
-                tx.rollback()?;
-                return Ok(None);
-            }
-            if ordered_segment_ids.len() != existing_ids.len() {
-                anyhow::bail!("Reorder request must include every project segment exactly once.");
-            }
-
-            let existing_set = existing_ids
-                .iter()
-                .collect::<std::collections::HashSet<_>>();
-            let requested_set = ordered_segment_ids
-                .iter()
-                .collect::<std::collections::HashSet<_>>();
-            if existing_set != requested_set {
-                anyhow::bail!("Reorder request contains unknown or missing segment ids.");
-            }
-
-            let now = now_unix_millis_i64();
-            for (position, segment_id) in ordered_segment_ids.iter().enumerate() {
-                tx.execute(
-                    r#"
-                    UPDATE studio_project_segments
-                    SET position = ?3, updated_at = ?4, speech_record_id = NULL
-                    WHERE project_id = ?1 AND id = ?2
-                    "#,
-                    params![
-                        project_id.as_str(),
-                        segment_id.as_str(),
-                        usize_to_i64(position),
-                        now
-                    ],
-                )?;
-            }
-
-            sync_project_source_text(&tx, project_id.as_str())?;
-            touch_project(&tx, project_id.as_str(), now)?;
-            tx.commit()?;
-            fetch_project(&conn, &project_id)
-        })
-        .await
-    }
-
-    pub async fn delete_segments(
-        &self,
-        project_id: String,
-        segment_ids: Vec<String>,
-    ) -> anyhow::Result<Option<StudioProjectRecord>> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
-            let existing = {
-                let mut stmt = tx.prepare(
-                    r#"
-                    SELECT id, position
-                    FROM studio_project_segments
-                    WHERE project_id = ?1
-                    ORDER BY position ASC, id ASC
-                    "#,
-                )?;
-                let rows = stmt.query_map(params![project_id.as_str()], |row| {
-                    Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
-                })?;
-                let mut records = Vec::new();
-                for row in rows {
-                    records.push(row?);
-                }
-                records
-            };
-            if existing.is_empty() {
-                tx.rollback()?;
-                return Ok(None);
-            }
-
-            let remove_set = segment_ids
-                .into_iter()
-                .collect::<std::collections::HashSet<_>>();
-            if remove_set.is_empty() {
-                tx.rollback()?;
-                return fetch_project(&conn, &project_id);
-            }
-
-            let remaining_count = existing
-                .iter()
-                .filter(|(id, _)| !remove_set.contains(id))
-                .count();
-            if remaining_count == 0 {
-                anyhow::bail!("A project must keep at least one segment.");
-            }
-
-            for (segment_id, _) in &existing {
-                if remove_set.contains(segment_id) {
-                    tx.execute(
-                        r#"
-                        DELETE FROM studio_project_segments
-                        WHERE project_id = ?1 AND id = ?2
-                        "#,
-                        params![project_id.as_str(), segment_id.as_str()],
-                    )?;
-                }
-            }
-
-            let mut new_position = 0usize;
-            for (segment_id, _) in existing {
-                if remove_set.contains(segment_id.as_str()) {
-                    continue;
-                }
-                tx.execute(
-                    r#"
-                    UPDATE studio_project_segments
-                    SET position = ?3
-                    WHERE project_id = ?1 AND id = ?2
-                    "#,
-                    params![
-                        project_id.as_str(),
-                        segment_id.as_str(),
-                        usize_to_i64(new_position)
-                    ],
-                )?;
-                new_position += 1;
-            }
-
-            let now = now_unix_millis_i64();
-            sync_project_source_text(&tx, project_id.as_str())?;
-            touch_project(&tx, project_id.as_str(), now)?;
-            tx.commit()?;
-            fetch_project(&conn, &project_id)
-        })
-        .await
-    }
-
-    pub async fn attach_segment_record(
-        &self,
-        project_id: String,
-        segment_id: String,
-        speech_record_id: String,
-    ) -> anyhow::Result<Option<StudioProjectRecord>> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
-            let now = now_unix_millis_i64();
-
-            let updated = tx.execute(
-                r#"
-                UPDATE studio_project_segments
-                SET
-                    speech_record_id = ?3,
-                    updated_at = ?4
-                WHERE project_id = ?1 AND id = ?2
-                "#,
-                params![
-                    project_id.as_str(),
-                    segment_id.as_str(),
-                    speech_record_id,
-                    now
-                ],
-            )?;
-
-            if updated == 0 {
-                tx.rollback()?;
-                return Ok(None);
-            }
-
-            touch_project(&tx, project_id.as_str(), now)?;
-            tx.commit()?;
-            fetch_project(&conn, &project_id)
-        })
-        .await
-    }
-
-    pub async fn delete_project(&self, project_id: String) -> anyhow::Result<bool> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
-            tx.execute(
-                "DELETE FROM studio_project_segments WHERE project_id = ?1",
-                params![project_id.as_str()],
-            )?;
-            let deleted = tx.execute(
-                "DELETE FROM studio_projects WHERE id = ?1",
-                params![project_id.as_str()],
-            )?;
-            tx.commit()?;
-            Ok(deleted > 0)
-        })
-        .await
-    }
-
-    pub async fn list_folders(&self) -> anyhow::Result<Vec<StudioProjectFolderRecord>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let mut stmt = conn.prepare(
-                r#"
-                SELECT id, created_at, updated_at, name, parent_id, sort_order
-                FROM studio_project_folders
-                ORDER BY
-                    CASE WHEN parent_id IS NULL THEN 0 ELSE 1 END ASC,
-                    parent_id ASC,
-                    sort_order ASC,
-                    updated_at DESC,
-                    id DESC
-                "#,
-            )?;
-            let rows = stmt.query_map([], map_folder_row)?;
-            let mut folders = Vec::new();
-            for row in rows {
-                folders.push(row?);
-            }
-            Ok(folders)
-        })
-        .await
-    }
-
-    pub async fn create_folder(
-        &self,
-        record: NewStudioProjectFolderRecord,
-    ) -> anyhow::Result<StudioProjectFolderRecord> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let now = now_unix_millis_i64();
-            let id = new_uuid();
-            conn.execute(
-                r#"
-                INSERT INTO studio_project_folders (id, created_at, updated_at, name, parent_id, sort_order)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-                "#,
-                params![
-                    id.as_str(),
-                    now,
-                    now,
-                    record.name,
-                    record.parent_id,
-                    record.sort_order.unwrap_or(0),
-                ],
-            )?;
-            conn.query_row(
-                r#"
-                SELECT id, created_at, updated_at, name, parent_id, sort_order
-                FROM studio_project_folders
-                WHERE id = ?1
-                "#,
-                params![id.as_str()],
-                map_folder_row,
+                "Failed to restore Studio project snapshot segment",
             )
-            .map_err(Into::into)
-        })
-        .await
-    }
-
-    pub async fn get_project_meta(
-        &self,
-        project_id: String,
-    ) -> anyhow::Result<Option<StudioProjectMetaRecord>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            fetch_project_meta(&conn, project_id.as_str())
-        })
-        .await
-    }
-
-    pub async fn upsert_project_meta(
-        &self,
-        project_id: String,
-        update: UpsertStudioProjectMetaRecord,
-    ) -> anyhow::Result<Option<StudioProjectMetaRecord>> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
-            let exists = tx
-                .query_row(
-                    "SELECT 1 FROM studio_projects WHERE id = ?1",
-                    params![project_id.as_str()],
-                    |_| Ok(()),
-                )
-                .optional()?
-                .is_some();
-            if !exists {
-                tx.rollback()?;
-                return Ok(None);
-            }
-
-            let current = tx
-                .query_row(
-                    r#"
-                    SELECT folder_id, tags_json, default_export_format, last_render_job_id, last_rendered_at
-                    FROM studio_project_meta
-                    WHERE project_id = ?1
-                    "#,
-                    params![project_id.as_str()],
-                    |row| {
-                        Ok((
-                            row.get::<_, Option<String>>(0)?,
-                            row.get::<_, Option<String>>(1)?,
-                            row.get::<_, Option<String>>(2)?,
-                            row.get::<_, Option<String>>(3)?,
-                            row.get::<_, Option<i64>>(4)?,
-                        ))
-                    },
-                )
-                .optional()?;
-
-            let default_current_export = current
-                .as_ref()
-                .and_then(|(_, _, format, _, _)| format.as_deref())
-                .and_then(StudioProjectExportFormat::from_db_value)
-                .unwrap_or(StudioProjectExportFormat::Wav);
-            let next_folder_id = update.folder_id.unwrap_or_else(|| {
-                current
-                    .as_ref()
-                    .and_then(|(folder_id, _, _, _, _)| folder_id.clone())
-            });
-            let next_tags = update.tags.unwrap_or_else(|| {
-                current
-                    .as_ref()
-                    .and_then(|(_, tags_json, _, _, _)| tags_json.clone())
-                    .map(|raw| parse_json_string_vec(Some(raw)))
-                    .unwrap_or_default()
-            });
-            let next_export = update.default_export_format.unwrap_or(default_current_export);
-            let next_last_render_job_id = update.last_render_job_id.unwrap_or_else(|| {
-                current
-                    .as_ref()
-                    .and_then(|(_, _, _, last_render_job_id, _)| last_render_job_id.clone())
-            });
-            let next_last_rendered_at = update.last_rendered_at.unwrap_or_else(|| {
-                current
-                    .as_ref()
-                    .and_then(|(_, _, _, _, last_rendered_at)| *last_rendered_at)
-                    .map(i64_to_u64)
-            });
-            let next_last_rendered_at_i64 = next_last_rendered_at
-                .and_then(|value| i64::try_from(value).ok());
-
-            tx.execute(
-                r#"
-                INSERT INTO studio_project_meta (
-                    project_id,
-                    folder_id,
-                    tags_json,
-                    default_export_format,
-                    last_render_job_id,
-                    last_rendered_at
-                )
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-                ON CONFLICT(project_id) DO UPDATE SET
-                    folder_id = excluded.folder_id,
-                    tags_json = excluded.tags_json,
-                    default_export_format = excluded.default_export_format,
-                    last_render_job_id = excluded.last_render_job_id,
-                    last_rendered_at = excluded.last_rendered_at
-                "#,
-                params![
-                    project_id.as_str(),
-                    next_folder_id,
-                    encode_json_string_vec(next_tags.as_slice()),
-                    next_export.as_db_value(),
-                    next_last_render_job_id,
-                    next_last_rendered_at_i64,
-                ],
-            )?;
-
-            tx.commit()?;
-            fetch_project_meta(&conn, project_id.as_str())
-        })
-        .await
-    }
-
-    pub async fn list_project_pronunciations(
-        &self,
-        project_id: String,
-    ) -> anyhow::Result<Vec<StudioProjectPronunciationRecord>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let mut stmt = conn.prepare(
-                r#"
-                SELECT id, project_id, source_text, replacement_text, locale, created_at, updated_at
-                FROM studio_project_pronunciations
-                WHERE project_id = ?1
-                ORDER BY updated_at DESC, id DESC
-                "#,
-            )?;
-            let rows = stmt.query_map(params![project_id.as_str()], map_pronunciation_row)?;
-            let mut entries = Vec::new();
-            for row in rows {
-                entries.push(row?);
-            }
-            Ok(entries)
-        })
-        .await
-    }
-
-    pub async fn create_project_pronunciation(
-        &self,
-        project_id: String,
-        record: NewStudioProjectPronunciationRecord,
-    ) -> anyhow::Result<Option<StudioProjectPronunciationRecord>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let exists = conn
-                .query_row(
-                    "SELECT 1 FROM studio_projects WHERE id = ?1",
-                    params![project_id.as_str()],
-                    |_| Ok(()),
-                )
-                .optional()?
-                .is_some();
-            if !exists {
-                return Ok(None);
-            }
-
-            let now = now_unix_millis_i64();
-            let id = new_uuid();
-            conn.execute(
-                r#"
-                INSERT INTO studio_project_pronunciations (
-                    id, project_id, source_text, replacement_text, locale, created_at, updated_at
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-                "#,
-                params![
-                    id.as_str(),
-                    project_id.as_str(),
-                    record.source_text,
-                    record.replacement_text,
-                    record.locale,
-                    now,
-                    now,
-                ],
-            )?;
-
-            conn.query_row(
-                r#"
-                SELECT id, project_id, source_text, replacement_text, locale, created_at, updated_at
-                FROM studio_project_pronunciations
-                WHERE id = ?1
-                "#,
-                params![id.as_str()],
-                map_pronunciation_row,
-            )
-            .optional()
-            .map_err(Into::into)
-        })
-        .await
-    }
-
-    pub async fn delete_project_pronunciation(
-        &self,
-        project_id: String,
-        pronunciation_id: String,
-    ) -> anyhow::Result<bool> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let deleted = conn.execute(
-                r#"
-                DELETE FROM studio_project_pronunciations
-                WHERE project_id = ?1 AND id = ?2
-                "#,
-                params![project_id.as_str(), pronunciation_id.as_str()],
-            )?;
-            Ok(deleted > 0)
-        })
-        .await
-    }
-
-    pub async fn list_project_snapshots(
-        &self,
-        project_id: String,
-    ) -> anyhow::Result<Vec<StudioProjectSnapshotRecord>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let mut stmt = conn.prepare(
-                r#"
-                SELECT
-                    s.id,
-                    s.project_id,
-                    s.created_at,
-                    s.label,
-                    COALESCE(json_extract(s.project_json, '$.name'), p.name) AS project_name
-                FROM studio_project_snapshots s
-                LEFT JOIN studio_projects p ON p.id = s.project_id
-                WHERE s.project_id = ?1
-                ORDER BY s.created_at DESC, s.id DESC
-                "#,
-            )?;
-            let rows = stmt.query_map(params![project_id.as_str()], map_snapshot_row)?;
-            let mut snapshots = Vec::new();
-            for row in rows {
-                snapshots.push(row?);
-            }
-            Ok(snapshots)
-        })
-        .await
-    }
-
-    pub async fn create_project_snapshot(
-        &self,
-        project_id: String,
-        record: NewStudioProjectSnapshotRecord,
-    ) -> anyhow::Result<Option<StudioProjectSnapshotRecord>> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
-            let Some(project) = fetch_project(&tx, project_id.as_str())? else {
-                tx.rollback()?;
-                return Ok(None);
-            };
-            let payload = serde_json::to_string(&project)
-                .context("Failed to serialize project snapshot payload")?;
-            let now = now_unix_millis_i64();
-            let snapshot_id = new_uuid();
-            tx.execute(
-                r#"
-                INSERT INTO studio_project_snapshots (id, project_id, created_at, label, project_json)
-                VALUES (?1, ?2, ?3, ?4, ?5)
-                "#,
-                params![
-                    snapshot_id.as_str(),
-                    project_id.as_str(),
-                    now,
-                    record.label,
-                    payload,
-                ],
-            )?;
-            tx.commit()?;
-
-            conn.query_row(
-                r#"
-                SELECT
-                    s.id,
-                    s.project_id,
-                    s.created_at,
-                    s.label,
-                    COALESCE(json_extract(s.project_json, '$.name'), p.name) AS project_name
-                FROM studio_project_snapshots s
-                LEFT JOIN studio_projects p ON p.id = s.project_id
-                WHERE s.id = ?1
-                "#,
-                params![snapshot_id.as_str()],
-                map_snapshot_row,
-            )
-            .optional()
-            .map_err(Into::into)
-        })
-        .await
-    }
-
-    pub async fn restore_project_snapshot(
-        &self,
-        project_id: String,
-        snapshot_id: String,
-    ) -> anyhow::Result<Option<StudioProjectRecord>> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
-            let snapshot_json = tx
-                .query_row(
-                    r#"
-                    SELECT project_json
-                    FROM studio_project_snapshots
-                    WHERE id = ?1 AND project_id = ?2
-                    "#,
-                    params![snapshot_id.as_str(), project_id.as_str()],
-                    |row| row.get::<_, String>(0),
-                )
-                .optional()?;
-            let Some(snapshot_json) = snapshot_json else {
-                tx.rollback()?;
-                return Ok(None);
-            };
-
-            let snapshot: StudioProjectRecord = serde_json::from_str(snapshot_json.as_str())
-                .context("Failed to decode project snapshot payload")?;
-            let now = now_unix_millis_i64();
-            tx.execute(
-                r#"
-                UPDATE studio_projects
-                SET
-                    updated_at = ?2,
-                    name = ?3,
-                    source_filename = ?4,
-                    source_text = ?5,
-                    model_id = ?6,
-                    voice_mode = ?7,
-                    speaker = ?8,
-                    saved_voice_id = ?9,
-                    speed = ?10
-                WHERE id = ?1
-                "#,
-                params![
-                    project_id.as_str(),
-                    now,
-                    snapshot.name,
-                    snapshot.source_filename,
-                    snapshot.source_text,
-                    snapshot.model_id,
-                    snapshot.voice_mode.as_db_value(),
-                    snapshot.speaker,
-                    snapshot.saved_voice_id,
-                    snapshot.speed,
-                ],
-            )?;
-
-            tx.execute(
-                "DELETE FROM studio_project_segments WHERE project_id = ?1",
-                params![project_id.as_str()],
-            )?;
-            for segment in snapshot.segments {
-                tx.execute(
-                    r#"
-                    INSERT INTO studio_project_segments (
-                        id,
-                        project_id,
-                        position,
-                        text,
-                        model_id,
-                        voice_mode,
-                        speaker,
-                        saved_voice_id,
-                        speech_record_id,
-                        updated_at
-                    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
-                    "#,
-                    params![
-                        segment.id,
-                        project_id.as_str(),
-                        usize_to_i64(segment.position),
-                        segment.text,
-                        segment.model_id,
-                        segment.voice_mode.map(|value| value.as_db_value()),
-                        segment.speaker,
-                        segment.saved_voice_id,
-                        segment.speech_record_id,
-                        now,
-                    ],
-                )?;
-            }
-            touch_project(&tx, project_id.as_str(), now)?;
-            tx.commit()?;
-            fetch_project(&conn, project_id.as_str())
-        })
-        .await
+            .await?;
+        }
+        touch_project(&tx, &project_id, now).await?;
+        tx.commit()
+            .await
+            .context("Failed to commit Studio project snapshot restore transaction")?;
+        fetch_project(db, &project_id).await
     }
 
     pub async fn list_project_render_jobs(
         &self,
         project_id: String,
     ) -> anyhow::Result<Vec<StudioProjectRenderJobRecord>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let mut stmt = conn.prepare(
-                r#"
-                SELECT
-                    id,
-                    project_id,
-                    created_at,
-                    updated_at,
-                    status,
-                    error_message,
-                    queued_segment_ids_json
-                FROM studio_project_render_jobs
-                WHERE project_id = ?1
-                ORDER BY created_at DESC, id DESC
-                "#,
-            )?;
-            let rows = stmt.query_map(params![project_id.as_str()], map_render_job_row)?;
-            let mut jobs = Vec::new();
-            for row in rows {
-                jobs.push(row?);
-            }
-            Ok(jobs)
-        })
-        .await
+        let db = self.db.connection().await?;
+        let rows = query_all(
+            db,
+            STUDIO_PROJECT_RENDER_JOBS_SQL,
+            vec![project_id.into()],
+            "Failed to list Studio project render jobs",
+        )
+        .await?;
+        rows.iter().map(map_render_job_row).collect()
     }
 
     pub async fn create_project_render_job(
@@ -1981,73 +1857,48 @@ impl StudioProjectStore {
         project_id: String,
         record: NewStudioProjectRenderJobRecord,
     ) -> anyhow::Result<Option<StudioProjectRenderJobRecord>> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
-            let exists = tx
-                .query_row(
-                    "SELECT 1 FROM studio_projects WHERE id = ?1",
-                    params![project_id.as_str()],
-                    |_| Ok(()),
-                )
-                .optional()?
-                .is_some();
-            if !exists {
-                tx.rollback()?;
-                return Ok(None);
-            }
-            let now = now_unix_millis_i64();
-            let job_id = new_uuid();
-            tx.execute(
-                r#"
-                INSERT INTO studio_project_render_jobs (
-                    id,
-                    project_id,
-                    created_at,
-                    updated_at,
-                    status,
-                    error_message,
-                    queued_segment_ids_json
-                ) VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6)
-                "#,
-                params![
-                    job_id.as_str(),
-                    project_id.as_str(),
-                    now,
-                    now,
-                    StudioProjectRenderJobStatus::Queued.as_db_value(),
-                    encode_json_string_vec(record.queued_segment_ids.as_slice()),
-                ],
-            )?;
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start Studio project render job transaction")?;
+        let exists = project_exists(&tx, &project_id).await?;
+        if !exists {
+            return Ok(None);
+        }
+        let now = now_unix_millis_i64();
+        let job_id = new_uuid();
+        execute(
+            &tx,
+            r#"
+            INSERT INTO studio_project_render_jobs (
+                id,
+                project_id,
+                created_at,
+                updated_at,
+                status,
+                error_message,
+                queued_segment_ids_json
+            ) VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6)
+            "#,
+            vec![
+                job_id.clone().into(),
+                project_id.clone().into(),
+                now.into(),
+                now.into(),
+                StudioProjectRenderJobStatus::Queued.as_db_value().into(),
+                encode_json_string_vec(record.queued_segment_ids.as_slice()).into(),
+            ],
+            "Failed to create Studio project render job",
+        )
+        .await?;
 
-            tx.execute(
-                r#"
-                INSERT INTO studio_project_meta (
-                    project_id,
-                    folder_id,
-                    tags_json,
-                    default_export_format,
-                    last_render_job_id,
-                    last_rendered_at
-                )
-                VALUES (
-                    ?1,
-                    (SELECT folder_id FROM studio_project_meta WHERE project_id = ?1),
-                    COALESCE((SELECT tags_json FROM studio_project_meta WHERE project_id = ?1), '[]'),
-                    COALESCE((SELECT default_export_format FROM studio_project_meta WHERE project_id = ?1), 'wav'),
-                    ?2,
-                    (SELECT last_rendered_at FROM studio_project_meta WHERE project_id = ?1)
-                )
-                ON CONFLICT(project_id) DO UPDATE SET
-                    last_render_job_id = excluded.last_render_job_id
-                "#,
-                params![project_id.as_str(), job_id.as_str()],
-            )?;
+        upsert_last_render_job(&tx, &project_id, &job_id, None).await?;
 
-            tx.commit()?;
-            fetch_render_job(&conn, project_id.as_str(), job_id.as_str())
-        })
-        .await
+        tx.commit()
+            .await
+            .context("Failed to commit Studio project render job transaction")?;
+        fetch_render_job(db, &project_id, &job_id).await
     }
 
     pub async fn update_project_render_job(
@@ -2056,382 +1907,677 @@ impl StudioProjectStore {
         job_id: String,
         update: UpdateStudioProjectRenderJobRecord,
     ) -> anyhow::Result<Option<StudioProjectRenderJobRecord>> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
-            let current = tx
-                .query_row(
-                    r#"
-                    SELECT status, error_message
-                    FROM studio_project_render_jobs
-                    WHERE project_id = ?1 AND id = ?2
-                    "#,
-                    params![project_id.as_str(), job_id.as_str()],
-                    |row| {
-                        Ok((
-                            row.get::<_, String>(0)?,
-                            row.get::<_, Option<String>>(1)?,
-                        ))
-                    },
-                )
-                .optional()?;
-            let Some((current_status, current_error)) = current else {
-                tx.rollback()?;
-                return Ok(None);
-            };
-
-            let next_status = update
-                .status
-                .or_else(|| StudioProjectRenderJobStatus::from_db_value(current_status.as_str()))
-                .unwrap_or(StudioProjectRenderJobStatus::Queued);
-            let next_error = update.error_message.unwrap_or(current_error);
-            let now = now_unix_millis_i64();
-            tx.execute(
-                r#"
-                UPDATE studio_project_render_jobs
-                SET updated_at = ?3, status = ?4, error_message = ?5
-                WHERE project_id = ?1 AND id = ?2
-                "#,
-                params![
-                    project_id.as_str(),
-                    job_id.as_str(),
-                    now,
-                    next_status.as_db_value(),
-                    next_error,
-                ],
-            )?;
-
-            if next_status == StudioProjectRenderJobStatus::Completed {
-                tx.execute(
-                    r#"
-                    INSERT INTO studio_project_meta (
-                        project_id,
-                        folder_id,
-                        tags_json,
-                        default_export_format,
-                        last_render_job_id,
-                        last_rendered_at
-                    )
-                    VALUES (
-                        ?1,
-                        (SELECT folder_id FROM studio_project_meta WHERE project_id = ?1),
-                        COALESCE((SELECT tags_json FROM studio_project_meta WHERE project_id = ?1), '[]'),
-                        COALESCE((SELECT default_export_format FROM studio_project_meta WHERE project_id = ?1), 'wav'),
-                        ?2,
-                        ?3
-                    )
-                    ON CONFLICT(project_id) DO UPDATE SET
-                        last_render_job_id = excluded.last_render_job_id,
-                        last_rendered_at = excluded.last_rendered_at
-                    "#,
-                    params![project_id.as_str(), job_id.as_str(), now],
-                )?;
-            }
-
-            tx.commit()?;
-            fetch_render_job(&conn, project_id.as_str(), job_id.as_str())
-        })
-        .await
-    }
-
-    async fn run_blocking<T, F>(&self, work: F) -> anyhow::Result<T>
-    where
-        T: Send + 'static,
-        F: FnOnce(PathBuf) -> anyhow::Result<T> + Send + 'static,
-    {
-        let db_path = self.db_path.clone();
-        task::spawn_blocking(move || work(db_path))
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
             .await
-            .context("Studio project storage task join error")?
+            .context("Failed to start Studio project render job update transaction")?;
+        let current = query_one(
+            &tx,
+            r#"
+            SELECT status, error_message
+            FROM studio_project_render_jobs
+            WHERE project_id = ?1 AND id = ?2
+            "#,
+            vec![project_id.clone().into(), job_id.clone().into()],
+            "Failed to load Studio project render job for update",
+        )
+        .await?
+        .map(|row| {
+            Ok::<_, anyhow::Error>((
+                row.try_get_by_index::<String>(0)?,
+                row.try_get_by_index::<Option<String>>(1)?,
+            ))
+        })
+        .transpose()?;
+        let Some((current_status, current_error)) = current else {
+            return Ok(None);
+        };
+
+        let next_status = update
+            .status
+            .or_else(|| StudioProjectRenderJobStatus::from_db_value(current_status.as_str()))
+            .unwrap_or(StudioProjectRenderJobStatus::Queued);
+        let next_error = update.error_message.unwrap_or(current_error);
+        let now = now_unix_millis_i64();
+        execute(
+            &tx,
+            r#"
+            UPDATE studio_project_render_jobs
+            SET updated_at = ?3, status = ?4, error_message = ?5
+            WHERE project_id = ?1 AND id = ?2
+            "#,
+            vec![
+                project_id.clone().into(),
+                job_id.clone().into(),
+                now.into(),
+                next_status.as_db_value().into(),
+                next_error.into(),
+            ],
+            "Failed to update Studio project render job",
+        )
+        .await?;
+
+        if next_status == StudioProjectRenderJobStatus::Completed {
+            upsert_last_render_job(&tx, &project_id, &job_id, Some(now)).await?;
+        }
+
+        tx.commit()
+            .await
+            .context("Failed to commit Studio project render job update transaction")?;
+        fetch_render_job(db, &project_id, &job_id).await
     }
 }
 
-fn fetch_project(
-    conn: &Connection,
-    project_id: &str,
-) -> anyhow::Result<Option<StudioProjectRecord>> {
-    let project = conn
-        .query_row(
-            r#"
-            SELECT
-                id,
-                created_at,
-                updated_at,
-                name,
-                source_filename,
-                source_text,
-                model_id,
-                voice_mode,
-                speaker,
-                saved_voice_id,
-                speed
-            FROM studio_projects
-            WHERE id = ?1
-            "#,
-            params![project_id],
-            map_project_row,
-        )
-        .optional()?;
+const STUDIO_PROJECT_PAGE_SQL: &str = r#"
+    SELECT
+        p.id,
+        p.created_at,
+        p.updated_at,
+        p.name,
+        p.source_filename,
+        p.model_id,
+        p.voice_mode,
+        p.speaker,
+        p.saved_voice_id,
+        p.speed,
+        COUNT(s.id) AS segment_count,
+        COALESCE(SUM(CASE WHEN s.speech_record_id IS NOT NULL THEN 1 ELSE 0 END), 0) AS rendered_segment_count,
+        COALESCE(SUM(LENGTH(s.text)), 0) AS total_chars
+    FROM studio_projects p
+    LEFT JOIN studio_project_segments s ON s.project_id = p.id
+    GROUP BY
+        p.id,
+        p.created_at,
+        p.updated_at,
+        p.name,
+        p.source_filename,
+        p.model_id,
+        p.voice_mode,
+        p.speaker,
+        p.saved_voice_id,
+        p.speed
+    ORDER BY p.updated_at DESC, p.id DESC
+    LIMIT ?1
+"#;
+
+const STUDIO_PROJECT_PAGE_AFTER_CURSOR_SQL: &str = r#"
+    SELECT
+        p.id,
+        p.created_at,
+        p.updated_at,
+        p.name,
+        p.source_filename,
+        p.model_id,
+        p.voice_mode,
+        p.speaker,
+        p.saved_voice_id,
+        p.speed,
+        COUNT(s.id) AS segment_count,
+        COALESCE(SUM(CASE WHEN s.speech_record_id IS NOT NULL THEN 1 ELSE 0 END), 0) AS rendered_segment_count,
+        COALESCE(SUM(LENGTH(s.text)), 0) AS total_chars
+    FROM studio_projects p
+    LEFT JOIN studio_project_segments s ON s.project_id = p.id
+    WHERE p.updated_at < ?1 OR (p.updated_at = ?1 AND p.id < ?2)
+    GROUP BY
+        p.id,
+        p.created_at,
+        p.updated_at,
+        p.name,
+        p.source_filename,
+        p.model_id,
+        p.voice_mode,
+        p.speaker,
+        p.saved_voice_id,
+        p.speed
+    ORDER BY p.updated_at DESC, p.id DESC
+    LIMIT ?3
+"#;
+
+const STUDIO_PROJECT_BY_ID_SQL: &str = r#"
+    SELECT
+        id,
+        created_at,
+        updated_at,
+        name,
+        source_filename,
+        source_text,
+        model_id,
+        voice_mode,
+        speaker,
+        saved_voice_id,
+        speed
+    FROM studio_projects
+    WHERE id = ?1
+"#;
+
+const STUDIO_PROJECT_SEGMENTS_SQL: &str = r#"
+    SELECT
+        s.id,
+        s.project_id,
+        s.position,
+        s.text,
+        s.model_id,
+        s.voice_mode,
+        s.speaker,
+        s.saved_voice_id,
+        s.speech_record_id,
+        s.updated_at,
+        h.generation_time_ms,
+        h.audio_duration_secs,
+        h.audio_filename
+    FROM studio_project_segments s
+    LEFT JOIN speech_history_records h
+        ON h.id = s.speech_record_id
+       AND h.route_kind = 'text_to_speech'
+    WHERE s.project_id = ?1
+    ORDER BY s.position ASC, s.id ASC
+"#;
+
+const STUDIO_PROJECT_META_SQL: &str = r#"
+    SELECT
+        project_id,
+        folder_id,
+        tags_json,
+        default_export_format,
+        last_render_job_id,
+        last_rendered_at
+    FROM studio_project_meta
+    WHERE project_id = ?1
+"#;
+
+const STUDIO_PROJECT_SNAPSHOTS_SQL: &str = r#"
+    SELECT
+        s.id,
+        s.project_id,
+        s.created_at,
+        s.label,
+        COALESCE(json_extract(s.project_json, '$.name'), p.name) AS project_name
+    FROM studio_project_snapshots s
+    LEFT JOIN studio_projects p ON p.id = s.project_id
+    WHERE s.project_id = ?1
+    ORDER BY s.created_at DESC, s.id DESC
+"#;
+
+const STUDIO_PROJECT_SNAPSHOT_BY_ID_SQL: &str = r#"
+    SELECT
+        s.id,
+        s.project_id,
+        s.created_at,
+        s.label,
+        COALESCE(json_extract(s.project_json, '$.name'), p.name) AS project_name
+    FROM studio_project_snapshots s
+    LEFT JOIN studio_projects p ON p.id = s.project_id
+    WHERE s.id = ?1
+"#;
+
+const STUDIO_PROJECT_RENDER_JOBS_SQL: &str = r#"
+    SELECT
+        id,
+        project_id,
+        created_at,
+        updated_at,
+        status,
+        error_message,
+        queued_segment_ids_json
+    FROM studio_project_render_jobs
+    WHERE project_id = ?1
+    ORDER BY created_at DESC, id DESC
+"#;
+
+const STUDIO_PROJECT_RENDER_JOB_BY_ID_SQL: &str = r#"
+    SELECT
+        id,
+        project_id,
+        created_at,
+        updated_at,
+        status,
+        error_message,
+        queued_segment_ids_json
+    FROM studio_project_render_jobs
+    WHERE project_id = ?1 AND id = ?2
+"#;
+
+async fn fetch_project<C>(db: &C, project_id: &str) -> anyhow::Result<Option<StudioProjectRecord>>
+where
+    C: ConnectionTrait,
+{
+    let project = query_one(
+        db,
+        STUDIO_PROJECT_BY_ID_SQL,
+        vec![project_id.into()],
+        "Failed to load Studio project",
+    )
+    .await?
+    .as_ref()
+    .map(map_project_row)
+    .transpose()?;
 
     let Some(mut project) = project else {
         return Ok(None);
     };
 
-    let mut stmt = conn.prepare(
-        r#"
-        SELECT
-            s.id,
-            s.project_id,
-            s.position,
-            s.text,
-            s.model_id,
-            s.voice_mode,
-            s.speaker,
-            s.saved_voice_id,
-            s.speech_record_id,
-            s.updated_at,
-            h.generation_time_ms,
-            h.audio_duration_secs,
-            h.audio_filename
-        FROM studio_project_segments s
-        LEFT JOIN speech_history_records h
-            ON h.id = s.speech_record_id
-           AND h.route_kind = 'text_to_speech'
-        WHERE s.project_id = ?1
-        ORDER BY s.position ASC, s.id ASC
-        "#,
-    )?;
-
-    let rows = stmt.query_map(params![project_id], map_segment_row)?;
-    let mut segments = Vec::new();
-    for row in rows {
-        segments.push(row?);
-    }
-    project.segments = segments;
+    let rows = query_all(
+        db,
+        STUDIO_PROJECT_SEGMENTS_SQL,
+        vec![project_id.into()],
+        "Failed to load Studio project segments",
+    )
+    .await?;
+    project.segments = rows
+        .iter()
+        .map(map_segment_row)
+        .collect::<anyhow::Result<Vec<_>>>()?;
 
     Ok(Some(project))
 }
 
-fn map_project_summary_row(row: &Row<'_>) -> rusqlite::Result<StudioProjectSummary> {
-    let voice_mode_raw: String = row.get(6)?;
-    let segment_count = row.get::<_, i64>(10)?;
-    let rendered_segment_count = row.get::<_, i64>(11)?;
-    let total_chars = row.get::<_, i64>(12)?;
+async fn fetch_folder(
+    db: &DatabaseConnection,
+    folder_id: &str,
+) -> anyhow::Result<Option<StudioProjectFolderRecord>> {
+    query_one(
+        db,
+        r#"
+        SELECT id, created_at, updated_at, name, parent_id, sort_order
+        FROM studio_project_folders
+        WHERE id = ?1
+        "#,
+        vec![folder_id.into()],
+        "Failed to load Studio project folder",
+    )
+    .await?
+    .as_ref()
+    .map(map_folder_row)
+    .transpose()
+}
+
+async fn fetch_project_meta<C>(
+    db: &C,
+    project_id: &str,
+) -> anyhow::Result<Option<StudioProjectMetaRecord>>
+where
+    C: ConnectionTrait,
+{
+    query_one(
+        db,
+        STUDIO_PROJECT_META_SQL,
+        vec![project_id.into()],
+        "Failed to load Studio project metadata",
+    )
+    .await?
+    .as_ref()
+    .map(map_meta_row)
+    .transpose()
+}
+
+async fn fetch_project_pronunciation(
+    db: &DatabaseConnection,
+    pronunciation_id: &str,
+) -> anyhow::Result<Option<StudioProjectPronunciationRecord>> {
+    query_one(
+        db,
+        r#"
+        SELECT id, project_id, source_text, replacement_text, locale, created_at, updated_at
+        FROM studio_project_pronunciations
+        WHERE id = ?1
+        "#,
+        vec![pronunciation_id.into()],
+        "Failed to load Studio project pronunciation",
+    )
+    .await?
+    .as_ref()
+    .map(map_pronunciation_row)
+    .transpose()
+}
+
+async fn fetch_snapshot(
+    db: &DatabaseConnection,
+    snapshot_id: &str,
+) -> anyhow::Result<Option<StudioProjectSnapshotRecord>> {
+    query_one(
+        db,
+        STUDIO_PROJECT_SNAPSHOT_BY_ID_SQL,
+        vec![snapshot_id.into()],
+        "Failed to load Studio project snapshot",
+    )
+    .await?
+    .as_ref()
+    .map(map_snapshot_row)
+    .transpose()
+}
+
+async fn fetch_render_job<C>(
+    db: &C,
+    project_id: &str,
+    job_id: &str,
+) -> anyhow::Result<Option<StudioProjectRenderJobRecord>>
+where
+    C: ConnectionTrait,
+{
+    query_one(
+        db,
+        STUDIO_PROJECT_RENDER_JOB_BY_ID_SQL,
+        vec![project_id.into(), job_id.into()],
+        "Failed to load Studio project render job",
+    )
+    .await?
+    .as_ref()
+    .map(map_render_job_row)
+    .transpose()
+}
+
+async fn project_exists<C>(db: &C, project_id: &str) -> anyhow::Result<bool>
+where
+    C: ConnectionTrait,
+{
+    Ok(query_one(
+        db,
+        "SELECT 1 FROM studio_projects WHERE id = ?1",
+        vec![project_id.into()],
+        "Failed to check Studio project existence",
+    )
+    .await?
+    .is_some())
+}
+
+async fn touch_project<C>(db: &C, project_id: &str, updated_at: i64) -> anyhow::Result<()>
+where
+    C: ConnectionTrait,
+{
+    execute(
+        db,
+        "UPDATE studio_projects SET updated_at = ?2 WHERE id = ?1",
+        vec![project_id.into(), updated_at.into()],
+        "Failed to touch Studio project",
+    )
+    .await?;
+    Ok(())
+}
+
+async fn sync_project_source_text<C>(db: &C, project_id: &str) -> anyhow::Result<()>
+where
+    C: ConnectionTrait,
+{
+    let rows = query_all(
+        db,
+        r#"
+        SELECT text
+        FROM studio_project_segments
+        WHERE project_id = ?1
+        ORDER BY position ASC, id ASC
+        "#,
+        vec![project_id.into()],
+        "Failed to load Studio segment text for source sync",
+    )
+    .await?;
+
+    let segment_texts = rows
+        .iter()
+        .map(|row| row.try_get_by_index::<String>(0).map_err(Into::into))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    execute(
+        db,
+        "UPDATE studio_projects SET source_text = ?2 WHERE id = ?1",
+        vec![project_id.into(), segment_texts.join("\n\n").into()],
+        "Failed to sync Studio project source text",
+    )
+    .await?;
+    Ok(())
+}
+
+async fn upsert_last_render_job<C>(
+    db: &C,
+    project_id: &str,
+    job_id: &str,
+    last_rendered_at: Option<i64>,
+) -> anyhow::Result<()>
+where
+    C: ConnectionTrait,
+{
+    if let Some(last_rendered_at) = last_rendered_at {
+        execute(
+            db,
+            r#"
+            INSERT INTO studio_project_meta (
+                project_id,
+                folder_id,
+                tags_json,
+                default_export_format,
+                last_render_job_id,
+                last_rendered_at
+            )
+            VALUES (
+                ?1,
+                (SELECT folder_id FROM studio_project_meta WHERE project_id = ?1),
+                COALESCE((SELECT tags_json FROM studio_project_meta WHERE project_id = ?1), '[]'),
+                COALESCE((SELECT default_export_format FROM studio_project_meta WHERE project_id = ?1), 'wav'),
+                ?2,
+                ?3
+            )
+            ON CONFLICT(project_id) DO UPDATE SET
+                last_render_job_id = excluded.last_render_job_id,
+                last_rendered_at = excluded.last_rendered_at
+            "#,
+            vec![project_id.into(), job_id.into(), last_rendered_at.into()],
+            "Failed to update Studio project completed render metadata",
+        )
+        .await?;
+    } else {
+        execute(
+            db,
+            r#"
+            INSERT INTO studio_project_meta (
+                project_id,
+                folder_id,
+                tags_json,
+                default_export_format,
+                last_render_job_id,
+                last_rendered_at
+            )
+            VALUES (
+                ?1,
+                (SELECT folder_id FROM studio_project_meta WHERE project_id = ?1),
+                COALESCE((SELECT tags_json FROM studio_project_meta WHERE project_id = ?1), '[]'),
+                COALESCE((SELECT default_export_format FROM studio_project_meta WHERE project_id = ?1), 'wav'),
+                ?2,
+                (SELECT last_rendered_at FROM studio_project_meta WHERE project_id = ?1)
+            )
+            ON CONFLICT(project_id) DO UPDATE SET
+                last_render_job_id = excluded.last_render_job_id
+            "#,
+            vec![project_id.into(), job_id.into()],
+            "Failed to update Studio project render metadata",
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+async fn execute<C>(
+    db: &C,
+    sql: impl Into<String>,
+    values: Vec<Value>,
+    context: &'static str,
+) -> anyhow::Result<u64>
+where
+    C: ConnectionTrait,
+{
+    let result = db
+        .execute_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            sql,
+            values,
+        ))
+        .await
+        .context(context)?;
+    Ok(result.rows_affected())
+}
+
+async fn query_one<C>(
+    db: &C,
+    sql: impl Into<String>,
+    values: Vec<Value>,
+    context: &'static str,
+) -> anyhow::Result<Option<QueryResult>>
+where
+    C: ConnectionTrait,
+{
+    db.query_one_raw(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        sql,
+        values,
+    ))
+    .await
+    .context(context)
+}
+
+async fn query_all<C>(
+    db: &C,
+    sql: impl Into<String>,
+    values: Vec<Value>,
+    context: &'static str,
+) -> anyhow::Result<Vec<QueryResult>>
+where
+    C: ConnectionTrait,
+{
+    db.query_all_raw(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        sql,
+        values,
+    ))
+    .await
+    .context(context)
+}
+
+fn map_project_summary_row(row: &QueryResult) -> anyhow::Result<StudioProjectSummary> {
+    let voice_mode_raw: String = row.try_get_by_index(6)?;
+    let segment_count = row.try_get_by_index::<i64>(10)?;
+    let rendered_segment_count = row.try_get_by_index::<i64>(11)?;
+    let total_chars = row.try_get_by_index::<i64>(12)?;
 
     Ok(StudioProjectSummary {
-        id: row.get(0)?,
-        created_at: i64_to_u64(row.get(1)?),
-        updated_at: i64_to_u64(row.get(2)?),
-        name: row.get(3)?,
-        source_filename: row.get(4)?,
-        model_id: row.get(5)?,
+        id: row.try_get_by_index(0)?,
+        created_at: i64_to_u64(row.try_get_by_index(1)?),
+        updated_at: i64_to_u64(row.try_get_by_index(2)?),
+        name: row.try_get_by_index(3)?,
+        source_filename: row.try_get_by_index(4)?,
+        model_id: row.try_get_by_index(5)?,
         voice_mode: StudioProjectVoiceMode::from_db_value(voice_mode_raw.as_str())
             .unwrap_or(StudioProjectVoiceMode::BuiltIn),
-        speaker: row.get(7)?,
-        saved_voice_id: row.get(8)?,
-        speed: row.get(9)?,
+        speaker: row.try_get_by_index(7)?,
+        saved_voice_id: row.try_get_by_index(8)?,
+        speed: row.try_get_by_index(9)?,
         segment_count: i64_to_usize(segment_count).unwrap_or_default(),
         rendered_segment_count: i64_to_usize(rendered_segment_count).unwrap_or_default(),
         total_chars: i64_to_usize(total_chars).unwrap_or_default(),
     })
 }
 
-fn map_project_row(row: &Row<'_>) -> rusqlite::Result<StudioProjectRecord> {
-    let voice_mode_raw: String = row.get(7)?;
+fn map_project_row(row: &QueryResult) -> anyhow::Result<StudioProjectRecord> {
+    let voice_mode_raw: String = row.try_get_by_index(7)?;
     Ok(StudioProjectRecord {
-        id: row.get(0)?,
-        created_at: i64_to_u64(row.get(1)?),
-        updated_at: i64_to_u64(row.get(2)?),
-        name: row.get(3)?,
-        source_filename: row.get(4)?,
-        source_text: row.get(5)?,
-        model_id: row.get(6)?,
+        id: row.try_get_by_index(0)?,
+        created_at: i64_to_u64(row.try_get_by_index(1)?),
+        updated_at: i64_to_u64(row.try_get_by_index(2)?),
+        name: row.try_get_by_index(3)?,
+        source_filename: row.try_get_by_index(4)?,
+        source_text: row.try_get_by_index(5)?,
+        model_id: row.try_get_by_index(6)?,
         voice_mode: StudioProjectVoiceMode::from_db_value(voice_mode_raw.as_str())
             .unwrap_or(StudioProjectVoiceMode::BuiltIn),
-        speaker: row.get(8)?,
-        saved_voice_id: row.get(9)?,
-        speed: row.get(10)?,
+        speaker: row.try_get_by_index(8)?,
+        saved_voice_id: row.try_get_by_index(9)?,
+        speed: row.try_get_by_index(10)?,
         segments: Vec::new(),
     })
 }
 
-fn map_segment_row(row: &Row<'_>) -> rusqlite::Result<StudioProjectSegmentRecord> {
-    let text: String = row.get(3)?;
-    let voice_mode_raw: Option<String> = row.get(5)?;
+fn map_segment_row(row: &QueryResult) -> anyhow::Result<StudioProjectSegmentRecord> {
+    let text: String = row.try_get_by_index(3)?;
+    let voice_mode_raw: Option<String> = row.try_get_by_index(5)?;
     Ok(StudioProjectSegmentRecord {
-        id: row.get(0)?,
-        project_id: row.get(1)?,
-        position: i64_to_usize(row.get(2)?).unwrap_or_default(),
+        id: row.try_get_by_index(0)?,
+        project_id: row.try_get_by_index(1)?,
+        position: i64_to_usize(row.try_get_by_index(2)?).unwrap_or_default(),
         input_chars: text.chars().count(),
         text,
-        model_id: row.get(4)?,
+        model_id: row.try_get_by_index(4)?,
         voice_mode: voice_mode_raw
             .as_deref()
             .and_then(StudioProjectVoiceMode::from_db_value),
-        speaker: row.get(6)?,
-        saved_voice_id: row.get(7)?,
-        speech_record_id: row.get(8)?,
-        updated_at: i64_to_u64(row.get(9)?),
-        generation_time_ms: row.get(10)?,
-        audio_duration_secs: row.get(11)?,
-        audio_filename: row.get(12)?,
+        speaker: row.try_get_by_index(6)?,
+        saved_voice_id: row.try_get_by_index(7)?,
+        speech_record_id: row.try_get_by_index(8)?,
+        updated_at: i64_to_u64(row.try_get_by_index(9)?),
+        generation_time_ms: row.try_get_by_index(10)?,
+        audio_duration_secs: row.try_get_by_index(11)?,
+        audio_filename: row.try_get_by_index(12)?,
     })
 }
 
-fn sqlite_table_has_column(
-    conn: &Connection,
-    table_name: &str,
-    column_name: &str,
-) -> anyhow::Result<bool> {
-    let mut stmt = conn.prepare(&format!("PRAGMA table_info({table_name})"))?;
-    let mut rows = stmt.query([])?;
-    while let Some(row) = rows.next()? {
-        let name: String = row.get(1)?;
-        if name == column_name {
-            return Ok(true);
-        }
-    }
-    Ok(false)
-}
-
-fn ensure_sqlite_table_column(
-    conn: &Connection,
-    table_name: &str,
-    column_name: &str,
-    column_definition: &str,
-) -> anyhow::Result<()> {
-    if sqlite_table_has_column(conn, table_name, column_name)? {
-        return Ok(());
-    }
-    conn.execute(
-        &format!("ALTER TABLE {table_name} ADD COLUMN {column_name} {column_definition}"),
-        [],
-    )?;
-    Ok(())
-}
-
-fn ensure_studio_project_segment_settings_columns(conn: &Connection) -> anyhow::Result<()> {
-    ensure_sqlite_table_column(conn, "studio_project_segments", "model_id", "TEXT NULL")?;
-    ensure_sqlite_table_column(conn, "studio_project_segments", "voice_mode", "TEXT NULL")?;
-    ensure_sqlite_table_column(conn, "studio_project_segments", "speaker", "TEXT NULL")?;
-    ensure_sqlite_table_column(
-        conn,
-        "studio_project_segments",
-        "saved_voice_id",
-        "TEXT NULL",
-    )?;
-    Ok(())
-}
-
-fn fetch_project_meta(
-    conn: &Connection,
-    project_id: &str,
-) -> anyhow::Result<Option<StudioProjectMetaRecord>> {
-    conn.query_row(
-        r#"
-        SELECT
-            project_id,
-            folder_id,
-            tags_json,
-            default_export_format,
-            last_render_job_id,
-            last_rendered_at
-        FROM studio_project_meta
-        WHERE project_id = ?1
-        "#,
-        params![project_id],
-        map_meta_row,
-    )
-    .optional()
-    .map_err(Into::into)
-}
-
-fn fetch_render_job(
-    conn: &Connection,
-    project_id: &str,
-    job_id: &str,
-) -> anyhow::Result<Option<StudioProjectRenderJobRecord>> {
-    conn.query_row(
-        r#"
-        SELECT
-            id,
-            project_id,
-            created_at,
-            updated_at,
-            status,
-            error_message,
-            queued_segment_ids_json
-        FROM studio_project_render_jobs
-        WHERE project_id = ?1 AND id = ?2
-        "#,
-        params![project_id, job_id],
-        map_render_job_row,
-    )
-    .optional()
-    .map_err(Into::into)
-}
-
-fn map_folder_row(row: &Row<'_>) -> rusqlite::Result<StudioProjectFolderRecord> {
+fn map_folder_row(row: &QueryResult) -> anyhow::Result<StudioProjectFolderRecord> {
     Ok(StudioProjectFolderRecord {
-        id: row.get(0)?,
-        created_at: i64_to_u64(row.get(1)?),
-        updated_at: i64_to_u64(row.get(2)?),
-        name: row.get(3)?,
-        parent_id: row.get(4)?,
-        sort_order: row.get(5)?,
+        id: row.try_get_by_index(0)?,
+        created_at: i64_to_u64(row.try_get_by_index(1)?),
+        updated_at: i64_to_u64(row.try_get_by_index(2)?),
+        name: row.try_get_by_index(3)?,
+        parent_id: row.try_get_by_index(4)?,
+        sort_order: row.try_get_by_index(5)?,
     })
 }
 
-fn map_meta_row(row: &Row<'_>) -> rusqlite::Result<StudioProjectMetaRecord> {
-    let tags_json = row.get::<_, Option<String>>(2)?;
-    let export_format_raw = row.get::<_, Option<String>>(3)?;
-    let last_rendered_at = row.get::<_, Option<i64>>(5)?;
+fn map_meta_row(row: &QueryResult) -> anyhow::Result<StudioProjectMetaRecord> {
+    let tags_json = row.try_get_by_index::<Option<String>>(2)?;
+    let export_format_raw = row.try_get_by_index::<Option<String>>(3)?;
+    let last_rendered_at = row.try_get_by_index::<Option<i64>>(5)?;
     Ok(StudioProjectMetaRecord {
-        project_id: row.get(0)?,
-        folder_id: row.get(1)?,
+        project_id: row.try_get_by_index(0)?,
+        folder_id: row.try_get_by_index(1)?,
         tags: parse_json_string_vec(tags_json),
         default_export_format: export_format_raw
             .as_deref()
             .and_then(StudioProjectExportFormat::from_db_value)
             .unwrap_or(StudioProjectExportFormat::Wav),
-        last_render_job_id: row.get(4)?,
+        last_render_job_id: row.try_get_by_index(4)?,
         last_rendered_at: last_rendered_at.map(i64_to_u64),
     })
 }
 
-fn map_pronunciation_row(row: &Row<'_>) -> rusqlite::Result<StudioProjectPronunciationRecord> {
+fn map_pronunciation_row(row: &QueryResult) -> anyhow::Result<StudioProjectPronunciationRecord> {
     Ok(StudioProjectPronunciationRecord {
-        id: row.get(0)?,
-        project_id: row.get(1)?,
-        source_text: row.get(2)?,
-        replacement_text: row.get(3)?,
-        locale: row.get(4)?,
-        created_at: i64_to_u64(row.get(5)?),
-        updated_at: i64_to_u64(row.get(6)?),
+        id: row.try_get_by_index(0)?,
+        project_id: row.try_get_by_index(1)?,
+        source_text: row.try_get_by_index(2)?,
+        replacement_text: row.try_get_by_index(3)?,
+        locale: row.try_get_by_index(4)?,
+        created_at: i64_to_u64(row.try_get_by_index(5)?),
+        updated_at: i64_to_u64(row.try_get_by_index(6)?),
     })
 }
 
-fn map_snapshot_row(row: &Row<'_>) -> rusqlite::Result<StudioProjectSnapshotRecord> {
+fn map_snapshot_row(row: &QueryResult) -> anyhow::Result<StudioProjectSnapshotRecord> {
     Ok(StudioProjectSnapshotRecord {
-        id: row.get(0)?,
-        project_id: row.get(1)?,
-        created_at: i64_to_u64(row.get(2)?),
-        label: row.get(3)?,
-        project_name: row.get(4)?,
+        id: row.try_get_by_index(0)?,
+        project_id: row.try_get_by_index(1)?,
+        created_at: i64_to_u64(row.try_get_by_index(2)?),
+        label: row.try_get_by_index(3)?,
+        project_name: row.try_get_by_index(4)?,
     })
 }
 
-fn map_render_job_row(row: &Row<'_>) -> rusqlite::Result<StudioProjectRenderJobRecord> {
-    let status_raw: String = row.get(4)?;
-    let queued_segment_ids_json = row.get::<_, Option<String>>(6)?;
+fn map_render_job_row(row: &QueryResult) -> anyhow::Result<StudioProjectRenderJobRecord> {
+    let status_raw: String = row.try_get_by_index(4)?;
+    let queued_segment_ids_json = row.try_get_by_index::<Option<String>>(6)?;
     Ok(StudioProjectRenderJobRecord {
-        id: row.get(0)?,
-        project_id: row.get(1)?,
-        created_at: i64_to_u64(row.get(2)?),
-        updated_at: i64_to_u64(row.get(3)?),
+        id: row.try_get_by_index(0)?,
+        project_id: row.try_get_by_index(1)?,
+        created_at: i64_to_u64(row.try_get_by_index(2)?),
+        updated_at: i64_to_u64(row.try_get_by_index(3)?),
         status: StudioProjectRenderJobStatus::from_db_value(status_raw.as_str())
             .unwrap_or(StudioProjectRenderJobStatus::Queued),
-        error_message: row.get(5)?,
+        error_message: row.try_get_by_index(5)?,
         queued_segment_ids: parse_json_string_vec(queued_segment_ids_json),
     })
 }
@@ -2443,37 +2589,6 @@ fn parse_json_string_vec(raw: Option<String>) -> Vec<String> {
 
 fn encode_json_string_vec(values: &[String]) -> String {
     serde_json::to_string(values).unwrap_or_else(|_| "[]".to_string())
-}
-
-fn touch_project(conn: &Connection, project_id: &str, updated_at: i64) -> anyhow::Result<()> {
-    conn.execute(
-        "UPDATE studio_projects SET updated_at = ?2 WHERE id = ?1",
-        params![project_id, updated_at],
-    )?;
-    Ok(())
-}
-
-fn sync_project_source_text(conn: &Connection, project_id: &str) -> anyhow::Result<()> {
-    let mut stmt = conn.prepare(
-        r#"
-        SELECT text
-        FROM studio_project_segments
-        WHERE project_id = ?1
-        ORDER BY position ASC, id ASC
-        "#,
-    )?;
-    let rows = stmt.query_map(params![project_id], |row| row.get::<_, String>(0))?;
-
-    let mut segment_texts = Vec::new();
-    for row in rows {
-        segment_texts.push(row?);
-    }
-
-    conn.execute(
-        "UPDATE studio_projects SET source_text = ?2 WHERE id = ?1",
-        params![project_id, segment_texts.join("\n\n")],
-    )?;
-    Ok(())
 }
 
 fn now_unix_millis_i64() -> i64 {
@@ -2502,7 +2617,6 @@ mod tests {
         NewStudioProjectRecord, NewStudioProjectSegment, StudioProjectStore,
         StudioProjectVoiceMode, UpdateStudioProjectRecord,
     };
-    use crate::storage_layout;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -2516,6 +2630,17 @@ mod tests {
         root
     }
 
+    async fn initialize_test_store(db_path: PathBuf, media_dir: PathBuf) -> StudioProjectStore {
+        let store =
+            StudioProjectStore::initialize_at(db_path, media_dir).expect("store should initialize");
+        store
+            .db
+            .connection()
+            .await
+            .expect("schema should initialize");
+        store
+    }
+
     #[tokio::test]
     async fn create_and_update_project_round_trips_segments() {
         let root = test_env_root("studio-project-store");
@@ -2523,35 +2648,7 @@ mod tests {
         let media_dir = root.join("media");
         std::fs::create_dir_all(&root).expect("root should be created");
 
-        let store =
-            StudioProjectStore::initialize_at(db_path, media_dir).expect("store should initialize");
-        let conn = storage_layout::open_sqlite_connection(&store.db_path)
-            .expect("speech schema connection should open");
-        conn.execute_batch(
-            r#"
-            CREATE TABLE IF NOT EXISTS speech_history_records (
-                id TEXT PRIMARY KEY,
-                created_at INTEGER NOT NULL,
-                route_kind TEXT NOT NULL,
-                model_id TEXT NULL,
-                speaker TEXT NULL,
-                language TEXT NULL,
-                saved_voice_id TEXT NULL,
-                speed REAL NULL,
-                input_text TEXT NOT NULL,
-                voice_description TEXT NULL,
-                reference_text TEXT NULL,
-                generation_time_ms REAL NULL,
-                audio_duration_secs REAL NULL,
-                rtf REAL NULL,
-                tokens_generated INTEGER NULL,
-                audio_mime_type TEXT NOT NULL,
-                audio_filename TEXT NULL,
-                audio_storage_path TEXT NOT NULL
-            );
-            "#,
-        )
-        .expect("speech schema should initialize");
+        let store = initialize_test_store(db_path, media_dir).await;
         let created = store
             .create_project(NewStudioProjectRecord {
                 name: "Narration project".to_string(),
@@ -2629,35 +2726,7 @@ mod tests {
         let media_dir = root.join("media");
         std::fs::create_dir_all(&root).expect("root should be created");
 
-        let store =
-            StudioProjectStore::initialize_at(db_path, media_dir).expect("store should initialize");
-        let conn = storage_layout::open_sqlite_connection(&store.db_path)
-            .expect("speech schema connection should open");
-        conn.execute_batch(
-            r#"
-            CREATE TABLE IF NOT EXISTS speech_history_records (
-                id TEXT PRIMARY KEY,
-                created_at INTEGER NOT NULL,
-                route_kind TEXT NOT NULL,
-                model_id TEXT NULL,
-                speaker TEXT NULL,
-                language TEXT NULL,
-                saved_voice_id TEXT NULL,
-                speed REAL NULL,
-                input_text TEXT NOT NULL,
-                voice_description TEXT NULL,
-                reference_text TEXT NULL,
-                generation_time_ms REAL NULL,
-                audio_duration_secs REAL NULL,
-                rtf REAL NULL,
-                tokens_generated INTEGER NULL,
-                audio_mime_type TEXT NOT NULL,
-                audio_filename TEXT NULL,
-                audio_storage_path TEXT NOT NULL
-            );
-            "#,
-        )
-        .expect("speech schema should initialize");
+        let store = initialize_test_store(db_path, media_dir).await;
 
         let created = store
             .create_project(NewStudioProjectRecord {
@@ -2735,35 +2804,7 @@ mod tests {
         let media_dir = root.join("media");
         std::fs::create_dir_all(&root).expect("root should be created");
 
-        let store =
-            StudioProjectStore::initialize_at(db_path, media_dir).expect("store should initialize");
-        let conn = storage_layout::open_sqlite_connection(&store.db_path)
-            .expect("speech schema connection should open");
-        conn.execute_batch(
-            r#"
-            CREATE TABLE IF NOT EXISTS speech_history_records (
-                id TEXT PRIMARY KEY,
-                created_at INTEGER NOT NULL,
-                route_kind TEXT NOT NULL,
-                model_id TEXT NULL,
-                speaker TEXT NULL,
-                language TEXT NULL,
-                saved_voice_id TEXT NULL,
-                speed REAL NULL,
-                input_text TEXT NOT NULL,
-                voice_description TEXT NULL,
-                reference_text TEXT NULL,
-                generation_time_ms REAL NULL,
-                audio_duration_secs REAL NULL,
-                rtf REAL NULL,
-                tokens_generated INTEGER NULL,
-                audio_mime_type TEXT NOT NULL,
-                audio_filename TEXT NULL,
-                audio_storage_path TEXT NOT NULL
-            );
-            "#,
-        )
-        .expect("speech schema should initialize");
+        let store = initialize_test_store(db_path, media_dir).await;
 
         let created = store
             .create_project(NewStudioProjectRecord {

--- a/crates/izwi-server/src/transcription_store.rs
+++ b/crates/izwi-server/src/transcription_store.rs
@@ -1,13 +1,17 @@
 //! Persistent transcription history storage backed by SQLite.
 
-use anyhow::{anyhow, Context};
-use rusqlite::{params, Connection, OptionalExtension, Row};
+use anyhow::{Context, anyhow};
+use sea_orm::sea_query::Expr;
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, QueryFilter, QueryResult, Set, Statement,
+};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::task;
 
 use crate::{
+    db::StoreDatabase,
+    entity::transcription_records,
     ids::new_uuid,
     storage_layout::{self, MediaGroup},
 };
@@ -191,7 +195,7 @@ pub struct CompleteTranscriptionRecord {
 
 #[derive(Clone)]
 pub struct TranscriptionStore {
-    db_path: PathBuf,
+    db: StoreDatabase,
     media_root: PathBuf,
 }
 
@@ -207,57 +211,8 @@ impl TranscriptionStore {
         storage_layout::ensure_storage_dirs(&db_path, &media_root)
             .context("Failed to prepare transcription storage layout")?;
 
-        let conn = storage_layout::open_sqlite_connection(&db_path).with_context(|| {
-            format!(
-                "Failed to open transcription database: {}",
-                db_path.display()
-            )
-        })?;
-
-        conn.execute_batch(
-            r#"
-            CREATE TABLE IF NOT EXISTS transcription_records (
-                id TEXT PRIMARY KEY,
-                created_at INTEGER NOT NULL,
-                model_id TEXT NULL,
-                aligner_model_id TEXT NULL,
-                language TEXT NULL,
-                processing_status TEXT NOT NULL DEFAULT 'ready',
-                processing_error TEXT NULL,
-                duration_secs REAL NULL,
-                processing_time_ms REAL NOT NULL,
-                rtf REAL NULL,
-                audio_mime_type TEXT NOT NULL,
-                audio_filename TEXT NULL,
-                audio_storage_path TEXT NOT NULL,
-                transcription TEXT NOT NULL,
-                segments_json TEXT NOT NULL DEFAULT '[]',
-                words_json TEXT NOT NULL DEFAULT '[]',
-                summary_status TEXT NOT NULL DEFAULT 'not_requested',
-                summary_model_id TEXT NULL,
-                summary_text TEXT NULL,
-                summary_error TEXT NULL,
-                summary_updated_at INTEGER NULL
-            );
-
-            CREATE INDEX IF NOT EXISTS idx_transcription_records_created_at
-                ON transcription_records(created_at DESC);
-            "#,
-        )
-        .context("Failed to initialize transcription database schema")?;
-        ensure_transcription_records_aligner_model_id_column(&conn)?;
-        ensure_transcription_records_processing_status_column(&conn)?;
-        ensure_transcription_records_processing_error_column(&conn)?;
-        ensure_transcription_records_segments_json_column(&conn)?;
-        ensure_transcription_records_words_json_column(&conn)?;
-        ensure_transcription_records_summary_status_column(&conn)?;
-        ensure_transcription_records_summary_model_id_column(&conn)?;
-        ensure_transcription_records_summary_text_column(&conn)?;
-        ensure_transcription_records_summary_error_column(&conn)?;
-        ensure_transcription_records_summary_updated_at_column(&conn)?;
-
         Ok(Self {
-            db_path,
+            db: StoreDatabase::new(db_path),
             media_root,
         })
     }
@@ -270,341 +225,182 @@ impl TranscriptionStore {
         Vec<TranscriptionRecordSummary>,
         Option<TranscriptionRecordListCursor>,
     )> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let list_limit = i64::try_from(limit.clamp(1, 500).max(1)).unwrap_or(200);
-            let fetch_limit = list_limit.saturating_add(1);
+        let db = self.db.connection().await?;
+        let list_limit = i64::try_from(limit.clamp(1, 500).max(1)).unwrap_or(200);
+        let fetch_limit = list_limit.saturating_add(1);
+        let rows = if let Some(cursor) = cursor {
+            let cursor_created_at = i64::try_from(cursor.created_at).unwrap_or(i64::MAX);
+            db.query_all_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                TRANSCRIPTION_PAGE_AFTER_CURSOR_SQL,
+                vec![
+                    cursor_created_at.into(),
+                    cursor.id.into(),
+                    fetch_limit.into(),
+                ],
+            ))
+            .await
+        } else {
+            db.query_all_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                TRANSCRIPTION_PAGE_SQL,
+                vec![fetch_limit.into()],
+            ))
+            .await
+        }
+        .context("Failed to list transcription records")?;
 
-            let mut records = Vec::new();
-            if let Some(cursor) = cursor {
-                let cursor_created_at = i64::try_from(cursor.created_at).unwrap_or(i64::MAX);
-                let mut stmt = conn.prepare(
-                    r#"
-                    SELECT
-                        id,
-                        created_at,
-                        model_id,
-                        language,
-                        processing_status,
-                        processing_error,
-                        duration_secs,
-                        processing_time_ms,
-                        rtf,
-                        audio_mime_type,
-                        audio_filename,
-                        transcription,
-                        summary_status,
-                        summary_text
-                    FROM transcription_records
-                    WHERE created_at < ?1 OR (created_at = ?1 AND id < ?2)
-                    ORDER BY created_at DESC, id DESC
-                    LIMIT ?3
-                    "#,
-                )?;
+        let mut records = rows
+            .iter()
+            .map(map_transcription_summary)
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let page_limit = usize::try_from(list_limit).unwrap_or(200);
+        let has_more = records.len() > page_limit;
+        if has_more {
+            records.truncate(page_limit);
+        }
+        let next_cursor = if has_more {
+            records.last().map(|record| TranscriptionRecordListCursor {
+                created_at: record.created_at,
+                id: record.id.clone(),
+            })
+        } else {
+            None
+        };
 
-                let rows =
-                    stmt.query_map(params![cursor_created_at, cursor.id, fetch_limit], |row| {
-                        let processing_status =
-                            parse_processing_status(row.get::<_, Option<String>>(4)?);
-                        let processing_error: Option<String> = row.get(5)?;
-                        let transcription: String = row.get(11)?;
-                        let summary_status =
-                            parse_summary_status(row.get::<_, Option<String>>(12)?);
-                        let summary_text: Option<String> = row.get(13)?;
-                        Ok(TranscriptionRecordSummary {
-                            id: row.get(0)?,
-                            created_at: i64_to_u64(row.get(1)?),
-                            model_id: row.get(2)?,
-                            language: row.get(3)?,
-                            processing_status,
-                            processing_error: processing_error.clone(),
-                            duration_secs: row.get(6)?,
-                            processing_time_ms: row.get(7)?,
-                            rtf: row.get(8)?,
-                            audio_mime_type: row.get(9)?,
-                            audio_filename: row.get(10)?,
-                            transcription_preview: transcription_preview(
-                                processing_status,
-                                processing_error.as_deref(),
-                                &transcription,
-                            ),
-                            transcription_chars: transcription.chars().count(),
-                            summary_status,
-                            summary_preview: summary_preview(summary_text.as_deref()),
-                            summary_chars: summary_text
-                                .as_ref()
-                                .map(|text| text.chars().count())
-                                .unwrap_or(0),
-                        })
-                    })?;
-
-                for row in rows {
-                    records.push(row?);
-                }
-            } else {
-                let mut stmt = conn.prepare(
-                    r#"
-                    SELECT
-                        id,
-                        created_at,
-                        model_id,
-                        language,
-                        processing_status,
-                        processing_error,
-                        duration_secs,
-                        processing_time_ms,
-                        rtf,
-                        audio_mime_type,
-                        audio_filename,
-                        transcription,
-                        summary_status,
-                        summary_text
-                    FROM transcription_records
-                    ORDER BY created_at DESC, id DESC
-                    LIMIT ?1
-                    "#,
-                )?;
-
-                let rows = stmt.query_map(params![fetch_limit], |row| {
-                    let processing_status =
-                        parse_processing_status(row.get::<_, Option<String>>(4)?);
-                    let processing_error: Option<String> = row.get(5)?;
-                    let transcription: String = row.get(11)?;
-                    let summary_status = parse_summary_status(row.get::<_, Option<String>>(12)?);
-                    let summary_text: Option<String> = row.get(13)?;
-                    Ok(TranscriptionRecordSummary {
-                        id: row.get(0)?,
-                        created_at: i64_to_u64(row.get(1)?),
-                        model_id: row.get(2)?,
-                        language: row.get(3)?,
-                        processing_status,
-                        processing_error: processing_error.clone(),
-                        duration_secs: row.get(6)?,
-                        processing_time_ms: row.get(7)?,
-                        rtf: row.get(8)?,
-                        audio_mime_type: row.get(9)?,
-                        audio_filename: row.get(10)?,
-                        transcription_preview: transcription_preview(
-                            processing_status,
-                            processing_error.as_deref(),
-                            &transcription,
-                        ),
-                        transcription_chars: transcription.chars().count(),
-                        summary_status,
-                        summary_preview: summary_preview(summary_text.as_deref()),
-                        summary_chars: summary_text
-                            .as_ref()
-                            .map(|text| text.chars().count())
-                            .unwrap_or(0),
-                    })
-                })?;
-
-                for row in rows {
-                    records.push(row?);
-                }
-            }
-
-            let page_limit = usize::try_from(list_limit).unwrap_or(200);
-            let has_more = records.len() > page_limit;
-            if has_more {
-                records.truncate(page_limit);
-            }
-            let next_cursor = if has_more {
-                records.last().map(|record| TranscriptionRecordListCursor {
-                    created_at: record.created_at,
-                    id: record.id.clone(),
-                })
-            } else {
-                None
-            };
-
-            Ok((records, next_cursor))
-        })
-        .await
+        Ok((records, next_cursor))
     }
 
     pub async fn get_record(
         &self,
         record_id: String,
     ) -> anyhow::Result<Option<TranscriptionRecord>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let record = fetch_record_without_audio(&conn, &record_id)?;
-            Ok(record)
-        })
-        .await
+        let db = self.db.connection().await?;
+        fetch_record_without_audio(db, &record_id).await
     }
 
     pub async fn get_audio(
         &self,
         record_id: String,
     ) -> anyhow::Result<Option<StoredTranscriptionAudio>> {
-        let media_root = self.media_root.clone();
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let audio = conn
-                .query_row(
-                    r#"
-                    SELECT audio_storage_path, audio_mime_type, audio_filename
-                    FROM transcription_records
-                    WHERE id = ?1
-                    "#,
-                    params![record_id],
-                    |row| {
-                        Ok((
-                            row.get::<_, String>(0)?,
-                            row.get::<_, String>(1)?,
-                            row.get::<_, Option<String>>(2)?,
-                        ))
-                    },
-                )
-                .optional()?;
-
-            let Some((audio_storage_path, audio_mime_type, audio_filename)) = audio else {
-                return Ok(None);
-            };
-
-            let audio_bytes =
-                storage_layout::read_media_file(&media_root, audio_storage_path.as_str())?;
-
-            Ok(Some(StoredTranscriptionAudio {
-                audio_bytes,
-                audio_mime_type,
-                audio_filename,
-            }))
-        })
-        .await
+        let db = self.db.connection().await?;
+        let row = db
+            .query_one_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                "SELECT audio_storage_path, audio_mime_type, audio_filename FROM transcription_records WHERE id = ?1",
+                vec![record_id.into()],
+            ))
+            .await
+            .context("Failed to load transcription audio metadata")?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        let audio_storage_path: String = row.try_get_by_index(0)?;
+        let audio_mime_type: String = row.try_get_by_index(1)?;
+        let audio_filename: Option<String> = row.try_get_by_index(2)?;
+        let audio_bytes =
+            storage_layout::read_media_file(&self.media_root, audio_storage_path.as_str())?;
+        Ok(Some(StoredTranscriptionAudio {
+            audio_bytes,
+            audio_mime_type,
+            audio_filename,
+        }))
     }
 
     pub async fn create_record(
         &self,
         record: NewTranscriptionRecord,
     ) -> anyhow::Result<TranscriptionRecord> {
-        let media_root = self.media_root.clone();
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let now = now_unix_millis_i64();
-            let record_id = new_uuid();
+        let db = self.db.connection().await?;
+        let now = now_unix_millis_i64();
+        let record_id = new_uuid();
+        let model_id = sanitize_optional_text(record.model_id.as_deref(), 160);
+        let aligner_model_id = sanitize_optional_text(record.aligner_model_id.as_deref(), 160);
+        let language = sanitize_optional_text(record.language.as_deref(), 80);
+        let processing_error = sanitize_optional_text(record.processing_error.as_deref(), 1_000);
+        let processing_status =
+            normalize_processing_status(record.processing_status, processing_error.as_deref());
+        let duration_secs = record.duration_secs.filter(|v| v.is_finite() && *v >= 0.0);
+        let processing_time_ms = if record.processing_time_ms.is_finite() {
+            record.processing_time_ms.max(0.0)
+        } else {
+            0.0
+        };
+        let rtf = record.rtf.filter(|v| v.is_finite() && *v >= 0.0);
+        let audio_mime_type = sanitize_audio_mime_type(record.audio_mime_type.as_str());
+        let audio_filename = sanitize_optional_text(record.audio_filename.as_deref(), 260);
+        let transcription = sanitize_required_text(record.transcription.as_str(), 100_000);
+        let segments = sanitize_segments(record.segments);
+        let words = sanitize_words(record.words);
+        let summary_model_id = sanitize_optional_text(record.summary_model_id.as_deref(), 160);
+        let summary_text = sanitize_optional_text(record.summary_text.as_deref(), 20_000);
+        let summary_error = sanitize_optional_text(record.summary_error.as_deref(), 1_000);
+        let summary_status = normalize_summary_status(
+            record.summary_status,
+            summary_text.as_deref(),
+            summary_error.as_deref(),
+        );
+        let summary_updated_at = normalize_optional_timestamp_i64(record.summary_updated_at)
+            .or_else(|| {
+                if summary_status == TranscriptionSummaryStatus::NotRequested {
+                    None
+                } else {
+                    Some(now)
+                }
+            });
 
-            let model_id = sanitize_optional_text(record.model_id.as_deref(), 160);
-            let aligner_model_id = sanitize_optional_text(record.aligner_model_id.as_deref(), 160);
-            let language = sanitize_optional_text(record.language.as_deref(), 80);
-            let processing_error =
-                sanitize_optional_text(record.processing_error.as_deref(), 1_000);
-            let processing_status = normalize_processing_status(
-                record.processing_status,
-                processing_error.as_deref(),
-            );
-            let duration_secs = record.duration_secs.filter(|v| v.is_finite() && *v >= 0.0);
-            let processing_time_ms = if record.processing_time_ms.is_finite() {
-                record.processing_time_ms.max(0.0)
-            } else {
-                0.0
-            };
-            let rtf = record.rtf.filter(|v| v.is_finite() && *v >= 0.0);
-            let audio_mime_type = sanitize_audio_mime_type(record.audio_mime_type.as_str());
-            let audio_filename = sanitize_optional_text(record.audio_filename.as_deref(), 260);
-            let transcription = sanitize_required_text(record.transcription.as_str(), 100_000);
-            let segments = sanitize_segments(record.segments);
-            let words = sanitize_words(record.words);
-            let summary_model_id = sanitize_optional_text(record.summary_model_id.as_deref(), 160);
-            let summary_text = sanitize_optional_text(record.summary_text.as_deref(), 20_000);
-            let summary_error = sanitize_optional_text(record.summary_error.as_deref(), 1_000);
-            let summary_status = normalize_summary_status(
-                record.summary_status,
-                summary_text.as_deref(),
-                summary_error.as_deref(),
-            );
-            let summary_updated_at = normalize_optional_timestamp_i64(record.summary_updated_at)
-                .or_else(|| {
-                    if summary_status == TranscriptionSummaryStatus::NotRequested {
-                        None
-                    } else {
-                        Some(now)
-                    }
-                });
+        if record.audio_bytes.is_empty() {
+            return Err(anyhow!("Audio payload cannot be empty"));
+        }
 
-            if record.audio_bytes.is_empty() {
-                return Err(anyhow!("Audio payload cannot be empty"));
-            }
+        let audio_storage_path = storage_layout::persist_audio_file(
+            &self.media_root,
+            MediaGroup::Uploads,
+            "transcription",
+            &record_id,
+            audio_filename.as_deref(),
+            audio_mime_type.as_str(),
+            &record.audio_bytes,
+        )?;
 
-            let audio_storage_path = storage_layout::persist_audio_file(
-                &media_root,
-                MediaGroup::Uploads,
-                "transcription",
-                &record_id,
-                audio_filename.as_deref(),
-                audio_mime_type.as_str(),
-                &record.audio_bytes,
-            )?;
+        let segments_json =
+            serde_json::to_string(&segments).context("Failed serializing segments")?;
+        let words_json = serde_json::to_string(&words).context("Failed serializing words")?;
 
-            let segments_json =
-                serde_json::to_string(&segments).context("Failed serializing segments")?;
-            let words_json = serde_json::to_string(&words).context("Failed serializing words")?;
+        if let Err(err) =
+            transcription_records::Entity::insert(transcription_records::ActiveModel {
+                id: Set(record_id.clone()),
+                created_at: Set(now),
+                model_id: Set(model_id),
+                aligner_model_id: Set(aligner_model_id),
+                language: Set(language),
+                processing_status: Set(processing_status.as_db_value().to_string()),
+                processing_error: Set(processing_error),
+                duration_secs: Set(duration_secs),
+                processing_time_ms: Set(processing_time_ms),
+                rtf: Set(rtf),
+                audio_mime_type: Set(audio_mime_type),
+                audio_filename: Set(audio_filename),
+                audio_storage_path: Set(audio_storage_path.clone()),
+                transcription: Set(transcription),
+                segments_json: Set(segments_json),
+                words_json: Set(words_json),
+                summary_status: Set(summary_status.as_db_value().to_string()),
+                summary_model_id: Set(summary_model_id),
+                summary_text: Set(summary_text),
+                summary_error: Set(summary_error),
+                summary_updated_at: Set(summary_updated_at),
+            })
+            .exec(db)
+            .await
+        {
+            let _ = storage_layout::delete_media_file(&self.media_root, Some(&audio_storage_path));
+            return Err(err).context("Failed to insert transcription record");
+        }
 
-            if let Err(err) = conn.execute(
-                r#"
-                INSERT INTO transcription_records (
-                    id,
-                    created_at,
-                    model_id,
-                    aligner_model_id,
-                    language,
-                    processing_status,
-                    processing_error,
-                    duration_secs,
-                    processing_time_ms,
-                    rtf,
-                    audio_mime_type,
-                    audio_filename,
-                    audio_storage_path,
-                    transcription,
-                    segments_json,
-                    words_json,
-                    summary_status,
-                    summary_model_id,
-                    summary_text,
-                    summary_error,
-                    summary_updated_at
-                )
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)
-                "#,
-                params![
-                    &record_id,
-                    now,
-                    model_id,
-                    aligner_model_id,
-                    language,
-                    processing_status.as_db_value(),
-                    processing_error,
-                    duration_secs,
-                    processing_time_ms,
-                    rtf,
-                    audio_mime_type,
-                    audio_filename,
-                    audio_storage_path,
-                    transcription,
-                    segments_json,
-                    words_json,
-                    summary_status.as_db_value(),
-                    summary_model_id,
-                    summary_text,
-                    summary_error,
-                    summary_updated_at,
-                ],
-            ) {
-                let _ = storage_layout::delete_media_file(
-                    &media_root,
-                    Some(audio_storage_path.as_str()),
-                );
-                return Err(err).context("Failed to insert transcription record");
-            }
-
-            let created = fetch_record_without_audio(&conn, &record_id)?
-                .ok_or_else(|| anyhow!("Failed to fetch created transcription record"))?;
-            Ok(created)
-        })
-        .await
+        fetch_record_without_audio(db, &record_id)
+            .await?
+            .ok_or_else(|| anyhow!("Failed to fetch created transcription record"))
     }
 
     pub async fn update_summary(
@@ -612,55 +408,53 @@ impl TranscriptionStore {
         record_id: String,
         update: UpdateTranscriptionSummary,
     ) -> anyhow::Result<Option<TranscriptionRecord>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let now = now_unix_millis_i64();
-
-            let summary_model_id = sanitize_optional_text(update.model_id.as_deref(), 160);
-            let summary_text = sanitize_optional_text(update.text.as_deref(), 20_000);
-            let summary_error = sanitize_optional_text(update.error.as_deref(), 1_000);
-            let summary_status = normalize_summary_status(
-                update.status,
-                summary_text.as_deref(),
-                summary_error.as_deref(),
-            );
-            let summary_updated_at =
-                normalize_optional_timestamp_i64(update.updated_at).or_else(|| {
-                    if summary_status == TranscriptionSummaryStatus::NotRequested {
-                        None
-                    } else {
-                        Some(now)
-                    }
-                });
-
-            let changed = conn.execute(
-                r#"
-                UPDATE transcription_records
-                SET
-                    summary_status = ?2,
-                    summary_model_id = ?3,
-                    summary_text = ?4,
-                    summary_error = ?5,
-                    summary_updated_at = ?6
-                WHERE id = ?1
-                "#,
-                params![
-                    record_id,
-                    summary_status.as_db_value(),
-                    summary_model_id,
-                    summary_text,
-                    summary_error,
-                    summary_updated_at,
-                ],
-            )?;
-
-            if changed == 0 {
-                return Ok(None);
-            }
-
-            fetch_record_without_audio(&conn, &record_id)
-        })
-        .await
+        let db = self.db.connection().await?;
+        let now = now_unix_millis_i64();
+        let summary_model_id = sanitize_optional_text(update.model_id.as_deref(), 160);
+        let summary_text = sanitize_optional_text(update.text.as_deref(), 20_000);
+        let summary_error = sanitize_optional_text(update.error.as_deref(), 1_000);
+        let summary_status = normalize_summary_status(
+            update.status,
+            summary_text.as_deref(),
+            summary_error.as_deref(),
+        );
+        let summary_updated_at =
+            normalize_optional_timestamp_i64(update.updated_at).or_else(|| {
+                if summary_status == TranscriptionSummaryStatus::NotRequested {
+                    None
+                } else {
+                    Some(now)
+                }
+            });
+        let result = transcription_records::Entity::update_many()
+            .col_expr(
+                transcription_records::Column::SummaryStatus,
+                Expr::value(summary_status.as_db_value()),
+            )
+            .col_expr(
+                transcription_records::Column::SummaryModelId,
+                Expr::value(summary_model_id),
+            )
+            .col_expr(
+                transcription_records::Column::SummaryText,
+                Expr::value(summary_text),
+            )
+            .col_expr(
+                transcription_records::Column::SummaryError,
+                Expr::value(summary_error),
+            )
+            .col_expr(
+                transcription_records::Column::SummaryUpdatedAt,
+                Expr::value(summary_updated_at),
+            )
+            .filter(transcription_records::Column::Id.eq(record_id.clone()))
+            .exec(db)
+            .await
+            .context("Failed to update transcription summary")?;
+        if result.rows_affected == 0 {
+            return Ok(None);
+        }
+        fetch_record_without_audio(db, &record_id).await
     }
 
     pub async fn update_processing_status(
@@ -669,30 +463,26 @@ impl TranscriptionStore {
         status: TranscriptionProcessingStatus,
         error: Option<String>,
     ) -> anyhow::Result<Option<TranscriptionRecord>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let processing_error = sanitize_optional_text(error.as_deref(), 1_000);
-            let processing_status =
-                normalize_processing_status(status, processing_error.as_deref());
-
-            let changed = conn.execute(
-                r#"
-                UPDATE transcription_records
-                SET
-                    processing_status = ?2,
-                    processing_error = ?3
-                WHERE id = ?1
-                "#,
-                params![record_id, processing_status.as_db_value(), processing_error,],
-            )?;
-
-            if changed == 0 {
-                return Ok(None);
-            }
-
-            fetch_record_without_audio(&conn, &record_id)
-        })
-        .await
+        let db = self.db.connection().await?;
+        let processing_error = sanitize_optional_text(error.as_deref(), 1_000);
+        let processing_status = normalize_processing_status(status, processing_error.as_deref());
+        let result = transcription_records::Entity::update_many()
+            .col_expr(
+                transcription_records::Column::ProcessingStatus,
+                Expr::value(processing_status.as_db_value()),
+            )
+            .col_expr(
+                transcription_records::Column::ProcessingError,
+                Expr::value(processing_error),
+            )
+            .filter(transcription_records::Column::Id.eq(record_id.clone()))
+            .exec(db)
+            .await
+            .context("Failed to update transcription processing status")?;
+        if result.rows_affected == 0 {
+            return Ok(None);
+        }
+        fetch_record_without_audio(db, &record_id).await
     }
 
     pub async fn complete_record(
@@ -700,185 +490,266 @@ impl TranscriptionStore {
         record_id: String,
         record: CompleteTranscriptionRecord,
     ) -> anyhow::Result<Option<TranscriptionRecord>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-
-            let model_id = sanitize_optional_text(record.model_id.as_deref(), 160);
-            let aligner_model_id = sanitize_optional_text(record.aligner_model_id.as_deref(), 160);
-            let language = sanitize_optional_text(record.language.as_deref(), 80);
-            let duration_secs = record.duration_secs.filter(|v| v.is_finite() && *v >= 0.0);
-            let processing_time_ms = if record.processing_time_ms.is_finite() {
-                record.processing_time_ms.max(0.0)
-            } else {
-                0.0
-            };
-            let rtf = record.rtf.filter(|v| v.is_finite() && *v >= 0.0);
-            let transcription = sanitize_required_text(record.transcription.as_str(), 100_000);
-            let segments = sanitize_segments(record.segments);
-            let words = sanitize_words(record.words);
-            let summary_model_id = sanitize_optional_text(record.summary_model_id.as_deref(), 160);
-            let summary_text = sanitize_optional_text(record.summary_text.as_deref(), 20_000);
-            let summary_error = sanitize_optional_text(record.summary_error.as_deref(), 1_000);
-            let summary_status = normalize_summary_status(
-                record.summary_status,
-                summary_text.as_deref(),
-                summary_error.as_deref(),
-            );
-            let summary_updated_at = normalize_optional_timestamp_i64(record.summary_updated_at);
-            let segments_json =
-                serde_json::to_string(&segments).context("Failed serializing segments")?;
-            let words_json = serde_json::to_string(&words).context("Failed serializing words")?;
-
-            let changed = conn.execute(
-                r#"
-                UPDATE transcription_records
-                SET
-                    model_id = ?2,
-                    aligner_model_id = ?3,
-                    language = ?4,
-                    processing_status = ?5,
-                    processing_error = NULL,
-                    duration_secs = ?6,
-                    processing_time_ms = ?7,
-                    rtf = ?8,
-                    transcription = ?9,
-                    segments_json = ?10,
-                    words_json = ?11,
-                    summary_status = ?12,
-                    summary_model_id = ?13,
-                    summary_text = ?14,
-                    summary_error = ?15,
-                    summary_updated_at = ?16
-                WHERE id = ?1
-                "#,
-                params![
-                    record_id,
-                    model_id,
-                    aligner_model_id,
-                    language,
-                    TranscriptionProcessingStatus::Ready.as_db_value(),
-                    duration_secs,
-                    processing_time_ms,
-                    rtf,
-                    transcription,
-                    segments_json,
-                    words_json,
-                    summary_status.as_db_value(),
-                    summary_model_id,
-                    summary_text,
-                    summary_error,
-                    summary_updated_at,
-                ],
-            )?;
-
-            if changed == 0 {
-                return Ok(None);
-            }
-
-            fetch_record_without_audio(&conn, &record_id)
-        })
-        .await
+        let db = self.db.connection().await?;
+        let model_id = sanitize_optional_text(record.model_id.as_deref(), 160);
+        let aligner_model_id = sanitize_optional_text(record.aligner_model_id.as_deref(), 160);
+        let language = sanitize_optional_text(record.language.as_deref(), 80);
+        let duration_secs = record.duration_secs.filter(|v| v.is_finite() && *v >= 0.0);
+        let processing_time_ms = if record.processing_time_ms.is_finite() {
+            record.processing_time_ms.max(0.0)
+        } else {
+            0.0
+        };
+        let rtf = record.rtf.filter(|v| v.is_finite() && *v >= 0.0);
+        let transcription = sanitize_required_text(record.transcription.as_str(), 100_000);
+        let segments = sanitize_segments(record.segments);
+        let words = sanitize_words(record.words);
+        let summary_model_id = sanitize_optional_text(record.summary_model_id.as_deref(), 160);
+        let summary_text = sanitize_optional_text(record.summary_text.as_deref(), 20_000);
+        let summary_error = sanitize_optional_text(record.summary_error.as_deref(), 1_000);
+        let summary_status = normalize_summary_status(
+            record.summary_status,
+            summary_text.as_deref(),
+            summary_error.as_deref(),
+        );
+        let summary_updated_at = normalize_optional_timestamp_i64(record.summary_updated_at);
+        let segments_json =
+            serde_json::to_string(&segments).context("Failed serializing segments")?;
+        let words_json = serde_json::to_string(&words).context("Failed serializing words")?;
+        let result = transcription_records::Entity::update_many()
+            .col_expr(
+                transcription_records::Column::ModelId,
+                Expr::value(model_id),
+            )
+            .col_expr(
+                transcription_records::Column::AlignerModelId,
+                Expr::value(aligner_model_id),
+            )
+            .col_expr(
+                transcription_records::Column::Language,
+                Expr::value(language),
+            )
+            .col_expr(
+                transcription_records::Column::ProcessingStatus,
+                Expr::value(TranscriptionProcessingStatus::Ready.as_db_value()),
+            )
+            .col_expr(
+                transcription_records::Column::ProcessingError,
+                Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                transcription_records::Column::DurationSecs,
+                Expr::value(duration_secs),
+            )
+            .col_expr(
+                transcription_records::Column::ProcessingTimeMs,
+                Expr::value(processing_time_ms),
+            )
+            .col_expr(transcription_records::Column::Rtf, Expr::value(rtf))
+            .col_expr(
+                transcription_records::Column::Transcription,
+                Expr::value(transcription),
+            )
+            .col_expr(
+                transcription_records::Column::SegmentsJson,
+                Expr::value(segments_json),
+            )
+            .col_expr(
+                transcription_records::Column::WordsJson,
+                Expr::value(words_json),
+            )
+            .col_expr(
+                transcription_records::Column::SummaryStatus,
+                Expr::value(summary_status.as_db_value()),
+            )
+            .col_expr(
+                transcription_records::Column::SummaryModelId,
+                Expr::value(summary_model_id),
+            )
+            .col_expr(
+                transcription_records::Column::SummaryText,
+                Expr::value(summary_text),
+            )
+            .col_expr(
+                transcription_records::Column::SummaryError,
+                Expr::value(summary_error),
+            )
+            .col_expr(
+                transcription_records::Column::SummaryUpdatedAt,
+                Expr::value(summary_updated_at),
+            )
+            .filter(transcription_records::Column::Id.eq(record_id.clone()))
+            .exec(db)
+            .await
+            .context("Failed to complete transcription record")?;
+        if result.rows_affected == 0 {
+            return Ok(None);
+        }
+        fetch_record_without_audio(db, &record_id).await
     }
 
     pub async fn delete_record(&self, record_id: String) -> anyhow::Result<bool> {
-        let media_root = self.media_root.clone();
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let audio_storage_path = conn
-                .query_row(
-                    "SELECT audio_storage_path FROM transcription_records WHERE id = ?1",
-                    params![&record_id],
-                    |row| row.get::<_, Option<String>>(0),
-                )
-                .optional()?
-                .flatten();
-
-            let changed = conn.execute(
-                "DELETE FROM transcription_records WHERE id = ?1",
-                params![record_id],
-            )?;
-
-            if changed > 0 {
-                storage_layout::delete_media_file(&media_root, audio_storage_path.as_deref())?;
-            }
-
-            Ok(changed > 0)
-        })
-        .await
-    }
-
-    async fn run_blocking<F, T>(&self, task_fn: F) -> anyhow::Result<T>
-    where
-        F: FnOnce(PathBuf) -> anyhow::Result<T> + Send + 'static,
-        T: Send + 'static,
-    {
-        let db_path = self.db_path.clone();
-        task::spawn_blocking(move || task_fn(db_path))
+        let db = self.db.connection().await?;
+        let audio_storage_path = db
+            .query_one_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                "SELECT audio_storage_path FROM transcription_records WHERE id = ?1",
+                vec![record_id.clone().into()],
+            ))
             .await
-            .map_err(|err| anyhow!("Transcription storage worker failed: {err}"))?
+            .context("Failed to load transcription media path")?
+            .map(|row| row.try_get_by_index::<Option<String>>(0))
+            .transpose()?
+            .flatten();
+        let result = transcription_records::Entity::delete_by_id(record_id)
+            .exec(db)
+            .await
+            .context("Failed to delete transcription record")?;
+        if result.rows_affected > 0 {
+            storage_layout::delete_media_file(&self.media_root, audio_storage_path.as_deref())?;
+        }
+        Ok(result.rows_affected > 0)
     }
 }
 
-fn fetch_record_without_audio(
-    conn: &Connection,
+const TRANSCRIPTION_PAGE_SQL: &str = r#"
+    SELECT
+        id,
+        created_at,
+        model_id,
+        language,
+        processing_status,
+        processing_error,
+        duration_secs,
+        processing_time_ms,
+        rtf,
+        audio_mime_type,
+        audio_filename,
+        transcription,
+        summary_status,
+        summary_text
+    FROM transcription_records
+    ORDER BY created_at DESC, id DESC
+    LIMIT ?1
+"#;
+
+const TRANSCRIPTION_PAGE_AFTER_CURSOR_SQL: &str = r#"
+    SELECT
+        id,
+        created_at,
+        model_id,
+        language,
+        processing_status,
+        processing_error,
+        duration_secs,
+        processing_time_ms,
+        rtf,
+        audio_mime_type,
+        audio_filename,
+        transcription,
+        summary_status,
+        summary_text
+    FROM transcription_records
+    WHERE created_at < ?1 OR (created_at = ?1 AND id < ?2)
+    ORDER BY created_at DESC, id DESC
+    LIMIT ?3
+"#;
+
+const TRANSCRIPTION_RECORD_COLUMNS: &str = r#"
+    id,
+    created_at,
+    model_id,
+    aligner_model_id,
+    language,
+    processing_status,
+    processing_error,
+    duration_secs,
+    processing_time_ms,
+    rtf,
+    audio_mime_type,
+    audio_filename,
+    transcription,
+    segments_json,
+    words_json,
+    summary_status,
+    summary_model_id,
+    summary_text,
+    summary_error,
+    summary_updated_at
+"#;
+
+async fn fetch_record_without_audio(
+    db: &sea_orm::DatabaseConnection,
     record_id: &str,
 ) -> anyhow::Result<Option<TranscriptionRecord>> {
-    let record = conn
-        .query_row(
-            r#"
-            SELECT
-                id,
-                created_at,
-                model_id,
-                aligner_model_id,
-                language,
-                processing_status,
-                processing_error,
-                duration_secs,
-                processing_time_ms,
-                rtf,
-                audio_mime_type,
-                audio_filename,
-                transcription,
-                segments_json,
-                words_json,
-                summary_status,
-                summary_model_id,
-                summary_text,
-                summary_error,
-                summary_updated_at
-            FROM transcription_records
-            WHERE id = ?1
-            "#,
-            params![record_id],
-            map_transcription_record,
-        )
-        .optional()?;
-    Ok(record)
+    let row = db
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            format!(
+                "SELECT {TRANSCRIPTION_RECORD_COLUMNS} FROM transcription_records WHERE id = ?1"
+            ),
+            vec![record_id.into()],
+        ))
+        .await
+        .context("Failed to load transcription record")?;
+    row.as_ref().map(map_transcription_record).transpose()
 }
 
-fn map_transcription_record(row: &Row<'_>) -> rusqlite::Result<TranscriptionRecord> {
+fn map_transcription_summary(row: &QueryResult) -> anyhow::Result<TranscriptionRecordSummary> {
+    let processing_status = parse_processing_status(row.try_get_by_index(4)?);
+    let processing_error: Option<String> = row.try_get_by_index(5)?;
+    let transcription: String = row.try_get_by_index(11)?;
+    let summary_status = parse_summary_status(row.try_get_by_index(12)?);
+    let summary_text: Option<String> = row.try_get_by_index(13)?;
+    Ok(TranscriptionRecordSummary {
+        id: row.try_get_by_index(0)?,
+        created_at: i64_to_u64(row.try_get_by_index(1)?),
+        model_id: row.try_get_by_index(2)?,
+        language: row.try_get_by_index(3)?,
+        processing_status,
+        processing_error: processing_error.clone(),
+        duration_secs: row.try_get_by_index(6)?,
+        processing_time_ms: row.try_get_by_index(7)?,
+        rtf: row.try_get_by_index(8)?,
+        audio_mime_type: row.try_get_by_index(9)?,
+        audio_filename: row.try_get_by_index(10)?,
+        transcription_preview: transcription_preview(
+            processing_status,
+            processing_error.as_deref(),
+            &transcription,
+        ),
+        transcription_chars: transcription.chars().count(),
+        summary_status,
+        summary_preview: summary_preview(summary_text.as_deref()),
+        summary_chars: summary_text
+            .as_ref()
+            .map(|text| text.chars().count())
+            .unwrap_or(0),
+    })
+}
+
+fn map_transcription_record(row: &QueryResult) -> anyhow::Result<TranscriptionRecord> {
     Ok(TranscriptionRecord {
-        id: row.get(0)?,
-        created_at: i64_to_u64(row.get(1)?),
-        model_id: row.get(2)?,
-        aligner_model_id: row.get(3)?,
-        language: row.get(4)?,
-        processing_status: parse_processing_status(row.get(5)?),
-        processing_error: row.get(6)?,
-        duration_secs: row.get(7)?,
-        processing_time_ms: row.get(8)?,
-        rtf: row.get(9)?,
-        audio_mime_type: row.get(10)?,
-        audio_filename: row.get(11)?,
-        transcription: row.get(12)?,
-        segments: parse_json_vec(row.get(13)?),
-        words: parse_json_vec(row.get(14)?),
-        summary_status: parse_summary_status(row.get(15)?),
-        summary_model_id: row.get(16)?,
-        summary_text: row.get(17)?,
-        summary_error: row.get(18)?,
-        summary_updated_at: row.get::<_, Option<i64>>(19)?.map(i64_to_u64),
+        id: row.try_get_by_index(0)?,
+        created_at: i64_to_u64(row.try_get_by_index(1)?),
+        model_id: row.try_get_by_index(2)?,
+        aligner_model_id: row.try_get_by_index(3)?,
+        language: row.try_get_by_index(4)?,
+        processing_status: parse_processing_status(row.try_get_by_index(5)?),
+        processing_error: row.try_get_by_index(6)?,
+        duration_secs: row.try_get_by_index(7)?,
+        processing_time_ms: row.try_get_by_index(8)?,
+        rtf: row.try_get_by_index(9)?,
+        audio_mime_type: row.try_get_by_index(10)?,
+        audio_filename: row.try_get_by_index(11)?,
+        transcription: row.try_get_by_index(12)?,
+        segments: parse_json_vec(row.try_get_by_index(13)?),
+        words: parse_json_vec(row.try_get_by_index(14)?),
+        summary_status: parse_summary_status(row.try_get_by_index(15)?),
+        summary_model_id: row.try_get_by_index(16)?,
+        summary_text: row.try_get_by_index(17)?,
+        summary_error: row.try_get_by_index(18)?,
+        summary_updated_at: row.try_get_by_index::<Option<i64>>(19)?.map(i64_to_u64),
     })
 }
 
@@ -1061,159 +932,6 @@ fn sanitize_audio_mime_type(raw: &str) -> String {
     }
 }
 
-fn ensure_transcription_records_aligner_model_id_column(conn: &Connection) -> anyhow::Result<()> {
-    if transcription_records_has_column(conn, "aligner_model_id")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE transcription_records ADD COLUMN aligner_model_id TEXT NULL",
-        [],
-    )
-    .context("Failed adding transcription_records.aligner_model_id column")?;
-    Ok(())
-}
-
-fn ensure_transcription_records_processing_status_column(conn: &Connection) -> anyhow::Result<()> {
-    if transcription_records_has_column(conn, "processing_status")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE transcription_records ADD COLUMN processing_status TEXT NOT NULL DEFAULT 'ready'",
-        [],
-    )
-    .context("Failed adding transcription_records.processing_status column")?;
-    Ok(())
-}
-
-fn ensure_transcription_records_processing_error_column(conn: &Connection) -> anyhow::Result<()> {
-    if transcription_records_has_column(conn, "processing_error")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE transcription_records ADD COLUMN processing_error TEXT NULL",
-        [],
-    )
-    .context("Failed adding transcription_records.processing_error column")?;
-    Ok(())
-}
-
-fn ensure_transcription_records_segments_json_column(conn: &Connection) -> anyhow::Result<()> {
-    if transcription_records_has_column(conn, "segments_json")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE transcription_records ADD COLUMN segments_json TEXT NOT NULL DEFAULT '[]'",
-        [],
-    )
-    .context("Failed adding transcription_records.segments_json column")?;
-    Ok(())
-}
-
-fn ensure_transcription_records_words_json_column(conn: &Connection) -> anyhow::Result<()> {
-    if transcription_records_has_column(conn, "words_json")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE transcription_records ADD COLUMN words_json TEXT NOT NULL DEFAULT '[]'",
-        [],
-    )
-    .context("Failed adding transcription_records.words_json column")?;
-    Ok(())
-}
-
-fn ensure_transcription_records_summary_status_column(conn: &Connection) -> anyhow::Result<()> {
-    if transcription_records_has_column(conn, "summary_status")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE transcription_records ADD COLUMN summary_status TEXT NOT NULL DEFAULT 'not_requested'",
-        [],
-    )
-    .context("Failed adding transcription_records.summary_status column")?;
-    Ok(())
-}
-
-fn ensure_transcription_records_summary_model_id_column(conn: &Connection) -> anyhow::Result<()> {
-    if transcription_records_has_column(conn, "summary_model_id")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE transcription_records ADD COLUMN summary_model_id TEXT NULL",
-        [],
-    )
-    .context("Failed adding transcription_records.summary_model_id column")?;
-    Ok(())
-}
-
-fn ensure_transcription_records_summary_text_column(conn: &Connection) -> anyhow::Result<()> {
-    if transcription_records_has_column(conn, "summary_text")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE transcription_records ADD COLUMN summary_text TEXT NULL",
-        [],
-    )
-    .context("Failed adding transcription_records.summary_text column")?;
-    Ok(())
-}
-
-fn ensure_transcription_records_summary_error_column(conn: &Connection) -> anyhow::Result<()> {
-    if transcription_records_has_column(conn, "summary_error")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE transcription_records ADD COLUMN summary_error TEXT NULL",
-        [],
-    )
-    .context("Failed adding transcription_records.summary_error column")?;
-    Ok(())
-}
-
-fn ensure_transcription_records_summary_updated_at_column(conn: &Connection) -> anyhow::Result<()> {
-    if transcription_records_has_column(conn, "summary_updated_at")? {
-        return Ok(());
-    }
-
-    conn.execute(
-        "ALTER TABLE transcription_records ADD COLUMN summary_updated_at INTEGER NULL",
-        [],
-    )
-    .context("Failed adding transcription_records.summary_updated_at column")?;
-    Ok(())
-}
-
-fn transcription_records_has_column(conn: &Connection, target: &str) -> anyhow::Result<bool> {
-    let mut stmt = conn
-        .prepare("PRAGMA table_info(transcription_records)")
-        .context("Failed to inspect transcription_records schema")?;
-    let mut rows = stmt
-        .query([])
-        .context("Failed to query transcription_records schema info")?;
-
-    while let Some(row) = rows
-        .next()
-        .context("Failed reading transcription_records schema row")?
-    {
-        let name: String = row
-            .get(1)
-            .context("Failed reading transcription_records column name")?;
-        if name == target {
-            return Ok(true);
-        }
-    }
-
-    Ok(false)
-}
-
 fn parse_json_vec<T>(raw: Option<String>) -> Vec<T>
 where
     T: for<'de> Deserialize<'de>,
@@ -1244,11 +962,7 @@ fn now_unix_millis_i64() -> i64 {
 }
 
 fn i64_to_u64(value: i64) -> u64 {
-    if value.is_negative() {
-        0
-    } else {
-        value as u64
-    }
+    if value.is_negative() { 0 } else { value as u64 }
 }
 
 #[allow(dead_code)]

--- a/crates/izwi-server/src/voice_observation_store.rs
+++ b/crates/izwi-server/src/voice_observation_store.rs
@@ -1,10 +1,14 @@
-use anyhow::{anyhow, Context};
-use rusqlite::{params, Connection, OptionalExtension, Row};
+use anyhow::{Context, anyhow};
+use sea_orm::sea_query::Expr;
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, QueryFilter, QueryResult, Statement,
+    TransactionTrait,
+};
 use serde::Serialize;
-use std::path::PathBuf;
-use tokio::task;
 
-use crate::{ids::new_uuid, storage_layout};
+use crate::db::StoreDatabase;
+use crate::entity::voice_observations;
+use crate::ids::new_uuid;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct VoiceObservation {
@@ -31,52 +35,14 @@ pub struct CandidateObservation {
 
 #[derive(Clone)]
 pub struct VoiceObservationStore {
-    db_path: PathBuf,
+    db: StoreDatabase,
 }
 
 impl VoiceObservationStore {
     pub fn initialize() -> anyhow::Result<Self> {
-        let db_path = storage_layout::resolve_db_path();
-        let media_root = storage_layout::resolve_media_root();
-
-        storage_layout::ensure_storage_dirs(&db_path, &media_root)
-            .context("Failed to prepare voice observation storage layout")?;
-
-        let conn = storage_layout::open_sqlite_connection(&db_path).with_context(|| {
-            format!(
-                "Failed to open voice observation database: {}",
-                db_path.display()
-            )
-        })?;
-        conn.execute_batch(
-            r#"
-            CREATE TABLE IF NOT EXISTS voice_observations (
-                id TEXT PRIMARY KEY,
-                profile_id TEXT NOT NULL,
-                category TEXT NOT NULL,
-                summary TEXT NOT NULL,
-                canonical_summary TEXT NOT NULL,
-                confidence REAL NOT NULL,
-                source_turn_id TEXT NULL,
-                source_user_text TEXT NULL,
-                source_assistant_text TEXT NULL,
-                times_seen INTEGER NOT NULL DEFAULT 1,
-                created_at INTEGER NOT NULL,
-                updated_at INTEGER NOT NULL,
-                forgotten_at INTEGER NULL,
-                FOREIGN KEY(profile_id) REFERENCES voice_profiles(id) ON DELETE CASCADE
-            );
-
-            CREATE INDEX IF NOT EXISTS idx_voice_observations_profile_updated_at
-                ON voice_observations(profile_id, updated_at DESC, created_at DESC);
-            CREATE UNIQUE INDEX IF NOT EXISTS idx_voice_observations_profile_canonical_active
-                ON voice_observations(profile_id, canonical_summary)
-                WHERE forgotten_at IS NULL;
-            "#,
-        )
-        .context("Failed to initialize voice observation database schema")?;
-
-        Ok(Self { db_path })
+        Ok(Self {
+            db: StoreDatabase::from_default_path()?,
+        })
     }
 
     pub async fn list_active(
@@ -84,38 +50,17 @@ impl VoiceObservationStore {
         profile_id: String,
         limit: usize,
     ) -> anyhow::Result<Vec<VoiceObservation>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let mut stmt = conn.prepare(
-                r#"
-                SELECT
-                    id,
-                    profile_id,
-                    category,
-                    summary,
-                    confidence,
-                    source_turn_id,
-                    source_user_text,
-                    source_assistant_text,
-                    times_seen,
-                    created_at,
-                    updated_at,
-                    forgotten_at
-                FROM voice_observations
-                WHERE profile_id = ?1
-                  AND forgotten_at IS NULL
-                ORDER BY confidence DESC, updated_at DESC, created_at DESC
-                LIMIT ?2
-                "#,
-            )?;
-            let rows = stmt.query_map(params![profile_id, limit.max(1) as i64], map_observation)?;
-            let mut observations = Vec::new();
-            for row in rows {
-                observations.push(row?);
-            }
-            Ok(observations)
-        })
-        .await
+        let db = self.db.connection().await?;
+        let limit = i64::try_from(limit.max(1)).context("Voice observation limit exceeds i64")?;
+        let rows = db
+            .query_all_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                OBSERVATIONS_ACTIVE_SQL,
+                vec![profile_id.into(), limit.into()],
+            ))
+            .await
+            .context("Failed to list voice observations")?;
+        rows.iter().map(map_observation).collect()
     }
 
     pub async fn upsert_candidates(
@@ -126,142 +71,144 @@ impl VoiceObservationStore {
         source_assistant_text: Option<String>,
         candidates: Vec<CandidateObservation>,
     ) -> anyhow::Result<Vec<VoiceObservation>> {
-        self.run_blocking(move |db_path| {
-            let mut conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let tx = conn.transaction()?;
-            let mut persisted = Vec::new();
-            let now = now_unix_millis_i64();
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start voice observation transaction")?;
+        let mut persisted = Vec::new();
+        let now = now_unix_millis_i64();
 
-            for candidate in candidates {
-                let Some(summary) = sanitize_summary(candidate.summary.as_str()) else {
-                    continue;
-                };
-                let category = sanitize_category(candidate.category.as_str());
-                let confidence = clamp_confidence(candidate.confidence);
-                let canonical_summary =
-                    build_canonical_summary(category.as_str(), summary.as_str());
+        for candidate in candidates {
+            let Some(summary) = sanitize_summary(candidate.summary.as_str()) else {
+                continue;
+            };
+            let category = sanitize_category(candidate.category.as_str());
+            let confidence = clamp_confidence(candidate.confidence);
+            let canonical_summary = build_canonical_summary(category.as_str(), summary.as_str());
 
-                let existing_id = tx
-                    .query_row(
-                        r#"
-                        SELECT id
-                        FROM voice_observations
-                        WHERE profile_id = ?1
-                          AND canonical_summary = ?2
-                          AND forgotten_at IS NULL
-                        LIMIT 1
-                        "#,
-                        params![profile_id, canonical_summary],
-                        |row| row.get::<_, String>(0),
+            let existing_id = tx
+                .query_one_raw(Statement::from_sql_and_values(
+                    DbBackend::Sqlite,
+                    r#"
+                    SELECT id
+                    FROM voice_observations
+                    WHERE profile_id = ?1
+                      AND canonical_summary = ?2
+                      AND forgotten_at IS NULL
+                    LIMIT 1
+                    "#,
+                    vec![profile_id.clone().into(), canonical_summary.clone().into()],
+                ))
+                .await
+                .context("Failed to find existing voice observation")?
+                .map(|row| row.try_get_by_index::<String>(0))
+                .transpose()?;
+
+            let observation = if let Some(existing_id) = existing_id {
+                tx.execute_raw(Statement::from_sql_and_values(
+                    DbBackend::Sqlite,
+                    r#"
+                    UPDATE voice_observations
+                    SET confidence = MAX(confidence, ?1),
+                        source_turn_id = ?2,
+                        source_user_text = ?3,
+                        source_assistant_text = ?4,
+                        times_seen = times_seen + 1,
+                        updated_at = ?5
+                    WHERE id = ?6
+                    "#,
+                    vec![
+                        f64::from(confidence).into(),
+                        sanitize_optional_text(source_turn_id.as_deref(), 160).into(),
+                        sanitize_optional_text(source_user_text.as_deref(), 16000).into(),
+                        sanitize_optional_text(source_assistant_text.as_deref(), 16000).into(),
+                        now.into(),
+                        existing_id.clone().into(),
+                    ],
+                ))
+                .await
+                .context("Failed to update voice observation")?;
+                fetch_observation(&tx, &existing_id)
+                    .await?
+                    .ok_or_else(|| anyhow!("Updated observation not found"))?
+            } else {
+                let observation_id = new_uuid();
+                tx.execute_raw(Statement::from_sql_and_values(
+                    DbBackend::Sqlite,
+                    r#"
+                    INSERT INTO voice_observations (
+                        id,
+                        profile_id,
+                        category,
+                        summary,
+                        canonical_summary,
+                        confidence,
+                        source_turn_id,
+                        source_user_text,
+                        source_assistant_text,
+                        times_seen,
+                        created_at,
+                        updated_at,
+                        forgotten_at
                     )
-                    .optional()?;
+                    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 1, ?10, ?10, NULL)
+                    "#,
+                    vec![
+                        observation_id.clone().into(),
+                        profile_id.clone().into(),
+                        category.into(),
+                        summary.into(),
+                        canonical_summary.into(),
+                        f64::from(confidence).into(),
+                        sanitize_optional_text(source_turn_id.as_deref(), 160).into(),
+                        sanitize_optional_text(source_user_text.as_deref(), 16000).into(),
+                        sanitize_optional_text(source_assistant_text.as_deref(), 16000).into(),
+                        now.into(),
+                    ],
+                ))
+                .await
+                .context("Failed to insert voice observation")?;
+                fetch_observation(&tx, &observation_id)
+                    .await?
+                    .ok_or_else(|| anyhow!("Inserted observation not found"))?
+            };
 
-                let observation = if let Some(existing_id) = existing_id {
-                    tx.execute(
-                        r#"
-                        UPDATE voice_observations
-                        SET confidence = MAX(confidence, ?1),
-                            source_turn_id = ?2,
-                            source_user_text = ?3,
-                            source_assistant_text = ?4,
-                            times_seen = times_seen + 1,
-                            updated_at = ?5
-                        WHERE id = ?6
-                        "#,
-                        params![
-                            confidence,
-                            sanitize_optional_text(source_turn_id.as_deref(), 160),
-                            sanitize_optional_text(source_user_text.as_deref(), 16000),
-                            sanitize_optional_text(source_assistant_text.as_deref(), 16000),
-                            now,
-                            existing_id,
-                        ],
-                    )?;
-                    fetch_observation(&tx, &existing_id)?
-                        .ok_or_else(|| anyhow!("Updated observation not found"))?
-                } else {
-                    let observation_id = new_uuid();
-                    tx.execute(
-                        r#"
-                        INSERT INTO voice_observations (
-                            id,
-                            profile_id,
-                            category,
-                            summary,
-                            canonical_summary,
-                            confidence,
-                            source_turn_id,
-                            source_user_text,
-                            source_assistant_text,
-                            times_seen,
-                            created_at,
-                            updated_at,
-                            forgotten_at
-                        )
-                        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 1, ?10, ?10, NULL)
-                        "#,
-                        params![
-                            observation_id,
-                            profile_id,
-                            category,
-                            summary,
-                            canonical_summary,
-                            confidence,
-                            sanitize_optional_text(source_turn_id.as_deref(), 160),
-                            sanitize_optional_text(source_user_text.as_deref(), 16000),
-                            sanitize_optional_text(source_assistant_text.as_deref(), 16000),
-                            now,
-                        ],
-                    )?;
-                    fetch_observation(&tx, &observation_id)?
-                        .ok_or_else(|| anyhow!("Inserted observation not found"))?
-                };
+            persisted.push(observation);
+        }
 
-                persisted.push(observation);
-            }
-
-            tx.commit()?;
-            Ok(persisted)
-        })
-        .await
+        tx.commit()
+            .await
+            .context("Failed to commit voice observation transaction")?;
+        Ok(persisted)
     }
 
     pub async fn forget_observation(&self, observation_id: String) -> anyhow::Result<bool> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let now = now_unix_millis_i64();
-            let updated = conn.execute(
-                r#"
-                UPDATE voice_observations
-                SET forgotten_at = ?1,
-                    updated_at = ?1
-                WHERE id = ?2
-                  AND forgotten_at IS NULL
-                "#,
-                params![now, observation_id],
-            )?;
-            Ok(updated > 0)
-        })
-        .await
+        let db = self.db.connection().await?;
+        let now = now_unix_millis_i64();
+        let result = voice_observations::Entity::update_many()
+            .col_expr(voice_observations::Column::ForgottenAt, Expr::value(now))
+            .col_expr(voice_observations::Column::UpdatedAt, Expr::value(now))
+            .filter(voice_observations::Column::Id.eq(observation_id))
+            .filter(voice_observations::Column::ForgottenAt.is_null())
+            .exec(db)
+            .await
+            .context("Failed to forget voice observation")?;
+        Ok(result.rows_affected > 0)
     }
 
     pub async fn clear_profile(&self, profile_id: String) -> anyhow::Result<usize> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let now = now_unix_millis_i64();
-            let updated = conn.execute(
-                r#"
-                UPDATE voice_observations
-                SET forgotten_at = ?1,
-                    updated_at = ?1
-                WHERE profile_id = ?2
-                  AND forgotten_at IS NULL
-                "#,
-                params![now, profile_id],
-            )?;
-            Ok(updated)
-        })
-        .await
+        let db = self.db.connection().await?;
+        let now = now_unix_millis_i64();
+        let result = voice_observations::Entity::update_many()
+            .col_expr(voice_observations::Column::ForgottenAt, Expr::value(now))
+            .col_expr(voice_observations::Column::UpdatedAt, Expr::value(now))
+            .filter(voice_observations::Column::ProfileId.eq(profile_id))
+            .filter(voice_observations::Column::ForgottenAt.is_null())
+            .exec(db)
+            .await
+            .context("Failed to clear voice observations")?;
+        usize::try_from(result.rows_affected).context("Voice observation update count overflow")
     }
 
     pub async fn build_context(
@@ -286,65 +233,81 @@ impl VoiceObservationStore {
         }
         Ok(Some(lines.join("\n")))
     }
-
-    async fn run_blocking<F, T>(&self, task_fn: F) -> anyhow::Result<T>
-    where
-        F: FnOnce(PathBuf) -> anyhow::Result<T> + Send + 'static,
-        T: Send + 'static,
-    {
-        let db_path = self.db_path.clone();
-        task::spawn_blocking(move || task_fn(db_path))
-            .await
-            .map_err(|err| anyhow!("Voice observation storage worker failed: {err}"))?
-    }
 }
 
-fn fetch_observation(
-    conn: &Connection,
+const OBSERVATIONS_ACTIVE_SQL: &str = r#"
+    SELECT
+        id,
+        profile_id,
+        category,
+        summary,
+        confidence,
+        source_turn_id,
+        source_user_text,
+        source_assistant_text,
+        times_seen,
+        created_at,
+        updated_at,
+        forgotten_at
+    FROM voice_observations
+    WHERE profile_id = ?1
+      AND forgotten_at IS NULL
+    ORDER BY confidence DESC, updated_at DESC, created_at DESC
+    LIMIT ?2
+"#;
+
+const OBSERVATION_BY_ID_SQL: &str = r#"
+    SELECT
+        id,
+        profile_id,
+        category,
+        summary,
+        confidence,
+        source_turn_id,
+        source_user_text,
+        source_assistant_text,
+        times_seen,
+        created_at,
+        updated_at,
+        forgotten_at
+    FROM voice_observations
+    WHERE id = ?1
+"#;
+
+async fn fetch_observation<C>(
+    conn: &C,
     observation_id: &str,
-) -> anyhow::Result<Option<VoiceObservation>> {
-    let observation = conn
-        .query_row(
-            r#"
-            SELECT
-                id,
-                profile_id,
-                category,
-                summary,
-                confidence,
-                source_turn_id,
-                source_user_text,
-                source_assistant_text,
-                times_seen,
-                created_at,
-                updated_at,
-                forgotten_at
-            FROM voice_observations
-            WHERE id = ?1
-            "#,
-            params![observation_id],
-            map_observation,
-        )
-        .optional()?;
-    Ok(observation)
+) -> anyhow::Result<Option<VoiceObservation>>
+where
+    C: ConnectionTrait,
+{
+    let row = conn
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            OBSERVATION_BY_ID_SQL,
+            vec![observation_id.into()],
+        ))
+        .await
+        .context("Failed to load voice observation")?;
+    row.as_ref().map(map_observation).transpose()
 }
 
-fn map_observation(row: &Row<'_>) -> rusqlite::Result<VoiceObservation> {
-    let times_seen: i64 = row.get(8)?;
+fn map_observation(row: &QueryResult) -> anyhow::Result<VoiceObservation> {
+    let times_seen: i64 = row.try_get_by_index(8)?;
     Ok(VoiceObservation {
-        id: row.get(0)?,
-        profile_id: row.get(1)?,
-        category: row.get(2)?,
-        summary: row.get(3)?,
-        confidence: row.get::<_, f64>(4)? as f32,
-        source_turn_id: row.get(5)?,
-        source_user_text: row.get(6)?,
-        source_assistant_text: row.get(7)?,
+        id: row.try_get_by_index(0)?,
+        profile_id: row.try_get_by_index(1)?,
+        category: row.try_get_by_index(2)?,
+        summary: row.try_get_by_index(3)?,
+        confidence: row.try_get_by_index::<f64>(4)? as f32,
+        source_turn_id: row.try_get_by_index(5)?,
+        source_user_text: row.try_get_by_index(6)?,
+        source_assistant_text: row.try_get_by_index(7)?,
         times_seen: times_seen.max(0) as usize,
-        created_at: row.get::<_, i64>(9)?.max(0) as u64,
-        updated_at: row.get::<_, i64>(10)?.max(0) as u64,
+        created_at: row.try_get_by_index::<i64>(9)?.max(0) as u64,
+        updated_at: row.try_get_by_index::<i64>(10)?.max(0) as u64,
         forgotten_at: row
-            .get::<_, Option<i64>>(11)?
+            .try_get_by_index::<Option<i64>>(11)?
             .map(|value| value.max(0) as u64),
     })
 }

--- a/crates/izwi-server/src/voice_store.rs
+++ b/crates/izwi-server/src/voice_store.rs
@@ -1,14 +1,15 @@
-use anyhow::{anyhow, Context};
-use rusqlite::{params, Connection, OptionalExtension, Row};
-use serde::Serialize;
-use std::path::PathBuf;
-use tokio::task;
-
-use crate::ids::new_uuid;
-use crate::storage_layout;
-use crate::voice_defaults::{
-    DEFAULT_VOICE_AGENT_SYSTEM_PROMPT, DEFAULT_VOICE_PROFILE_ID, DEFAULT_VOICE_PROFILE_NAME,
+use anyhow::{Context, anyhow};
+use sea_orm::sea_query::Expr;
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, DatabaseConnection, DbBackend, EntityTrait, QueryFilter,
+    QueryResult, Set, Statement,
 };
+use serde::Serialize;
+
+use crate::db::StoreDatabase;
+use crate::entity::{voice_profiles, voice_sessions, voice_turns};
+use crate::ids::new_uuid;
+use crate::voice_defaults::{DEFAULT_VOICE_AGENT_SYSTEM_PROMPT, DEFAULT_VOICE_PROFILE_ID};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct VoiceProfile {
@@ -85,77 +86,14 @@ pub struct CreateVoiceTurnRequest {
 
 #[derive(Clone)]
 pub struct VoiceStore {
-    db_path: PathBuf,
+    db: StoreDatabase,
 }
 
 impl VoiceStore {
     pub fn initialize() -> anyhow::Result<Self> {
-        let db_path = storage_layout::resolve_db_path();
-        let media_root = storage_layout::resolve_media_root();
-
-        storage_layout::ensure_storage_dirs(&db_path, &media_root)
-            .context("Failed to prepare voice storage layout")?;
-
-        let conn = storage_layout::open_sqlite_connection(&db_path)
-            .with_context(|| format!("Failed to open voice database: {}", db_path.display()))?;
-        conn.execute_batch(
-            r#"
-            CREATE TABLE IF NOT EXISTS voice_profiles (
-                id TEXT PRIMARY KEY,
-                name TEXT NOT NULL,
-                system_prompt TEXT NOT NULL,
-                observational_memory_enabled INTEGER NOT NULL DEFAULT 1,
-                created_at INTEGER NOT NULL,
-                updated_at INTEGER NOT NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS voice_sessions (
-                id TEXT PRIMARY KEY,
-                profile_id TEXT NOT NULL,
-                mode TEXT NOT NULL CHECK(mode IN ('modular', 'unified')),
-                system_prompt TEXT NOT NULL,
-                created_at INTEGER NOT NULL,
-                updated_at INTEGER NOT NULL,
-                ended_at INTEGER NULL,
-                FOREIGN KEY(profile_id) REFERENCES voice_profiles(id) ON DELETE CASCADE
-            );
-
-            CREATE TABLE IF NOT EXISTS voice_turns (
-                id TEXT PRIMARY KEY,
-                session_id TEXT NOT NULL,
-                utterance_id TEXT NOT NULL,
-                utterance_seq INTEGER NOT NULL,
-                mode TEXT NOT NULL CHECK(mode IN ('modular', 'unified')),
-                status TEXT NOT NULL CHECK(status IN ('processing', 'ok', 'error', 'timeout', 'interrupted', 'no_input')),
-                status_reason TEXT NULL,
-                vad_end_reason TEXT NULL,
-                user_text TEXT NULL,
-                assistant_text TEXT NULL,
-                assistant_raw_text TEXT NULL,
-                language TEXT NULL,
-                audio_duration_secs REAL NULL,
-                asr_model_id TEXT NULL,
-                text_model_id TEXT NULL,
-                tts_model_id TEXT NULL,
-                s2s_model_id TEXT NULL,
-                speaker TEXT NULL,
-                created_at INTEGER NOT NULL,
-                updated_at INTEGER NOT NULL,
-                FOREIGN KEY(session_id) REFERENCES voice_sessions(id) ON DELETE CASCADE
-            );
-
-            CREATE INDEX IF NOT EXISTS idx_voice_sessions_updated_at
-                ON voice_sessions(updated_at DESC, created_at DESC);
-            CREATE UNIQUE INDEX IF NOT EXISTS idx_voice_turns_session_utterance
-                ON voice_turns(session_id, utterance_seq);
-            CREATE INDEX IF NOT EXISTS idx_voice_turns_session_created_at
-                ON voice_turns(session_id, created_at ASC, id ASC);
-            "#,
-        )
-        .context("Failed to initialize voice database schema")?;
-        ensure_default_profile(&conn)?;
-
-        Ok(Self { db_path })
+        Ok(Self {
+            db: StoreDatabase::from_default_path()?,
+        })
     }
 
     pub async fn get_default_profile(&self) -> anyhow::Result<VoiceProfile> {
@@ -165,29 +103,8 @@ impl VoiceStore {
     }
 
     pub async fn get_profile(&self, profile_id: String) -> anyhow::Result<Option<VoiceProfile>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            ensure_default_profile(&conn)?;
-            let profile = conn
-                .query_row(
-                    r#"
-                SELECT
-                    id,
-                    name,
-                    system_prompt,
-                    observational_memory_enabled,
-                    created_at,
-                    updated_at
-                FROM voice_profiles
-                WHERE id = ?1
-                "#,
-                    params![profile_id],
-                    map_voice_profile,
-                )
-                .optional()?;
-            Ok(profile)
-        })
-        .await
+        let db = self.db.connection().await?;
+        fetch_voice_profile(db, &profile_id).await
     }
 
     pub async fn update_default_profile(
@@ -196,287 +113,188 @@ impl VoiceStore {
         system_prompt: Option<String>,
         observational_memory_enabled: Option<bool>,
     ) -> anyhow::Result<VoiceProfile> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            ensure_default_profile(&conn)?;
+        let db = self.db.connection().await?;
+        let current = fetch_voice_profile(db, DEFAULT_VOICE_PROFILE_ID)
+            .await?
+            .context("Default voice profile not found")?;
+        let next_name = sanitize_profile_name(name.as_deref()).unwrap_or(current.name);
+        let next_prompt =
+            sanitize_prompt(system_prompt.as_deref()).unwrap_or(current.system_prompt);
+        let next_memory_enabled =
+            observational_memory_enabled.unwrap_or(current.observational_memory_enabled);
+        let now = now_unix_millis_i64();
 
-            let current = conn
-                .query_row(
-                    r#"
-                    SELECT
-                        id,
-                        name,
-                        system_prompt,
-                        observational_memory_enabled,
-                        created_at,
-                        updated_at
-                    FROM voice_profiles
-                    WHERE id = ?1
-                    "#,
-                    params![DEFAULT_VOICE_PROFILE_ID],
-                    map_voice_profile,
-                )
-                .context("Default voice profile not found")?;
-
-            let next_name = sanitize_profile_name(name.as_deref()).unwrap_or(current.name);
-            let next_prompt =
-                sanitize_prompt(system_prompt.as_deref()).unwrap_or(current.system_prompt);
-            let next_memory_enabled =
-                observational_memory_enabled.unwrap_or(current.observational_memory_enabled);
-            let now = now_unix_millis_i64();
-
-            conn.execute(
-                r#"
-                UPDATE voice_profiles
-                SET name = ?1,
-                    system_prompt = ?2,
-                    observational_memory_enabled = ?3,
-                    updated_at = ?4
-                WHERE id = ?5
-                "#,
-                params![
-                    next_name,
-                    next_prompt,
-                    bool_to_i64(next_memory_enabled),
-                    now,
-                    DEFAULT_VOICE_PROFILE_ID
-                ],
-            )?;
-
-            conn.query_row(
-                r#"
-                SELECT
-                    id,
-                    name,
-                    system_prompt,
-                    observational_memory_enabled,
-                    created_at,
-                    updated_at
-                FROM voice_profiles
-                WHERE id = ?1
-                "#,
-                params![DEFAULT_VOICE_PROFILE_ID],
-                map_voice_profile,
+        voice_profiles::Entity::update_many()
+            .col_expr(voice_profiles::Column::Name, Expr::value(next_name))
+            .col_expr(
+                voice_profiles::Column::SystemPrompt,
+                Expr::value(next_prompt),
             )
+            .col_expr(
+                voice_profiles::Column::ObservationalMemoryEnabled,
+                Expr::value(bool_to_i64(next_memory_enabled)),
+            )
+            .col_expr(voice_profiles::Column::UpdatedAt, Expr::value(now))
+            .filter(voice_profiles::Column::Id.eq(DEFAULT_VOICE_PROFILE_ID))
+            .exec(db)
+            .await
+            .context("Failed to update default voice profile")?;
+
+        fetch_voice_profile(db, DEFAULT_VOICE_PROFILE_ID)
+            .await?
             .context("Updated voice profile not found")
-        })
-        .await
     }
 
     pub async fn create_session(
         &self,
         request: CreateVoiceSessionRequest,
     ) -> anyhow::Result<VoiceSessionSummary> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let now = now_unix_millis_i64();
-            let session_id = new_uuid();
+        let db = self.db.connection().await?;
+        let now = now_unix_millis_i64();
+        let session_id = new_uuid();
+        let mode = sanitize_mode(request.mode.as_str())?;
+        let system_prompt = sanitize_prompt(Some(request.system_prompt.as_str()))
+            .unwrap_or_else(|| DEFAULT_VOICE_AGENT_SYSTEM_PROMPT.to_string());
 
-            conn.execute(
-                r#"
-                INSERT INTO voice_sessions (
-                    id,
-                    profile_id,
-                    mode,
-                    system_prompt,
-                    created_at,
-                    updated_at,
-                    ended_at
-                )
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL)
-                "#,
-                params![
-                    session_id,
-                    request.profile_id,
-                    sanitize_mode(request.mode.as_str())?,
-                    sanitize_prompt(Some(request.system_prompt.as_str()))
-                        .unwrap_or_else(|| DEFAULT_VOICE_AGENT_SYSTEM_PROMPT.to_string()),
-                    now,
-                    now,
-                ],
-            )?;
-
-            fetch_session_summary(&conn, &session_id)?
-                .ok_or_else(|| anyhow!("Created voice session not found"))
+        voice_sessions::Entity::insert(voice_sessions::ActiveModel {
+            id: Set(session_id.clone()),
+            profile_id: Set(request.profile_id),
+            mode: Set(mode),
+            system_prompt: Set(system_prompt),
+            created_at: Set(now),
+            updated_at: Set(now),
+            ended_at: Set(None),
         })
+        .exec(db)
         .await
+        .context("Failed to create voice session")?;
+
+        fetch_session_summary(db, &session_id)
+            .await?
+            .ok_or_else(|| anyhow!("Created voice session not found"))
     }
 
     pub async fn end_session(&self, session_id: String) -> anyhow::Result<()> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let now = now_unix_millis_i64();
-            conn.execute(
-                r#"
-                UPDATE voice_sessions
-                SET updated_at = ?1,
-                    ended_at = COALESCE(ended_at, ?1)
-                WHERE id = ?2
-                "#,
-                params![now, session_id],
-            )?;
-            Ok(())
-        })
+        let db = self.db.connection().await?;
+        let now = now_unix_millis_i64();
+        db.execute_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            r#"
+            UPDATE voice_sessions
+            SET updated_at = ?1,
+                ended_at = COALESCE(ended_at, ?1)
+            WHERE id = ?2
+            "#,
+            vec![now.into(), session_id.into()],
+        ))
         .await
+        .context("Failed to end voice session")?;
+        Ok(())
     }
 
     pub async fn list_sessions(&self, limit: usize) -> anyhow::Result<Vec<VoiceSessionSummary>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let mut stmt = conn.prepare(
+        let db = self.db.connection().await?;
+        let limit = i64::try_from(limit.max(1)).context("Voice session limit exceeds i64")?;
+        let rows = db
+            .query_all_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
                 r#"
-                SELECT
-                    s.id,
-                    s.profile_id,
-                    s.mode,
-                    s.system_prompt,
-                    s.created_at,
-                    s.updated_at,
-                    s.ended_at,
-                    (
-                        SELECT COUNT(1)
-                        FROM voice_turns t
-                        WHERE t.session_id = s.id
-                    ) AS turn_count,
-                    (
-                        SELECT t.user_text
-                        FROM voice_turns t
-                        WHERE t.session_id = s.id
-                        ORDER BY t.created_at DESC, t.id DESC
-                        LIMIT 1
-                    ) AS last_user_text,
-                    (
-                        SELECT t.assistant_text
-                        FROM voice_turns t
-                        WHERE t.session_id = s.id
-                        ORDER BY t.created_at DESC, t.id DESC
-                        LIMIT 1
-                    ) AS last_assistant_text
-                FROM voice_sessions s
-                ORDER BY s.updated_at DESC, s.created_at DESC
-                LIMIT ?1
+            SELECT
+                s.id,
+                s.profile_id,
+                s.mode,
+                s.system_prompt,
+                s.created_at,
+                s.updated_at,
+                s.ended_at,
+                (
+                    SELECT COUNT(1)
+                    FROM voice_turns t
+                    WHERE t.session_id = s.id
+                ) AS turn_count,
+                (
+                    SELECT t.user_text
+                    FROM voice_turns t
+                    WHERE t.session_id = s.id
+                    ORDER BY t.created_at DESC, t.id DESC
+                    LIMIT 1
+                ) AS last_user_text,
+                (
+                    SELECT t.assistant_text
+                    FROM voice_turns t
+                    WHERE t.session_id = s.id
+                    ORDER BY t.created_at DESC, t.id DESC
+                    LIMIT 1
+                ) AS last_assistant_text
+            FROM voice_sessions s
+            ORDER BY s.updated_at DESC, s.created_at DESC
+            LIMIT ?1
                 "#,
-            )?;
-
-            let rows = stmt.query_map(params![limit.max(1) as i64], map_session_summary)?;
-            let mut sessions = Vec::new();
-            for row in rows {
-                sessions.push(row?);
-            }
-            Ok(sessions)
-        })
-        .await
+                vec![limit.into()],
+            ))
+            .await
+            .context("Failed to list voice sessions")?;
+        rows.iter().map(map_session_summary).collect()
     }
 
     pub async fn get_session(
         &self,
         session_id: String,
     ) -> anyhow::Result<Option<VoiceSessionDetail>> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let Some(session) = fetch_session_summary(&conn, &session_id)? else {
-                return Ok(None);
-            };
-
-            let mut stmt = conn.prepare(
-                r#"
-                SELECT
-                    id,
-                    session_id,
-                    utterance_id,
-                    utterance_seq,
-                    mode,
-                    status,
-                    status_reason,
-                    vad_end_reason,
-                    user_text,
-                    assistant_text,
-                    assistant_raw_text,
-                    language,
-                    audio_duration_secs,
-                    asr_model_id,
-                    text_model_id,
-                    tts_model_id,
-                    s2s_model_id,
-                    speaker,
-                    created_at,
-                    updated_at
-                FROM voice_turns
-                WHERE session_id = ?1
-                ORDER BY created_at ASC, id ASC
-                "#,
-            )?;
-            let rows = stmt.query_map(params![session_id], map_turn_record)?;
-            let mut turns = Vec::new();
-            for row in rows {
-                turns.push(row?);
-            }
-
-            Ok(Some(VoiceSessionDetail { session, turns }))
-        })
-        .await
+        let db = self.db.connection().await?;
+        let Some(session) = fetch_session_summary(db, &session_id).await? else {
+            return Ok(None);
+        };
+        let turns = list_session_turns(db, &session_id).await?;
+        Ok(Some(VoiceSessionDetail { session, turns }))
     }
 
     pub async fn create_turn(
         &self,
         request: CreateVoiceTurnRequest,
     ) -> anyhow::Result<VoiceTurnRecord> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let now = now_unix_millis_i64();
-            let turn_id = new_uuid();
-            let mode = sanitize_mode(request.mode.as_str())?;
+        let db = self.db.connection().await?;
+        let now = now_unix_millis_i64();
+        let turn_id = new_uuid();
+        let mode = sanitize_mode(request.mode.as_str())?;
+        let session_id = request.session_id;
 
-            conn.execute(
-                r#"
-                INSERT INTO voice_turns (
-                    id,
-                    session_id,
-                    utterance_id,
-                    utterance_seq,
-                    mode,
-                    status,
-                    status_reason,
-                    vad_end_reason,
-                    user_text,
-                    assistant_text,
-                    assistant_raw_text,
-                    language,
-                    audio_duration_secs,
-                    asr_model_id,
-                    text_model_id,
-                    tts_model_id,
-                    s2s_model_id,
-                    speaker,
-                    created_at,
-                    updated_at
-                )
-                VALUES (
-                    ?1, ?2, ?3, ?4, ?5, 'processing', NULL, ?6, NULL, NULL, NULL, NULL, NULL,
-                    ?7, ?8, ?9, ?10, ?11, ?12, ?12
-                )
-                "#,
-                params![
-                    turn_id,
-                    request.session_id,
-                    sanitize_required_text(request.utterance_id.as_str(), 160)?,
-                    u64_to_i64(request.utterance_seq)?,
-                    mode,
-                    sanitize_optional_text(request.vad_end_reason.as_deref(), 48),
-                    sanitize_optional_text(request.asr_model_id.as_deref(), 160),
-                    sanitize_optional_text(request.text_model_id.as_deref(), 160),
-                    sanitize_optional_text(request.tts_model_id.as_deref(), 160),
-                    sanitize_optional_text(request.s2s_model_id.as_deref(), 160),
-                    sanitize_optional_text(request.speaker.as_deref(), 160),
-                    now,
-                ],
-            )?;
-
-            touch_session_updated_at(&conn, request.session_id.as_str(), now)?;
-            fetch_turn_record(&conn, &turn_id)?
-                .ok_or_else(|| anyhow!("Created voice turn not found"))
+        voice_turns::Entity::insert(voice_turns::ActiveModel {
+            id: Set(turn_id.clone()),
+            session_id: Set(session_id.clone()),
+            utterance_id: Set(sanitize_required_text(request.utterance_id.as_str(), 160)?),
+            utterance_seq: Set(u64_to_i64(request.utterance_seq)?),
+            mode: Set(mode),
+            status: Set("processing".to_string()),
+            status_reason: Set(None),
+            vad_end_reason: Set(sanitize_optional_text(
+                request.vad_end_reason.as_deref(),
+                48,
+            )),
+            user_text: Set(None),
+            assistant_text: Set(None),
+            assistant_raw_text: Set(None),
+            language: Set(None),
+            audio_duration_secs: Set(None),
+            asr_model_id: Set(sanitize_optional_text(request.asr_model_id.as_deref(), 160)),
+            text_model_id: Set(sanitize_optional_text(
+                request.text_model_id.as_deref(),
+                160,
+            )),
+            tts_model_id: Set(sanitize_optional_text(request.tts_model_id.as_deref(), 160)),
+            s2s_model_id: Set(sanitize_optional_text(request.s2s_model_id.as_deref(), 160)),
+            speaker: Set(sanitize_optional_text(request.speaker.as_deref(), 160)),
+            created_at: Set(now),
+            updated_at: Set(now),
         })
+        .exec(db)
         .await
+        .context("Failed to create voice turn")?;
+
+        touch_session_updated_at(db, session_id.as_str(), now).await?;
+        fetch_turn_record(db, &turn_id)
+            .await?
+            .ok_or_else(|| anyhow!("Created voice turn not found"))
     }
 
     pub async fn update_turn_transcript(
@@ -486,32 +304,32 @@ impl VoiceStore {
         language: Option<String>,
         audio_duration_secs: Option<f32>,
     ) -> anyhow::Result<()> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let now = now_unix_millis_i64();
-            let session_id = fetch_turn_session_id(&conn, &turn_id)?
-                .ok_or_else(|| anyhow!("Voice turn not found"))?;
-            conn.execute(
-                r#"
-                UPDATE voice_turns
-                SET user_text = ?1,
-                    language = ?2,
-                    audio_duration_secs = ?3,
-                    updated_at = ?4
-                WHERE id = ?5
-                "#,
-                params![
-                    sanitize_optional_text(Some(user_text.as_str()), 16000),
-                    sanitize_optional_text(language.as_deref(), 64),
-                    audio_duration_secs.map(f64::from),
-                    now,
-                    turn_id,
-                ],
-            )?;
-            touch_session_updated_at(&conn, session_id.as_str(), now)?;
-            Ok(())
-        })
+        let db = self.db.connection().await?;
+        let now = now_unix_millis_i64();
+        let session_id = fetch_turn_session_id(db, &turn_id)
+            .await?
+            .ok_or_else(|| anyhow!("Voice turn not found"))?;
+        db.execute_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            r#"
+            UPDATE voice_turns
+            SET user_text = ?1,
+                language = ?2,
+                audio_duration_secs = ?3,
+                updated_at = ?4
+            WHERE id = ?5
+            "#,
+            vec![
+                sanitize_optional_text(Some(user_text.as_str()), 16000).into(),
+                sanitize_optional_text(language.as_deref(), 64).into(),
+                audio_duration_secs.map(f64::from).into(),
+                now.into(),
+                turn_id.into(),
+            ],
+        ))
         .await
+        .context("Failed to update voice turn transcript")?;
+        touch_session_updated_at(db, session_id.as_str(), now).await
     }
 
     pub async fn update_turn_assistant(
@@ -520,30 +338,30 @@ impl VoiceStore {
         assistant_text: Option<String>,
         assistant_raw_text: Option<String>,
     ) -> anyhow::Result<()> {
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let now = now_unix_millis_i64();
-            let session_id = fetch_turn_session_id(&conn, &turn_id)?
-                .ok_or_else(|| anyhow!("Voice turn not found"))?;
-            conn.execute(
-                r#"
-                UPDATE voice_turns
-                SET assistant_text = ?1,
-                    assistant_raw_text = ?2,
-                    updated_at = ?3
-                WHERE id = ?4
-                "#,
-                params![
-                    sanitize_optional_text(assistant_text.as_deref(), 16000),
-                    sanitize_optional_text(assistant_raw_text.as_deref(), 16000),
-                    now,
-                    turn_id,
-                ],
-            )?;
-            touch_session_updated_at(&conn, session_id.as_str(), now)?;
-            Ok(())
-        })
+        let db = self.db.connection().await?;
+        let now = now_unix_millis_i64();
+        let session_id = fetch_turn_session_id(db, &turn_id)
+            .await?
+            .ok_or_else(|| anyhow!("Voice turn not found"))?;
+        db.execute_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            r#"
+            UPDATE voice_turns
+            SET assistant_text = ?1,
+                assistant_raw_text = ?2,
+                updated_at = ?3
+            WHERE id = ?4
+            "#,
+            vec![
+                sanitize_optional_text(assistant_text.as_deref(), 16000).into(),
+                sanitize_optional_text(assistant_raw_text.as_deref(), 16000).into(),
+                now.into(),
+                turn_id.into(),
+            ],
+        ))
         .await
+        .context("Failed to update voice turn assistant text")?;
+        touch_session_updated_at(db, session_id.as_str(), now).await
     }
 
     pub async fn complete_turn(
@@ -553,88 +371,46 @@ impl VoiceStore {
         status_reason: Option<String>,
     ) -> anyhow::Result<()> {
         let status = sanitize_turn_status(status)?;
-        self.run_blocking(move |db_path| {
-            let conn = storage_layout::open_sqlite_connection(&db_path)?;
-            let now = now_unix_millis_i64();
-            let session_id = fetch_turn_session_id(&conn, &turn_id)?
-                .ok_or_else(|| anyhow!("Voice turn not found"))?;
-            conn.execute(
-                r#"
-                UPDATE voice_turns
-                SET status = ?1,
-                    status_reason = ?2,
-                    updated_at = ?3
-                WHERE id = ?4
-                "#,
-                params![
-                    status,
-                    sanitize_optional_text(status_reason.as_deref(), 160),
-                    now,
-                    turn_id,
-                ],
-            )?;
-            touch_session_updated_at(&conn, session_id.as_str(), now)?;
-            Ok(())
-        })
-        .await
-    }
-
-    async fn run_blocking<F, T>(&self, task_fn: F) -> anyhow::Result<T>
-    where
-        F: FnOnce(PathBuf) -> anyhow::Result<T> + Send + 'static,
-        T: Send + 'static,
-    {
-        let db_path = self.db_path.clone();
-        task::spawn_blocking(move || task_fn(db_path))
-            .await
-            .map_err(|err| anyhow!("Voice storage worker failed: {err}"))?
-    }
-}
-
-fn ensure_default_profile(conn: &Connection) -> anyhow::Result<()> {
-    let exists = conn
-        .query_row(
-            "SELECT 1 FROM voice_profiles WHERE id = ?1 LIMIT 1",
-            params![DEFAULT_VOICE_PROFILE_ID],
-            |_| Ok(()),
-        )
-        .optional()?
-        .is_some();
-    if exists {
-        return Ok(());
-    }
-
-    let now = now_unix_millis_i64();
-    conn.execute(
-        r#"
-        INSERT INTO voice_profiles (
-            id,
-            name,
-            system_prompt,
-            observational_memory_enabled,
-            created_at,
-            updated_at
-        )
-        VALUES (?1, ?2, ?3, 1, ?4, ?4)
-        "#,
-        params![
-            DEFAULT_VOICE_PROFILE_ID,
-            DEFAULT_VOICE_PROFILE_NAME,
-            DEFAULT_VOICE_AGENT_SYSTEM_PROMPT,
-            now,
-        ],
-    )?;
-
-    Ok(())
-}
-
-fn fetch_session_summary(
-    conn: &Connection,
-    session_id: &str,
-) -> anyhow::Result<Option<VoiceSessionSummary>> {
-    let session = conn
-        .query_row(
+        let db = self.db.connection().await?;
+        let now = now_unix_millis_i64();
+        let session_id = fetch_turn_session_id(db, &turn_id)
+            .await?
+            .ok_or_else(|| anyhow!("Voice turn not found"))?;
+        db.execute_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
             r#"
+            UPDATE voice_turns
+            SET status = ?1,
+                status_reason = ?2,
+                updated_at = ?3
+            WHERE id = ?4
+            "#,
+            vec![
+                status.into(),
+                sanitize_optional_text(status_reason.as_deref(), 160).into(),
+                now.into(),
+                turn_id.into(),
+            ],
+        ))
+        .await
+        .context("Failed to complete voice turn")?;
+        touch_session_updated_at(db, session_id.as_str(), now).await
+    }
+}
+
+const VOICE_PROFILE_BY_ID_SQL: &str = r#"
+    SELECT
+        id,
+        name,
+        system_prompt,
+        observational_memory_enabled,
+        created_at,
+        updated_at
+    FROM voice_profiles
+    WHERE id = ?1
+"#;
+
+const SESSION_SUMMARY_BY_ID_SQL: &str = r#"
             SELECT
                 s.id,
                 s.profile_id,
@@ -664,18 +440,9 @@ fn fetch_session_summary(
                 ) AS last_assistant_text
             FROM voice_sessions s
             WHERE s.id = ?1
-            "#,
-            params![session_id],
-            map_session_summary,
-        )
-        .optional()?;
-    Ok(session)
-}
+"#;
 
-fn fetch_turn_record(conn: &Connection, turn_id: &str) -> anyhow::Result<Option<VoiceTurnRecord>> {
-    let turn = conn
-        .query_row(
-            r#"
+const TURN_RECORD_BY_ID_SQL: &str = r#"
             SELECT
                 id,
                 session_id,
@@ -699,86 +466,179 @@ fn fetch_turn_record(conn: &Connection, turn_id: &str) -> anyhow::Result<Option<
                 updated_at
             FROM voice_turns
             WHERE id = ?1
-            "#,
-            params![turn_id],
-            map_turn_record,
-        )
-        .optional()?;
-    Ok(turn)
+"#;
+
+const SESSION_TURNS_SQL: &str = r#"
+            SELECT
+                id,
+                session_id,
+                utterance_id,
+                utterance_seq,
+                mode,
+                status,
+                status_reason,
+                vad_end_reason,
+                user_text,
+                assistant_text,
+                assistant_raw_text,
+                language,
+                audio_duration_secs,
+                asr_model_id,
+                text_model_id,
+                tts_model_id,
+                s2s_model_id,
+                speaker,
+                created_at,
+                updated_at
+            FROM voice_turns
+            WHERE session_id = ?1
+            ORDER BY created_at ASC, id ASC
+"#;
+
+async fn fetch_voice_profile(
+    db: &DatabaseConnection,
+    profile_id: &str,
+) -> anyhow::Result<Option<VoiceProfile>> {
+    let row = db
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            VOICE_PROFILE_BY_ID_SQL,
+            vec![profile_id.into()],
+        ))
+        .await
+        .context("Failed to load voice profile")?;
+    row.as_ref().map(map_voice_profile).transpose()
 }
 
-fn fetch_turn_session_id(conn: &Connection, turn_id: &str) -> anyhow::Result<Option<String>> {
-    Ok(conn
-        .query_row(
+async fn fetch_session_summary(
+    db: &DatabaseConnection,
+    session_id: &str,
+) -> anyhow::Result<Option<VoiceSessionSummary>> {
+    let row = db
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            SESSION_SUMMARY_BY_ID_SQL,
+            vec![session_id.into()],
+        ))
+        .await
+        .context("Failed to load voice session summary")?;
+    row.as_ref().map(map_session_summary).transpose()
+}
+
+async fn list_session_turns(
+    db: &DatabaseConnection,
+    session_id: &str,
+) -> anyhow::Result<Vec<VoiceTurnRecord>> {
+    let rows = db
+        .query_all_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            SESSION_TURNS_SQL,
+            vec![session_id.into()],
+        ))
+        .await
+        .context("Failed to list voice turns")?;
+    rows.iter().map(map_turn_record).collect()
+}
+
+async fn fetch_turn_record(
+    db: &DatabaseConnection,
+    turn_id: &str,
+) -> anyhow::Result<Option<VoiceTurnRecord>> {
+    let row = db
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            TURN_RECORD_BY_ID_SQL,
+            vec![turn_id.into()],
+        ))
+        .await
+        .context("Failed to load voice turn")?;
+    row.as_ref().map(map_turn_record).transpose()
+}
+
+async fn fetch_turn_session_id(
+    db: &DatabaseConnection,
+    turn_id: &str,
+) -> anyhow::Result<Option<String>> {
+    let row = db
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
             "SELECT session_id FROM voice_turns WHERE id = ?1",
-            params![turn_id],
-            |row| row.get(0),
-        )
-        .optional()?)
+            vec![turn_id.into()],
+        ))
+        .await
+        .context("Failed to load voice turn session id")?;
+    row.map(|row| row.try_get_by_index(0))
+        .transpose()
+        .map_err(Into::into)
 }
 
-fn touch_session_updated_at(
-    conn: &Connection,
+async fn touch_session_updated_at(
+    db: &DatabaseConnection,
     session_id: &str,
     updated_at: i64,
 ) -> anyhow::Result<()> {
-    conn.execute(
+    db.execute_raw(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
         "UPDATE voice_sessions SET updated_at = ?1 WHERE id = ?2",
-        params![updated_at, session_id],
-    )?;
+        vec![updated_at.into(), session_id.into()],
+    ))
+    .await
+    .context("Failed to touch voice session")?;
     Ok(())
 }
 
-fn map_voice_profile(row: &Row<'_>) -> rusqlite::Result<VoiceProfile> {
+fn map_voice_profile(row: &QueryResult) -> anyhow::Result<VoiceProfile> {
     Ok(VoiceProfile {
-        id: row.get(0)?,
-        name: row.get(1)?,
-        system_prompt: row.get(2)?,
-        observational_memory_enabled: i64_to_bool(row.get(3)?),
-        created_at: i64_to_u64(row.get(4)?),
-        updated_at: i64_to_u64(row.get(5)?),
+        id: row.try_get_by_index(0)?,
+        name: row.try_get_by_index(1)?,
+        system_prompt: row.try_get_by_index(2)?,
+        observational_memory_enabled: i64_to_bool(row.try_get_by_index(3)?),
+        created_at: i64_to_u64(row.try_get_by_index(4)?),
+        updated_at: i64_to_u64(row.try_get_by_index(5)?),
     })
 }
 
-fn map_session_summary(row: &Row<'_>) -> rusqlite::Result<VoiceSessionSummary> {
-    let turn_count_raw: i64 = row.get(7)?;
+fn map_session_summary(row: &QueryResult) -> anyhow::Result<VoiceSessionSummary> {
+    let turn_count_raw: i64 = row.try_get_by_index(7)?;
     Ok(VoiceSessionSummary {
-        id: row.get(0)?,
-        profile_id: row.get(1)?,
-        mode: row.get(2)?,
-        system_prompt: row.get(3)?,
-        created_at: i64_to_u64(row.get(4)?),
-        updated_at: i64_to_u64(row.get(5)?),
-        ended_at: row.get::<_, Option<i64>>(6)?.map(i64_to_u64),
+        id: row.try_get_by_index(0)?,
+        profile_id: row.try_get_by_index(1)?,
+        mode: row.try_get_by_index(2)?,
+        system_prompt: row.try_get_by_index(3)?,
+        created_at: i64_to_u64(row.try_get_by_index(4)?),
+        updated_at: i64_to_u64(row.try_get_by_index(5)?),
+        ended_at: row.try_get_by_index::<Option<i64>>(6)?.map(i64_to_u64),
         turn_count: i64_to_usize(turn_count_raw),
-        last_user_text: row.get(8)?,
-        last_assistant_text: row.get(9)?,
+        last_user_text: row.try_get_by_index(8)?,
+        last_assistant_text: row.try_get_by_index(9)?,
     })
 }
 
-fn map_turn_record(row: &Row<'_>) -> rusqlite::Result<VoiceTurnRecord> {
-    let utterance_seq: i64 = row.get(3)?;
+fn map_turn_record(row: &QueryResult) -> anyhow::Result<VoiceTurnRecord> {
+    let utterance_seq: i64 = row.try_get_by_index(3)?;
     Ok(VoiceTurnRecord {
-        id: row.get(0)?,
-        session_id: row.get(1)?,
-        utterance_id: row.get(2)?,
+        id: row.try_get_by_index(0)?,
+        session_id: row.try_get_by_index(1)?,
+        utterance_id: row.try_get_by_index(2)?,
         utterance_seq: i64_to_u64(utterance_seq),
-        mode: row.get(4)?,
-        status: row.get(5)?,
-        status_reason: row.get(6)?,
-        vad_end_reason: row.get(7)?,
-        user_text: row.get(8)?,
-        assistant_text: row.get(9)?,
-        assistant_raw_text: row.get(10)?,
-        language: row.get(11)?,
-        audio_duration_secs: row.get::<_, Option<f64>>(12)?.map(|value| value as f32),
-        asr_model_id: row.get(13)?,
-        text_model_id: row.get(14)?,
-        tts_model_id: row.get(15)?,
-        s2s_model_id: row.get(16)?,
-        speaker: row.get(17)?,
-        created_at: i64_to_u64(row.get(18)?),
-        updated_at: i64_to_u64(row.get(19)?),
+        mode: row.try_get_by_index(4)?,
+        status: row.try_get_by_index(5)?,
+        status_reason: row.try_get_by_index(6)?,
+        vad_end_reason: row.try_get_by_index(7)?,
+        user_text: row.try_get_by_index(8)?,
+        assistant_text: row.try_get_by_index(9)?,
+        assistant_raw_text: row.try_get_by_index(10)?,
+        language: row.try_get_by_index(11)?,
+        audio_duration_secs: row
+            .try_get_by_index::<Option<f64>>(12)?
+            .map(|value| value as f32),
+        asr_model_id: row.try_get_by_index(13)?,
+        text_model_id: row.try_get_by_index(14)?,
+        tts_model_id: row.try_get_by_index(15)?,
+        s2s_model_id: row.try_get_by_index(16)?,
+        speaker: row.try_get_by_index(17)?,
+        created_at: i64_to_u64(row.try_get_by_index(18)?),
+        updated_at: i64_to_u64(row.try_get_by_index(19)?),
     })
 }
 
@@ -822,11 +682,7 @@ fn sanitize_optional_text(raw: Option<&str>, max_len: usize) -> Option<String> {
 }
 
 fn bool_to_i64(value: bool) -> i64 {
-    if value {
-        1
-    } else {
-        0
-    }
+    if value { 1 } else { 0 }
 }
 
 fn i64_to_bool(value: i64) -> bool {


### PR DESCRIPTION
Migrates all server SQLite stores from direct rusqlite access to SeaORM, adds shared schema migration infrastructure, preserves existing data/layout behavior, and removes the direct rusqlite dependency.