### PR TITLE
Add Open Models action to diarization modal

### DIFF
--- a/ui/src/features/diarization/components/NewDiarizationModal.tsx
+++ b/ui/src/features/diarization/components/NewDiarizationModal.tsx
@@ -3,6 +3,7 @@ import {
   AlertTriangle,
   Loader2,
   Mic,
+  Settings2,
   Square,
   Upload,
 } from "lucide-react";
@@ -56,6 +57,7 @@ interface NewDiarizationModalProps {
   canLoadAnyManagedModels?: boolean;
   canUnloadAnyManagedModels?: boolean;
   isManagedModelActionBusy?: boolean;
+  onOpenModelManager: () => void;
   onLoadAllManagedModels: () => void;
   onUnloadAllManagedModels: () => void;
   onCreated: (record: DiarizationRecord) => Promise<void> | void;
@@ -84,6 +86,7 @@ export function NewDiarizationModal({
   canLoadAnyManagedModels = false,
   canUnloadAnyManagedModels = false,
   isManagedModelActionBusy = false,
+  onOpenModelManager,
   onLoadAllManagedModels,
   onUnloadAllManagedModels,
   onCreated,
@@ -683,6 +686,18 @@ export function NewDiarizationModal({
                       <Loader2 className="h-4 w-4 animate-spin" />
                     ) : null}
                     {readinessActionLabel}
+                  </Button>
+
+                  <Button
+                    type="button"
+                    variant="default"
+                    size="sm"
+                    className="mt-2 h-9 w-full gap-2"
+                    onClick={onOpenModelManager}
+                    disabled={isSubmitting || isRecording}
+                  >
+                    <Settings2 className="h-4 w-4" />
+                    Open Models
                   </Button>
                 </div>
               </div>

--- a/ui/src/features/diarization/route.test.tsx
+++ b/ui/src/features/diarization/route.test.tsx
@@ -34,8 +34,38 @@ vi.mock("@/api", () => ({
   },
 }));
 
+const componentMocks = vi.hoisted(() => ({
+  routeModelModal: vi.fn(
+    ({
+      isOpen,
+      title,
+      zIndexClassName,
+      models = [],
+      sections = [],
+    }: {
+      isOpen: boolean;
+      title: string;
+      zIndexClassName?: string;
+      models?: ModelInfo[];
+      sections?: Array<{ title?: string; models: ModelInfo[] }>;
+    }) =>
+      isOpen ? (
+        <div
+          data-testid="route-model-modal"
+          data-z-index={zIndexClassName ?? ""}
+          data-models={models.map((model) => model.variant).join(",")}
+          data-sections={sections
+            .map((section) => section.title ?? "")
+            .join(",")}
+        >
+          {title}
+        </div>
+      ) : null,
+  ),
+}));
+
 vi.mock("@/features/models/components/RouteModelModal", () => ({
-  RouteModelModal: () => null,
+  RouteModelModal: componentMocks.routeModelModal,
 }));
 
 const baseModels: ModelInfo[] = [
@@ -209,6 +239,7 @@ describe("DiarizationPage routes", () => {
     apiMocks.deleteDiarizationRecord.mockReset();
     apiMocks.createDiarizationRecord.mockReset();
     apiMocks.diarizationRecordAudioUrl.mockReset();
+    componentMocks.routeModelModal.mockClear();
 
     apiMocks.listDiarizationRecords.mockResolvedValue([]);
     apiMocks.listDiarizationRecordPage.mockImplementation(async () => ({
@@ -597,6 +628,85 @@ describe("DiarizationPage routes", () => {
     expect(props.onLoad).toHaveBeenCalledWith("Qwen3.5-4B");
     expect(props.onDownload).toHaveBeenCalledWith("Whisper-Large-v3-Turbo");
     expect(props.onUnload).not.toHaveBeenCalled();
+  });
+
+  it("opens configured diarization models from the new modal readiness panel", async () => {
+    const props = createRouteProps({
+      models: [
+        {
+          variant: "diar_streaming_sortformer_4spk-v2.1",
+          status: "downloaded" as const,
+          local_path: "/models/diar",
+          size_bytes: null,
+          download_progress: null,
+          error_message: null,
+        },
+        {
+          variant: "Whisper-Large-v3-Turbo",
+          status: "not_downloaded" as const,
+          local_path: "/models/asr",
+          size_bytes: null,
+          download_progress: null,
+          error_message: null,
+        },
+        {
+          variant: "Qwen3-ForcedAligner-0.6B",
+          status: "ready" as const,
+          local_path: "/models/aligner",
+          size_bytes: null,
+          download_progress: null,
+          error_message: null,
+        },
+        {
+          variant: "Qwen3.5-4B",
+          status: "downloaded" as const,
+          local_path: "/models/llm",
+          size_bytes: null,
+          download_progress: null,
+          error_message: null,
+        },
+      ],
+      selectedModel: "diar_streaming_sortformer_4spk-v2.1",
+    });
+
+    renderRoute("/diarization", props);
+
+    await waitFor(() =>
+      expect(apiMocks.listDiarizationRecords).toHaveBeenCalledTimes(1),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /New diarization/i }));
+
+    const loadButton = await screen.findByRole("button", {
+      name: "Load Models",
+    });
+    const openModelsButton = screen.getByRole("button", {
+      name: "Open Models",
+    });
+    expect(
+      loadButton.compareDocumentPosition(openModelsButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    fireEvent.click(openModelsButton);
+
+    const modelModal = await screen.findByTestId("route-model-modal");
+    expect(modelModal).toHaveTextContent("Diarization Models");
+    expect(modelModal).toHaveAttribute("data-z-index", "z-[70]");
+    expect(modelModal.getAttribute("data-models")).toContain(
+      "diar_streaming_sortformer_4spk-v2.1",
+    );
+    expect(modelModal.getAttribute("data-models")).toContain(
+      "Whisper-Large-v3-Turbo",
+    );
+    expect(modelModal.getAttribute("data-models")).toContain(
+      "Qwen3-ForcedAligner-0.6B",
+    );
+    expect(modelModal.getAttribute("data-models")).toContain("Qwen3.5-4B");
+    expect(modelModal.getAttribute("data-sections")).toBe(
+      "Diarization,ASR,Forced Aligner,Refiner + Summary",
+    );
+    expect(props.onError).not.toHaveBeenCalled();
   });
 
   it("shows unload only after the full diarization stack is ready", async () => {

--- a/ui/src/features/diarization/route.tsx
+++ b/ui/src/features/diarization/route.tsx
@@ -630,6 +630,7 @@ export function DiarizationPage({
             canLoadAnyManagedModels={canLoadAnyManagedModels}
             canUnloadAnyManagedModels={canUnloadAnyManagedModels}
             isManagedModelActionBusy={isManagedModelActionBusy}
+            onOpenModelManager={openModelManager}
             onLoadAllManagedModels={handleLoadAllManagedModels}
             onUnloadAllManagedModels={handleUnloadAllManagedModels}
             onCreated={handleCreatedRecord}
@@ -656,6 +657,7 @@ export function DiarizationPage({
         onDelete={onDelete}
         onUseModel={onSelect}
         emptyMessage="No diarization pipeline models available for this route."
+        zIndexClassName={isNewDiarizationModalOpen ? "z-[70]" : "z-50"}
       />
     </PageShell>
   );

--- a/ui/src/features/transcription/route.tsx
+++ b/ui/src/features/transcription/route.tsx
@@ -44,6 +44,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { Settings2 } from "lucide-react";
 
 const TRANSCRIPTION_PREFERRED_SUMMARY_MODELS = ["Qwen3.5-4B"] as const;
+type ModelModalContext = "transcription" | "diarization";
 
 interface TranscriptionPageProps {
   models: ModelInfo[];
@@ -87,6 +88,8 @@ export function TranscriptionPage({
   >(null);
   const [streamingRecord, setStreamingRecord] =
     useState<TranscriptionRecord | null>(null);
+  const [modelModalContext, setModelModalContext] =
+    useState<ModelModalContext>("transcription");
   const viewConfig = VIEW_CONFIGS.transcription;
   const transcriptionAlignerModels = useMemo(
     () => filterAndSortModels(models, isTranscriptionAlignerVariant),
@@ -291,7 +294,7 @@ export function TranscriptionPage({
   const isDiarizationManagedModelActionBusy = diarizationManagedModels.some(
     (model) => model.status === "loading" || model.status === "downloading",
   );
-  const modelSections = useMemo(
+  const transcriptionModelSections = useMemo(
     () => [
       {
         key: "asr",
@@ -315,6 +318,41 @@ export function TranscriptionPage({
       },
     ],
     [transcriptionAlignerModels, transcriptionModels, transcriptionSummaryModels],
+  );
+  const diarizationModelSections = useMemo(
+    () => [
+      {
+        key: "diarization",
+        title: "Diarization",
+        description: "Speaker segmentation model used by this route.",
+        models: diarizationModels,
+      },
+      {
+        key: "asr",
+        title: "ASR",
+        description: "Transcript generation model in the diarization pipeline.",
+        models: diarizationAsrPipelineModels,
+      },
+      {
+        key: "aligner",
+        title: "Forced Aligner",
+        description: "Word timing alignment model for speaker attribution.",
+        models: diarizationAlignerPipelineModels,
+      },
+      {
+        key: "llm",
+        title: "Refiner + Summary",
+        description:
+          "LLM used for transcript refinement and diarization summaries.",
+        models: diarizationLlmPipelineModels,
+      },
+    ],
+    [
+      diarizationAlignerPipelineModels,
+      diarizationAsrPipelineModels,
+      diarizationLlmPipelineModels,
+      diarizationModels,
+    ],
   );
   const {
     records,
@@ -357,9 +395,17 @@ export function TranscriptionPage({
     }
   }, [record, streamingRecord]);
 
-  const handleOpenModels = useCallback(() => {
+  const openTranscriptionModelManager = useCallback(() => {
+    setModelModalContext("transcription");
     openModelManager();
   }, [openModelManager]);
+  const openDiarizationModelManager = useCallback(() => {
+    setModelModalContext("diarization");
+    openModelManager();
+  }, [openModelManager]);
+  const handleOpenModels = useCallback(() => {
+    openTranscriptionModelManager();
+  }, [openTranscriptionModelManager]);
   const handleOpenNewTranscriptionModal = useCallback(() => {
     setNewSpeechTextMode("transcription");
     setIsNewTranscriptionModalOpen(true);
@@ -426,7 +472,7 @@ export function TranscriptionPage({
       return;
     }
     if (!summaryModelReady) {
-      openModelManager();
+      openTranscriptionModelManager();
       setRecordSummaryRefreshError(summaryModelRequirementMessage);
       onError(summaryModelRequirementMessage);
       return;
@@ -450,7 +496,7 @@ export function TranscriptionPage({
     }
   }, [
     onError,
-    openModelManager,
+    openTranscriptionModelManager,
     recordId,
     recordSummaryRefreshPending,
     refreshRecord,
@@ -468,6 +514,15 @@ export function TranscriptionPage({
   const detailAudioUrl = useMemo(
     () => (recordId ? api.transcriptionRecordAudioUrl(recordId) : null),
     [recordId],
+  );
+  const isDiarizationModelModal = modelModalContext === "diarization";
+  const transcriptionModalModels = useMemo(
+    () => [
+      ...transcriptionModels,
+      ...transcriptionAlignerModels,
+      ...transcriptionSummaryModels,
+    ],
+    [transcriptionAlignerModels, transcriptionModels, transcriptionSummaryModels],
   );
   const timestampAlignerReady = useMemo(
     () =>
@@ -680,15 +735,14 @@ export function TranscriptionPage({
                       timestampAlignerModelId={resolvedAlignerModel}
                       timestampAlignerReady={timestampAlignerReady}
                       timestampAlignerModelStatus={selectedAlignerModelStatus}
-                      onOpenModelManager={() => {
-                        openModelManager();
-                      }}
+                      onOpenModelManager={openTranscriptionModelManager}
                       onModelRequired={() => {
+                        setModelModalContext("transcription");
                         requestModel();
                         onError("Select and load an ASR model to start transcribing.");
                       }}
                       onTimestampAlignerRequired={() => {
-                        openModelManager();
+                        openTranscriptionModelManager();
                         onError("Load the timestamp aligner model to enable timestamps.");
                       }}
                       onCreated={async (createdRecord: TranscriptionRecord) => {
@@ -748,6 +802,7 @@ export function TranscriptionPage({
                       canLoadAnyManagedModels={canLoadAnyDiarizationManagedModels}
                       canUnloadAnyManagedModels={canUnloadAnyDiarizationManagedModels}
                       isManagedModelActionBusy={isDiarizationManagedModelActionBusy}
+                      onOpenModelManager={openDiarizationModelManager}
                       onLoadAllManagedModels={handleLoadAllDiarizationManagedModels}
                       onUnloadAllManagedModels={handleUnloadAllDiarizationManagedModels}
                       onCreated={handleCreatedDiarizationRecord}
@@ -763,16 +818,20 @@ export function TranscriptionPage({
       <RouteModelModal
         isOpen={isModelModalOpen}
         onClose={closeModelModal}
-        title="Transcription Models"
-        description="Manage ASR models, the optional timestamp aligner, and the summary model for this route."
-        models={[
-          ...transcriptionModels,
-          ...transcriptionAlignerModels,
-          ...transcriptionSummaryModels,
-        ]}
+        title={
+          isDiarizationModelModal ? "Diarization Models" : "Transcription Models"
+        }
+        description={
+          isDiarizationModelModal
+            ? "Manage diarization pipeline models for /v1/diarizations."
+            : "Manage ASR models, the optional timestamp aligner, and the summary model for this route."
+        }
+        models={
+          isDiarizationModelModal ? diarizationPipelineModels : transcriptionModalModels
+        }
         loading={loading}
-        selectedVariant={resolvedSelectedModel}
-        intentVariant={intentVariant}
+        selectedVariant={isDiarizationModelModal ? null : resolvedSelectedModel}
+        intentVariant={isDiarizationModelModal ? null : intentVariant}
         downloadProgress={downloadProgress}
         onDownload={onDownload}
         onCancelDownload={onCancelDownload}
@@ -780,11 +839,23 @@ export function TranscriptionPage({
         onUnload={onUnload}
         onDelete={onDelete}
         onUseModel={onSelect}
-        emptyMessage="No transcription models available for this route."
-        sections={modelSections}
-        canUseModel={(variant) =>
-          transcriptionModels.some((model) => model.variant === variant)
+        emptyMessage={
+          isDiarizationModelModal
+            ? "No diarization pipeline models available for this route."
+            : "No transcription models available for this route."
         }
+        sections={
+          isDiarizationModelModal
+            ? diarizationModelSections
+            : transcriptionModelSections
+        }
+        canUseModel={
+          isDiarizationModelModal
+            ? undefined
+            : (variant) =>
+                transcriptionModels.some((model) => model.variant === variant)
+        }
+        selectionMode={isDiarizationModelModal ? "manage" : "route"}
         zIndexClassName={
           isNewTranscriptionModalOpen ? "z-[70]" : "z-50"
         }


### PR DESCRIPTION
Adds a matching Open Models button under Load Models and wires it to the configured diarization pipeline model manager with route test coverage.