### PR TITLE
Add enterprise persistence hooks for database and media storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3683,6 +3683,7 @@ name = "izwi-hooks"
 version = "0.1.0-beta-15"
 dependencies = [
  "async-trait",
+ "sea-orm",
  "serde",
  "serde_json",
  "thiserror 1.0.69",

--- a/crates/izwi-hooks/Cargo.toml
+++ b/crates/izwi-hooks/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sea-orm = { version = "=2.0.0-rc.38", default-features = false }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/izwi-hooks/src/lib.rs
+++ b/crates/izwi-hooks/src/lib.rs
@@ -18,6 +18,8 @@ pub type HookMetadata = BTreeMap<String, String>;
 pub enum HookError {
     #[error("enterprise hook denied request: {0}")]
     Denied(String),
+    #[error("enterprise hook did not find resource: {0}")]
+    NotFound(String),
     #[error("enterprise hook failed: {0}")]
     Failed(String),
 }

--- a/crates/izwi-hooks/src/lib.rs
+++ b/crates/izwi-hooks/src/lib.rs
@@ -5,6 +5,7 @@
 //! [`EnterpriseHooks`] bundle into the reusable server entry point.
 
 use async_trait::async_trait;
+use sea_orm::DatabaseConnection;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt;
@@ -383,6 +384,139 @@ impl DesktopPolicy {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatabaseProviderRequest {
+    pub purpose: String,
+    pub metadata: HookMetadata,
+}
+
+impl DatabaseProviderRequest {
+    pub fn server_runtime() -> Self {
+        Self {
+            purpose: "server_runtime".to_string(),
+            metadata: HookMetadata::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DatabaseBackend {
+    Sqlite,
+    Postgres,
+    Mysql,
+    Other(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DatabaseMigrationMode {
+    IzwiManaged,
+    ProviderManaged,
+    Disabled,
+}
+
+#[derive(Clone)]
+pub struct DatabaseConnectionDecision {
+    pub connection: DatabaseConnection,
+    pub backend: DatabaseBackend,
+    pub migration_mode: DatabaseMigrationMode,
+    pub metadata: HookMetadata,
+}
+
+#[derive(Clone)]
+pub enum DatabaseProviderDecision {
+    UseDefault,
+    UseConnection(DatabaseConnectionDecision),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MediaStorageProviderRequest {
+    pub purpose: String,
+    pub metadata: HookMetadata,
+}
+
+impl MediaStorageProviderRequest {
+    pub fn server_media() -> Self {
+        Self {
+            purpose: "server_media".to_string(),
+            metadata: HookMetadata::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MediaNamespace {
+    TranscriptionUpload,
+    DiarizationUpload,
+    GeneratedSpeech,
+    SavedVoice,
+    ChatMedia,
+    Export,
+    Other(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MediaObjectKey {
+    pub key: String,
+}
+
+impl MediaObjectKey {
+    pub fn new(key: impl Into<String>) -> Self {
+        Self { key: key.into() }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MediaObjectMetadata {
+    pub content_type: String,
+    pub filename: Option<String>,
+    pub content_length: Option<u64>,
+    pub sha256: Option<String>,
+    pub tenant_id: Option<String>,
+    pub attributes: HookMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MediaWriteRequest {
+    pub namespace: MediaNamespace,
+    pub record_id: String,
+    pub preferred_filename: Option<String>,
+    pub content_type: String,
+    pub metadata: HookMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StoredMediaObject {
+    pub key: MediaObjectKey,
+    pub metadata: MediaObjectMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MediaReadRequest {
+    pub key: MediaObjectKey,
+    pub metadata: HookMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StoredMediaBytes {
+    pub bytes: Vec<u8>,
+    pub metadata: MediaObjectMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MediaDeleteRequest {
+    pub key: MediaObjectKey,
+    pub metadata: HookMetadata,
+}
+
+#[derive(Clone)]
+pub enum MediaStorageProviderDecision {
+    UseDefault,
+    UseProvider(Arc<dyn MediaStorageProvider>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Edition {
     Community,
@@ -446,6 +580,35 @@ pub trait DesktopPolicyProvider: Send + Sync {
     async fn desktop_policy(&self, request: &DesktopPolicyRequest) -> HookResult<DesktopPolicy>;
 }
 
+#[async_trait]
+pub trait DatabaseProvider: Send + Sync {
+    async fn resolve_database(
+        &self,
+        request: &DatabaseProviderRequest,
+    ) -> HookResult<DatabaseProviderDecision>;
+}
+
+#[async_trait]
+pub trait MediaStorageResolver: Send + Sync {
+    async fn resolve_media_storage(
+        &self,
+        request: &MediaStorageProviderRequest,
+    ) -> HookResult<MediaStorageProviderDecision>;
+}
+
+#[async_trait]
+pub trait MediaStorageProvider: Send + Sync {
+    async fn put(
+        &self,
+        request: MediaWriteRequest,
+        bytes: Vec<u8>,
+    ) -> HookResult<StoredMediaObject>;
+
+    async fn get(&self, request: MediaReadRequest) -> HookResult<StoredMediaBytes>;
+
+    async fn delete(&self, request: MediaDeleteRequest) -> HookResult<()>;
+}
+
 pub trait EditionCapabilities: Send + Sync {
     fn edition(&self) -> Edition;
     fn capability_enabled(&self, capability: &str) -> bool;
@@ -464,6 +627,8 @@ pub struct EnterpriseHooks {
     pub admin_workflows: Arc<dyn AdminWorkflowHooks>,
     pub agent_tools: Arc<dyn AgentToolPolicy>,
     pub desktop_policy: Arc<dyn DesktopPolicyProvider>,
+    pub database: Arc<dyn DatabaseProvider>,
+    pub media_storage: Arc<dyn MediaStorageResolver>,
     pub edition: Arc<dyn EditionCapabilities>,
 }
 
@@ -481,6 +646,8 @@ impl EnterpriseHooks {
             admin_workflows: Arc::new(NoopAdminWorkflowHooks),
             agent_tools: Arc::new(NoopAgentToolPolicy),
             desktop_policy: Arc::new(NoopDesktopPolicyProvider),
+            database: Arc::new(NoopDatabaseProvider),
+            media_storage: Arc::new(NoopMediaStorageResolver),
             edition: Arc::new(NoopEditionCapabilities),
         }
     }
@@ -617,6 +784,32 @@ impl DesktopPolicyProvider for NoopDesktopPolicyProvider {
 }
 
 #[derive(Debug, Default)]
+pub struct NoopDatabaseProvider;
+
+#[async_trait]
+impl DatabaseProvider for NoopDatabaseProvider {
+    async fn resolve_database(
+        &self,
+        _request: &DatabaseProviderRequest,
+    ) -> HookResult<DatabaseProviderDecision> {
+        Ok(DatabaseProviderDecision::UseDefault)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct NoopMediaStorageResolver;
+
+#[async_trait]
+impl MediaStorageResolver for NoopMediaStorageResolver {
+    async fn resolve_media_storage(
+        &self,
+        _request: &MediaStorageProviderRequest,
+    ) -> HookResult<MediaStorageProviderDecision> {
+        Ok(MediaStorageProviderDecision::UseDefault)
+    }
+}
+
+#[derive(Debug, Default)]
 pub struct NoopEditionCapabilities;
 
 impl EditionCapabilities for NoopEditionCapabilities {
@@ -682,5 +875,33 @@ mod tests {
 
         assert_eq!(hooks.edition.edition(), Edition::Community);
         assert!(!hooks.edition.capability_enabled("enterprise.sso"));
+        assert!(!hooks
+            .edition
+            .capability_enabled("enterprise.persistence.database"));
+        assert!(!hooks
+            .edition
+            .capability_enabled("enterprise.persistence.storage"));
+    }
+
+    #[tokio::test]
+    async fn noop_persistence_hooks_use_local_defaults() {
+        let hooks = EnterpriseHooks::noop();
+
+        let database = hooks
+            .database
+            .resolve_database(&DatabaseProviderRequest::server_runtime())
+            .await
+            .expect("noop database hook should succeed");
+        assert!(matches!(database, DatabaseProviderDecision::UseDefault));
+
+        let media_storage = hooks
+            .media_storage
+            .resolve_media_storage(&MediaStorageProviderRequest::server_media())
+            .await
+            .expect("noop media storage hook should succeed");
+        assert!(matches!(
+            media_storage,
+            MediaStorageProviderDecision::UseDefault
+        ));
     }
 }

--- a/crates/izwi-server/Cargo.toml
+++ b/crates/izwi-server/Cargo.toml
@@ -12,6 +12,8 @@ path = "src/main.rs"
 [features]
 default = []
 cuda = ["izwi-core/cuda"]
+db-mysql = ["sea-orm/sqlx-mysql"]
+db-postgres = ["sea-orm/sqlx-postgres"]
 
 [dependencies]
 tokio = { workspace = true }

--- a/crates/izwi-server/src/api/media/handlers.rs
+++ b/crates/izwi-server/src/api/media/handlers.rs
@@ -1,12 +1,12 @@
 use axum::{
     body::Body,
     extract::{Path, State},
-    http::{header, StatusCode},
+    http::{StatusCode, header},
     response::Response,
 };
 
 use crate::error::ApiError;
-use crate::persistence::{read_media_object, MediaStorageError};
+use crate::persistence::{MediaStorageError, read_media_object};
 use crate::state::AppState;
 use crate::storage_layout;
 
@@ -83,30 +83,7 @@ fn normalize_content_type(content_type: &str) -> Option<String> {
 }
 
 fn content_type_from_path(path: &str) -> &'static str {
-    let extension = std::path::Path::new(path)
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .map(|ext| ext.to_ascii_lowercase());
-
-    match extension.as_deref() {
-        Some("jpg") | Some("jpeg") => "image/jpeg",
-        Some("png") => "image/png",
-        Some("webp") => "image/webp",
-        Some("gif") => "image/gif",
-        Some("bmp") => "image/bmp",
-        Some("svg") => "image/svg+xml",
-        Some("avif") => "image/avif",
-        Some("heic") => "image/heic",
-        Some("heif") => "image/heif",
-        Some("mp4") => "video/mp4",
-        Some("webm") => "video/webm",
-        Some("mov") => "video/quicktime",
-        Some("avi") => "video/x-msvideo",
-        Some("mkv") => "video/x-matroska",
-        Some("mpeg") | Some("mpg") => "video/mpeg",
-        Some("3gp") => "video/3gpp",
-        _ => "application/octet-stream",
-    }
+    storage_layout::content_type_from_media_path(path)
 }
 
 #[cfg(test)]

--- a/crates/izwi-server/src/api/media/handlers.rs
+++ b/crates/izwi-server/src/api/media/handlers.rs
@@ -1,21 +1,32 @@
 use axum::{
     body::Body,
-    extract::Path,
+    extract::{Path, State},
     http::{header, StatusCode},
     response::Response,
 };
 
 use crate::error::ApiError;
+use crate::persistence::read_media_object;
+use crate::state::AppState;
 use crate::storage_layout;
 
-pub async fn get_media(Path(path): Path<String>) -> Result<Response, ApiError> {
+pub async fn get_media(
+    State(state): State<AppState>,
+    Path(path): Path<String>,
+) -> Result<Response, ApiError> {
     let trimmed = path.trim();
     if trimmed.is_empty() {
         return Err(ApiError::bad_request("Media path cannot be empty"));
     }
 
-    let media_root = storage_layout::resolve_media_root();
-    let bytes = storage_layout::read_media_file(&media_root, trimmed).map_err(map_media_error)?;
+    let bytes = if let Some(persistence) = state.persistence.as_ref() {
+        read_media_object(&persistence.media_storage(), trimmed)
+            .await
+            .map_err(map_media_error)?
+    } else {
+        let media_root = storage_layout::resolve_media_root();
+        storage_layout::read_media_file(&media_root, trimmed).map_err(map_media_error)?
+    };
     let content_type = content_type_from_path(trimmed);
 
     Response::builder()

--- a/crates/izwi-server/src/api/media/handlers.rs
+++ b/crates/izwi-server/src/api/media/handlers.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 
 use crate::error::ApiError;
-use crate::persistence::read_media_object;
+use crate::persistence::{read_media_object, MediaStorageError};
 use crate::state::AppState;
 use crate::storage_layout;
 
@@ -19,25 +19,38 @@ pub async fn get_media(
         return Err(ApiError::bad_request("Media path cannot be empty"));
     }
 
-    let bytes = if let Some(persistence) = state.persistence.as_ref() {
-        read_media_object(&persistence.media_storage(), trimmed)
+    let (bytes, content_type) = if let Some(persistence) = state.persistence.as_ref() {
+        let stored = read_media_object(&persistence.media_storage(), trimmed)
             .await
-            .map_err(map_media_error)?
+            .map_err(map_media_error)?;
+        let content_type = normalize_content_type(&stored.metadata.content_type)
+            .unwrap_or_else(|| content_type_from_path(trimmed).to_string());
+        (stored.bytes, content_type)
     } else {
         let media_root = storage_layout::resolve_media_root();
-        storage_layout::read_media_file(&media_root, trimmed).map_err(map_media_error)?
+        (
+            storage_layout::read_media_file(&media_root, trimmed).map_err(map_media_error)?,
+            content_type_from_path(trimmed).to_string(),
+        )
     };
-    let content_type = content_type_from_path(trimmed);
 
     Response::builder()
         .status(StatusCode::OK)
-        .header(header::CONTENT_TYPE, content_type)
+        .header(header::CONTENT_TYPE, content_type.as_str())
         .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")
         .body(Body::from(bytes))
         .map_err(|err| ApiError::internal(format!("Failed building media response: {err}")))
 }
 
-fn map_media_error(err: anyhow::Error) -> ApiError {
+fn map_media_error(err: impl Into<anyhow::Error>) -> ApiError {
+    let err = err.into();
+    if err
+        .downcast_ref::<MediaStorageError>()
+        .is_some_and(MediaStorageError::is_not_found)
+    {
+        return ApiError::not_found("Media file not found");
+    }
+
     let message = err.to_string();
     if message.contains("Unsafe media path component")
         || message.contains("Absolute media paths are not allowed")
@@ -54,6 +67,19 @@ fn map_media_error(err: anyhow::Error) -> ApiError {
     }
 
     ApiError::internal(format!("Failed reading media file: {err}"))
+}
+
+fn normalize_content_type(content_type: &str) -> Option<String> {
+    if content_type.contains(['\r', '\n']) {
+        return None;
+    }
+
+    let trimmed = content_type.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 fn content_type_from_path(path: &str) -> &'static str {
@@ -80,5 +106,32 @@ fn content_type_from_path(path: &str) -> &'static str {
         Some("mpeg") | Some("mpg") => "video/mpeg",
         Some("3gp") => "video/3gpp",
         _ => "application/octet-stream",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_content_type_is_normalized_for_http_header() {
+        assert_eq!(
+            normalize_content_type(" audio/custom-codec "),
+            Some("audio/custom-codec".to_string())
+        );
+        assert_eq!(normalize_content_type("\ntext/plain"), None);
+        assert_eq!(normalize_content_type(""), None);
+    }
+
+    #[test]
+    fn media_storage_not_found_maps_to_404() {
+        let error = MediaStorageError::NotFound {
+            key: "opaque-key".to_string(),
+            message: "missing".to_string(),
+        };
+
+        let api_error = map_media_error(error);
+
+        assert_eq!(api_error.status, StatusCode::NOT_FOUND);
     }
 }

--- a/crates/izwi-server/src/api/request_context.rs
+++ b/crates/izwi-server/src/api/request_context.rs
@@ -251,6 +251,7 @@ async fn record_request_outcome(
 fn auth_failure_status(err: &HookError) -> StatusCode {
     match err {
         HookError::Denied(_) => StatusCode::UNAUTHORIZED,
+        HookError::NotFound(_) => StatusCode::INTERNAL_SERVER_ERROR,
         HookError::Failed(_) => StatusCode::INTERNAL_SERVER_ERROR,
     }
 }
@@ -258,6 +259,7 @@ fn auth_failure_status(err: &HookError) -> StatusCode {
 fn policy_failure_status(err: &HookError) -> StatusCode {
     match err {
         HookError::Denied(_) => StatusCode::FORBIDDEN,
+        HookError::NotFound(_) => StatusCode::INTERNAL_SERVER_ERROR,
         HookError::Failed(_) => StatusCode::INTERNAL_SERVER_ERROR,
     }
 }

--- a/crates/izwi-server/src/chat_store.rs
+++ b/crates/izwi-server/src/chat_store.rs
@@ -52,6 +52,10 @@ impl ChatStore {
         })
     }
 
+    pub fn initialize_with_database(db: StoreDatabase) -> Self {
+        Self { db }
+    }
+
     pub async fn list_threads(&self) -> anyhow::Result<Vec<ChatThreadSummary>> {
         let db = self.db.connection().await?;
         let rows = db

--- a/crates/izwi-server/src/chat_store.rs
+++ b/crates/izwi-server/src/chat_store.rs
@@ -1,16 +1,16 @@
 //! Persistent chat thread storage backed by SQLite.
 
-use anyhow::{Context, anyhow};
+use anyhow::{anyhow, Context};
 use sea_orm::sea_query::Expr;
 use sea_orm::{
-    ColumnTrait, ConnectionTrait, DatabaseConnection, DbBackend, EntityTrait, QueryFilter,
-    QueryResult, Set, Statement, TransactionTrait,
+    ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryResult, Set,
+    TransactionTrait,
 };
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::db::StoreDatabase;
+use crate::db::{raw, StoreDatabase};
 use crate::entity::{chat_messages, chat_threads};
 use crate::ids::new_uuid;
 
@@ -59,10 +59,7 @@ impl ChatStore {
     pub async fn list_threads(&self) -> anyhow::Result<Vec<ChatThreadSummary>> {
         let db = self.db.connection().await?;
         let rows = db
-            .query_all_raw(Statement::from_string(
-                DbBackend::Sqlite,
-                THREAD_SUMMARY_LIST_SQL.to_string(),
-            ))
+            .query_all_raw(raw::statement_without_values(db, THREAD_SUMMARY_LIST_SQL))
             .await
             .context("Failed to list chat threads")?;
         rows.iter().map(map_thread_summary).collect()
@@ -117,11 +114,11 @@ impl ChatStore {
     pub async fn list_messages(&self, thread_id: String) -> anyhow::Result<Vec<ChatThreadMessage>> {
         let db = self.db.connection().await?;
         let rows = db
-            .query_all_raw(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
+            .query_all_raw(raw::statement(
+                db,
                 CHAT_MESSAGES_LIST_SQL,
                 vec![thread_id.into()],
-            ))
+            )?)
             .await
             .context("Failed to list chat messages")?;
         rows.iter().map(map_thread_message).collect()
@@ -294,11 +291,11 @@ async fn fetch_thread_summary(
     thread_id: &str,
 ) -> anyhow::Result<Option<ChatThreadSummary>> {
     let row = db
-        .query_one_raw(Statement::from_sql_and_values(
-            DbBackend::Sqlite,
+        .query_one_raw(raw::statement(
+            db,
             THREAD_SUMMARY_BY_ID_SQL,
             vec![thread_id.into()],
-        ))
+        )?)
         .await
         .context("Failed to load chat thread summary")?;
     row.as_ref().map(map_thread_summary).transpose()
@@ -379,7 +376,11 @@ fn opt_usize_to_i64(value: Option<usize>) -> anyhow::Result<Option<i64>> {
 }
 
 fn i64_to_u64(value: i64) -> u64 {
-    if value.is_negative() { 0 } else { value as u64 }
+    if value.is_negative() {
+        0
+    } else {
+        value as u64
+    }
 }
 
 fn i64_to_usize(value: i64) -> usize {
@@ -424,13 +425,11 @@ mod tests {
     async fn persists_threads_messages_and_content_parts() {
         with_env_lock(async {
             let (_temp, store) = setup_store();
-            assert!(
-                store
-                    .list_threads()
-                    .await
-                    .expect("threads should list")
-                    .is_empty()
-            );
+            assert!(store
+                .list_threads()
+                .await
+                .expect("threads should list")
+                .is_empty());
 
             let thread = store
                 .create_thread(
@@ -497,19 +496,15 @@ mod tests {
                 .expect("thread should exist");
             assert_eq!(updated.title, "Renamed");
 
-            assert!(
-                store
-                    .delete_thread(thread.id.clone())
-                    .await
-                    .expect("thread should delete")
-            );
-            assert!(
-                store
-                    .list_messages(thread.id)
-                    .await
-                    .expect("messages should list")
-                    .is_empty()
-            );
+            assert!(store
+                .delete_thread(thread.id.clone())
+                .await
+                .expect("thread should delete"));
+            assert!(store
+                .list_messages(thread.id)
+                .await
+                .expect("messages should list")
+                .is_empty());
             clear_env();
         })
         .await;

--- a/crates/izwi-server/src/db/mod.rs
+++ b/crates/izwi-server/src/db/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod migrator;
 pub mod raw;
+pub mod schema_contract;
 pub mod sqlite;
 
 pub use sqlite::StoreDatabase;

--- a/crates/izwi-server/src/db/mod.rs
+++ b/crates/izwi-server/src/db/mod.rs
@@ -3,4 +3,4 @@
 pub mod migrator;
 pub mod sqlite;
 
-pub use sqlite::{StoreDatabase, initialize_default};
+pub use sqlite::StoreDatabase;

--- a/crates/izwi-server/src/db/mod.rs
+++ b/crates/izwi-server/src/db/mod.rs
@@ -1,6 +1,7 @@
 //! SeaORM-backed database initialization.
 
 pub mod migrator;
+pub mod raw;
 pub mod sqlite;
 
 pub use sqlite::StoreDatabase;

--- a/crates/izwi-server/src/db/raw.rs
+++ b/crates/izwi-server/src/db/raw.rs
@@ -1,11 +1,7 @@
 use anyhow::{bail, Context};
 use sea_orm::{ConnectionTrait, DbBackend, Statement, Value};
 
-pub fn statement<C>(
-    db: &C,
-    sql: impl Into<String>,
-    values: Vec<Value>,
-) -> anyhow::Result<Statement>
+pub fn statement<C>(db: &C, sql: impl Into<String>, values: Vec<Value>) -> anyhow::Result<Statement>
 where
     C: ConnectionTrait,
 {
@@ -28,12 +24,24 @@ where
     Statement::from_string(db.get_database_backend(), sql)
 }
 
-pub fn json_extract_text(backend: DbBackend, expression: &str, key: &str) -> anyhow::Result<String> {
+pub fn json_extract_text(
+    backend: DbBackend,
+    expression: &str,
+    key: &str,
+) -> anyhow::Result<String> {
     validate_json_key(key)?;
     Ok(match backend {
         DbBackend::Sqlite => format!("json_extract({expression}, '$.{key}')"),
         DbBackend::Postgres => format!("(({expression})::jsonb ->> '{key}')"),
         DbBackend::MySql => format!("JSON_UNQUOTE(JSON_EXTRACT({expression}, '$.{key}'))"),
+        _ => bail!("Unsupported SeaORM database backend: {backend:?}"),
+    })
+}
+
+pub fn greatest(backend: DbBackend, left: &str, right: &str) -> anyhow::Result<String> {
+    Ok(match backend {
+        DbBackend::Sqlite => format!("MAX({left}, {right})"),
+        DbBackend::Postgres | DbBackend::MySql => format!("GREATEST({left}, {right})"),
         _ => bail!("Unsupported SeaORM database backend: {backend:?}"),
     })
 }
@@ -192,12 +200,9 @@ mod tests {
     #[test]
     fn postgres_rewrites_indexed_placeholders_without_duplication() {
         let values = vec!["first".into(), 2_i64.into()];
-        let statement = statement_for_backend(
-            DbBackend::Postgres,
-            "SELECT ?1, ?2, ?1, '?'",
-            values,
-        )
-        .expect("statement should build");
+        let statement =
+            statement_for_backend(DbBackend::Postgres, "SELECT ?1, ?2, ?1, '?'", values)
+                .expect("statement should build");
 
         assert_eq!(statement.sql, "SELECT $1, $2, $1, '?'");
         assert_eq!(statement.values.expect("values").0.len(), 2);
@@ -206,9 +211,8 @@ mod tests {
     #[test]
     fn mysql_rewrites_indexed_placeholders_and_duplicates_reused_values() {
         let values = vec!["first".into(), 2_i64.into()];
-        let statement =
-            statement_for_backend(DbBackend::MySql, "SELECT ?1, ?2, ?1, '?2'", values)
-                .expect("statement should build");
+        let statement = statement_for_backend(DbBackend::MySql, "SELECT ?1, ?2, ?1, '?2'", values)
+            .expect("statement should build");
 
         assert_eq!(statement.sql, "SELECT ?, ?, ?, '?2'");
         assert_eq!(statement.values.expect("values").0.len(), 3);
@@ -247,6 +251,22 @@ mod tests {
         assert_eq!(
             json_extract_text(DbBackend::MySql, "project_json", "name").expect("mysql"),
             "JSON_UNQUOTE(JSON_EXTRACT(project_json, '$.name'))"
+        );
+    }
+
+    #[test]
+    fn greatest_fragments_are_backend_specific() {
+        assert_eq!(
+            greatest(DbBackend::Sqlite, "confidence", "?1").expect("sqlite"),
+            "MAX(confidence, ?1)"
+        );
+        assert_eq!(
+            greatest(DbBackend::Postgres, "confidence", "?1").expect("postgres"),
+            "GREATEST(confidence, ?1)"
+        );
+        assert_eq!(
+            greatest(DbBackend::MySql, "confidence", "?1").expect("mysql"),
+            "GREATEST(confidence, ?1)"
         );
     }
 }

--- a/crates/izwi-server/src/db/raw.rs
+++ b/crates/izwi-server/src/db/raw.rs
@@ -1,0 +1,252 @@
+use anyhow::{bail, Context};
+use sea_orm::{ConnectionTrait, DbBackend, Statement, Value};
+
+pub fn statement<C>(
+    db: &C,
+    sql: impl Into<String>,
+    values: Vec<Value>,
+) -> anyhow::Result<Statement>
+where
+    C: ConnectionTrait,
+{
+    statement_for_backend(db.get_database_backend(), sql, values)
+}
+
+pub fn statement_for_backend(
+    backend: DbBackend,
+    sql: impl Into<String>,
+    values: Vec<Value>,
+) -> anyhow::Result<Statement> {
+    let (sql, values) = rewrite_indexed_placeholders(backend, sql.into(), values)?;
+    Ok(Statement::from_sql_and_values(backend, sql, values))
+}
+
+pub fn statement_without_values<C>(db: &C, sql: impl Into<String>) -> Statement
+where
+    C: ConnectionTrait,
+{
+    Statement::from_string(db.get_database_backend(), sql)
+}
+
+pub fn json_extract_text(backend: DbBackend, expression: &str, key: &str) -> anyhow::Result<String> {
+    validate_json_key(key)?;
+    Ok(match backend {
+        DbBackend::Sqlite => format!("json_extract({expression}, '$.{key}')"),
+        DbBackend::Postgres => format!("(({expression})::jsonb ->> '{key}')"),
+        DbBackend::MySql => format!("JSON_UNQUOTE(JSON_EXTRACT({expression}, '$.{key}'))"),
+        _ => bail!("Unsupported SeaORM database backend: {backend:?}"),
+    })
+}
+
+fn rewrite_indexed_placeholders(
+    backend: DbBackend,
+    sql: String,
+    values: Vec<Value>,
+) -> anyhow::Result<(String, Vec<Value>)> {
+    if values.is_empty() {
+        return Ok((sql, values));
+    }
+
+    let placeholders = parse_placeholders(&sql)?;
+    if placeholders.is_empty() {
+        return Ok((sql, values));
+    }
+
+    match backend {
+        DbBackend::Sqlite => Ok((sql, values)),
+        DbBackend::Postgres => rewrite_postgres(sql, placeholders, values),
+        DbBackend::MySql => rewrite_mysql(sql, placeholders, values),
+        _ => bail!("Unsupported SeaORM database backend: {backend:?}"),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Placeholder {
+    start: usize,
+    end: usize,
+    index: usize,
+}
+
+fn parse_placeholders(sql: &str) -> anyhow::Result<Vec<Placeholder>> {
+    let bytes = sql.as_bytes();
+    let mut placeholders = Vec::new();
+    let mut index = 0;
+    let mut in_single_quote = false;
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+
+        if byte == b'\'' {
+            if in_single_quote && bytes.get(index + 1) == Some(&b'\'') {
+                index += 2;
+                continue;
+            }
+            in_single_quote = !in_single_quote;
+            index += 1;
+            continue;
+        }
+
+        if in_single_quote || byte != b'?' {
+            index += 1;
+            continue;
+        }
+
+        let digits_start = index + 1;
+        let mut digits_end = digits_start;
+        while bytes
+            .get(digits_end)
+            .is_some_and(|candidate| candidate.is_ascii_digit())
+        {
+            digits_end += 1;
+        }
+
+        if digits_end == digits_start {
+            index += 1;
+            continue;
+        }
+
+        let placeholder_index = sql[digits_start..digits_end]
+            .parse::<usize>()
+            .context("Invalid SQL placeholder index")?;
+        if placeholder_index == 0 {
+            bail!("SQL placeholders are one-indexed: ?0 is invalid");
+        }
+
+        placeholders.push(Placeholder {
+            start: index,
+            end: digits_end,
+            index: placeholder_index,
+        });
+        index = digits_end;
+    }
+
+    Ok(placeholders)
+}
+
+fn rewrite_postgres(
+    sql: String,
+    placeholders: Vec<Placeholder>,
+    values: Vec<Value>,
+) -> anyhow::Result<(String, Vec<Value>)> {
+    let mut rewritten = String::with_capacity(sql.len() + placeholders.len());
+    let mut cursor = 0;
+
+    for placeholder in placeholders {
+        ensure_value_exists(&values, placeholder.index)?;
+        rewritten.push_str(&sql[cursor..placeholder.start]);
+        rewritten.push('$');
+        rewritten.push_str(&placeholder.index.to_string());
+        cursor = placeholder.end;
+    }
+
+    rewritten.push_str(&sql[cursor..]);
+    Ok((rewritten, values))
+}
+
+fn rewrite_mysql(
+    sql: String,
+    placeholders: Vec<Placeholder>,
+    values: Vec<Value>,
+) -> anyhow::Result<(String, Vec<Value>)> {
+    let mut rewritten = String::with_capacity(sql.len());
+    let mut rewritten_values = Vec::with_capacity(placeholders.len());
+    let mut cursor = 0;
+
+    for placeholder in placeholders {
+        ensure_value_exists(&values, placeholder.index)?;
+        rewritten.push_str(&sql[cursor..placeholder.start]);
+        rewritten.push('?');
+        rewritten_values.push(values[placeholder.index - 1].clone());
+        cursor = placeholder.end;
+    }
+
+    rewritten.push_str(&sql[cursor..]);
+    Ok((rewritten, rewritten_values))
+}
+
+fn ensure_value_exists(values: &[Value], placeholder_index: usize) -> anyhow::Result<()> {
+    if placeholder_index > values.len() {
+        bail!(
+            "SQL placeholder ?{placeholder_index} has no matching value; only {} values were supplied",
+            values.len()
+        );
+    }
+    Ok(())
+}
+
+fn validate_json_key(key: &str) -> anyhow::Result<()> {
+    if key.is_empty()
+        || !key
+            .chars()
+            .all(|candidate| candidate.is_ascii_alphanumeric() || candidate == '_')
+    {
+        bail!("JSON key is not safe for raw SQL fragment: {key}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn postgres_rewrites_indexed_placeholders_without_duplication() {
+        let values = vec!["first".into(), 2_i64.into()];
+        let statement = statement_for_backend(
+            DbBackend::Postgres,
+            "SELECT ?1, ?2, ?1, '?'",
+            values,
+        )
+        .expect("statement should build");
+
+        assert_eq!(statement.sql, "SELECT $1, $2, $1, '?'");
+        assert_eq!(statement.values.expect("values").0.len(), 2);
+    }
+
+    #[test]
+    fn mysql_rewrites_indexed_placeholders_and_duplicates_reused_values() {
+        let values = vec!["first".into(), 2_i64.into()];
+        let statement =
+            statement_for_backend(DbBackend::MySql, "SELECT ?1, ?2, ?1, '?2'", values)
+                .expect("statement should build");
+
+        assert_eq!(statement.sql, "SELECT ?, ?, ?, '?2'");
+        assert_eq!(statement.values.expect("values").0.len(), 3);
+    }
+
+    #[test]
+    fn sqlite_keeps_indexed_placeholders() {
+        let values = vec!["first".into()];
+        let statement = statement_for_backend(DbBackend::Sqlite, "SELECT ?1", values)
+            .expect("statement should build");
+
+        assert_eq!(statement.sql, "SELECT ?1");
+    }
+
+    #[test]
+    fn missing_placeholder_values_are_rejected() {
+        let error = statement_for_backend(DbBackend::Postgres, "SELECT ?2", vec!["first".into()])
+            .expect_err("missing value should fail");
+
+        assert!(
+            error.to_string().contains("has no matching value"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn json_text_fragments_are_backend_specific() {
+        assert_eq!(
+            json_extract_text(DbBackend::Sqlite, "project_json", "name").expect("sqlite"),
+            "json_extract(project_json, '$.name')"
+        );
+        assert_eq!(
+            json_extract_text(DbBackend::Postgres, "project_json", "name").expect("postgres"),
+            "((project_json)::jsonb ->> 'name')"
+        );
+        assert_eq!(
+            json_extract_text(DbBackend::MySql, "project_json", "name").expect("mysql"),
+            "JSON_UNQUOTE(JSON_EXTRACT(project_json, '$.name'))"
+        );
+    }
+}

--- a/crates/izwi-server/src/db/schema_contract.rs
+++ b/crates/izwi-server/src/db/schema_contract.rs
@@ -1,0 +1,397 @@
+use crate::{db::raw, voice_defaults::DEFAULT_VOICE_PROFILE_ID};
+use anyhow::{Context, bail};
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend};
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, Copy)]
+struct RequiredSchemaTable {
+    name: &'static str,
+    columns: &'static [&'static str],
+}
+
+const REQUIRED_SCHEMA_TABLES: &[RequiredSchemaTable] = &[
+    RequiredSchemaTable {
+        name: "chat_threads",
+        columns: &["id", "title", "model_id", "created_at", "updated_at"],
+    },
+    RequiredSchemaTable {
+        name: "chat_messages",
+        columns: &[
+            "id",
+            "thread_id",
+            "role",
+            "content",
+            "content_parts",
+            "created_at",
+            "tokens_generated",
+            "generation_time_ms",
+        ],
+    },
+    RequiredSchemaTable {
+        name: "voice_profiles",
+        columns: &[
+            "id",
+            "name",
+            "system_prompt",
+            "observational_memory_enabled",
+            "created_at",
+            "updated_at",
+        ],
+    },
+    RequiredSchemaTable {
+        name: "voice_sessions",
+        columns: &[
+            "id",
+            "profile_id",
+            "mode",
+            "system_prompt",
+            "created_at",
+            "updated_at",
+            "ended_at",
+        ],
+    },
+    RequiredSchemaTable {
+        name: "voice_turns",
+        columns: &[
+            "id",
+            "session_id",
+            "utterance_id",
+            "utterance_seq",
+            "mode",
+            "status",
+            "status_reason",
+            "vad_end_reason",
+            "user_text",
+            "assistant_text",
+            "assistant_raw_text",
+            "language",
+            "audio_duration_secs",
+            "asr_model_id",
+            "text_model_id",
+            "tts_model_id",
+            "s2s_model_id",
+            "speaker",
+            "created_at",
+            "updated_at",
+        ],
+    },
+    RequiredSchemaTable {
+        name: "voice_observations",
+        columns: &[
+            "id",
+            "profile_id",
+            "category",
+            "summary",
+            "canonical_summary",
+            "confidence",
+            "source_turn_id",
+            "source_user_text",
+            "source_assistant_text",
+            "times_seen",
+            "created_at",
+            "updated_at",
+            "forgotten_at",
+        ],
+    },
+    RequiredSchemaTable {
+        name: "onboarding_state",
+        columns: &["id", "completed_at", "analytics_opt_in"],
+    },
+    RequiredSchemaTable {
+        name: "transcription_records",
+        columns: &[
+            "id",
+            "created_at",
+            "model_id",
+            "aligner_model_id",
+            "language",
+            "processing_status",
+            "processing_error",
+            "duration_secs",
+            "processing_time_ms",
+            "rtf",
+            "audio_mime_type",
+            "audio_filename",
+            "audio_storage_path",
+            "transcription",
+            "segments_json",
+            "words_json",
+            "summary_status",
+            "summary_model_id",
+            "summary_text",
+            "summary_error",
+            "summary_updated_at",
+        ],
+    },
+    RequiredSchemaTable {
+        name: "diarization_records",
+        columns: &[
+            "id",
+            "created_at",
+            "model_id",
+            "asr_model_id",
+            "aligner_model_id",
+            "llm_model_id",
+            "processing_status",
+            "processing_error",
+            "min_speakers",
+            "max_speakers",
+            "min_speech_duration_ms",
+            "min_silence_duration_ms",
+            "enable_llm_refinement",
+            "processing_time_ms",
+            "duration_secs",
+            "rtf",
+            "speaker_count",
+            "alignment_coverage",
+            "unattributed_words",
+            "llm_refined",
+            "asr_text",
+            "raw_transcript",
+            "transcript",
+            "summary_status",
+            "summary_model_id",
+            "summary_text",
+            "summary_error",
+            "summary_updated_at",
+            "segments_json",
+            "words_json",
+            "utterances_json",
+            "speaker_name_overrides_json",
+            "audio_mime_type",
+            "audio_filename",
+            "audio_storage_path",
+        ],
+    },
+    RequiredSchemaTable {
+        name: "speech_history_records",
+        columns: &[
+            "id",
+            "created_at",
+            "route_kind",
+            "processing_status",
+            "processing_error",
+            "model_id",
+            "speaker",
+            "language",
+            "saved_voice_id",
+            "speed",
+            "input_text",
+            "voice_description",
+            "reference_text",
+            "generation_time_ms",
+            "audio_duration_secs",
+            "rtf",
+            "tokens_generated",
+            "audio_mime_type",
+            "audio_filename",
+            "audio_storage_path",
+        ],
+    },
+    RequiredSchemaTable {
+        name: "saved_voices",
+        columns: &[
+            "id",
+            "created_at",
+            "updated_at",
+            "name",
+            "reference_text",
+            "audio_mime_type",
+            "audio_filename",
+            "audio_storage_path",
+            "source_route_kind",
+            "source_record_id",
+        ],
+    },
+    RequiredSchemaTable {
+        name: "studio_projects",
+        columns: &[
+            "id",
+            "created_at",
+            "updated_at",
+            "name",
+            "source_filename",
+            "source_text",
+            "model_id",
+            "voice_mode",
+            "speaker",
+            "saved_voice_id",
+            "speed",
+        ],
+    },
+    RequiredSchemaTable {
+        name: "studio_project_segments",
+        columns: &[
+            "id",
+            "project_id",
+            "position",
+            "text",
+            "model_id",
+            "voice_mode",
+            "speaker",
+            "saved_voice_id",
+            "speech_record_id",
+            "updated_at",
+        ],
+    },
+    RequiredSchemaTable {
+        name: "studio_project_folders",
+        columns: &[
+            "id",
+            "created_at",
+            "updated_at",
+            "name",
+            "parent_id",
+            "sort_order",
+        ],
+    },
+    RequiredSchemaTable {
+        name: "studio_project_meta",
+        columns: &[
+            "project_id",
+            "folder_id",
+            "tags_json",
+            "default_export_format",
+            "last_render_job_id",
+            "last_rendered_at",
+        ],
+    },
+    RequiredSchemaTable {
+        name: "studio_project_pronunciations",
+        columns: &[
+            "id",
+            "project_id",
+            "source_text",
+            "replacement_text",
+            "locale",
+            "created_at",
+            "updated_at",
+        ],
+    },
+    RequiredSchemaTable {
+        name: "studio_project_snapshots",
+        columns: &["id", "project_id", "created_at", "label", "project_json"],
+    },
+    RequiredSchemaTable {
+        name: "studio_project_render_jobs",
+        columns: &[
+            "id",
+            "project_id",
+            "created_at",
+            "updated_at",
+            "status",
+            "error_message",
+            "queued_segment_ids_json",
+        ],
+    },
+];
+
+pub async fn validate_provider_managed_schema(db: &DatabaseConnection) -> anyhow::Result<()> {
+    let mut missing_tables = Vec::new();
+    let mut missing_columns = Vec::new();
+
+    for table in REQUIRED_SCHEMA_TABLES {
+        let columns = load_table_columns(db, table.name)
+            .await
+            .with_context(|| format!("Failed to inspect enterprise table {}", table.name))?;
+
+        if columns.is_empty() {
+            missing_tables.push(table.name);
+            continue;
+        }
+
+        for required_column in table.columns {
+            if !columns.contains(*required_column) {
+                missing_columns.push(format!("{}.{}", table.name, required_column));
+            }
+        }
+    }
+
+    if !missing_tables.is_empty() || !missing_columns.is_empty() {
+        bail!(
+            "Enterprise database schema is incomplete. Missing tables: [{}]. Missing columns: [{}]. Run the provider-managed schema setup before starting Izwi.",
+            missing_tables.join(", "),
+            missing_columns.join(", ")
+        );
+    }
+
+    validate_required_seed_data(db).await?;
+    Ok(())
+}
+
+async fn load_table_columns(
+    db: &DatabaseConnection,
+    table: &'static str,
+) -> anyhow::Result<HashSet<String>> {
+    let backend = db.get_database_backend();
+    let rows = match backend {
+        DbBackend::Sqlite => {
+            db.query_all_raw(raw::statement_without_values(
+                db,
+                format!("PRAGMA table_info({table})"),
+            ))
+            .await?
+        }
+        DbBackend::Postgres => {
+            db.query_all_raw(raw::statement(
+                db,
+                r#"
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_schema = ANY (current_schemas(false))
+                  AND table_name = ?1
+                "#,
+                vec![table.into()],
+            )?)
+            .await?
+        }
+        DbBackend::MySql => {
+            db.query_all_raw(raw::statement(
+                db,
+                r#"
+                SELECT COLUMN_NAME
+                FROM information_schema.columns
+                WHERE table_schema = DATABASE()
+                  AND table_name = ?1
+                "#,
+                vec![table.into()],
+            )?)
+            .await?
+        }
+        _ => bail!("Unsupported SeaORM database backend: {backend:?}"),
+    };
+
+    let column_index = if matches!(backend, DbBackend::Sqlite) {
+        1
+    } else {
+        0
+    };
+
+    rows.into_iter()
+        .map(|row| {
+            row.try_get_by_index::<String>(column_index)
+                .map(|name| name.to_ascii_lowercase())
+                .map_err(Into::into)
+        })
+        .collect()
+}
+
+async fn validate_required_seed_data(db: &DatabaseConnection) -> anyhow::Result<()> {
+    let exists = db
+        .query_one_raw(raw::statement(
+            db,
+            "SELECT 1 FROM voice_profiles WHERE id = ?1 LIMIT 1",
+            vec![DEFAULT_VOICE_PROFILE_ID.into()],
+        )?)
+        .await?
+        .is_some();
+
+    if !exists {
+        bail!(
+            "Enterprise database schema is missing required seed data: voice_profiles.{}",
+            DEFAULT_VOICE_PROFILE_ID
+        );
+    }
+
+    Ok(())
+}

--- a/crates/izwi-server/src/db/sqlite.rs
+++ b/crates/izwi-server/src/db/sqlite.rs
@@ -1,6 +1,6 @@
 use crate::{db::migrator::Migrator, storage_layout};
 use anyhow::Context;
-use sea_orm::{ConnectOptions, Database, DatabaseConnection, sqlx::sqlite::SqliteJournalMode};
+use sea_orm::{sqlx::sqlite::SqliteJournalMode, ConnectOptions, Database, DatabaseConnection};
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -10,6 +10,7 @@ use tokio::sync::OnceCell;
 const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(3);
 const SQLITE_MAX_CONNECTIONS: u32 = 5;
 
+#[cfg(test)]
 pub async fn initialize_default() -> anyhow::Result<DatabaseConnection> {
     let db = connect_default().await?;
     Migrator::up(&db)

--- a/crates/izwi-server/src/db/sqlite.rs
+++ b/crates/izwi-server/src/db/sqlite.rs
@@ -1,6 +1,7 @@
 use crate::{db::migrator::Migrator, storage_layout};
 use anyhow::Context;
 use sea_orm::{ConnectOptions, Database, DatabaseConnection, sqlx::sqlite::SqliteJournalMode};
+use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -52,7 +53,7 @@ pub async fn connect_path(db_path: &Path) -> anyhow::Result<DatabaseConnection> 
 
 #[derive(Clone)]
 pub struct StoreDatabase {
-    db_path: PathBuf,
+    db_path: Option<PathBuf>,
     connection: Arc<OnceCell<DatabaseConnection>>,
 }
 
@@ -67,22 +68,48 @@ impl StoreDatabase {
 
     pub fn new(db_path: PathBuf) -> Self {
         Self {
-            db_path,
+            db_path: Some(db_path),
             connection: Arc::new(OnceCell::new()),
         }
     }
 
+    pub fn from_connection(connection: DatabaseConnection) -> Self {
+        let cell = OnceCell::new();
+        cell.set(connection)
+            .map_err(|_| ())
+            .expect("new OnceCell should accept initial database connection");
+        Self {
+            db_path: None,
+            connection: Arc::new(cell),
+        }
+    }
+
     pub async fn connection(&self) -> anyhow::Result<&DatabaseConnection> {
-        let db_path = self.db_path.clone();
+        if let Some(db_path) = self.db_path.clone() {
+            return self
+                .connection
+                .get_or_try_init(|| async move {
+                    let db = connect_path(&db_path).await?;
+                    Migrator::up(&db)
+                        .await
+                        .context("Failed to run SQLite migrations for SeaORM store")?;
+                    Ok(db)
+                })
+                .await;
+        }
+
         self.connection
-            .get_or_try_init(|| async move {
-                let db = connect_path(&db_path).await?;
-                Migrator::up(&db)
-                    .await
-                    .context("Failed to run SQLite migrations for SeaORM store")?;
-                Ok(db)
-            })
-            .await
+            .get()
+            .context("Store database was constructed without a connection")
+    }
+}
+
+impl fmt::Debug for StoreDatabase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StoreDatabase")
+            .field("db_path", &self.db_path)
+            .field("has_connection", &self.connection.get().is_some())
+            .finish()
     }
 }
 

--- a/crates/izwi-server/src/diarization_store.rs
+++ b/crates/izwi-server/src/diarization_store.rs
@@ -274,6 +274,16 @@ impl DiarizationStore {
         })
     }
 
+    pub fn initialize_with_database(
+        db: StoreDatabase,
+        media_root: PathBuf,
+    ) -> anyhow::Result<Self> {
+        storage_layout::ensure_media_dirs(&media_root)
+            .context("Failed to prepare diarization media storage layout")?;
+
+        Ok(Self { db, media_root })
+    }
+
     pub async fn list_records_page(
         &self,
         limit: usize,

--- a/crates/izwi-server/src/diarization_store.rs
+++ b/crates/izwi-server/src/diarization_store.rs
@@ -1,6 +1,7 @@
 //! Persistent diarization history storage backed by SQLite.
 
-use anyhow::{Context, anyhow};
+use anyhow::{anyhow, Context};
+use izwi_hooks::{HookMetadata, MediaNamespace, MediaStorageProvider};
 use sea_orm::sea_query::Expr;
 use sea_orm::{
     ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, QueryFilter, QueryResult, Set, Statement,
@@ -8,13 +9,17 @@ use sea_orm::{
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
     db::StoreDatabase,
     entity::diarization_records,
     ids::new_uuid,
-    storage_layout::{self, MediaGroup},
+    persistence::{
+        delete_media_object, persist_audio_object, read_media_object, LocalMediaStorageProvider,
+    },
+    storage_layout,
 };
 
 const DEFAULT_LIST_LIMIT: usize = 200;
@@ -253,7 +258,7 @@ pub struct CompleteDiarizationRecord {
 #[derive(Clone)]
 pub struct DiarizationStore {
     db: StoreDatabase,
-    media_root: PathBuf,
+    media_storage: Arc<dyn MediaStorageProvider>,
 }
 
 impl DiarizationStore {
@@ -270,18 +275,15 @@ impl DiarizationStore {
 
         Ok(Self {
             db: StoreDatabase::new(db_path),
-            media_root,
+            media_storage: Arc::new(LocalMediaStorageProvider::new(media_root)),
         })
     }
 
-    pub fn initialize_with_database(
+    pub fn initialize_with_storage(
         db: StoreDatabase,
-        media_root: PathBuf,
-    ) -> anyhow::Result<Self> {
-        storage_layout::ensure_media_dirs(&media_root)
-            .context("Failed to prepare diarization media storage layout")?;
-
-        Ok(Self { db, media_root })
+        media_storage: Arc<dyn MediaStorageProvider>,
+    ) -> Self {
+        Self { db, media_storage }
     }
 
     pub async fn list_records_page(
@@ -369,8 +371,9 @@ impl DiarizationStore {
         let audio_storage_path: String = row.try_get_by_index(0)?;
         let audio_mime_type: String = row.try_get_by_index(1)?;
         let audio_filename: Option<String> = row.try_get_by_index(2)?;
-        let audio_bytes =
-            storage_layout::read_media_file(&self.media_root, audio_storage_path.as_str())?;
+        let audio_bytes = read_media_object(&self.media_storage, audio_storage_path.as_str())
+            .await
+            .context("Failed to read diarization media")?;
 
         Ok(Some(StoredDiarizationAudio {
             audio_bytes,
@@ -452,15 +455,16 @@ impl DiarizationStore {
             return Err(anyhow!("Audio payload cannot be empty"));
         }
 
-        let audio_storage_path = storage_layout::persist_audio_file(
-            &self.media_root,
-            MediaGroup::Uploads,
-            "diarization",
+        let audio_storage_path = persist_audio_object(
+            &self.media_storage,
+            MediaNamespace::DiarizationUpload,
             &record_id,
             audio_filename.as_deref(),
             audio_mime_type.as_str(),
             &record.audio_bytes,
-        )?;
+            HookMetadata::new(),
+        )
+        .await?;
 
         let segments_json =
             serde_json::to_string(&record.segments).context("Failed serializing segments")?;
@@ -515,10 +519,8 @@ impl DiarizationStore {
         .exec(db)
         .await
         {
-            let _ = storage_layout::delete_media_file(
-                &self.media_root,
-                Some(audio_storage_path.as_str()),
-            );
+            let _ =
+                delete_media_object(&self.media_storage, Some(audio_storage_path.as_str())).await;
             return Err(err).context("Failed to insert diarization record");
         }
 
@@ -537,7 +539,7 @@ impl DiarizationStore {
             .context("Failed to delete diarization record")?;
 
         if result.rows_affected > 0 {
-            storage_layout::delete_media_file(&self.media_root, audio_storage_path.as_deref())?;
+            delete_media_object(&self.media_storage, audio_storage_path.as_deref()).await?;
         }
 
         Ok(result.rows_affected > 0)
@@ -1357,7 +1359,11 @@ fn now_unix_millis_i64() -> i64 {
 }
 
 fn i64_to_u64(value: i64) -> u64 {
-    if value.is_negative() { 0 } else { value as u64 }
+    if value.is_negative() {
+        0
+    } else {
+        value as u64
+    }
 }
 
 fn i64_to_usize(value: i64) -> Option<usize> {
@@ -1608,10 +1614,9 @@ mod tests {
             .await
             .expect_err("unknown speaker should fail");
 
-        assert!(
-            err.to_string()
-                .contains("Unknown diarization speaker label")
-        );
+        assert!(err
+            .to_string()
+            .contains("Unknown diarization speaker label"));
         std::fs::remove_dir_all(root).expect("test temp dir should be removable");
     }
 

--- a/crates/izwi-server/src/diarization_store.rs
+++ b/crates/izwi-server/src/diarization_store.rs
@@ -371,12 +371,12 @@ impl DiarizationStore {
         let audio_storage_path: String = row.try_get_by_index(0)?;
         let audio_mime_type: String = row.try_get_by_index(1)?;
         let audio_filename: Option<String> = row.try_get_by_index(2)?;
-        let audio_bytes = read_media_object(&self.media_storage, audio_storage_path.as_str())
+        let audio = read_media_object(&self.media_storage, audio_storage_path.as_str())
             .await
             .context("Failed to read diarization media")?;
 
         Ok(Some(StoredDiarizationAudio {
-            audio_bytes,
+            audio_bytes: audio.bytes,
             audio_mime_type,
             audio_filename,
         }))

--- a/crates/izwi-server/src/diarization_store.rs
+++ b/crates/izwi-server/src/diarization_store.rs
@@ -3,9 +3,7 @@
 use anyhow::{anyhow, Context};
 use izwi_hooks::{HookMetadata, MediaNamespace, MediaStorageProvider};
 use sea_orm::sea_query::Expr;
-use sea_orm::{
-    ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, QueryFilter, QueryResult, Set, Statement,
-};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryResult, Set};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
@@ -13,7 +11,7 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
-    db::StoreDatabase,
+    db::{raw, StoreDatabase},
     entity::diarization_records,
     ids::new_uuid,
     persistence::{
@@ -300,22 +298,22 @@ impl DiarizationStore {
 
         let rows = if let Some(cursor) = cursor {
             let cursor_created_at = i64::try_from(cursor.created_at).unwrap_or(i64::MAX);
-            db.query_all_raw(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
+            db.query_all_raw(raw::statement(
+                db,
                 DIARIZATION_PAGE_AFTER_CURSOR_SQL,
                 vec![
                     cursor_created_at.into(),
                     cursor.id.into(),
                     fetch_limit.into(),
                 ],
-            ))
+            )?)
             .await
         } else {
-            db.query_all_raw(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
+            db.query_all_raw(raw::statement(
+                db,
                 DIARIZATION_PAGE_SQL,
                 vec![fetch_limit.into()],
-            ))
+            )?)
             .await
         }
         .context("Failed to list diarization records")?;
@@ -353,15 +351,15 @@ impl DiarizationStore {
     ) -> anyhow::Result<Option<StoredDiarizationAudio>> {
         let db = self.db.connection().await?;
         let audio = db
-            .query_one_raw(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
+            .query_one_raw(raw::statement(
+                db,
                 r#"
                 SELECT audio_storage_path, audio_mime_type, audio_filename
                 FROM diarization_records
                 WHERE id = ?1
                 "#,
                 vec![record_id.into()],
-            ))
+            )?)
             .await
             .context("Failed to load diarization audio metadata")?;
         let Some(row) = audio else {
@@ -945,11 +943,11 @@ async fn fetch_record_without_audio(
     record_id: &str,
 ) -> anyhow::Result<Option<DiarizationRecord>> {
     let row = db
-        .query_one_raw(Statement::from_sql_and_values(
-            DbBackend::Sqlite,
+        .query_one_raw(raw::statement(
+            db,
             format!("SELECT {DIARIZATION_RECORD_COLUMNS} FROM diarization_records WHERE id = ?1"),
             vec![record_id.into()],
-        ))
+        )?)
         .await
         .context("Failed to load diarization record")?;
     row.as_ref().map(map_diarization_record).transpose()
@@ -960,11 +958,11 @@ async fn fetch_audio_storage_path(
     record_id: &str,
 ) -> anyhow::Result<Option<Option<String>>> {
     let row = db
-        .query_one_raw(Statement::from_sql_and_values(
-            DbBackend::Sqlite,
+        .query_one_raw(raw::statement(
+            db,
             "SELECT audio_storage_path FROM diarization_records WHERE id = ?1",
             vec![record_id.into()],
-        ))
+        )?)
         .await
         .context("Failed to load diarization media path")?;
     row.map(|row| row.try_get_by_index::<Option<String>>(0))

--- a/crates/izwi-server/src/lib.rs
+++ b/crates/izwi-server/src/lib.rs
@@ -18,6 +18,7 @@ mod error;
 mod ids;
 mod logging;
 mod onboarding_store;
+mod persistence;
 mod saved_voice_store;
 mod speech_history_store;
 mod state;

--- a/crates/izwi-server/src/lib.rs
+++ b/crates/izwi-server/src/lib.rs
@@ -38,6 +38,7 @@ use izwi_core::{
 };
 use izwi_hooks::EnterpriseHooks;
 use logging::{LogFormat, SERVICE_NAME, SERVICE_VERSION};
+use persistence::PersistenceContext;
 use state::AppState;
 
 #[derive(Debug, Parser)]
@@ -112,8 +113,13 @@ async fn run_with_args(args: ServerArgs, enterprise_hooks: EnterpriseHooks) -> a
 
     // Create runtime service
     let runtime = RuntimeService::new(config)?;
-    db::initialize_default().await?;
-    let state = AppState::with_enterprise_hooks(runtime, &serve_config, enterprise_hooks)?;
+    let persistence = PersistenceContext::resolve(&enterprise_hooks).await?;
+    let state = AppState::with_enterprise_hooks_and_persistence(
+        runtime,
+        &serve_config,
+        enterprise_hooks,
+        persistence,
+    )?;
     let mut startup_warnings = preload_configured_models(&state).await;
     startup_warnings.extend(warmup_preloaded_asr_models(&state).await);
     if !startup_warnings.is_empty() {

--- a/crates/izwi-server/src/lib.rs
+++ b/crates/izwi-server/src/lib.rs
@@ -114,6 +114,12 @@ async fn run_with_args(args: ServerArgs, enterprise_hooks: EnterpriseHooks) -> a
     // Create runtime service
     let runtime = RuntimeService::new(config)?;
     let persistence = PersistenceContext::resolve(&enterprise_hooks).await?;
+    info!(
+        database_backend = ?persistence.database.backend(),
+        database_migration_mode = ?persistence.database.migration_mode(),
+        database_metadata_keys = persistence.database.metadata().len(),
+        "Persistence database resolved"
+    );
     let state = AppState::with_enterprise_hooks_and_persistence(
         runtime,
         &serve_config,

--- a/crates/izwi-server/src/onboarding_store.rs
+++ b/crates/izwi-server/src/onboarding_store.rs
@@ -30,6 +30,10 @@ impl OnboardingStore {
         })
     }
 
+    pub fn initialize_with_database(db: StoreDatabase) -> Self {
+        Self { db }
+    }
+
     pub async fn get_state(&self) -> anyhow::Result<OnboardingState> {
         let db = self.db.connection().await?;
         read_state(db).await

--- a/crates/izwi-server/src/persistence/mod.rs
+++ b/crates/izwi-server/src/persistence/mod.rs
@@ -1,0 +1,344 @@
+use crate::{db, db::migrator::Migrator, storage_layout};
+use anyhow::Context;
+use izwi_hooks::{
+    DatabaseBackend, DatabaseConnectionDecision, DatabaseMigrationMode, DatabaseProviderDecision,
+    DatabaseProviderRequest, EnterpriseHooks, HookError, HookMetadata, HookResult,
+    MediaDeleteRequest, MediaNamespace, MediaObjectKey, MediaObjectMetadata, MediaReadRequest,
+    MediaStorageProvider, MediaStorageProviderDecision, MediaStorageProviderRequest,
+    MediaWriteRequest, StoredMediaBytes, StoredMediaObject,
+};
+use sea_orm::DatabaseConnection;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct PersistenceContext {
+    pub database: DatabaseContext,
+    pub media_storage: Arc<dyn MediaStorageProvider>,
+}
+
+impl PersistenceContext {
+    pub async fn resolve(enterprise_hooks: &EnterpriseHooks) -> anyhow::Result<Self> {
+        let database = resolve_database(enterprise_hooks).await?;
+        let media_storage = resolve_media_storage(enterprise_hooks).await?;
+
+        Ok(Self {
+            database,
+            media_storage,
+        })
+    }
+
+    pub async fn local_default() -> anyhow::Result<Self> {
+        let hooks = EnterpriseHooks::noop();
+        Self::resolve(&hooks).await
+    }
+}
+
+#[derive(Clone)]
+pub struct DatabaseContext {
+    connection: DatabaseConnection,
+    backend: DatabaseBackend,
+    migration_mode: DatabaseMigrationMode,
+    metadata: HookMetadata,
+}
+
+impl DatabaseContext {
+    pub fn new(
+        connection: DatabaseConnection,
+        backend: DatabaseBackend,
+        migration_mode: DatabaseMigrationMode,
+        metadata: HookMetadata,
+    ) -> Self {
+        Self {
+            connection,
+            backend,
+            migration_mode,
+            metadata,
+        }
+    }
+
+    pub fn connection(&self) -> DatabaseConnection {
+        self.connection.clone()
+    }
+
+    pub fn backend(&self) -> &DatabaseBackend {
+        &self.backend
+    }
+
+    pub fn migration_mode(&self) -> &DatabaseMigrationMode {
+        &self.migration_mode
+    }
+
+    pub fn metadata(&self) -> &HookMetadata {
+        &self.metadata
+    }
+}
+
+async fn resolve_database(enterprise_hooks: &EnterpriseHooks) -> anyhow::Result<DatabaseContext> {
+    match enterprise_hooks
+        .database
+        .resolve_database(&DatabaseProviderRequest::server_runtime())
+        .await
+        .map_err(|err| anyhow::anyhow!("Enterprise database hook failed: {err}"))?
+    {
+        DatabaseProviderDecision::UseDefault => local_database_context().await,
+        DatabaseProviderDecision::UseConnection(decision) => provider_database_context(decision).await,
+    }
+}
+
+async fn local_database_context() -> anyhow::Result<DatabaseContext> {
+    let connection = db::sqlite::connect_default().await?;
+    Migrator::up(&connection)
+        .await
+        .context("Failed to run local SQLite migrations")?;
+
+    Ok(DatabaseContext::new(
+        connection,
+        DatabaseBackend::Sqlite,
+        DatabaseMigrationMode::IzwiManaged,
+        HookMetadata::new(),
+    ))
+}
+
+async fn provider_database_context(
+    decision: DatabaseConnectionDecision,
+) -> anyhow::Result<DatabaseContext> {
+    if matches!(decision.migration_mode, DatabaseMigrationMode::IzwiManaged) {
+        Migrator::up(&decision.connection)
+            .await
+            .context("Failed to run Izwi-managed migrations on enterprise database")?;
+    }
+
+    Ok(DatabaseContext::new(
+        decision.connection,
+        decision.backend,
+        decision.migration_mode,
+        decision.metadata,
+    ))
+}
+
+async fn resolve_media_storage(
+    enterprise_hooks: &EnterpriseHooks,
+) -> anyhow::Result<Arc<dyn MediaStorageProvider>> {
+    match enterprise_hooks
+        .media_storage
+        .resolve_media_storage(&MediaStorageProviderRequest::server_media())
+        .await
+        .map_err(|err| anyhow::anyhow!("Enterprise media storage hook failed: {err}"))?
+    {
+        MediaStorageProviderDecision::UseDefault => Ok(Arc::new(LocalMediaStorageProvider::new(
+            storage_layout::resolve_media_root(),
+        ))),
+        MediaStorageProviderDecision::UseProvider(provider) => Ok(provider),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalMediaStorageProvider {
+    media_root: PathBuf,
+}
+
+impl LocalMediaStorageProvider {
+    pub fn new(media_root: PathBuf) -> Self {
+        Self { media_root }
+    }
+
+    pub fn media_root(&self) -> &PathBuf {
+        &self.media_root
+    }
+}
+
+#[async_trait::async_trait]
+impl MediaStorageProvider for LocalMediaStorageProvider {
+    async fn put(
+        &self,
+        request: MediaWriteRequest,
+        bytes: Vec<u8>,
+    ) -> HookResult<StoredMediaObject> {
+        let content_length = bytes.len() as u64;
+        let (group, namespace) = local_namespace(&request.namespace, &request.metadata);
+        let key = storage_layout::persist_audio_file(
+            &self.media_root,
+            group,
+            &namespace,
+            &request.record_id,
+            request.preferred_filename.as_deref(),
+            &request.content_type,
+            &bytes,
+        )
+        .map_err(|err| HookError::Failed(err.to_string()))?;
+
+        Ok(StoredMediaObject {
+            key: MediaObjectKey::new(key),
+            metadata: MediaObjectMetadata {
+                content_type: request.content_type,
+                filename: request.preferred_filename,
+                content_length: Some(content_length),
+                sha256: None,
+                tenant_id: None,
+                attributes: request.metadata,
+            },
+        })
+    }
+
+    async fn get(&self, request: MediaReadRequest) -> HookResult<StoredMediaBytes> {
+        let bytes = storage_layout::read_media_file(&self.media_root, &request.key.key)
+            .map_err(|err| HookError::Failed(err.to_string()))?;
+
+        Ok(StoredMediaBytes {
+            metadata: MediaObjectMetadata {
+                content_type: content_type_from_key(&request.key.key).to_string(),
+                filename: filename_from_key(&request.key.key),
+                content_length: Some(bytes.len() as u64),
+                sha256: None,
+                tenant_id: None,
+                attributes: request.metadata,
+            },
+            bytes,
+        })
+    }
+
+    async fn delete(&self, request: MediaDeleteRequest) -> HookResult<()> {
+        storage_layout::delete_media_file(&self.media_root, Some(&request.key.key))
+            .map_err(|err| HookError::Failed(err.to_string()))
+    }
+}
+
+fn local_namespace(
+    namespace: &MediaNamespace,
+    metadata: &HookMetadata,
+) -> (storage_layout::MediaGroup, String) {
+    match namespace {
+        MediaNamespace::TranscriptionUpload => (
+            storage_layout::MediaGroup::Uploads,
+            "transcription".to_string(),
+        ),
+        MediaNamespace::DiarizationUpload => (
+            storage_layout::MediaGroup::Uploads,
+            "diarization".to_string(),
+        ),
+        MediaNamespace::GeneratedSpeech => {
+            let route_kind = metadata.get("route_kind").map(String::as_str).unwrap_or("speech");
+            (
+                storage_layout::MediaGroup::Generated,
+                format!("speech/{route_kind}"),
+            )
+        }
+        MediaNamespace::SavedVoice => (storage_layout::MediaGroup::Generated, "voices".to_string()),
+        MediaNamespace::ChatMedia => (storage_layout::MediaGroup::Uploads, "chat".to_string()),
+        MediaNamespace::Export => (storage_layout::MediaGroup::Generated, "exports".to_string()),
+        MediaNamespace::Other(namespace) => (
+            storage_layout::MediaGroup::Generated,
+            sanitize_namespace(namespace),
+        ),
+    }
+}
+
+fn sanitize_namespace(namespace: &str) -> String {
+    namespace
+        .split('/')
+        .filter(|segment| {
+            !segment.is_empty()
+                && segment
+                    .chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn content_type_from_key(key: &str) -> &'static str {
+    match std::path::Path::new(key)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("wav") => "audio/wav",
+        Some("mp3") => "audio/mpeg",
+        Some("ogg") => "audio/ogg",
+        Some("flac") => "audio/flac",
+        Some("webm") => "audio/webm",
+        Some("m4a") => "audio/mp4",
+        Some("aac") => "audio/aac",
+        _ => "application/octet-stream",
+    }
+}
+
+fn filename_from_key(key: &str) -> Option<String> {
+    std::path::Path::new(key)
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::env_lock;
+    use sea_orm::DbBackend;
+
+    #[tokio::test]
+    async fn noop_hooks_resolve_local_persistence() {
+        let _guard = env_lock();
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("izwi.sqlite3");
+        let media_dir = temp_dir.path().join("media");
+        std::env::set_var("IZWI_DB_PATH", &db_path);
+        std::env::set_var("IZWI_MEDIA_DIR", &media_dir);
+
+        let context = PersistenceContext::local_default()
+            .await
+            .expect("local persistence resolves");
+
+        assert_eq!(
+            context.database.connection().get_database_backend(),
+            DbBackend::Sqlite
+        );
+        assert!(db_path.exists());
+        assert!(media_dir.exists());
+
+        std::env::remove_var("IZWI_DB_PATH");
+        std::env::remove_var("IZWI_MEDIA_DIR");
+    }
+
+    #[tokio::test]
+    async fn local_media_provider_round_trips_bytes() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let provider = LocalMediaStorageProvider::new(temp_dir.path().to_path_buf());
+        let mut metadata = HookMetadata::new();
+        metadata.insert("route_kind".to_string(), "tts".to_string());
+
+        let stored = provider
+            .put(
+                MediaWriteRequest {
+                    namespace: MediaNamespace::GeneratedSpeech,
+                    record_id: "record-1".to_string(),
+                    preferred_filename: Some("speech.wav".to_string()),
+                    content_type: "audio/wav".to_string(),
+                    metadata,
+                },
+                b"audio".to_vec(),
+            )
+            .await
+            .expect("write media");
+
+        assert_eq!(stored.key.key, "generated/speech/tts/record-1.wav");
+
+        let bytes = provider
+            .get(MediaReadRequest {
+                key: stored.key.clone(),
+                metadata: HookMetadata::new(),
+            })
+            .await
+            .expect("read media");
+        assert_eq!(bytes.bytes, b"audio");
+
+        provider
+            .delete(MediaDeleteRequest {
+                key: stored.key,
+                metadata: HookMetadata::new(),
+            })
+            .await
+            .expect("delete media");
+    }
+}

--- a/crates/izwi-server/src/persistence/mod.rs
+++ b/crates/izwi-server/src/persistence/mod.rs
@@ -1,5 +1,9 @@
-use crate::{db, db::migrator::Migrator, storage_layout};
-use anyhow::{bail, Context};
+use crate::{
+    db,
+    db::{migrator::Migrator, schema_contract::validate_provider_managed_schema},
+    storage_layout,
+};
+use anyhow::{Context, bail};
 use izwi_hooks::{
     DatabaseBackend, DatabaseConnectionDecision, DatabaseMigrationMode, DatabaseProviderDecision,
     DatabaseProviderRequest, EnterpriseHooks, HookError, HookMetadata, HookResult,
@@ -196,11 +200,13 @@ async fn provider_database_context(
         Migrator::up(&decision.connection)
             .await
             .context("Failed to run Izwi-managed migrations on enterprise database")?;
+    } else {
+        validate_provider_managed_schema(&decision.connection).await?;
     }
 
     Ok(DatabaseContext::new(
         decision.connection,
-        decision.backend,
+        actual_backend,
         decision.migration_mode,
         decision.metadata,
     ))
@@ -237,13 +243,12 @@ fn validate_declared_backend(
 }
 
 fn validate_supported_database_backend(backend: &DatabaseBackend) -> anyhow::Result<()> {
-    if matches!(backend, DatabaseBackend::Sqlite) {
-        return Ok(());
+    match backend {
+        DatabaseBackend::Sqlite | DatabaseBackend::Postgres | DatabaseBackend::Mysql => Ok(()),
+        DatabaseBackend::Other(name) => {
+            bail!("Enterprise database backend {name:?} is not supported by this runtime")
+        }
     }
-
-    bail!(
-        "Enterprise database backend {backend:?} is not enabled yet: runtime stores and migrations currently require SQLite-compatible SQL"
-    );
 }
 
 fn validate_migration_mode_for_backend(
@@ -533,11 +538,13 @@ mod tests {
 
     #[test]
     fn izwi_managed_migrations_are_restricted_to_sqlite() {
-        assert!(validate_migration_mode_for_backend(
-            &DatabaseBackend::Sqlite,
-            &DatabaseMigrationMode::IzwiManaged,
-        )
-        .is_ok());
+        assert!(
+            validate_migration_mode_for_backend(
+                &DatabaseBackend::Sqlite,
+                &DatabaseMigrationMode::IzwiManaged,
+            )
+            .is_ok()
+        );
 
         let error = validate_migration_mode_for_backend(
             &DatabaseBackend::Postgres,
@@ -551,21 +558,99 @@ mod tests {
                 .contains("Izwi-managed migrations currently require the local SQLite backend"),
             "{error}"
         );
+
+        assert!(
+            validate_migration_mode_for_backend(
+                &DatabaseBackend::Postgres,
+                &DatabaseMigrationMode::ProviderManaged,
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_migration_mode_for_backend(
+                &DatabaseBackend::Mysql,
+                &DatabaseMigrationMode::Disabled,
+            )
+            .is_ok()
+        );
     }
 
     #[test]
-    fn non_sqlite_backends_are_rejected_until_store_sql_is_portable() {
-        let error = validate_supported_database_backend(&DatabaseBackend::Postgres)
-            .expect_err("postgres should be rejected until store SQL is portable");
+    fn supported_database_backends_accept_portable_store_sql() {
+        assert!(validate_supported_database_backend(&DatabaseBackend::Sqlite).is_ok());
+        assert!(validate_supported_database_backend(&DatabaseBackend::Postgres).is_ok());
+        assert!(validate_supported_database_backend(&DatabaseBackend::Mysql).is_ok());
+
+        let error =
+            validate_supported_database_backend(&DatabaseBackend::Other("unsupported".to_string()))
+                .expect_err("unknown backend should be rejected");
 
         assert!(
             error
                 .to_string()
-                .contains("runtime stores and migrations currently require SQLite-compatible SQL"),
+                .contains("is not supported by this runtime"),
             "{error}"
         );
+    }
 
-        assert!(validate_supported_database_backend(&DatabaseBackend::Sqlite).is_ok());
+    #[tokio::test]
+    async fn provider_managed_database_requires_schema_contract() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let connection = db::sqlite::connect_path(&temp_dir.path().join("enterprise.sqlite3"))
+            .await
+            .expect("sqlite connection");
+        let mut hooks = EnterpriseHooks::noop();
+        hooks.database = Arc::new(StaticDatabaseProvider {
+            decision: DatabaseProviderDecision::UseConnection(DatabaseConnectionDecision {
+                connection,
+                backend: DatabaseBackend::Sqlite,
+                migration_mode: DatabaseMigrationMode::ProviderManaged,
+                metadata: HookMetadata::new(),
+            }),
+        });
+
+        let error = match PersistenceContext::resolve(&hooks).await {
+            Ok(_) => panic!("empty provider-managed schema should fail"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("Enterprise database schema is incomplete"),
+            "{error}"
+        );
+        assert!(error.to_string().contains("chat_threads"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn provider_managed_database_accepts_valid_schema_contract() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let connection = db::sqlite::connect_path(&temp_dir.path().join("enterprise.sqlite3"))
+            .await
+            .expect("sqlite connection");
+        Migrator::up(&connection)
+            .await
+            .expect("provider-managed test schema");
+
+        let mut hooks = EnterpriseHooks::noop();
+        hooks.database = Arc::new(StaticDatabaseProvider {
+            decision: DatabaseProviderDecision::UseConnection(DatabaseConnectionDecision {
+                connection,
+                backend: DatabaseBackend::Sqlite,
+                migration_mode: DatabaseMigrationMode::ProviderManaged,
+                metadata: HookMetadata::new(),
+            }),
+        });
+
+        let context = PersistenceContext::resolve(&hooks)
+            .await
+            .expect("provider-managed schema should validate");
+        assert_eq!(context.database.backend(), &DatabaseBackend::Sqlite);
+        assert_eq!(
+            context.database.migration_mode(),
+            &DatabaseMigrationMode::ProviderManaged
+        );
     }
 
     #[tokio::test]

--- a/crates/izwi-server/src/persistence/mod.rs
+++ b/crates/izwi-server/src/persistence/mod.rs
@@ -1,5 +1,5 @@
 use crate::{db, db::migrator::Migrator, storage_layout};
-use anyhow::Context;
+use anyhow::{bail, Context};
 use izwi_hooks::{
     DatabaseBackend, DatabaseConnectionDecision, DatabaseMigrationMode, DatabaseProviderDecision,
     DatabaseProviderRequest, EnterpriseHooks, HookError, HookMetadata, HookResult,
@@ -7,7 +7,7 @@ use izwi_hooks::{
     MediaStorageProvider, MediaStorageProviderDecision, MediaStorageProviderRequest,
     MediaWriteRequest, StoredMediaBytes, StoredMediaObject,
 };
-use sea_orm::DatabaseConnection;
+use sea_orm::{DatabaseConnection, DatabaseConnectionType, DbBackend};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -168,6 +168,10 @@ async fn local_database_context() -> anyhow::Result<DatabaseContext> {
 async fn provider_database_context(
     decision: DatabaseConnectionDecision,
 ) -> anyhow::Result<DatabaseContext> {
+    let actual_backend = actual_database_backend(&decision.connection)?;
+    validate_declared_backend(&decision.backend, &actual_backend)?;
+    validate_migration_mode_for_backend(&actual_backend, &decision.migration_mode)?;
+
     if matches!(decision.migration_mode, DatabaseMigrationMode::IzwiManaged) {
         Migrator::up(&decision.connection)
             .await
@@ -180,6 +184,51 @@ async fn provider_database_context(
         decision.migration_mode,
         decision.metadata,
     ))
+}
+
+fn actual_database_backend(connection: &DatabaseConnection) -> anyhow::Result<DatabaseBackend> {
+    if matches!(&connection.inner, DatabaseConnectionType::Disconnected) {
+        bail!("Enterprise database hook returned a disconnected SeaORM connection");
+    }
+
+    Ok(hook_backend_from_seaorm(connection.get_database_backend()))
+}
+
+fn hook_backend_from_seaorm(backend: DbBackend) -> DatabaseBackend {
+    match backend {
+        DbBackend::Sqlite => DatabaseBackend::Sqlite,
+        DbBackend::Postgres => DatabaseBackend::Postgres,
+        DbBackend::MySql => DatabaseBackend::Mysql,
+        _ => DatabaseBackend::Other(format!("{backend:?}")),
+    }
+}
+
+fn validate_declared_backend(
+    declared: &DatabaseBackend,
+    actual: &DatabaseBackend,
+) -> anyhow::Result<()> {
+    if matches!(declared, DatabaseBackend::Other(_)) || declared == actual {
+        return Ok(());
+    }
+
+    bail!(
+        "Enterprise database hook declared backend {declared:?}, but the SeaORM connection reports {actual:?}"
+    );
+}
+
+fn validate_migration_mode_for_backend(
+    backend: &DatabaseBackend,
+    migration_mode: &DatabaseMigrationMode,
+) -> anyhow::Result<()> {
+    if matches!(migration_mode, DatabaseMigrationMode::IzwiManaged)
+        && !matches!(backend, DatabaseBackend::Sqlite)
+    {
+        bail!(
+            "Izwi-managed migrations currently require the local SQLite backend; enterprise database providers must use provider-managed or disabled migrations for {backend:?}"
+        );
+    }
+
+    Ok(())
 }
 
 async fn resolve_media_storage(
@@ -339,6 +388,7 @@ fn filename_from_key(key: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test_support::env_lock;
+    use izwi_hooks::{DatabaseProvider, DatabaseProviderDecision};
     use sea_orm::DbBackend;
 
     #[tokio::test]
@@ -404,5 +454,85 @@ mod tests {
             })
             .await
             .expect("delete media");
+    }
+
+    #[tokio::test]
+    async fn enterprise_database_backend_mismatch_is_rejected() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let connection = db::sqlite::connect_path(&temp_dir.path().join("enterprise.sqlite3"))
+            .await
+            .expect("sqlite connection");
+        let mut hooks = EnterpriseHooks::noop();
+        hooks.database = Arc::new(StaticDatabaseProvider {
+            decision: DatabaseProviderDecision::UseConnection(DatabaseConnectionDecision {
+                connection,
+                backend: DatabaseBackend::Postgres,
+                migration_mode: DatabaseMigrationMode::ProviderManaged,
+                metadata: HookMetadata::new(),
+            }),
+        });
+
+        let error = match PersistenceContext::resolve(&hooks).await {
+            Ok(_) => panic!("backend mismatch should fail"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("declared backend Postgres, but the SeaORM connection reports Sqlite"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn izwi_managed_migrations_are_restricted_to_sqlite() {
+        assert!(validate_migration_mode_for_backend(
+            &DatabaseBackend::Sqlite,
+            &DatabaseMigrationMode::IzwiManaged,
+        )
+        .is_ok());
+
+        let error = validate_migration_mode_for_backend(
+            &DatabaseBackend::Postgres,
+            &DatabaseMigrationMode::IzwiManaged,
+        )
+        .expect_err("managed migrations should reject non-sqlite backends");
+
+        assert!(
+            error
+                .to_string()
+                .contains("Izwi-managed migrations currently require the local SQLite backend"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn provider_managed_modes_accept_non_sqlite_backends() {
+        assert!(validate_migration_mode_for_backend(
+            &DatabaseBackend::Postgres,
+            &DatabaseMigrationMode::ProviderManaged,
+        )
+        .is_ok());
+        assert!(validate_migration_mode_for_backend(
+            &DatabaseBackend::Mysql,
+            &DatabaseMigrationMode::Disabled,
+        )
+        .is_ok());
+    }
+
+    #[derive(Clone)]
+    struct StaticDatabaseProvider {
+        decision: DatabaseProviderDecision,
+    }
+
+    #[async_trait::async_trait]
+    impl DatabaseProvider for StaticDatabaseProvider {
+        async fn resolve_database(
+            &self,
+            _request: &DatabaseProviderRequest,
+        ) -> HookResult<DatabaseProviderDecision> {
+            Ok(self.decision.clone())
+        }
     }
 }

--- a/crates/izwi-server/src/persistence/mod.rs
+++ b/crates/izwi-server/src/persistence/mod.rs
@@ -403,21 +403,7 @@ fn sanitize_namespace(namespace: &str) -> String {
 }
 
 fn content_type_from_key(key: &str) -> &'static str {
-    match std::path::Path::new(key)
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .map(|ext| ext.to_ascii_lowercase())
-        .as_deref()
-    {
-        Some("wav") => "audio/wav",
-        Some("mp3") => "audio/mpeg",
-        Some("ogg") => "audio/ogg",
-        Some("flac") => "audio/flac",
-        Some("webm") => "audio/webm",
-        Some("m4a") => "audio/mp4",
-        Some("aac") => "audio/aac",
-        _ => "application/octet-stream",
-    }
+    storage_layout::content_type_from_media_path(key)
 }
 
 fn filename_from_key(key: &str) -> Option<String> {
@@ -505,6 +491,36 @@ mod tests {
             })
             .await
             .expect("delete media");
+    }
+
+    #[tokio::test]
+    async fn local_media_provider_preserves_image_and_video_content_types() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let provider = LocalMediaStorageProvider::new(temp_dir.path().to_path_buf());
+        let image_path = temp_dir.path().join("images/example.png");
+        let video_path = temp_dir.path().join("videos/example.mp4");
+        std::fs::create_dir_all(image_path.parent().expect("image parent")).expect("image dir");
+        std::fs::create_dir_all(video_path.parent().expect("video parent")).expect("video dir");
+        std::fs::write(&image_path, b"image").expect("image file");
+        std::fs::write(&video_path, b"video").expect("video file");
+
+        let image = provider
+            .get(MediaReadRequest {
+                key: MediaObjectKey::new("images/example.png"),
+                metadata: HookMetadata::new(),
+            })
+            .await
+            .expect("read image");
+        let video = provider
+            .get(MediaReadRequest {
+                key: MediaObjectKey::new("videos/example.mp4"),
+                metadata: HookMetadata::new(),
+            })
+            .await
+            .expect("read video");
+
+        assert_eq!(image.metadata.content_type, "image/png");
+        assert_eq!(video.metadata.content_type, "video/mp4");
     }
 
     #[tokio::test]

--- a/crates/izwi-server/src/persistence/mod.rs
+++ b/crates/izwi-server/src/persistence/mod.rs
@@ -108,16 +108,18 @@ pub async fn persist_audio_object(
 pub async fn read_media_object(
     provider: &Arc<dyn MediaStorageProvider>,
     key: &str,
-) -> anyhow::Result<Vec<u8>> {
-    let stored = provider
+) -> Result<StoredMediaBytes, MediaStorageError> {
+    let key = key.to_string();
+    provider
         .get(MediaReadRequest {
-            key: MediaObjectKey::new(key),
+            key: MediaObjectKey::new(key.clone()),
             metadata: HookMetadata::new(),
         })
         .await
-        .map_err(|err| anyhow::anyhow!("Media storage read failed: {err}"))?;
-
-    Ok(stored.bytes)
+        .map_err(|err| match err {
+            HookError::NotFound(message) => MediaStorageError::NotFound { key, message },
+            err => MediaStorageError::ReadFailed(err),
+        })
 }
 
 pub async fn delete_media_object(
@@ -128,13 +130,30 @@ pub async fn delete_media_object(
         return Ok(());
     };
 
-    provider
+    match provider
         .delete(MediaDeleteRequest {
             key: MediaObjectKey::new(key),
             metadata: HookMetadata::new(),
         })
         .await
-        .map_err(|err| anyhow::anyhow!("Media storage delete failed: {err}"))
+    {
+        Ok(()) | Err(HookError::NotFound(_)) => Ok(()),
+        Err(err) => Err(anyhow::anyhow!("Media storage delete failed: {err}")),
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MediaStorageError {
+    #[error("media storage object not found: {key}: {message}")]
+    NotFound { key: String, message: String },
+    #[error("media storage read failed: {0}")]
+    ReadFailed(#[source] HookError),
+}
+
+impl MediaStorageError {
+    pub fn is_not_found(&self) -> bool {
+        matches!(self, Self::NotFound { .. })
+    }
 }
 
 async fn resolve_database(enterprise_hooks: &EnterpriseHooks) -> anyhow::Result<DatabaseContext> {
@@ -170,6 +189,7 @@ async fn provider_database_context(
 ) -> anyhow::Result<DatabaseContext> {
     let actual_backend = actual_database_backend(&decision.connection)?;
     validate_declared_backend(&decision.backend, &actual_backend)?;
+    validate_supported_database_backend(&actual_backend)?;
     validate_migration_mode_for_backend(&actual_backend, &decision.migration_mode)?;
 
     if matches!(decision.migration_mode, DatabaseMigrationMode::IzwiManaged) {
@@ -213,6 +233,16 @@ fn validate_declared_backend(
 
     bail!(
         "Enterprise database hook declared backend {declared:?}, but the SeaORM connection reports {actual:?}"
+    );
+}
+
+fn validate_supported_database_backend(backend: &DatabaseBackend) -> anyhow::Result<()> {
+    if matches!(backend, DatabaseBackend::Sqlite) {
+        return Ok(());
+    }
+
+    bail!(
+        "Enterprise database backend {backend:?} is not enabled yet: runtime stores and migrations currently require SQLite-compatible SQL"
     );
 }
 
@@ -292,17 +322,24 @@ impl MediaStorageProvider for LocalMediaStorageProvider {
     }
 
     async fn get(&self, request: MediaReadRequest) -> HookResult<StoredMediaBytes> {
-        let bytes = storage_layout::read_media_file(&self.media_root, &request.key.key)
-            .map_err(|err| HookError::Failed(err.to_string()))?;
+        let key = request.key.key;
+        let metadata = request.metadata;
+        let bytes = storage_layout::read_media_file(&self.media_root, &key).map_err(|err| {
+            if is_not_found_error(&err) {
+                HookError::NotFound(key.clone())
+            } else {
+                HookError::Failed(err.to_string())
+            }
+        })?;
 
         Ok(StoredMediaBytes {
             metadata: MediaObjectMetadata {
-                content_type: content_type_from_key(&request.key.key).to_string(),
-                filename: filename_from_key(&request.key.key),
+                content_type: content_type_from_key(&key).to_string(),
+                filename: filename_from_key(&key),
                 content_length: Some(bytes.len() as u64),
                 sha256: None,
                 tenant_id: None,
-                attributes: request.metadata,
+                attributes: metadata,
             },
             bytes,
         })
@@ -384,6 +421,14 @@ fn filename_from_key(key: &str) -> Option<String> {
         .map(|name| name.to_string_lossy().to_string())
 }
 
+fn is_not_found_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|io| io.kind() == std::io::ErrorKind::NotFound)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -422,7 +467,7 @@ mod tests {
         let mut metadata = HookMetadata::new();
         metadata.insert("route_kind".to_string(), "tts".to_string());
 
-        let stored = provider
+        let object = provider
             .put(
                 MediaWriteRequest {
                     namespace: MediaNamespace::GeneratedSpeech,
@@ -436,20 +481,21 @@ mod tests {
             .await
             .expect("write media");
 
-        assert_eq!(stored.key.key, "generated/speech/tts/record-1.wav");
+        assert_eq!(object.key.key, "generated/speech/tts/record-1.wav");
 
-        let bytes = provider
+        let stored = provider
             .get(MediaReadRequest {
-                key: stored.key.clone(),
+                key: object.key.clone(),
                 metadata: HookMetadata::new(),
             })
             .await
             .expect("read media");
-        assert_eq!(bytes.bytes, b"audio");
+        assert_eq!(stored.bytes, b"audio");
+        assert_eq!(stored.metadata.content_type, "audio/wav");
 
         provider
             .delete(MediaDeleteRequest {
-                key: stored.key,
+                key: object.key,
                 metadata: HookMetadata::new(),
             })
             .await
@@ -508,17 +554,32 @@ mod tests {
     }
 
     #[test]
-    fn provider_managed_modes_accept_non_sqlite_backends() {
-        assert!(validate_migration_mode_for_backend(
-            &DatabaseBackend::Postgres,
-            &DatabaseMigrationMode::ProviderManaged,
-        )
-        .is_ok());
-        assert!(validate_migration_mode_for_backend(
-            &DatabaseBackend::Mysql,
-            &DatabaseMigrationMode::Disabled,
-        )
-        .is_ok());
+    fn non_sqlite_backends_are_rejected_until_store_sql_is_portable() {
+        let error = validate_supported_database_backend(&DatabaseBackend::Postgres)
+            .expect_err("postgres should be rejected until store SQL is portable");
+
+        assert!(
+            error
+                .to_string()
+                .contains("runtime stores and migrations currently require SQLite-compatible SQL"),
+            "{error}"
+        );
+
+        assert!(validate_supported_database_backend(&DatabaseBackend::Sqlite).is_ok());
+    }
+
+    #[tokio::test]
+    async fn local_media_provider_reports_missing_objects_as_not_found() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let provider = Arc::new(LocalMediaStorageProvider::new(
+            temp_dir.path().to_path_buf(),
+        )) as Arc<dyn MediaStorageProvider>;
+
+        let error = read_media_object(&provider, "generated/missing/object.wav")
+            .await
+            .expect_err("missing object should fail");
+
+        assert!(error.is_not_found(), "{error}");
     }
 
     #[derive(Clone)]

--- a/crates/izwi-server/src/persistence/mod.rs
+++ b/crates/izwi-server/src/persistence/mod.rs
@@ -28,9 +28,14 @@ impl PersistenceContext {
         })
     }
 
+    #[cfg(test)]
     pub async fn local_default() -> anyhow::Result<Self> {
         let hooks = EnterpriseHooks::noop();
         Self::resolve(&hooks).await
+    }
+
+    pub fn media_storage(&self) -> Arc<dyn MediaStorageProvider> {
+        self.media_storage.clone()
     }
 }
 
@@ -74,6 +79,64 @@ impl DatabaseContext {
     }
 }
 
+pub async fn persist_audio_object(
+    provider: &Arc<dyn MediaStorageProvider>,
+    namespace: MediaNamespace,
+    record_id: impl Into<String>,
+    preferred_filename: Option<&str>,
+    mime_type: &str,
+    bytes: &[u8],
+    metadata: HookMetadata,
+) -> anyhow::Result<String> {
+    let stored = provider
+        .put(
+            MediaWriteRequest {
+                namespace,
+                record_id: record_id.into(),
+                preferred_filename: preferred_filename.map(str::to_string),
+                content_type: mime_type.to_string(),
+                metadata,
+            },
+            bytes.to_vec(),
+        )
+        .await
+        .map_err(|err| anyhow::anyhow!("Media storage write failed: {err}"))?;
+
+    Ok(stored.key.key)
+}
+
+pub async fn read_media_object(
+    provider: &Arc<dyn MediaStorageProvider>,
+    key: &str,
+) -> anyhow::Result<Vec<u8>> {
+    let stored = provider
+        .get(MediaReadRequest {
+            key: MediaObjectKey::new(key),
+            metadata: HookMetadata::new(),
+        })
+        .await
+        .map_err(|err| anyhow::anyhow!("Media storage read failed: {err}"))?;
+
+    Ok(stored.bytes)
+}
+
+pub async fn delete_media_object(
+    provider: &Arc<dyn MediaStorageProvider>,
+    key: Option<&str>,
+) -> anyhow::Result<()> {
+    let Some(key) = key.filter(|key| !key.trim().is_empty()) else {
+        return Ok(());
+    };
+
+    provider
+        .delete(MediaDeleteRequest {
+            key: MediaObjectKey::new(key),
+            metadata: HookMetadata::new(),
+        })
+        .await
+        .map_err(|err| anyhow::anyhow!("Media storage delete failed: {err}"))
+}
+
 async fn resolve_database(enterprise_hooks: &EnterpriseHooks) -> anyhow::Result<DatabaseContext> {
     match enterprise_hooks
         .database
@@ -82,7 +145,9 @@ async fn resolve_database(enterprise_hooks: &EnterpriseHooks) -> anyhow::Result<
         .map_err(|err| anyhow::anyhow!("Enterprise database hook failed: {err}"))?
     {
         DatabaseProviderDecision::UseDefault => local_database_context().await,
-        DatabaseProviderDecision::UseConnection(decision) => provider_database_context(decision).await,
+        DatabaseProviderDecision::UseConnection(decision) => {
+            provider_database_context(decision).await
+        }
     }
 }
 
@@ -141,10 +206,6 @@ pub struct LocalMediaStorageProvider {
 impl LocalMediaStorageProvider {
     pub fn new(media_root: PathBuf) -> Self {
         Self { media_root }
-    }
-
-    pub fn media_root(&self) -> &PathBuf {
-        &self.media_root
     }
 }
 
@@ -218,7 +279,10 @@ fn local_namespace(
             "diarization".to_string(),
         ),
         MediaNamespace::GeneratedSpeech => {
-            let route_kind = metadata.get("route_kind").map(String::as_str).unwrap_or("speech");
+            let route_kind = metadata
+                .get("route_kind")
+                .map(String::as_str)
+                .unwrap_or("speech");
             (
                 storage_layout::MediaGroup::Generated,
                 format!("speech/{route_kind}"),

--- a/crates/izwi-server/src/saved_voice_store.rs
+++ b/crates/izwi-server/src/saved_voice_store.rs
@@ -2,13 +2,13 @@
 
 use anyhow::{anyhow, Context};
 use izwi_hooks::{HookMetadata, MediaNamespace, MediaStorageProvider};
-use sea_orm::{ConnectionTrait, DbBackend, EntityTrait, QueryResult, Set, Statement};
+use sea_orm::{ConnectionTrait, EntityTrait, QueryResult, Set};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
-    db::StoreDatabase,
+    db::{raw, StoreDatabase},
     entity::saved_voices,
     ids::new_uuid,
     persistence::{
@@ -135,8 +135,8 @@ impl SavedVoiceStore {
         let rows = if let Some(cursor) = cursor {
             let cursor_updated_at = i64::try_from(cursor.updated_at).unwrap_or(i64::MAX);
             let cursor_created_at = i64::try_from(cursor.created_at).unwrap_or(i64::MAX);
-            db.query_all_raw(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
+            db.query_all_raw(raw::statement(
+                db,
                 SAVED_VOICE_PAGE_AFTER_CURSOR_SQL,
                 vec![
                     cursor_updated_at.into(),
@@ -144,14 +144,14 @@ impl SavedVoiceStore {
                     cursor.id.into(),
                     fetch_limit.into(),
                 ],
-            ))
+            )?)
             .await
         } else {
-            db.query_all_raw(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
+            db.query_all_raw(raw::statement(
+                db,
                 SAVED_VOICE_PAGE_SQL,
                 vec![fetch_limit.into()],
-            ))
+            )?)
             .await
         }
         .context("Failed to list saved voices")?;
@@ -189,15 +189,15 @@ impl SavedVoiceStore {
     ) -> anyhow::Result<Option<StoredSavedVoiceAudio>> {
         let db = self.db.connection().await?;
         let audio = db
-            .query_one_raw(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
+            .query_one_raw(raw::statement(
+                db,
                 r#"
                 SELECT audio_storage_path, audio_mime_type, audio_filename
                 FROM saved_voices
                 WHERE id = ?1
                 "#,
                 vec![voice_id.into()],
-            ))
+            )?)
             .await
             .context("Failed to load saved voice audio metadata")?;
 
@@ -275,11 +275,11 @@ impl SavedVoiceStore {
     pub async fn delete_voice(&self, voice_id: String) -> anyhow::Result<bool> {
         let db = self.db.connection().await?;
         let audio_storage_path = db
-            .query_one_raw(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
+            .query_one_raw(raw::statement(
+                db,
                 "SELECT audio_storage_path FROM saved_voices WHERE id = ?1",
                 vec![voice_id.clone().into()],
-            ))
+            )?)
             .await
             .context("Failed to load saved voice media path")?
             .map(|row| row.try_get_by_index::<Option<String>>(0))
@@ -357,11 +357,11 @@ async fn fetch_voice_without_audio(
     voice_id: &str,
 ) -> anyhow::Result<Option<SavedVoice>> {
     let row = db
-        .query_one_raw(Statement::from_sql_and_values(
-            DbBackend::Sqlite,
+        .query_one_raw(raw::statement(
+            db,
             format!("SELECT {SAVED_VOICE_COLUMNS} FROM saved_voices WHERE id = ?1"),
             vec![voice_id.into()],
-        ))
+        )?)
         .await
         .context("Failed to load saved voice")?;
     row.as_ref().map(map_saved_voice).transpose()

--- a/crates/izwi-server/src/saved_voice_store.rs
+++ b/crates/izwi-server/src/saved_voice_store.rs
@@ -208,12 +208,12 @@ impl SavedVoiceStore {
         let audio_storage_path: String = row.try_get_by_index(0)?;
         let audio_mime_type: String = row.try_get_by_index(1)?;
         let audio_filename: Option<String> = row.try_get_by_index(2)?;
-        let audio_bytes = read_media_object(&self.media_storage, audio_storage_path.as_str())
+        let audio = read_media_object(&self.media_storage, audio_storage_path.as_str())
             .await
             .context("Failed to read saved voice media")?;
 
         Ok(Some(StoredSavedVoiceAudio {
-            audio_bytes,
+            audio_bytes: audio.bytes,
             audio_mime_type,
             audio_filename,
         }))

--- a/crates/izwi-server/src/saved_voice_store.rs
+++ b/crates/izwi-server/src/saved_voice_store.rs
@@ -1,16 +1,20 @@
 //! Persistent saved voice storage backed by SQLite.
 
-use anyhow::{Context, anyhow};
+use anyhow::{anyhow, Context};
+use izwi_hooks::{HookMetadata, MediaNamespace, MediaStorageProvider};
 use sea_orm::{ConnectionTrait, DbBackend, EntityTrait, QueryResult, Set, Statement};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
     db::StoreDatabase,
     entity::saved_voices,
     ids::new_uuid,
-    storage_layout::{self, MediaGroup},
+    persistence::{
+        delete_media_object, persist_audio_object, read_media_object, LocalMediaStorageProvider,
+    },
+    storage_layout,
 };
 
 const DEFAULT_LIST_LIMIT: usize = 500;
@@ -94,7 +98,7 @@ pub struct NewSavedVoice {
 #[derive(Clone)]
 pub struct SavedVoiceStore {
     db: StoreDatabase,
-    media_root: PathBuf,
+    media_storage: Arc<dyn MediaStorageProvider>,
 }
 
 impl SavedVoiceStore {
@@ -107,18 +111,15 @@ impl SavedVoiceStore {
 
         Ok(Self {
             db: StoreDatabase::new(db_path),
-            media_root,
+            media_storage: Arc::new(LocalMediaStorageProvider::new(media_root)),
         })
     }
 
-    pub fn initialize_with_database(
+    pub fn initialize_with_storage(
         db: StoreDatabase,
-        media_root: PathBuf,
-    ) -> anyhow::Result<Self> {
-        storage_layout::ensure_media_dirs(&media_root)
-            .context("Failed to prepare saved voice media storage layout")?;
-
-        Ok(Self { db, media_root })
+        media_storage: Arc<dyn MediaStorageProvider>,
+    ) -> Self {
+        Self { db, media_storage }
     }
 
     pub async fn list_voices_page(
@@ -207,8 +208,9 @@ impl SavedVoiceStore {
         let audio_storage_path: String = row.try_get_by_index(0)?;
         let audio_mime_type: String = row.try_get_by_index(1)?;
         let audio_filename: Option<String> = row.try_get_by_index(2)?;
-        let audio_bytes =
-            storage_layout::read_media_file(&self.media_root, audio_storage_path.as_str())?;
+        let audio_bytes = read_media_object(&self.media_storage, audio_storage_path.as_str())
+            .await
+            .context("Failed to read saved voice media")?;
 
         Ok(Some(StoredSavedVoiceAudio {
             audio_bytes,
@@ -235,15 +237,16 @@ impl SavedVoiceStore {
             return Err(anyhow!("Audio payload cannot be empty"));
         }
 
-        let audio_storage_path = storage_layout::persist_audio_file(
-            &self.media_root,
-            MediaGroup::Generated,
-            "voices",
+        let audio_storage_path = persist_audio_object(
+            &self.media_storage,
+            MediaNamespace::SavedVoice,
             &voice_id,
             audio_filename.as_deref(),
             audio_mime_type.as_str(),
             &voice.audio_bytes,
-        )?;
+            HookMetadata::new(),
+        )
+        .await?;
 
         if let Err(err) = saved_voices::Entity::insert(saved_voices::ActiveModel {
             id: Set(voice_id.clone()),
@@ -260,7 +263,7 @@ impl SavedVoiceStore {
         .exec(db)
         .await
         {
-            let _ = storage_layout::delete_media_file(&self.media_root, Some(&audio_storage_path));
+            let _ = delete_media_object(&self.media_storage, Some(&audio_storage_path)).await;
             return Err(err).context("Failed to insert saved voice");
         }
 
@@ -289,7 +292,7 @@ impl SavedVoiceStore {
             .context("Failed to delete saved voice")?;
 
         if result.rows_affected > 0 {
-            storage_layout::delete_media_file(&self.media_root, audio_storage_path.as_deref())?;
+            delete_media_object(&self.media_storage, audio_storage_path.as_deref()).await?;
         }
 
         Ok(result.rows_affected > 0)
@@ -464,7 +467,11 @@ fn now_unix_millis_i64() -> i64 {
 }
 
 fn i64_to_u64(value: i64) -> u64 {
-    if value.is_negative() { 0 } else { value as u64 }
+    if value.is_negative() {
+        0
+    } else {
+        value as u64
+    }
 }
 
 #[allow(dead_code)]
@@ -531,19 +538,15 @@ mod tests {
         assert_eq!(voices.len(), 1);
         assert_eq!(voices[0].name, "Demo Voice");
 
-        assert!(
-            store
-                .delete_voice(created.id.clone())
-                .await
-                .expect("voice should delete")
-        );
-        assert!(
-            store
-                .get_voice(created.id)
-                .await
-                .expect("voice lookup should succeed")
-                .is_none()
-        );
+        assert!(store
+            .delete_voice(created.id.clone())
+            .await
+            .expect("voice should delete"));
+        assert!(store
+            .get_voice(created.id)
+            .await
+            .expect("voice lookup should succeed")
+            .is_none());
 
         clear_env();
     }

--- a/crates/izwi-server/src/saved_voice_store.rs
+++ b/crates/izwi-server/src/saved_voice_store.rs
@@ -111,6 +111,16 @@ impl SavedVoiceStore {
         })
     }
 
+    pub fn initialize_with_database(
+        db: StoreDatabase,
+        media_root: PathBuf,
+    ) -> anyhow::Result<Self> {
+        storage_layout::ensure_media_dirs(&media_root)
+            .context("Failed to prepare saved voice media storage layout")?;
+
+        Ok(Self { db, media_root })
+    }
+
     pub async fn list_voices_page(
         &self,
         limit: usize,

--- a/crates/izwi-server/src/speech_history_store.rs
+++ b/crates/izwi-server/src/speech_history_store.rs
@@ -307,12 +307,12 @@ impl SpeechHistoryStore {
             return Ok(None);
         };
 
-        let audio_bytes = read_media_object(&self.media_storage, audio_storage_path.as_str())
+        let audio = read_media_object(&self.media_storage, audio_storage_path.as_str())
             .await
             .context("Failed to read speech history media")?;
 
         Ok(Some(StoredSpeechAudio {
-            audio_bytes,
+            audio_bytes: audio.bytes,
             audio_mime_type,
             audio_filename,
         }))

--- a/crates/izwi-server/src/speech_history_store.rs
+++ b/crates/izwi-server/src/speech_history_store.rs
@@ -1,19 +1,23 @@
 //! Persistent speech generation history storage backed by SQLite.
 
-use anyhow::{Context, anyhow};
+use anyhow::{anyhow, Context};
+use izwi_hooks::{HookMetadata, MediaNamespace, MediaStorageProvider};
 use sea_orm::sea_query::Expr;
 use sea_orm::{
     ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, QueryFilter, QueryResult, Set, Statement,
 };
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
     db::StoreDatabase,
     entity::speech_history_records,
     ids::new_uuid,
-    storage_layout::{self, MediaGroup},
+    persistence::{
+        delete_media_object, persist_audio_object, read_media_object, LocalMediaStorageProvider,
+    },
+    storage_layout,
 };
 
 const DEFAULT_LIST_LIMIT: usize = 200;
@@ -183,7 +187,7 @@ pub struct CompleteSpeechHistoryRecord {
 #[derive(Clone)]
 pub struct SpeechHistoryStore {
     db: StoreDatabase,
-    media_root: PathBuf,
+    media_storage: Arc<dyn MediaStorageProvider>,
 }
 
 impl SpeechHistoryStore {
@@ -196,18 +200,15 @@ impl SpeechHistoryStore {
 
         Ok(Self {
             db: StoreDatabase::new(db_path),
-            media_root,
+            media_storage: Arc::new(LocalMediaStorageProvider::new(media_root)),
         })
     }
 
-    pub fn initialize_with_database(
+    pub fn initialize_with_storage(
         db: StoreDatabase,
-        media_root: PathBuf,
-    ) -> anyhow::Result<Self> {
-        storage_layout::ensure_media_dirs(&media_root)
-            .context("Failed to prepare speech history media storage layout")?;
-
-        Ok(Self { db, media_root })
+        media_storage: Arc<dyn MediaStorageProvider>,
+    ) -> Self {
+        Self { db, media_storage }
     }
 
     pub async fn list_records_page(
@@ -306,8 +307,9 @@ impl SpeechHistoryStore {
             return Ok(None);
         };
 
-        let audio_bytes =
-            storage_layout::read_media_file(&self.media_root, audio_storage_path.as_str())?;
+        let audio_bytes = read_media_object(&self.media_storage, audio_storage_path.as_str())
+            .await
+            .context("Failed to read speech history media")?;
 
         Ok(Some(StoredSpeechAudio {
             audio_bytes,
@@ -362,16 +364,23 @@ impl SpeechHistoryStore {
         }
 
         let audio_storage_path = if has_audio_payload {
-            let namespace = format!("speech/{}", route_kind.as_db_value());
-            Some(storage_layout::persist_audio_file(
-                &self.media_root,
-                MediaGroup::Generated,
-                namespace.as_str(),
-                &record_id,
-                audio_filename.as_deref(),
-                audio_mime_type.as_str(),
-                &record.audio_bytes,
-            )?)
+            let mut metadata = HookMetadata::new();
+            metadata.insert(
+                "route_kind".to_string(),
+                route_kind.as_db_value().to_string(),
+            );
+            Some(
+                persist_audio_object(
+                    &self.media_storage,
+                    MediaNamespace::GeneratedSpeech,
+                    &record_id,
+                    audio_filename.as_deref(),
+                    audio_mime_type.as_str(),
+                    &record.audio_bytes,
+                    metadata,
+                )
+                .await?,
+            )
         } else {
             None
         };
@@ -403,7 +412,7 @@ impl SpeechHistoryStore {
             .await
         {
             if let Some(path) = audio_storage_path.as_deref() {
-                let _ = storage_layout::delete_media_file(&self.media_root, Some(path));
+                let _ = delete_media_object(&self.media_storage, Some(path)).await;
             }
             return Err(err).context("Failed to insert speech history record");
         }
@@ -481,16 +490,21 @@ impl SpeechHistoryStore {
             ));
         }
 
-        let namespace = format!("speech/{}", route_kind.as_db_value());
-        let next_audio_storage_path = storage_layout::persist_audio_file(
-            &self.media_root,
-            MediaGroup::Generated,
-            namespace.as_str(),
+        let mut metadata = HookMetadata::new();
+        metadata.insert(
+            "route_kind".to_string(),
+            route_kind.as_db_value().to_string(),
+        );
+        let next_audio_storage_path = persist_audio_object(
+            &self.media_storage,
+            MediaNamespace::GeneratedSpeech,
             &record_id,
             audio_filename.as_deref(),
             audio_mime_type.as_str(),
             &record.audio_bytes,
-        )?;
+            metadata,
+        )
+        .await?;
 
         let previous_audio_storage_path = fetch_audio_storage_path(db, route_kind, &record_id)
             .await?
@@ -566,16 +580,14 @@ impl SpeechHistoryStore {
             .context("Failed to complete speech history record")?;
 
         if result.rows_affected == 0 {
-            let _ = storage_layout::delete_media_file(
-                &self.media_root,
-                Some(next_audio_storage_path.as_str()),
-            );
+            let _ =
+                delete_media_object(&self.media_storage, Some(next_audio_storage_path.as_str()))
+                    .await;
             return Ok(None);
         }
 
         if let Some(previous_path) = sanitize_media_path(previous_audio_storage_path.as_deref()) {
-            let _ =
-                storage_layout::delete_media_file(&self.media_root, Some(previous_path.as_str()));
+            let _ = delete_media_object(&self.media_storage, Some(previous_path.as_str())).await;
         }
 
         fetch_record_without_audio(db, route_kind, &record_id).await
@@ -599,7 +611,7 @@ impl SpeechHistoryStore {
 
         if result.rows_affected > 0 {
             let normalized_audio_path = sanitize_media_path(audio_storage_path.as_deref());
-            storage_layout::delete_media_file(&self.media_root, normalized_audio_path.as_deref())?;
+            delete_media_object(&self.media_storage, normalized_audio_path.as_deref()).await?;
         }
 
         Ok(result.rows_affected > 0)
@@ -853,7 +865,11 @@ fn now_unix_millis_i64() -> i64 {
 }
 
 fn i64_to_u64(value: i64) -> u64 {
-    if value.is_negative() { 0 } else { value as u64 }
+    if value.is_negative() {
+        0
+    } else {
+        value as u64
+    }
 }
 
 fn i64_to_usize(value: i64) -> Option<usize> {
@@ -957,19 +973,15 @@ mod tests {
         );
         assert_eq!(failed.processing_error.as_deref(), Some("boom"));
 
-        assert!(
-            store
-                .delete_record(SpeechRouteKind::TextToSpeech, created.id.clone())
-                .await
-                .expect("record should delete")
-        );
-        assert!(
-            store
-                .get_record(SpeechRouteKind::TextToSpeech, created.id)
-                .await
-                .expect("record lookup should succeed")
-                .is_none()
-        );
+        assert!(store
+            .delete_record(SpeechRouteKind::TextToSpeech, created.id.clone())
+            .await
+            .expect("record should delete"));
+        assert!(store
+            .get_record(SpeechRouteKind::TextToSpeech, created.id)
+            .await
+            .expect("record lookup should succeed")
+            .is_none());
 
         clear_env();
     }
@@ -988,13 +1000,11 @@ mod tests {
             })
             .await
             .expect("pending record should create");
-        assert!(
-            store
-                .get_audio(SpeechRouteKind::TextToSpeech, pending.id.clone())
-                .await
-                .expect("audio lookup should succeed")
-                .is_none()
-        );
+        assert!(store
+            .get_audio(SpeechRouteKind::TextToSpeech, pending.id.clone())
+            .await
+            .expect("audio lookup should succeed")
+            .is_none());
 
         let completed = store
             .complete_record(

--- a/crates/izwi-server/src/speech_history_store.rs
+++ b/crates/izwi-server/src/speech_history_store.rs
@@ -200,6 +200,16 @@ impl SpeechHistoryStore {
         })
     }
 
+    pub fn initialize_with_database(
+        db: StoreDatabase,
+        media_root: PathBuf,
+    ) -> anyhow::Result<Self> {
+        storage_layout::ensure_media_dirs(&media_root)
+            .context("Failed to prepare speech history media storage layout")?;
+
+        Ok(Self { db, media_root })
+    }
+
     pub async fn list_records_page(
         &self,
         route_kind: SpeechRouteKind,

--- a/crates/izwi-server/src/speech_history_store.rs
+++ b/crates/izwi-server/src/speech_history_store.rs
@@ -3,15 +3,13 @@
 use anyhow::{anyhow, Context};
 use izwi_hooks::{HookMetadata, MediaNamespace, MediaStorageProvider};
 use sea_orm::sea_query::Expr;
-use sea_orm::{
-    ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, QueryFilter, QueryResult, Set, Statement,
-};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryResult, Set};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
-    db::StoreDatabase,
+    db::{raw, StoreDatabase},
     entity::speech_history_records,
     ids::new_uuid,
     persistence::{
@@ -226,8 +224,8 @@ impl SpeechHistoryStore {
 
         let rows = if let Some(cursor) = cursor {
             let cursor_created_at = i64::try_from(cursor.created_at).unwrap_or(i64::MAX);
-            db.query_all_raw(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
+            db.query_all_raw(raw::statement(
+                db,
                 SPEECH_HISTORY_PAGE_AFTER_CURSOR_SQL,
                 vec![
                     route_kind.as_db_value().into(),
@@ -235,14 +233,14 @@ impl SpeechHistoryStore {
                     cursor.id.into(),
                     fetch_limit.into(),
                 ],
-            ))
+            )?)
             .await
         } else {
-            db.query_all_raw(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
+            db.query_all_raw(raw::statement(
+                db,
                 SPEECH_HISTORY_PAGE_SQL,
                 vec![route_kind.as_db_value().into(), fetch_limit.into()],
-            ))
+            )?)
             .await
         }
         .context("Failed to list speech history records")?;
@@ -285,15 +283,15 @@ impl SpeechHistoryStore {
     ) -> anyhow::Result<Option<StoredSpeechAudio>> {
         let db = self.db.connection().await?;
         let audio = db
-            .query_one_raw(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
+            .query_one_raw(raw::statement(
+                db,
                 r#"
                 SELECT audio_storage_path, audio_mime_type, audio_filename
                 FROM speech_history_records
                 WHERE route_kind = ?1 AND id = ?2
                 "#,
                 vec![route_kind.as_db_value().into(), record_id.into()],
-            ))
+            )?)
             .await
             .context("Failed to load speech history audio metadata")?;
         let Some(row) = audio else {
@@ -697,13 +695,13 @@ async fn fetch_record_without_audio(
     record_id: &str,
 ) -> anyhow::Result<Option<SpeechHistoryRecord>> {
     let row = db
-        .query_one_raw(Statement::from_sql_and_values(
-            DbBackend::Sqlite,
+        .query_one_raw(raw::statement(
+            db,
             format!(
                 "SELECT {SPEECH_HISTORY_RECORD_COLUMNS} FROM speech_history_records WHERE route_kind = ?1 AND id = ?2"
             ),
             vec![route_kind.as_db_value().into(), record_id.into()],
-        ))
+        )?)
         .await
         .context("Failed to load speech history record")?;
     row.as_ref().map(map_speech_history_record).transpose()
@@ -715,11 +713,11 @@ async fn fetch_audio_storage_path(
     record_id: &str,
 ) -> anyhow::Result<Option<Option<String>>> {
     let row = db
-        .query_one_raw(Statement::from_sql_and_values(
-            DbBackend::Sqlite,
+        .query_one_raw(raw::statement(
+            db,
             "SELECT audio_storage_path FROM speech_history_records WHERE route_kind = ?1 AND id = ?2",
             vec![route_kind.as_db_value().into(), record_id.into()],
-        ))
+        )?)
         .await
         .context("Failed to load speech history media path")?;
     row.map(|row| row.try_get_by_index::<Option<String>>(0))

--- a/crates/izwi-server/src/state.rs
+++ b/crates/izwi-server/src/state.rs
@@ -1,10 +1,13 @@
 //! Application state management with high-concurrency optimizations
 
 use crate::chat_store::ChatStore;
+use crate::db::StoreDatabase;
 use crate::diarization_store::DiarizationStore;
 use crate::onboarding_store::OnboardingStore;
+use crate::persistence::PersistenceContext;
 use crate::saved_voice_store::SavedVoiceStore;
 use crate::speech_history_store::SpeechHistoryStore;
+use crate::storage_layout;
 use crate::studio_project_store::StudioProjectStore;
 use crate::transcription_store::TranscriptionStore;
 use crate::voice_observation_store::VoiceObservationStore;
@@ -148,6 +151,8 @@ pub struct AppState {
     pub runtime: Arc<RuntimeService>,
     /// Enterprise integration hooks. Community builds use no-op hooks.
     pub enterprise_hooks: EnterpriseHooks,
+    /// Startup-resolved persistence providers. Older unit helpers may omit this.
+    pub persistence: Option<PersistenceContext>,
     /// Server lifecycle state used by readiness and liveness probes.
     pub lifecycle: ServerLifecycle,
     /// Concurrency limiter to prevent resource exhaustion
@@ -216,6 +221,74 @@ impl AppState {
         Ok(Self {
             runtime: Arc::new(runtime),
             enterprise_hooks,
+            persistence: None,
+            lifecycle: ServerLifecycle::new(),
+            request_semaphore: Arc::new(Semaphore::new(max_concurrent_requests)),
+            request_timeout_secs,
+            response_store_limit,
+            agent_session_store_limit,
+            response_store: Arc::new(RwLock::new(HashMap::new())),
+            agent_session_store: Arc::new(RwLock::new(HashMap::new())),
+            chat_store,
+            transcription_store,
+            diarization_store,
+            speech_history_store,
+            saved_voice_store,
+            onboarding_store,
+            studio_store,
+            voice_store,
+            voice_observation_store,
+        })
+    }
+
+    pub fn with_enterprise_hooks_and_persistence(
+        runtime: RuntimeService,
+        serve_config: &ServeRuntimeConfig,
+        enterprise_hooks: EnterpriseHooks,
+        persistence: PersistenceContext,
+    ) -> anyhow::Result<Self> {
+        let (max_concurrent_requests, request_timeout_secs) = request_limits(serve_config);
+        let response_store_limit = store_limit_from_env(
+            "IZWI_MAX_RESPONSE_STORE_ENTRIES",
+            DEFAULT_RESPONSE_STORE_LIMIT,
+        );
+        let agent_session_store_limit = store_limit_from_env(
+            "IZWI_MAX_AGENT_SESSION_STORE_ENTRIES",
+            DEFAULT_AGENT_SESSION_STORE_LIMIT,
+        );
+        let store_database = StoreDatabase::from_connection(persistence.database.connection());
+        let media_root = storage_layout::resolve_media_root();
+
+        let chat_store = Arc::new(ChatStore::initialize_with_database(store_database.clone()));
+        let transcription_store = Arc::new(TranscriptionStore::initialize_with_database(
+            store_database.clone(),
+            media_root.clone(),
+        )?);
+        let diarization_store = Arc::new(DiarizationStore::initialize_with_database(
+            store_database.clone(),
+            media_root.clone(),
+        )?);
+        let speech_history_store = Arc::new(SpeechHistoryStore::initialize_with_database(
+            store_database.clone(),
+            media_root.clone(),
+        )?);
+        let saved_voice_store = Arc::new(SavedVoiceStore::initialize_with_database(
+            store_database.clone(),
+            media_root,
+        )?);
+        let studio_store = Arc::new(StudioProjectStore::initialize_with_database(
+            store_database.clone(),
+        ));
+        let voice_store = Arc::new(VoiceStore::initialize_with_database(store_database.clone()));
+        let voice_observation_store = Arc::new(VoiceObservationStore::initialize_with_database(
+            store_database.clone(),
+        ));
+        let onboarding_store = Arc::new(OnboardingStore::initialize_with_database(store_database));
+
+        Ok(Self {
+            runtime: Arc::new(runtime),
+            enterprise_hooks,
+            persistence: Some(persistence),
             lifecycle: ServerLifecycle::new(),
             request_semaphore: Arc::new(Semaphore::new(max_concurrent_requests)),
             request_timeout_secs,

--- a/crates/izwi-server/src/state.rs
+++ b/crates/izwi-server/src/state.rs
@@ -7,7 +7,6 @@ use crate::onboarding_store::OnboardingStore;
 use crate::persistence::PersistenceContext;
 use crate::saved_voice_store::SavedVoiceStore;
 use crate::speech_history_store::SpeechHistoryStore;
-use crate::storage_layout;
 use crate::studio_project_store::StudioProjectStore;
 use crate::transcription_store::TranscriptionStore;
 use crate::voice_observation_store::VoiceObservationStore;
@@ -257,25 +256,25 @@ impl AppState {
             DEFAULT_AGENT_SESSION_STORE_LIMIT,
         );
         let store_database = StoreDatabase::from_connection(persistence.database.connection());
-        let media_root = storage_layout::resolve_media_root();
+        let media_storage = persistence.media_storage();
 
         let chat_store = Arc::new(ChatStore::initialize_with_database(store_database.clone()));
-        let transcription_store = Arc::new(TranscriptionStore::initialize_with_database(
+        let transcription_store = Arc::new(TranscriptionStore::initialize_with_storage(
             store_database.clone(),
-            media_root.clone(),
-        )?);
-        let diarization_store = Arc::new(DiarizationStore::initialize_with_database(
+            media_storage.clone(),
+        ));
+        let diarization_store = Arc::new(DiarizationStore::initialize_with_storage(
             store_database.clone(),
-            media_root.clone(),
-        )?);
-        let speech_history_store = Arc::new(SpeechHistoryStore::initialize_with_database(
+            media_storage.clone(),
+        ));
+        let speech_history_store = Arc::new(SpeechHistoryStore::initialize_with_storage(
             store_database.clone(),
-            media_root.clone(),
-        )?);
-        let saved_voice_store = Arc::new(SavedVoiceStore::initialize_with_database(
+            media_storage.clone(),
+        ));
+        let saved_voice_store = Arc::new(SavedVoiceStore::initialize_with_storage(
             store_database.clone(),
-            media_root,
-        )?);
+            media_storage,
+        ));
         let studio_store = Arc::new(StudioProjectStore::initialize_with_database(
             store_database.clone(),
         ));

--- a/crates/izwi-server/src/storage_layout.rs
+++ b/crates/izwi-server/src/storage_layout.rs
@@ -1,6 +1,6 @@
 //! Shared storage layout and filesystem helpers for server persistence.
 
-use anyhow::{anyhow, Context};
+use anyhow::{Context, anyhow};
 use std::path::{Component, Path, PathBuf};
 
 const APP_NAME_DIR: &str = "izwi";
@@ -142,6 +142,39 @@ pub fn read_media_file(media_root: &Path, relative_path: &str) -> anyhow::Result
     let absolute_path = resolve_media_path(media_root, relative_path)?;
     std::fs::read(&absolute_path)
         .with_context(|| format!("Failed to read media file: {}", absolute_path.display()))
+}
+
+pub fn content_type_from_media_path(path: &str) -> &'static str {
+    let extension = Path::new(path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase());
+
+    match extension.as_deref() {
+        Some("jpg") | Some("jpeg") => "image/jpeg",
+        Some("png") => "image/png",
+        Some("webp") => "image/webp",
+        Some("gif") => "image/gif",
+        Some("bmp") => "image/bmp",
+        Some("svg") => "image/svg+xml",
+        Some("avif") => "image/avif",
+        Some("heic") => "image/heic",
+        Some("heif") => "image/heif",
+        Some("mp4") => "video/mp4",
+        Some("webm") => "video/webm",
+        Some("mov") => "video/quicktime",
+        Some("avi") => "video/x-msvideo",
+        Some("mkv") => "video/x-matroska",
+        Some("mpeg") | Some("mpg") => "video/mpeg",
+        Some("3gp") => "video/3gpp",
+        Some("wav") => "audio/wav",
+        Some("mp3") => "audio/mpeg",
+        Some("ogg") => "audio/ogg",
+        Some("flac") => "audio/flac",
+        Some("m4a") => "audio/mp4",
+        Some("aac") => "audio/aac",
+        _ => "application/octet-stream",
+    }
 }
 
 pub fn delete_media_file(media_root: &Path, relative_path: Option<&str>) -> anyhow::Result<()> {

--- a/crates/izwi-server/src/storage_layout.rs
+++ b/crates/izwi-server/src/storage_layout.rs
@@ -49,6 +49,10 @@ pub fn ensure_storage_dirs(db_path: &Path, media_root: &Path) -> anyhow::Result<
         })?;
     }
 
+    ensure_media_dirs(media_root)
+}
+
+pub fn ensure_media_dirs(media_root: &Path) -> anyhow::Result<()> {
     std::fs::create_dir_all(media_root).with_context(|| {
         format!(
             "Failed to create media root directory: {}",

--- a/crates/izwi-server/src/studio_project_store.rs
+++ b/crates/izwi-server/src/studio_project_store.rs
@@ -301,6 +301,10 @@ impl StudioProjectStore {
         })
     }
 
+    pub fn initialize_with_database(db: StoreDatabase) -> Self {
+        Self { db }
+    }
+
     pub async fn list_projects_page(
         &self,
         limit: usize,

--- a/crates/izwi-server/src/studio_project_store.rs
+++ b/crates/izwi-server/src/studio_project_store.rs
@@ -1,16 +1,14 @@
 //! Persistent text-to-speech project storage backed by SQLite.
 
-use anyhow::{Context, anyhow};
-use sea_orm::{
-    ConnectionTrait, DatabaseConnection, DbBackend, QueryResult, Statement, TransactionTrait, Value,
-};
+use anyhow::{anyhow, Context};
+use sea_orm::{ConnectionTrait, DatabaseConnection, QueryResult, TransactionTrait, Value};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
-    db::StoreDatabase,
+    db::{raw, StoreDatabase},
     ids::new_uuid,
     storage_layout::{self},
 };
@@ -1566,36 +1564,56 @@ impl StudioProjectStore {
         let next_last_rendered_at_i64 =
             next_last_rendered_at.and_then(|value| i64::try_from(value).ok());
 
-        execute(
-            &tx,
-            r#"
-            INSERT INTO studio_project_meta (
-                project_id,
-                folder_id,
-                tags_json,
-                default_export_format,
-                last_render_job_id,
-                last_rendered_at
+        if current.is_some() {
+            execute(
+                &tx,
+                r#"
+                UPDATE studio_project_meta
+                SET
+                    folder_id = ?2,
+                    tags_json = ?3,
+                    default_export_format = ?4,
+                    last_render_job_id = ?5,
+                    last_rendered_at = ?6
+                WHERE project_id = ?1
+                "#,
+                vec![
+                    project_id.clone().into(),
+                    next_folder_id.into(),
+                    encode_json_string_vec(next_tags.as_slice()).into(),
+                    next_export.as_db_value().into(),
+                    next_last_render_job_id.into(),
+                    next_last_rendered_at_i64.into(),
+                ],
+                "Failed to update Studio project metadata",
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-            ON CONFLICT(project_id) DO UPDATE SET
-                folder_id = excluded.folder_id,
-                tags_json = excluded.tags_json,
-                default_export_format = excluded.default_export_format,
-                last_render_job_id = excluded.last_render_job_id,
-                last_rendered_at = excluded.last_rendered_at
-            "#,
-            vec![
-                project_id.clone().into(),
-                next_folder_id.into(),
-                encode_json_string_vec(next_tags.as_slice()).into(),
-                next_export.as_db_value().into(),
-                next_last_render_job_id.into(),
-                next_last_rendered_at_i64.into(),
-            ],
-            "Failed to upsert Studio project metadata",
-        )
-        .await?;
+            .await?;
+        } else {
+            execute(
+                &tx,
+                r#"
+                INSERT INTO studio_project_meta (
+                    project_id,
+                    folder_id,
+                    tags_json,
+                    default_export_format,
+                    last_render_job_id,
+                    last_rendered_at
+                )
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                "#,
+                vec![
+                    project_id.clone().into(),
+                    next_folder_id.into(),
+                    encode_json_string_vec(next_tags.as_slice()).into(),
+                    next_export.as_db_value().into(),
+                    next_last_render_job_id.into(),
+                    next_last_rendered_at_i64.into(),
+                ],
+                "Failed to insert Studio project metadata",
+            )
+            .await?;
+        }
 
         tx.commit()
             .await
@@ -1684,7 +1702,7 @@ impl StudioProjectStore {
         let db = self.db.connection().await?;
         let rows = query_all(
             db,
-            STUDIO_PROJECT_SNAPSHOTS_SQL,
+            studio_project_snapshots_sql(db)?,
             vec![project_id.into()],
             "Failed to list Studio project snapshots",
         )
@@ -2090,30 +2108,42 @@ const STUDIO_PROJECT_META_SQL: &str = r#"
     WHERE project_id = ?1
 "#;
 
-const STUDIO_PROJECT_SNAPSHOTS_SQL: &str = r#"
-    SELECT
-        s.id,
-        s.project_id,
-        s.created_at,
-        s.label,
-        COALESCE(json_extract(s.project_json, '$.name'), p.name) AS project_name
-    FROM studio_project_snapshots s
-    LEFT JOIN studio_projects p ON p.id = s.project_id
-    WHERE s.project_id = ?1
-    ORDER BY s.created_at DESC, s.id DESC
-"#;
+fn studio_project_snapshots_sql<C>(db: &C) -> anyhow::Result<String>
+where
+    C: ConnectionTrait,
+{
+    studio_project_snapshot_summary_sql(
+        db,
+        "WHERE s.project_id = ?1\n    ORDER BY s.created_at DESC, s.id DESC",
+    )
+}
 
-const STUDIO_PROJECT_SNAPSHOT_BY_ID_SQL: &str = r#"
+fn studio_project_snapshot_by_id_sql<C>(db: &C) -> anyhow::Result<String>
+where
+    C: ConnectionTrait,
+{
+    studio_project_snapshot_summary_sql(db, "WHERE s.id = ?1")
+}
+
+fn studio_project_snapshot_summary_sql<C>(db: &C, predicate: &str) -> anyhow::Result<String>
+where
+    C: ConnectionTrait,
+{
+    let project_name = raw::json_extract_text(db.get_database_backend(), "s.project_json", "name")?;
+    Ok(format!(
+        r#"
     SELECT
         s.id,
         s.project_id,
         s.created_at,
         s.label,
-        COALESCE(json_extract(s.project_json, '$.name'), p.name) AS project_name
+        COALESCE({project_name}, p.name) AS project_name
     FROM studio_project_snapshots s
     LEFT JOIN studio_projects p ON p.id = s.project_id
-    WHERE s.id = ?1
-"#;
+    {predicate}
+"#
+    ))
+}
 
 const STUDIO_PROJECT_RENDER_JOBS_SQL: &str = r#"
     SELECT
@@ -2241,7 +2271,7 @@ async fn fetch_snapshot(
 ) -> anyhow::Result<Option<StudioProjectSnapshotRecord>> {
     query_one(
         db,
-        STUDIO_PROJECT_SNAPSHOT_BY_ID_SQL,
+        studio_project_snapshot_by_id_sql(db)?,
         vec![snapshot_id.into()],
         "Failed to load Studio project snapshot",
     )
@@ -2340,61 +2370,82 @@ async fn upsert_last_render_job<C>(
 where
     C: ConnectionTrait,
 {
-    if let Some(last_rendered_at) = last_rendered_at {
-        execute(
-            db,
-            r#"
-            INSERT INTO studio_project_meta (
-                project_id,
-                folder_id,
-                tags_json,
-                default_export_format,
-                last_render_job_id,
-                last_rendered_at
+    let exists = query_one(
+        db,
+        "SELECT 1 FROM studio_project_meta WHERE project_id = ?1",
+        vec![project_id.into()],
+        "Failed to check Studio project render metadata",
+    )
+    .await?
+    .is_some();
+
+    match (exists, last_rendered_at) {
+        (true, Some(last_rendered_at)) => {
+            execute(
+                db,
+                r#"
+                UPDATE studio_project_meta
+                SET
+                    last_render_job_id = ?2,
+                    last_rendered_at = ?3
+                WHERE project_id = ?1
+                "#,
+                vec![project_id.into(), job_id.into(), last_rendered_at.into()],
+                "Failed to update Studio project completed render metadata",
             )
-            VALUES (
-                ?1,
-                (SELECT folder_id FROM studio_project_meta WHERE project_id = ?1),
-                COALESCE((SELECT tags_json FROM studio_project_meta WHERE project_id = ?1), '[]'),
-                COALESCE((SELECT default_export_format FROM studio_project_meta WHERE project_id = ?1), 'wav'),
-                ?2,
-                ?3
+            .await?;
+        }
+        (true, None) => {
+            execute(
+                db,
+                r#"
+                UPDATE studio_project_meta
+                SET last_render_job_id = ?2
+                WHERE project_id = ?1
+                "#,
+                vec![project_id.into(), job_id.into()],
+                "Failed to update Studio project render metadata",
             )
-            ON CONFLICT(project_id) DO UPDATE SET
-                last_render_job_id = excluded.last_render_job_id,
-                last_rendered_at = excluded.last_rendered_at
-            "#,
-            vec![project_id.into(), job_id.into(), last_rendered_at.into()],
-            "Failed to update Studio project completed render metadata",
-        )
-        .await?;
-    } else {
-        execute(
-            db,
-            r#"
-            INSERT INTO studio_project_meta (
-                project_id,
-                folder_id,
-                tags_json,
-                default_export_format,
-                last_render_job_id,
-                last_rendered_at
+            .await?;
+        }
+        (false, Some(last_rendered_at)) => {
+            execute(
+                db,
+                r#"
+                INSERT INTO studio_project_meta (
+                    project_id,
+                    folder_id,
+                    tags_json,
+                    default_export_format,
+                    last_render_job_id,
+                    last_rendered_at
+                )
+                VALUES (?1, NULL, '[]', 'wav', ?2, ?3)
+                "#,
+                vec![project_id.into(), job_id.into(), last_rendered_at.into()],
+                "Failed to insert Studio project completed render metadata",
             )
-            VALUES (
-                ?1,
-                (SELECT folder_id FROM studio_project_meta WHERE project_id = ?1),
-                COALESCE((SELECT tags_json FROM studio_project_meta WHERE project_id = ?1), '[]'),
-                COALESCE((SELECT default_export_format FROM studio_project_meta WHERE project_id = ?1), 'wav'),
-                ?2,
-                (SELECT last_rendered_at FROM studio_project_meta WHERE project_id = ?1)
+            .await?;
+        }
+        (false, None) => {
+            execute(
+                db,
+                r#"
+                INSERT INTO studio_project_meta (
+                    project_id,
+                    folder_id,
+                    tags_json,
+                    default_export_format,
+                    last_render_job_id,
+                    last_rendered_at
+                )
+                VALUES (?1, NULL, '[]', 'wav', ?2, NULL)
+                "#,
+                vec![project_id.into(), job_id.into()],
+                "Failed to insert Studio project render metadata",
             )
-            ON CONFLICT(project_id) DO UPDATE SET
-                last_render_job_id = excluded.last_render_job_id
-            "#,
-            vec![project_id.into(), job_id.into()],
-            "Failed to update Studio project render metadata",
-        )
-        .await?;
+            .await?;
+        }
     }
     Ok(())
 }
@@ -2408,14 +2459,8 @@ async fn execute<C>(
 where
     C: ConnectionTrait,
 {
-    let result = db
-        .execute_raw(Statement::from_sql_and_values(
-            DbBackend::Sqlite,
-            sql,
-            values,
-        ))
-        .await
-        .context(context)?;
+    let statement = raw::statement(db, sql, values).context(context)?;
+    let result = db.execute_raw(statement).await.context(context)?;
     Ok(result.rows_affected())
 }
 
@@ -2428,13 +2473,8 @@ async fn query_one<C>(
 where
     C: ConnectionTrait,
 {
-    db.query_one_raw(Statement::from_sql_and_values(
-        DbBackend::Sqlite,
-        sql,
-        values,
-    ))
-    .await
-    .context(context)
+    let statement = raw::statement(db, sql, values).context(context)?;
+    db.query_one_raw(statement).await.context(context)
 }
 
 async fn query_all<C>(
@@ -2446,13 +2486,8 @@ async fn query_all<C>(
 where
     C: ConnectionTrait,
 {
-    db.query_all_raw(Statement::from_sql_and_values(
-        DbBackend::Sqlite,
-        sql,
-        values,
-    ))
-    .await
-    .context(context)
+    let statement = raw::statement(db, sql, values).context(context)?;
+    db.query_all_raw(statement).await.context(context)
 }
 
 fn map_project_summary_row(row: &QueryResult) -> anyhow::Result<StudioProjectSummary> {

--- a/crates/izwi-server/src/transcription_store.rs
+++ b/crates/izwi-server/src/transcription_store.rs
@@ -3,16 +3,14 @@
 use anyhow::{anyhow, Context};
 use izwi_hooks::{HookMetadata, MediaNamespace, MediaStorageProvider};
 use sea_orm::sea_query::Expr;
-use sea_orm::{
-    ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, QueryFilter, QueryResult, Set, Statement,
-};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryResult, Set};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
-    db::StoreDatabase,
+    db::{raw, StoreDatabase},
     entity::transcription_records,
     ids::new_uuid,
     persistence::{
@@ -242,22 +240,22 @@ impl TranscriptionStore {
         let fetch_limit = list_limit.saturating_add(1);
         let rows = if let Some(cursor) = cursor {
             let cursor_created_at = i64::try_from(cursor.created_at).unwrap_or(i64::MAX);
-            db.query_all_raw(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
+            db.query_all_raw(raw::statement(
+                db,
                 TRANSCRIPTION_PAGE_AFTER_CURSOR_SQL,
                 vec![
                     cursor_created_at.into(),
                     cursor.id.into(),
                     fetch_limit.into(),
                 ],
-            ))
+            )?)
             .await
         } else {
-            db.query_all_raw(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
+            db.query_all_raw(raw::statement(
+                db,
                 TRANSCRIPTION_PAGE_SQL,
                 vec![fetch_limit.into()],
-            ))
+            )?)
             .await
         }
         .context("Failed to list transcription records")?;
@@ -297,11 +295,11 @@ impl TranscriptionStore {
     ) -> anyhow::Result<Option<StoredTranscriptionAudio>> {
         let db = self.db.connection().await?;
         let row = db
-            .query_one_raw(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
+            .query_one_raw(raw::statement(
+                db,
                 "SELECT audio_storage_path, audio_mime_type, audio_filename FROM transcription_records WHERE id = ?1",
                 vec![record_id.into()],
-            ))
+            )?)
             .await
             .context("Failed to load transcription audio metadata")?;
         let Some(row) = row else {
@@ -605,11 +603,11 @@ impl TranscriptionStore {
     pub async fn delete_record(&self, record_id: String) -> anyhow::Result<bool> {
         let db = self.db.connection().await?;
         let audio_storage_path = db
-            .query_one_raw(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
+            .query_one_raw(raw::statement(
+                db,
                 "SELECT audio_storage_path FROM transcription_records WHERE id = ?1",
                 vec![record_id.clone().into()],
-            ))
+            )?)
             .await
             .context("Failed to load transcription media path")?
             .map(|row| row.try_get_by_index::<Option<String>>(0))
@@ -697,13 +695,13 @@ async fn fetch_record_without_audio(
     record_id: &str,
 ) -> anyhow::Result<Option<TranscriptionRecord>> {
     let row = db
-        .query_one_raw(Statement::from_sql_and_values(
-            DbBackend::Sqlite,
+        .query_one_raw(raw::statement(
+            db,
             format!(
                 "SELECT {TRANSCRIPTION_RECORD_COLUMNS} FROM transcription_records WHERE id = ?1"
             ),
             vec![record_id.into()],
-        ))
+        )?)
         .await
         .context("Failed to load transcription record")?;
     row.as_ref().map(map_transcription_record).transpose()

--- a/crates/izwi-server/src/transcription_store.rs
+++ b/crates/izwi-server/src/transcription_store.rs
@@ -217,6 +217,16 @@ impl TranscriptionStore {
         })
     }
 
+    pub fn initialize_with_database(
+        db: StoreDatabase,
+        media_root: PathBuf,
+    ) -> anyhow::Result<Self> {
+        storage_layout::ensure_media_dirs(&media_root)
+            .context("Failed to prepare transcription media storage layout")?;
+
+        Ok(Self { db, media_root })
+    }
+
     pub async fn list_records_page(
         &self,
         limit: usize,

--- a/crates/izwi-server/src/transcription_store.rs
+++ b/crates/izwi-server/src/transcription_store.rs
@@ -1,19 +1,24 @@
 //! Persistent transcription history storage backed by SQLite.
 
-use anyhow::{Context, anyhow};
+use anyhow::{anyhow, Context};
+use izwi_hooks::{HookMetadata, MediaNamespace, MediaStorageProvider};
 use sea_orm::sea_query::Expr;
 use sea_orm::{
     ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, QueryFilter, QueryResult, Set, Statement,
 };
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
     db::StoreDatabase,
     entity::transcription_records,
     ids::new_uuid,
-    storage_layout::{self, MediaGroup},
+    persistence::{
+        delete_media_object, persist_audio_object, read_media_object, LocalMediaStorageProvider,
+    },
+    storage_layout,
 };
 
 const DEFAULT_LIST_LIMIT: usize = 200;
@@ -196,7 +201,7 @@ pub struct CompleteTranscriptionRecord {
 #[derive(Clone)]
 pub struct TranscriptionStore {
     db: StoreDatabase,
-    media_root: PathBuf,
+    media_storage: Arc<dyn MediaStorageProvider>,
 }
 
 impl TranscriptionStore {
@@ -213,18 +218,15 @@ impl TranscriptionStore {
 
         Ok(Self {
             db: StoreDatabase::new(db_path),
-            media_root,
+            media_storage: Arc::new(LocalMediaStorageProvider::new(media_root)),
         })
     }
 
-    pub fn initialize_with_database(
+    pub fn initialize_with_storage(
         db: StoreDatabase,
-        media_root: PathBuf,
-    ) -> anyhow::Result<Self> {
-        storage_layout::ensure_media_dirs(&media_root)
-            .context("Failed to prepare transcription media storage layout")?;
-
-        Ok(Self { db, media_root })
+        media_storage: Arc<dyn MediaStorageProvider>,
+    ) -> Self {
+        Self { db, media_storage }
     }
 
     pub async fn list_records_page(
@@ -308,8 +310,9 @@ impl TranscriptionStore {
         let audio_storage_path: String = row.try_get_by_index(0)?;
         let audio_mime_type: String = row.try_get_by_index(1)?;
         let audio_filename: Option<String> = row.try_get_by_index(2)?;
-        let audio_bytes =
-            storage_layout::read_media_file(&self.media_root, audio_storage_path.as_str())?;
+        let audio_bytes = read_media_object(&self.media_storage, audio_storage_path.as_str())
+            .await
+            .context("Failed to read transcription media")?;
         Ok(Some(StoredTranscriptionAudio {
             audio_bytes,
             audio_mime_type,
@@ -363,15 +366,16 @@ impl TranscriptionStore {
             return Err(anyhow!("Audio payload cannot be empty"));
         }
 
-        let audio_storage_path = storage_layout::persist_audio_file(
-            &self.media_root,
-            MediaGroup::Uploads,
-            "transcription",
+        let audio_storage_path = persist_audio_object(
+            &self.media_storage,
+            MediaNamespace::TranscriptionUpload,
             &record_id,
             audio_filename.as_deref(),
             audio_mime_type.as_str(),
             &record.audio_bytes,
-        )?;
+            HookMetadata::new(),
+        )
+        .await?;
 
         let segments_json =
             serde_json::to_string(&segments).context("Failed serializing segments")?;
@@ -404,7 +408,7 @@ impl TranscriptionStore {
             .exec(db)
             .await
         {
-            let _ = storage_layout::delete_media_file(&self.media_root, Some(&audio_storage_path));
+            let _ = delete_media_object(&self.media_storage, Some(&audio_storage_path)).await;
             return Err(err).context("Failed to insert transcription record");
         }
 
@@ -616,7 +620,7 @@ impl TranscriptionStore {
             .await
             .context("Failed to delete transcription record")?;
         if result.rows_affected > 0 {
-            storage_layout::delete_media_file(&self.media_root, audio_storage_path.as_deref())?;
+            delete_media_object(&self.media_storage, audio_storage_path.as_deref()).await?;
         }
         Ok(result.rows_affected > 0)
     }
@@ -972,7 +976,11 @@ fn now_unix_millis_i64() -> i64 {
 }
 
 fn i64_to_u64(value: i64) -> u64 {
-    if value.is_negative() { 0 } else { value as u64 }
+    if value.is_negative() {
+        0
+    } else {
+        value as u64
+    }
 }
 
 #[allow(dead_code)]

--- a/crates/izwi-server/src/transcription_store.rs
+++ b/crates/izwi-server/src/transcription_store.rs
@@ -310,11 +310,11 @@ impl TranscriptionStore {
         let audio_storage_path: String = row.try_get_by_index(0)?;
         let audio_mime_type: String = row.try_get_by_index(1)?;
         let audio_filename: Option<String> = row.try_get_by_index(2)?;
-        let audio_bytes = read_media_object(&self.media_storage, audio_storage_path.as_str())
+        let audio = read_media_object(&self.media_storage, audio_storage_path.as_str())
             .await
             .context("Failed to read transcription media")?;
         Ok(Some(StoredTranscriptionAudio {
-            audio_bytes,
+            audio_bytes: audio.bytes,
             audio_mime_type,
             audio_filename,
         }))

--- a/crates/izwi-server/src/voice_observation_store.rs
+++ b/crates/izwi-server/src/voice_observation_store.rs
@@ -1,12 +1,11 @@
-use anyhow::{Context, anyhow};
+use anyhow::{anyhow, Context};
 use sea_orm::sea_query::Expr;
 use sea_orm::{
-    ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, QueryFilter, QueryResult, Statement,
-    TransactionTrait,
+    ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryResult, TransactionTrait,
 };
 use serde::Serialize;
 
-use crate::db::StoreDatabase;
+use crate::db::{raw, StoreDatabase};
 use crate::entity::voice_observations;
 use crate::ids::new_uuid;
 
@@ -57,11 +56,11 @@ impl VoiceObservationStore {
         let db = self.db.connection().await?;
         let limit = i64::try_from(limit.max(1)).context("Voice observation limit exceeds i64")?;
         let rows = db
-            .query_all_raw(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
+            .query_all_raw(raw::statement(
+                db,
                 OBSERVATIONS_ACTIVE_SQL,
                 vec![profile_id.into(), limit.into()],
-            ))
+            )?)
             .await
             .context("Failed to list voice observations")?;
         rows.iter().map(map_observation).collect()
@@ -92,8 +91,8 @@ impl VoiceObservationStore {
             let canonical_summary = build_canonical_summary(category.as_str(), summary.as_str());
 
             let existing_id = tx
-                .query_one_raw(Statement::from_sql_and_values(
-                    DbBackend::Sqlite,
+                .query_one_raw(raw::statement(
+                    &tx,
                     r#"
                     SELECT id
                     FROM voice_observations
@@ -103,25 +102,28 @@ impl VoiceObservationStore {
                     LIMIT 1
                     "#,
                     vec![profile_id.clone().into(), canonical_summary.clone().into()],
-                ))
+                )?)
                 .await
                 .context("Failed to find existing voice observation")?
                 .map(|row| row.try_get_by_index::<String>(0))
                 .transpose()?;
 
             let observation = if let Some(existing_id) = existing_id {
-                tx.execute_raw(Statement::from_sql_and_values(
-                    DbBackend::Sqlite,
-                    r#"
+                let confidence_expr = raw::greatest(tx.get_database_backend(), "confidence", "?1")?;
+                tx.execute_raw(raw::statement(
+                    &tx,
+                    format!(
+                        r#"
                     UPDATE voice_observations
-                    SET confidence = MAX(confidence, ?1),
+                    SET confidence = {confidence_expr},
                         source_turn_id = ?2,
                         source_user_text = ?3,
                         source_assistant_text = ?4,
                         times_seen = times_seen + 1,
                         updated_at = ?5
                     WHERE id = ?6
-                    "#,
+                    "#
+                    ),
                     vec![
                         f64::from(confidence).into(),
                         sanitize_optional_text(source_turn_id.as_deref(), 160).into(),
@@ -130,7 +132,7 @@ impl VoiceObservationStore {
                         now.into(),
                         existing_id.clone().into(),
                     ],
-                ))
+                )?)
                 .await
                 .context("Failed to update voice observation")?;
                 fetch_observation(&tx, &existing_id)
@@ -138,8 +140,8 @@ impl VoiceObservationStore {
                     .ok_or_else(|| anyhow!("Updated observation not found"))?
             } else {
                 let observation_id = new_uuid();
-                tx.execute_raw(Statement::from_sql_and_values(
-                    DbBackend::Sqlite,
+                tx.execute_raw(raw::statement(
+                    &tx,
                     r#"
                     INSERT INTO voice_observations (
                         id,
@@ -170,7 +172,7 @@ impl VoiceObservationStore {
                         sanitize_optional_text(source_assistant_text.as_deref(), 16000).into(),
                         now.into(),
                     ],
-                ))
+                )?)
                 .await
                 .context("Failed to insert voice observation")?;
                 fetch_observation(&tx, &observation_id)
@@ -286,11 +288,11 @@ where
     C: ConnectionTrait,
 {
     let row = conn
-        .query_one_raw(Statement::from_sql_and_values(
-            DbBackend::Sqlite,
+        .query_one_raw(raw::statement(
+            conn,
             OBSERVATION_BY_ID_SQL,
             vec![observation_id.into()],
-        ))
+        )?)
         .await
         .context("Failed to load voice observation")?;
     row.as_ref().map(map_observation).transpose()

--- a/crates/izwi-server/src/voice_observation_store.rs
+++ b/crates/izwi-server/src/voice_observation_store.rs
@@ -45,6 +45,10 @@ impl VoiceObservationStore {
         })
     }
 
+    pub fn initialize_with_database(db: StoreDatabase) -> Self {
+        Self { db }
+    }
+
     pub async fn list_active(
         &self,
         profile_id: String,

--- a/crates/izwi-server/src/voice_store.rs
+++ b/crates/izwi-server/src/voice_store.rs
@@ -96,6 +96,10 @@ impl VoiceStore {
         })
     }
 
+    pub fn initialize_with_database(db: StoreDatabase) -> Self {
+        Self { db }
+    }
+
     pub async fn get_default_profile(&self) -> anyhow::Result<VoiceProfile> {
         self.get_profile(DEFAULT_VOICE_PROFILE_ID.to_string())
             .await?

--- a/crates/izwi-server/src/voice_store.rs
+++ b/crates/izwi-server/src/voice_store.rs
@@ -1,12 +1,11 @@
-use anyhow::{Context, anyhow};
+use anyhow::{anyhow, Context};
 use sea_orm::sea_query::Expr;
 use sea_orm::{
-    ColumnTrait, ConnectionTrait, DatabaseConnection, DbBackend, EntityTrait, QueryFilter,
-    QueryResult, Set, Statement,
+    ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryResult, Set,
 };
 use serde::Serialize;
 
-use crate::db::StoreDatabase;
+use crate::db::{raw, StoreDatabase};
 use crate::entity::{voice_profiles, voice_sessions, voice_turns};
 use crate::ids::new_uuid;
 use crate::voice_defaults::{DEFAULT_VOICE_AGENT_SYSTEM_PROMPT, DEFAULT_VOICE_PROFILE_ID};
@@ -181,8 +180,8 @@ impl VoiceStore {
     pub async fn end_session(&self, session_id: String) -> anyhow::Result<()> {
         let db = self.db.connection().await?;
         let now = now_unix_millis_i64();
-        db.execute_raw(Statement::from_sql_and_values(
-            DbBackend::Sqlite,
+        db.execute_raw(raw::statement(
+            db,
             r#"
             UPDATE voice_sessions
             SET updated_at = ?1,
@@ -190,7 +189,7 @@ impl VoiceStore {
             WHERE id = ?2
             "#,
             vec![now.into(), session_id.into()],
-        ))
+        )?)
         .await
         .context("Failed to end voice session")?;
         Ok(())
@@ -200,8 +199,8 @@ impl VoiceStore {
         let db = self.db.connection().await?;
         let limit = i64::try_from(limit.max(1)).context("Voice session limit exceeds i64")?;
         let rows = db
-            .query_all_raw(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
+            .query_all_raw(raw::statement(
+                db,
                 r#"
             SELECT
                 s.id,
@@ -235,7 +234,7 @@ impl VoiceStore {
             LIMIT ?1
                 "#,
                 vec![limit.into()],
-            ))
+            )?)
             .await
             .context("Failed to list voice sessions")?;
         rows.iter().map(map_session_summary).collect()
@@ -313,8 +312,8 @@ impl VoiceStore {
         let session_id = fetch_turn_session_id(db, &turn_id)
             .await?
             .ok_or_else(|| anyhow!("Voice turn not found"))?;
-        db.execute_raw(Statement::from_sql_and_values(
-            DbBackend::Sqlite,
+        db.execute_raw(raw::statement(
+            db,
             r#"
             UPDATE voice_turns
             SET user_text = ?1,
@@ -330,7 +329,7 @@ impl VoiceStore {
                 now.into(),
                 turn_id.into(),
             ],
-        ))
+        )?)
         .await
         .context("Failed to update voice turn transcript")?;
         touch_session_updated_at(db, session_id.as_str(), now).await
@@ -347,8 +346,8 @@ impl VoiceStore {
         let session_id = fetch_turn_session_id(db, &turn_id)
             .await?
             .ok_or_else(|| anyhow!("Voice turn not found"))?;
-        db.execute_raw(Statement::from_sql_and_values(
-            DbBackend::Sqlite,
+        db.execute_raw(raw::statement(
+            db,
             r#"
             UPDATE voice_turns
             SET assistant_text = ?1,
@@ -362,7 +361,7 @@ impl VoiceStore {
                 now.into(),
                 turn_id.into(),
             ],
-        ))
+        )?)
         .await
         .context("Failed to update voice turn assistant text")?;
         touch_session_updated_at(db, session_id.as_str(), now).await
@@ -380,8 +379,8 @@ impl VoiceStore {
         let session_id = fetch_turn_session_id(db, &turn_id)
             .await?
             .ok_or_else(|| anyhow!("Voice turn not found"))?;
-        db.execute_raw(Statement::from_sql_and_values(
-            DbBackend::Sqlite,
+        db.execute_raw(raw::statement(
+            db,
             r#"
             UPDATE voice_turns
             SET status = ?1,
@@ -395,7 +394,7 @@ impl VoiceStore {
                 now.into(),
                 turn_id.into(),
             ],
-        ))
+        )?)
         .await
         .context("Failed to complete voice turn")?;
         touch_session_updated_at(db, session_id.as_str(), now).await
@@ -504,11 +503,11 @@ async fn fetch_voice_profile(
     profile_id: &str,
 ) -> anyhow::Result<Option<VoiceProfile>> {
     let row = db
-        .query_one_raw(Statement::from_sql_and_values(
-            DbBackend::Sqlite,
+        .query_one_raw(raw::statement(
+            db,
             VOICE_PROFILE_BY_ID_SQL,
             vec![profile_id.into()],
-        ))
+        )?)
         .await
         .context("Failed to load voice profile")?;
     row.as_ref().map(map_voice_profile).transpose()
@@ -519,11 +518,11 @@ async fn fetch_session_summary(
     session_id: &str,
 ) -> anyhow::Result<Option<VoiceSessionSummary>> {
     let row = db
-        .query_one_raw(Statement::from_sql_and_values(
-            DbBackend::Sqlite,
+        .query_one_raw(raw::statement(
+            db,
             SESSION_SUMMARY_BY_ID_SQL,
             vec![session_id.into()],
-        ))
+        )?)
         .await
         .context("Failed to load voice session summary")?;
     row.as_ref().map(map_session_summary).transpose()
@@ -534,11 +533,11 @@ async fn list_session_turns(
     session_id: &str,
 ) -> anyhow::Result<Vec<VoiceTurnRecord>> {
     let rows = db
-        .query_all_raw(Statement::from_sql_and_values(
-            DbBackend::Sqlite,
+        .query_all_raw(raw::statement(
+            db,
             SESSION_TURNS_SQL,
             vec![session_id.into()],
-        ))
+        )?)
         .await
         .context("Failed to list voice turns")?;
     rows.iter().map(map_turn_record).collect()
@@ -549,11 +548,11 @@ async fn fetch_turn_record(
     turn_id: &str,
 ) -> anyhow::Result<Option<VoiceTurnRecord>> {
     let row = db
-        .query_one_raw(Statement::from_sql_and_values(
-            DbBackend::Sqlite,
+        .query_one_raw(raw::statement(
+            db,
             TURN_RECORD_BY_ID_SQL,
             vec![turn_id.into()],
-        ))
+        )?)
         .await
         .context("Failed to load voice turn")?;
     row.as_ref().map(map_turn_record).transpose()
@@ -564,11 +563,11 @@ async fn fetch_turn_session_id(
     turn_id: &str,
 ) -> anyhow::Result<Option<String>> {
     let row = db
-        .query_one_raw(Statement::from_sql_and_values(
-            DbBackend::Sqlite,
+        .query_one_raw(raw::statement(
+            db,
             "SELECT session_id FROM voice_turns WHERE id = ?1",
             vec![turn_id.into()],
-        ))
+        )?)
         .await
         .context("Failed to load voice turn session id")?;
     row.map(|row| row.try_get_by_index(0))
@@ -581,11 +580,11 @@ async fn touch_session_updated_at(
     session_id: &str,
     updated_at: i64,
 ) -> anyhow::Result<()> {
-    db.execute_raw(Statement::from_sql_and_values(
-        DbBackend::Sqlite,
+    db.execute_raw(raw::statement(
+        db,
         "UPDATE voice_sessions SET updated_at = ?1 WHERE id = ?2",
         vec![updated_at.into(), session_id.into()],
-    ))
+    )?)
     .await
     .context("Failed to touch voice session")?;
     Ok(())
@@ -686,7 +685,11 @@ fn sanitize_optional_text(raw: Option<&str>, max_len: usize) -> Option<String> {
 }
 
 fn bool_to_i64(value: bool) -> i64 {
-    if value { 1 } else { 0 }
+    if value {
+        1
+    } else {
+        0
+    }
 }
 
 fn i64_to_bool(value: i64) -> bool {


### PR DESCRIPTION
Introduces pluggable enterprise database/media providers, shared server persistence wiring, backend-aware SQL helpers, provider-managed schema validation, and preserves OSS local media behavior.