### PR TITLE
Fix Kokoro CUDA Docker runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,9 +88,13 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y \
     libssl3 \
     ca-certificates \
+    debianutils \
     ffmpeg \
     libsndfile1 \
     espeak-ng \
+    tar \
+    unzip \
+    zip \
     curl \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -m -u 1000 izwi
@@ -144,9 +148,13 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y \
     libssl3 \
     ca-certificates \
+    debianutils \
     ffmpeg \
     libsndfile1 \
     espeak-ng \
+    tar \
+    unzip \
+    zip \
     curl \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -m -u 1000 izwi

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,7 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     ffmpeg \
     libsndfile1 \
+    espeak-ng \
     curl \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -m -u 1000 izwi
@@ -145,6 +146,7 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     ffmpeg \
     libsndfile1 \
+    espeak-ng \
     curl \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -m -u 1000 izwi

--- a/crates/izwi-core/src/error.rs
+++ b/crates/izwi-core/src/error.rs
@@ -31,6 +31,9 @@ pub enum Error {
     #[error("Configuration error: {0}")]
     ConfigError(String),
 
+    #[error("Missing runtime dependency: {0}")]
+    MissingDependency(String),
+
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
 

--- a/crates/izwi-core/src/models/architectures/kokoro/phonemizer.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/phonemizer.rs
@@ -25,7 +25,7 @@ impl EspeakPhonemizer {
                 return Ok(Self::new(path));
             }
         }
-        Err(Error::ModelLoadError(
+        Err(Error::MissingDependency(
             "espeak-ng not found; install it to enable Kokoro phonemization".to_string(),
         ))
     }

--- a/crates/izwi-server/src/error.rs
+++ b/crates/izwi-server/src/error.rs
@@ -35,6 +35,13 @@ impl ApiError {
             message: msg.into(),
         }
     }
+
+    pub fn service_unavailable(msg: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            message: msg.into(),
+        }
+    }
 }
 
 impl IntoResponse for ApiError {
@@ -45,6 +52,7 @@ impl IntoResponse for ApiError {
                 "type": match self.status {
                     StatusCode::BAD_REQUEST => "invalid_request_error",
                     StatusCode::NOT_FOUND => "not_found_error",
+                    StatusCode::SERVICE_UNAVAILABLE => "service_unavailable_error",
                     _ => "server_error",
                 },
                 "param": null,
@@ -60,7 +68,43 @@ impl From<izwi_core::Error> for ApiError {
         match &err {
             izwi_core::Error::ModelNotFound(_) => ApiError::not_found(err.to_string()),
             izwi_core::Error::ConfigError(_) => ApiError::bad_request(err.to_string()),
+            izwi_core::Error::MissingDependency(_) => {
+                ApiError::service_unavailable(err.to_string())
+            }
             _ => ApiError::internal(err.to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{body::to_bytes, http::StatusCode, response::IntoResponse};
+    use serde_json::Value;
+
+    use super::ApiError;
+
+    #[test]
+    fn missing_dependency_maps_to_service_unavailable() {
+        let api_error = ApiError::from(izwi_core::Error::MissingDependency(
+            "espeak-ng not found".to_string(),
+        ));
+
+        assert_eq!(api_error.status, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(api_error.message.contains("espeak-ng not found"));
+    }
+
+    #[tokio::test]
+    async fn service_unavailable_uses_openai_style_error_type() {
+        let response = ApiError::service_unavailable("missing espeak-ng").into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(body["error"]["type"], "service_unavailable_error");
+        assert_eq!(
+            body["error"]["code"],
+            StatusCode::SERVICE_UNAVAILABLE.as_str()
+        );
     }
 }

--- a/scripts/ci/check-backend-truth.sh
+++ b/scripts/ci/check-backend-truth.sh
@@ -38,23 +38,29 @@ smoke_docker_server() {
         "${image}" \
         --help >/dev/null
 
-    assert_docker_espeak "${image}"
+    assert_docker_runtime_commands "${image}"
 }
 
-assert_docker_espeak() {
+assert_docker_runtime_commands() {
     local image="$1"
 
-    echo "Checking Kokoro phonemizer dependency in ${image}"
+    echo "Checking runtime command dependencies in ${image}"
     docker run --rm \
         --entrypoint /bin/sh \
         "${image}" \
-        -c 'command -v espeak-ng >/dev/null'
+        -c '
+            set -eu
+
+            for cmd in espeak-ng tar unzip zip which; do
+                command -v "${cmd}" >/dev/null
+            done
+        '
 }
 
 audit_cuda_docker_server() {
     local image="$1"
 
-    assert_docker_espeak "${image}"
+    assert_docker_runtime_commands "${image}"
 
     echo "Auditing CUDA dependencies in ${image}"
     docker run --rm \

--- a/scripts/ci/check-backend-truth.sh
+++ b/scripts/ci/check-backend-truth.sh
@@ -37,10 +37,24 @@ smoke_docker_server() {
         --entrypoint /usr/local/bin/izwi-server \
         "${image}" \
         --help >/dev/null
+
+    assert_docker_espeak "${image}"
+}
+
+assert_docker_espeak() {
+    local image="$1"
+
+    echo "Checking Kokoro phonemizer dependency in ${image}"
+    docker run --rm \
+        --entrypoint /bin/sh \
+        "${image}" \
+        -c 'command -v espeak-ng >/dev/null'
 }
 
 audit_cuda_docker_server() {
     local image="$1"
+
+    assert_docker_espeak "${image}"
 
     echo "Auditing CUDA dependencies in ${image}"
     docker run --rm \


### PR DESCRIPTION
Installs Kokoro and Parakeet runtime tools in Docker images, maps missing phonemizer dependencies to 503, and adds CI checks for required runtime commands.