### PR TITLE
Unify VAD on shared Earshot implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,6 +1860,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
+name = "earshot"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7984231f8b4c72eb3b88c70040dc1e4ff6803fa9169e93c0ac465942d74fa36a"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3798,6 +3804,13 @@ dependencies = [
  "tracing-subscriber",
  "utoipa",
  "uuid",
+]
+
+[[package]]
+name = "izwi-vad"
+version = "0.1.0-beta-15"
+dependencies = [
+ "earshot",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3646,6 +3646,10 @@ dependencies = [
 [[package]]
 name = "izwi-asr-toolkit"
 version = "0.1.0-beta-15"
+dependencies = [
+ "hound",
+ "izwi-vad",
+]
 
 [[package]]
 name = "izwi-cli"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3715,6 +3715,7 @@ dependencies = [
  "image",
  "indicatif 0.17.11",
  "izwi-asr-toolkit",
+ "izwi-vad",
  "memmap2",
  "rand 0.8.5",
  "rand_chacha 0.3.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3789,6 +3789,7 @@ dependencies = [
  "izwi-agent",
  "izwi-core",
  "izwi-hooks",
+ "izwi-vad",
  "scalar_api_reference",
  "sea-orm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/izwi-agent",
     "crates/izwi-core",
     "crates/izwi-hooks",
+    "crates/izwi-vad",
     "crates/izwi-server",
     "crates/izwi-cli",
     "crates/izwi-desktop",

--- a/crates/izwi-asr-toolkit/Cargo.toml
+++ b/crates/izwi-asr-toolkit/Cargo.toml
@@ -6,3 +6,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+izwi-vad = { path = "../izwi-vad" }
+
+[dev-dependencies]
+hound = { workspace = true }

--- a/crates/izwi-asr-toolkit/src/lib.rs
+++ b/crates/izwi-asr-toolkit/src/lib.rs
@@ -87,20 +87,6 @@ impl SpeechRegion {
 /// Tunables for speech-island planning before Whisper-style long-form ASR.
 #[derive(Debug, Clone)]
 pub struct AsrSpeechChunkConfig {
-    /// Retained for config compatibility. Shared VAD uses fixed 16 ms frames.
-    pub analysis_frame_ms: u32,
-    /// Deprecated compatibility field from the earlier adaptive-energy VAD; ignored by shared VAD.
-    #[deprecated(note = "shared ASR VAD uses Earshot score thresholds; this field is ignored")]
-    pub energy_floor_quantile: f32,
-    /// Deprecated compatibility field from the earlier adaptive-energy VAD; ignored by shared VAD.
-    #[deprecated(note = "shared ASR VAD uses Earshot score thresholds; this field is ignored")]
-    pub onset_energy_scale: f32,
-    /// Deprecated compatibility field from the earlier adaptive-energy VAD; ignored by shared VAD.
-    #[deprecated(note = "shared ASR VAD uses Earshot score thresholds; this field is ignored")]
-    pub offset_energy_scale: f32,
-    /// Deprecated compatibility field from the earlier adaptive-energy VAD; ignored by shared VAD.
-    #[deprecated(note = "shared ASR VAD uses Earshot score thresholds; this field is ignored")]
-    pub min_energy: f32,
     /// Earshot score required to enter speech.
     pub start_threshold: f32,
     /// Earshot score below which active speech may exit.
@@ -116,14 +102,8 @@ pub struct AsrSpeechChunkConfig {
 }
 
 impl Default for AsrSpeechChunkConfig {
-    #[allow(deprecated)]
     fn default() -> Self {
         Self {
-            analysis_frame_ms: 20,
-            energy_floor_quantile: 0.2,
-            onset_energy_scale: 3.0,
-            offset_energy_scale: 1.8,
-            min_energy: 0.003,
             start_threshold: DEFAULT_SPEECH_THRESHOLD,
             end_threshold: DEFAULT_EXIT_THRESHOLD,
             min_speech_secs: 0.25,

--- a/crates/izwi-asr-toolkit/src/lib.rs
+++ b/crates/izwi-asr-toolkit/src/lib.rs
@@ -2,6 +2,8 @@
 
 use std::cmp;
 
+use izwi_vad::{detect_speech_regions_f32, VadRegionConfig};
+
 /// Tunables for long-form ASR chunking and transcript stitching.
 #[derive(Debug, Clone)]
 pub struct AsrLongFormConfig {
@@ -83,15 +85,15 @@ impl SpeechRegion {
 /// Tunables for speech-island planning before Whisper-style long-form ASR.
 #[derive(Debug, Clone)]
 pub struct AsrSpeechChunkConfig {
-    /// RMS frame length for speech activity analysis.
+    /// Retained for config compatibility. Shared VAD uses fixed 16 ms frames.
     pub analysis_frame_ms: u32,
-    /// Noise floor quantile used to build adaptive onset/offset thresholds.
+    /// Retained for compatibility with earlier adaptive-energy VAD settings.
     pub energy_floor_quantile: f32,
-    /// Scale over the adaptive floor required to enter speech.
+    /// Retained for compatibility with earlier adaptive-energy VAD settings.
     pub onset_energy_scale: f32,
-    /// Scale over the adaptive floor required to remain in speech.
+    /// Retained for compatibility with earlier adaptive-energy VAD settings.
     pub offset_energy_scale: f32,
-    /// Absolute minimum onset threshold for quiet/silent clips.
+    /// Retained for compatibility with earlier adaptive-energy VAD settings.
     pub min_energy: f32,
     /// Minimum continuous speech duration required to emit a region.
     pub min_speech_secs: f32,
@@ -141,13 +143,6 @@ impl SpeechChunkPlan {
             no_speech: true,
         }
     }
-}
-
-#[derive(Debug, Clone, Copy)]
-struct FrameEnergy {
-    start_sample: usize,
-    end_sample: usize,
-    rms: f32,
 }
 
 /// Build chunk boundaries for long-form ASR.
@@ -292,53 +287,23 @@ pub fn plan_speech_audio_chunks(
         return SpeechChunkPlan::no_speech(samples.len());
     }
 
-    let frame_samples = ms_to_samples(speech_config.analysis_frame_ms.max(5), sample_rate).max(1);
-    let frames = speech_energy_frames(samples, frame_samples);
-    if frames.is_empty() {
-        return SpeechChunkPlan::no_speech(samples.len());
-    }
-
-    let mut energies: Vec<f32> = frames.iter().map(|frame| frame.rms).collect();
-    let floor = percentile(
-        &mut energies,
-        speech_config.energy_floor_quantile.clamp(0.0, 1.0),
-    );
-    let peak = frames
-        .iter()
-        .fold(0.0f32, |current, frame| current.max(frame.rms));
-    let mut onset_threshold =
-        (floor * speech_config.onset_energy_scale.max(1.0)).max(speech_config.min_energy);
-    if peak > speech_config.min_energy {
-        onset_threshold = onset_threshold.min(peak * 0.5);
-    }
-    let mut offset_threshold =
-        (floor * speech_config.offset_energy_scale.max(1.0)).max(speech_config.min_energy * 0.5);
-    if offset_threshold >= onset_threshold {
-        offset_threshold = onset_threshold * 0.75;
-    }
-
-    let mut regions = detect_speech_regions(
-        &frames,
-        samples.len(),
-        sample_rate,
-        onset_threshold,
-        offset_threshold,
-        speech_config.min_speech_secs,
-        speech_config.min_silence_secs,
-    );
-    if regions.is_empty() {
-        return SpeechChunkPlan::no_speech(samples.len());
-    }
-
-    apply_region_padding(
-        &mut regions,
-        samples.len(),
-        secs_to_samples(speech_config.speech_pad_secs, sample_rate as f32),
-    );
-    regions = merge_close_regions(
-        &regions,
-        secs_to_samples(speech_config.merge_gap_secs, sample_rate as f32),
-    );
+    let vad_config = VadRegionConfig {
+        min_speech_ms: secs_to_ms(speech_config.min_speech_secs),
+        min_silence_ms: secs_to_ms(speech_config.min_silence_secs),
+        speech_pad_ms: secs_to_ms(speech_config.speech_pad_secs),
+        merge_gap_ms: secs_to_ms(speech_config.merge_gap_secs),
+        ..VadRegionConfig::default()
+    };
+    let regions = match detect_speech_regions_f32(samples, sample_rate, &vad_config) {
+        Ok(regions) => regions
+            .into_iter()
+            .map(|region| SpeechRegion {
+                start_sample: region.start_sample,
+                end_sample: region.end_sample,
+            })
+            .collect::<Vec<_>>(),
+        Err(_) => Vec::new(),
+    };
     if regions.is_empty() {
         return SpeechChunkPlan::no_speech(samples.len());
     }
@@ -371,130 +336,6 @@ pub fn plan_speech_audio_chunks(
         skipped_samples: samples.len().saturating_sub(included_samples),
         no_speech: false,
     }
-}
-
-fn speech_energy_frames(samples: &[f32], frame_samples: usize) -> Vec<FrameEnergy> {
-    let frame_samples = frame_samples.max(1);
-    let mut frames = Vec::new();
-    let mut start = 0usize;
-    while start < samples.len() {
-        let end = (start + frame_samples).min(samples.len());
-        frames.push(FrameEnergy {
-            start_sample: start,
-            end_sample: end,
-            rms: local_rms(&samples[start..end]),
-        });
-        start = end;
-    }
-    frames
-}
-
-fn local_rms(samples: &[f32]) -> f32 {
-    if samples.is_empty() {
-        return 0.0;
-    }
-    let sum_squares = samples.iter().map(|sample| sample * sample).sum::<f32>();
-    (sum_squares / samples.len() as f32).sqrt()
-}
-
-fn detect_speech_regions(
-    frames: &[FrameEnergy],
-    total_samples: usize,
-    sample_rate: u32,
-    onset_threshold: f32,
-    offset_threshold: f32,
-    min_speech_secs: f32,
-    min_silence_secs: f32,
-) -> Vec<SpeechRegion> {
-    let min_speech_samples = secs_to_samples(min_speech_secs.max(0.0), sample_rate as f32);
-    let min_silence_samples = secs_to_samples(min_silence_secs.max(0.0), sample_rate as f32);
-    let mut regions = Vec::new();
-    let mut in_speech = false;
-    let mut active_start: Option<usize> = None;
-    let mut speech_start = 0usize;
-    let mut silence_start: Option<usize> = None;
-
-    for frame in frames {
-        if !in_speech {
-            if frame.rms >= onset_threshold {
-                let start = *active_start.get_or_insert(frame.start_sample);
-                if frame.end_sample.saturating_sub(start) >= min_speech_samples {
-                    in_speech = true;
-                    speech_start = start;
-                    silence_start = None;
-                }
-            } else {
-                active_start = None;
-            }
-            continue;
-        }
-
-        if frame.rms < offset_threshold {
-            let start = *silence_start.get_or_insert(frame.start_sample);
-            if frame.end_sample.saturating_sub(start) >= min_silence_samples {
-                if start > speech_start {
-                    regions.push(SpeechRegion {
-                        start_sample: speech_start,
-                        end_sample: start.min(total_samples),
-                    });
-                }
-                in_speech = false;
-                active_start = None;
-                silence_start = None;
-            }
-        } else {
-            silence_start = None;
-        }
-    }
-
-    if in_speech {
-        if total_samples > speech_start {
-            regions.push(SpeechRegion {
-                start_sample: speech_start,
-                end_sample: total_samples,
-            });
-        }
-    } else if let Some(start) = active_start {
-        if total_samples.saturating_sub(start) >= min_speech_samples {
-            regions.push(SpeechRegion {
-                start_sample: start,
-                end_sample: total_samples,
-            });
-        }
-    }
-
-    regions
-        .into_iter()
-        .filter(|region| region.len_samples() >= min_speech_samples)
-        .collect()
-}
-
-fn apply_region_padding(regions: &mut [SpeechRegion], total_samples: usize, pad_samples: usize) {
-    for region in regions {
-        region.start_sample = region.start_sample.saturating_sub(pad_samples);
-        region.end_sample = region
-            .end_sample
-            .saturating_add(pad_samples)
-            .min(total_samples);
-    }
-}
-
-fn merge_close_regions(regions: &[SpeechRegion], merge_gap_samples: usize) -> Vec<SpeechRegion> {
-    let mut merged: Vec<SpeechRegion> = Vec::new();
-    for region in regions.iter().copied() {
-        if region.end_sample <= region.start_sample {
-            continue;
-        }
-        if let Some(last) = merged.last_mut() {
-            let gap = region.start_sample.saturating_sub(last.end_sample);
-            if gap <= merge_gap_samples {
-                last.end_sample = last.end_sample.max(region.end_sample);
-                continue;
-            }
-        }
-        merged.push(region);
-    }
-    merged
 }
 
 fn merge_regions_into_chunks(
@@ -664,6 +505,10 @@ impl TranscriptAssembler {
 
 fn secs_to_samples(secs: f32, sample_rate: f32) -> usize {
     ((secs.max(0.0) * sample_rate).round() as usize).max(1)
+}
+
+fn secs_to_ms(secs: f32) -> u32 {
+    ((secs.max(0.0) * 1000.0).round() as u32).max(1)
 }
 
 fn ms_to_samples(ms: u32, sample_rate: u32) -> usize {
@@ -960,6 +805,21 @@ fn normalize_token(token: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
+
+    fn load_wav_mono_f32(name: &str) -> (Vec<f32>, u32) {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../data")
+            .join(name);
+        let mut reader = hound::WavReader::open(path).expect("test wav should open");
+        let spec = reader.spec();
+        assert_eq!(spec.channels, 1);
+        let samples = reader
+            .samples::<i16>()
+            .map(|sample| sample.expect("test wav sample") as f32 / 32768.0)
+            .collect::<Vec<_>>();
+        (samples, spec.sample_rate)
+    }
 
     #[test]
     fn short_audio_stays_single_chunk() {
@@ -1002,57 +862,49 @@ mod tests {
     }
 
     #[test]
-    fn speech_planner_finds_separate_speech_islands() {
+    fn speech_planner_detects_fixture_speech_with_shared_vad() {
         let cfg = AsrLongFormConfig::default();
         let speech_cfg = AsrSpeechChunkConfig {
-            speech_pad_secs: 0.0,
-            merge_gap_secs: 0.2,
-            min_speech_secs: 0.1,
-            min_silence_secs: 0.15,
+            min_speech_secs: 0.08,
+            min_silence_secs: 0.2,
             ..AsrSpeechChunkConfig::default()
         };
-        let sr = 1_000u32;
-        let mut samples = vec![0.0f32; 4_000];
-        samples[500..1_200].fill(0.2);
-        samples[2_200..3_000].fill(0.25);
+        let (samples, sr) = load_wav_mono_f32("fox.wav");
 
         let plan = plan_speech_audio_chunks(&samples, sr, &cfg, &speech_cfg, Some(30.0));
 
         assert!(!plan.no_speech);
-        assert_eq!(plan.speech_regions.len(), 2);
-        assert_eq!(plan.chunks.len(), 1);
-        assert!(plan.speech_regions[0].start_sample <= 500);
-        assert!(plan.speech_regions[0].end_sample >= 1_200);
-        assert!(plan.speech_regions[1].start_sample <= 2_200);
-        assert!(plan.speech_regions[1].end_sample >= 3_000);
-        assert!(plan.skipped_samples > 0);
+        assert!(!plan.speech_regions.is_empty());
+        assert!(!plan.chunks.is_empty());
+        assert!(plan.speech_samples > 0);
+        assert!(plan.included_samples <= samples.len());
     }
 
     #[test]
-    fn speech_planner_merges_short_gaps() {
+    fn region_chunker_combines_regions_under_model_limit() {
         let cfg = AsrLongFormConfig::default();
-        let speech_cfg = AsrSpeechChunkConfig {
-            speech_pad_secs: 0.0,
-            merge_gap_secs: 0.35,
-            min_speech_secs: 0.1,
-            min_silence_secs: 0.1,
-            ..AsrSpeechChunkConfig::default()
-        };
         let sr = 1_000u32;
-        let mut samples = vec![0.0f32; 2_000];
-        samples[200..800].fill(0.25);
-        samples[1_000..1_600].fill(0.25);
+        let samples = vec![0.0f32; 2_000];
+        let regions = vec![
+            SpeechRegion {
+                start_sample: 200,
+                end_sample: 800,
+            },
+            SpeechRegion {
+                start_sample: 1_000,
+                end_sample: 1_600,
+            },
+        ];
 
-        let plan = plan_speech_audio_chunks(&samples, sr, &cfg, &speech_cfg, Some(30.0));
+        let chunks = merge_regions_into_chunks(&samples, sr, &cfg, &regions, Some(30.0));
 
-        assert_eq!(plan.speech_regions.len(), 1);
-        assert_eq!(plan.chunks.len(), 1);
-        assert!(plan.chunks[0].start_sample <= 200);
-        assert!(plan.chunks[0].end_sample >= 1_600);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].start_sample, 200);
+        assert_eq!(chunks[0].end_sample, 1_600);
     }
 
     #[test]
-    fn speech_planner_respects_model_limit_for_long_regions() {
+    fn region_chunker_respects_model_limit_for_long_regions() {
         let cfg = AsrLongFormConfig {
             min_chunk_secs: 2.0,
             target_chunk_secs: 4.0,
@@ -1060,42 +912,20 @@ mod tests {
             overlap_secs: 0.5,
             ..AsrLongFormConfig::default()
         };
-        let speech_cfg = AsrSpeechChunkConfig {
-            speech_pad_secs: 0.0,
-            min_speech_secs: 0.1,
-            min_silence_secs: 0.2,
-            ..AsrSpeechChunkConfig::default()
-        };
         let sr = 1_000u32;
         let samples = vec![0.2f32; 16_000];
+        let regions = vec![SpeechRegion {
+            start_sample: 0,
+            end_sample: samples.len(),
+        }];
 
-        let plan = plan_speech_audio_chunks(&samples, sr, &cfg, &speech_cfg, Some(5.0));
+        let chunks = merge_regions_into_chunks(&samples, sr, &cfg, &regions, Some(5.0));
 
-        assert!(plan.chunks.len() >= 3);
+        assert!(chunks.len() >= 3);
         let max_allowed = secs_to_samples(5.0, sr as f32);
-        for chunk in &plan.chunks {
+        for chunk in &chunks {
             assert!(chunk.len_samples() <= max_allowed);
         }
-    }
-
-    #[test]
-    fn speech_planner_uses_input_sample_rate_for_timing() {
-        let cfg = AsrLongFormConfig::default();
-        let speech_cfg = AsrSpeechChunkConfig {
-            speech_pad_secs: 0.0,
-            min_speech_secs: 0.1,
-            min_silence_secs: 0.1,
-            ..AsrSpeechChunkConfig::default()
-        };
-        let sr = 8_000u32;
-        let mut samples = vec![0.0f32; 24_000];
-        samples[8_000..12_000].fill(0.2);
-
-        let plan = plan_speech_audio_chunks(&samples, sr, &cfg, &speech_cfg, Some(30.0));
-
-        assert_eq!(plan.speech_regions.len(), 1);
-        assert!(plan.speech_regions[0].start_sample <= 8_000);
-        assert!(plan.speech_regions[0].end_sample >= 12_000);
     }
 
     #[test]

--- a/crates/izwi-asr-toolkit/src/lib.rs
+++ b/crates/izwi-asr-toolkit/src/lib.rs
@@ -2,7 +2,9 @@
 
 use std::cmp;
 
-use izwi_vad::{detect_speech_regions_f32, VadRegionConfig};
+use izwi_vad::{
+    detect_speech_regions_f32, VadRegionConfig, DEFAULT_EXIT_THRESHOLD, DEFAULT_SPEECH_THRESHOLD,
+};
 
 /// Tunables for long-form ASR chunking and transcript stitching.
 #[derive(Debug, Clone)]
@@ -87,14 +89,22 @@ impl SpeechRegion {
 pub struct AsrSpeechChunkConfig {
     /// Retained for config compatibility. Shared VAD uses fixed 16 ms frames.
     pub analysis_frame_ms: u32,
-    /// Retained for compatibility with earlier adaptive-energy VAD settings.
+    /// Deprecated compatibility field from the earlier adaptive-energy VAD; ignored by shared VAD.
+    #[deprecated(note = "shared ASR VAD uses Earshot score thresholds; this field is ignored")]
     pub energy_floor_quantile: f32,
-    /// Retained for compatibility with earlier adaptive-energy VAD settings.
+    /// Deprecated compatibility field from the earlier adaptive-energy VAD; ignored by shared VAD.
+    #[deprecated(note = "shared ASR VAD uses Earshot score thresholds; this field is ignored")]
     pub onset_energy_scale: f32,
-    /// Retained for compatibility with earlier adaptive-energy VAD settings.
+    /// Deprecated compatibility field from the earlier adaptive-energy VAD; ignored by shared VAD.
+    #[deprecated(note = "shared ASR VAD uses Earshot score thresholds; this field is ignored")]
     pub offset_energy_scale: f32,
-    /// Retained for compatibility with earlier adaptive-energy VAD settings.
+    /// Deprecated compatibility field from the earlier adaptive-energy VAD; ignored by shared VAD.
+    #[deprecated(note = "shared ASR VAD uses Earshot score thresholds; this field is ignored")]
     pub min_energy: f32,
+    /// Earshot score required to enter speech.
+    pub start_threshold: f32,
+    /// Earshot score below which active speech may exit.
+    pub end_threshold: f32,
     /// Minimum continuous speech duration required to emit a region.
     pub min_speech_secs: f32,
     /// Minimum continuous silence duration required to close a region.
@@ -106,6 +116,7 @@ pub struct AsrSpeechChunkConfig {
 }
 
 impl Default for AsrSpeechChunkConfig {
+    #[allow(deprecated)]
     fn default() -> Self {
         Self {
             analysis_frame_ms: 20,
@@ -113,6 +124,8 @@ impl Default for AsrSpeechChunkConfig {
             onset_energy_scale: 3.0,
             offset_energy_scale: 1.8,
             min_energy: 0.003,
+            start_threshold: DEFAULT_SPEECH_THRESHOLD,
+            end_threshold: DEFAULT_EXIT_THRESHOLD,
             min_speech_secs: 0.25,
             min_silence_secs: 0.45,
             speech_pad_secs: 0.2,
@@ -287,13 +300,7 @@ pub fn plan_speech_audio_chunks(
         return SpeechChunkPlan::no_speech(samples.len());
     }
 
-    let vad_config = VadRegionConfig {
-        min_speech_ms: secs_to_ms(speech_config.min_speech_secs),
-        min_silence_ms: secs_to_ms(speech_config.min_silence_secs),
-        speech_pad_ms: secs_to_ms(speech_config.speech_pad_secs),
-        merge_gap_ms: secs_to_ms(speech_config.merge_gap_secs),
-        ..VadRegionConfig::default()
-    };
+    let vad_config = speech_config_to_vad_region_config(speech_config);
     let regions = match detect_speech_regions_f32(samples, sample_rate, &vad_config) {
         Ok(regions) => regions
             .into_iter()
@@ -335,6 +342,17 @@ pub fn plan_speech_audio_chunks(
         included_samples,
         skipped_samples: samples.len().saturating_sub(included_samples),
         no_speech: false,
+    }
+}
+
+fn speech_config_to_vad_region_config(speech_config: &AsrSpeechChunkConfig) -> VadRegionConfig {
+    VadRegionConfig {
+        start_threshold: speech_config.start_threshold,
+        end_threshold: speech_config.end_threshold,
+        min_speech_ms: secs_to_ms(speech_config.min_speech_secs),
+        min_silence_ms: secs_to_ms(speech_config.min_silence_secs),
+        speech_pad_ms: secs_to_ms(speech_config.speech_pad_secs),
+        merge_gap_ms: secs_to_ms(speech_config.merge_gap_secs),
     }
 }
 
@@ -859,6 +877,20 @@ mod tests {
         assert!(plan.chunks.is_empty());
         assert!(plan.speech_regions.is_empty());
         assert_eq!(plan.skipped_samples, samples.len());
+    }
+
+    #[test]
+    fn speech_config_exposes_shared_vad_thresholds() {
+        let speech_cfg = AsrSpeechChunkConfig {
+            start_threshold: 0.61,
+            end_threshold: 0.29,
+            ..AsrSpeechChunkConfig::default()
+        };
+
+        let vad_cfg = speech_config_to_vad_region_config(&speech_cfg);
+
+        assert_eq!(vad_cfg.start_threshold, 0.61);
+        assert_eq!(vad_cfg.end_threshold, 0.29);
     }
 
     #[test]

--- a/crates/izwi-core/Cargo.toml
+++ b/crates/izwi-core/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 izwi-asr-toolkit = { path = "../izwi-asr-toolkit" }
+izwi-vad = { path = "../izwi-vad" }
 
 tokio = { workspace = true }
 tokio-stream = { workspace = true }

--- a/crates/izwi-core/src/engine/executor/audio.rs
+++ b/crates/izwi-core/src/engine/executor/audio.rs
@@ -340,7 +340,6 @@ impl NativeExecutor {
             model_max_chunk_secs,
             streaming_low_latency,
             allow_speech_planner,
-            Self::env_bool("IZWI_ASR_VAD_CHUNKING").unwrap_or(false),
         )
     }
 
@@ -350,7 +349,6 @@ impl NativeExecutor {
         model_max_chunk_secs: Option<f32>,
         mut streaming_low_latency: bool,
         allow_speech_planner: bool,
-        vad_chunking_enabled: bool,
     ) -> PlannedAsrChunks {
         let planning_started = Instant::now();
         if allow_speech_planner {
@@ -369,7 +367,6 @@ impl NativeExecutor {
             && model_fit_limit_secs
                 .map(|limit| audio_secs <= limit)
                 .unwrap_or(false)
-            && !(allow_speech_planner && vad_chunking_enabled)
         {
             let mut single_chunk_cfg = Self::asr_long_form_config();
             let single_chunk_secs = audio_secs.max(single_chunk_cfg.min_chunk_secs.max(0.5));
@@ -406,7 +403,7 @@ impl NativeExecutor {
             .filter(|v| v.is_finite() && *v > 0.0)
             .map(|v| (v * 0.95).max(cfg.min_chunk_secs.max(1.0)));
 
-        if allow_speech_planner && vad_chunking_enabled {
+        if allow_speech_planner {
             let speech_cfg = AsrSpeechChunkConfig::default();
             let speech_plan =
                 plan_speech_audio_chunks(samples, sample_rate, &cfg, &speech_cfg, tuned_limit);
@@ -956,33 +953,22 @@ mod tests {
     }
 
     #[test]
-    fn vad_chunk_plan_is_disabled_by_default_path() {
+    fn speech_chunk_plan_is_default_for_allowed_models() {
         let sr = 16_000u32;
         let samples = vec![0.0f32; (sr as usize) * 4];
-        let plan = NativeExecutor::asr_chunk_plan_with_options(
-            &samples,
-            sr,
-            Some(30.0),
-            false,
-            true,
-            false,
-        );
-        assert_eq!(plan.planner, AsrChunkPlannerKind::Duration);
-        assert_eq!(plan.chunks.len(), 1);
+        let plan = NativeExecutor::asr_chunk_plan(&samples, sr, Some(30.0), false, true);
+        assert_eq!(plan.planner, AsrChunkPlannerKind::Speech);
+        assert!(plan.requires_chunk_path());
+        assert!(plan.chunks.is_empty());
+        assert!(plan.speech_plan.as_ref().expect("speech plan").no_speech);
     }
 
     #[test]
     fn vad_chunk_plan_can_return_no_speech() {
         let sr = 16_000u32;
         let samples = vec![0.0f32; (sr as usize) * 4];
-        let plan = NativeExecutor::asr_chunk_plan_with_options(
-            &samples,
-            sr,
-            Some(30.0),
-            false,
-            true,
-            true,
-        );
+        let plan =
+            NativeExecutor::asr_chunk_plan_with_options(&samples, sr, Some(30.0), false, true);
         assert_eq!(plan.planner, AsrChunkPlannerKind::Speech);
         assert!(plan.requires_chunk_path());
         assert!(plan.chunks.is_empty());
@@ -993,14 +979,8 @@ mod tests {
     fn chunk_plan_diagnostics_include_timing_and_seconds() {
         let sr = 16_000u32;
         let samples = vec![0.0f32; (sr as usize) * 4];
-        let plan = NativeExecutor::asr_chunk_plan_with_options(
-            &samples,
-            sr,
-            Some(30.0),
-            false,
-            true,
-            true,
-        );
+        let plan =
+            NativeExecutor::asr_chunk_plan_with_options(&samples, sr, Some(30.0), false, true);
 
         let diagnostics = plan.diagnostics();
         let chunking = diagnostics

--- a/crates/izwi-core/src/engine/signal_frontend.rs
+++ b/crates/izwi-core/src/engine/signal_frontend.rs
@@ -14,7 +14,7 @@
 //! │          SIGNAL FRONTEND              │
 //! │  ┌─────────────┐  ┌────────────────┐  │
 //! │  │     VAD     │  │    Feature     │  │
-//! │  │  (Silero)   │→ │   Extractor    │  │
+//! │  │  (Earshot)  │→ │   Extractor    │  │
 //! │  └─────────────┘  │  (Mel-Spec)    │  │
 //! │                   └────────────────┘  │
 //! │  ┌─────────────────────────────────┐  │
@@ -28,6 +28,8 @@
 
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
+
+use izwi_vad::{EndpointConfig, EndpointDetector, EndpointEvent, VadScorer, VAD_FRAME_MS};
 
 /// Configuration for the signal frontend.
 #[derive(Debug, Clone)]
@@ -108,117 +110,82 @@ pub struct AudioChunk {
 }
 
 /// Voice Activity Detector.
-///
-/// Currently implements a simple energy-based VAD.
-/// TODO: Integrate Silero VAD for production use.
 pub struct VoiceActivityDetector {
     config: SignalFrontendConfig,
     state: VadState,
     state_start: Instant,
-    speech_frames: usize,
-    silence_frames: usize,
-    /// Energy threshold for simple VAD
-    energy_threshold: f32,
-    /// Smoothed speech probability
-    smoothed_prob: f32,
+    scorer: VadScorer,
+    endpoint: EndpointDetector,
+    last_score: f32,
 }
 
 impl VoiceActivityDetector {
     /// Create a new VAD instance.
     pub fn new(config: SignalFrontendConfig) -> Self {
+        let endpoint = EndpointDetector::new(EndpointConfig {
+            start_threshold: config.vad_threshold,
+            end_threshold: (config.vad_threshold * 0.7).min(config.vad_threshold),
+            min_speech_ms: config.min_speech_duration_ms,
+            silence_ms: config.silence_end_duration_ms,
+            max_utterance_ms: 120_000,
+        });
         Self {
             config,
             state: VadState::Silence,
             state_start: Instant::now(),
-            speech_frames: 0,
-            silence_frames: 0,
-            energy_threshold: 0.01,
-            smoothed_prob: 0.0,
+            scorer: VadScorer::new(),
+            endpoint,
+            last_score: 0.0,
         }
     }
 
     /// Process an audio frame and return VAD result.
     pub fn process(&mut self, samples: &[f32], is_ai_speaking: bool) -> VadResult {
-        // Calculate frame energy (RMS)
-        let energy = Self::calculate_rms(samples);
+        let frames = self
+            .scorer
+            .push_f32(samples, self.config.sample_rate)
+            .unwrap_or_default();
+        let mut speech_now = false;
 
-        // Simple energy-based speech probability
-        // In production, this would use Silero VAD model
-        let raw_prob = (energy / self.energy_threshold).min(1.0);
+        if self.state == VadState::SpeechEnding && !frames.is_empty() {
+            self.set_state(VadState::Silence);
+        }
 
-        // Exponential smoothing
-        let alpha = 0.3;
-        self.smoothed_prob = alpha * raw_prob + (1.0 - alpha) * self.smoothed_prob;
-
-        let is_speech = self.smoothed_prob > self.config.vad_threshold;
-
-        // State machine for VAD
-        let frame_duration_ms =
-            (self.config.hop_size as f32 / self.config.sample_rate as f32 * 1000.0) as u32;
-
-        match self.state {
-            VadState::Silence => {
-                if is_speech {
-                    self.speech_frames += 1;
-                    let speech_duration = self.speech_frames as u32 * frame_duration_ms;
-                    if speech_duration >= self.config.min_speech_duration_ms {
-                        self.state = VadState::Speech;
-                        self.state_start = Instant::now();
-                        self.silence_frames = 0;
-                    }
-                } else {
-                    self.speech_frames = 0;
-                }
-            }
-            VadState::Speech => {
-                if !is_speech {
-                    self.silence_frames += 1;
-                    let silence_duration = self.silence_frames as u32 * frame_duration_ms;
-                    if silence_duration >= self.config.silence_end_duration_ms {
-                        self.state = VadState::SpeechEnding;
-                        self.state_start = Instant::now();
-                    }
-                } else {
-                    self.silence_frames = 0;
-                }
-            }
-            VadState::SpeechEnding => {
-                if is_speech {
-                    self.state = VadState::Speech;
-                    self.state_start = Instant::now();
-                    self.silence_frames = 0;
-                } else {
-                    self.state = VadState::Silence;
-                    self.state_start = Instant::now();
-                    self.speech_frames = 0;
+        for frame in frames {
+            self.last_score = frame.score;
+            let decision = self.endpoint.process_score(frame.score, VAD_FRAME_MS);
+            speech_now |= decision.is_speech;
+            for event in decision.events {
+                match event {
+                    EndpointEvent::SpeechStart => self.set_state(VadState::Speech),
+                    EndpointEvent::SpeechEnd(_) => self.set_state(VadState::SpeechEnding),
+                    EndpointEvent::NoiseRejected => self.set_state(VadState::Silence),
                 }
             }
         }
 
         VadResult {
             state: self.state,
-            speech_probability: self.smoothed_prob,
+            speech_probability: self.last_score,
             state_duration: self.state_start.elapsed(),
-            is_interruption: is_speech && is_ai_speaking,
+            is_interruption: speech_now && is_ai_speaking,
         }
     }
 
-    /// Calculate RMS energy of samples.
-    fn calculate_rms(samples: &[f32]) -> f32 {
-        if samples.is_empty() {
-            return 0.0;
+    fn set_state(&mut self, state: VadState) {
+        if self.state != state {
+            self.state = state;
+            self.state_start = Instant::now();
         }
-        let sum_squares: f32 = samples.iter().map(|s| s * s).sum();
-        (sum_squares / samples.len() as f32).sqrt()
     }
 
     /// Reset VAD state.
     pub fn reset(&mut self) {
         self.state = VadState::Silence;
         self.state_start = Instant::now();
-        self.speech_frames = 0;
-        self.silence_frames = 0;
-        self.smoothed_prob = 0.0;
+        self.scorer.reset();
+        self.endpoint.reset();
+        self.last_score = 0.0;
     }
 
     /// Get current state.
@@ -542,6 +509,21 @@ impl SignalFrontend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
+
+    fn load_wav_mono_f32(name: &str) -> (Vec<f32>, u32) {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../data")
+            .join(name);
+        let mut reader = hound::WavReader::open(path).expect("test wav should open");
+        let spec = reader.spec();
+        assert_eq!(spec.channels, 1);
+        let samples = reader
+            .samples::<i16>()
+            .map(|sample| sample.expect("test wav sample") as f32 / 32768.0)
+            .collect::<Vec<_>>();
+        (samples, spec.sample_rate)
+    }
 
     #[test]
     fn test_vad_silence() {
@@ -558,22 +540,28 @@ mod tests {
 
     #[test]
     fn test_vad_speech() {
+        let (samples, sr) = load_wav_mono_f32("fox.wav");
         let config = SignalFrontendConfig {
-            min_speech_duration_ms: 0, // Instant detection for test
+            sample_rate: sr,
+            min_speech_duration_ms: 32,
             ..Default::default()
         };
         let mut vad = VoiceActivityDetector::new(config);
+        let chunk_size = (sr as usize / 25).max(1);
 
-        // "Loud" samples
-        let samples: Vec<f32> = (0..160).map(|i| (i as f32 * 0.1).sin() * 0.5).collect();
-
-        // Process multiple frames to trigger speech state
-        for _ in 0..10 {
-            vad.process(&samples, false);
+        let mut detected = false;
+        let mut max_score = 0.0f32;
+        for chunk in samples.chunks(chunk_size) {
+            let result = vad.process(chunk, false);
+            max_score = max_score.max(result.speech_probability);
+            if result.state == VadState::Speech {
+                detected = true;
+                break;
+            }
         }
 
-        let result = vad.process(&samples, false);
-        assert!(result.speech_probability > 0.1);
+        assert!(detected);
+        assert!(max_score > 0.5);
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/sortformer/diarization/mod.rs
+++ b/crates/izwi-core/src/models/architectures/sortformer/diarization/mod.rs
@@ -9,6 +9,7 @@ use candle_nn::{
     batch_norm, layer_norm, Conv1d, Conv1dConfig, Conv2d, Conv2dConfig, LayerNorm, Linear, Module,
     ModuleT, VarBuilder,
 };
+use izwi_vad::{speech_mask_for_frames_f32, VadRegionConfig};
 use rustfft::num_complex::Complex;
 use rustfft::FftPlanner;
 
@@ -27,7 +28,6 @@ const DEFAULT_MIN_SILENCE_MS: f32 = 200.0;
 const PREEMPH: f32 = 0.97;
 const LOG_GUARD: f32 = 5.960_464_5e-8;
 const NORMALIZE_EPS: f32 = 1e-5;
-const REALTIME_VAD_THRESHOLD: f32 = 0.02;
 const TS_VAD_FRAME_LENGTH_SECS: f32 = 0.01;
 const TS_VAD_UNIT_FRAME_COUNT: usize = 8;
 
@@ -338,19 +338,15 @@ impl SortformerDiarizerModel {
             );
 
         let mut gated_probs = speaker_probs;
-        if sortformer_rms_gating_enabled() {
-            let frame_ms = frame_stride_samples as f32 * 1000.0 / TARGET_SAMPLE_RATE as f32;
-            let min_speech_frames = ((min_speech_ms / frame_ms).round() as usize).max(1);
-            let min_silence_frames = ((min_silence_ms / frame_ms).round() as usize).max(1);
-
+        if sortformer_vad_gating_enabled() {
             let frame_count = gated_probs.len();
-            let mut vad_mask = realtime_voice_vad_frame_mask(
+            let vad_mask = sortformer_vad_frame_mask(
                 &samples,
                 frame_count,
                 frame_stride_samples,
-                REALTIME_VAD_THRESHOLD,
+                min_speech_ms,
+                min_silence_ms,
             );
-            smooth_activity_mask(&mut vad_mask, min_speech_frames, min_silence_frames);
 
             for (frame_idx, active) in vad_mask.iter().copied().enumerate() {
                 if !active {
@@ -2059,8 +2055,10 @@ fn env_flag(key: &str) -> Option<bool> {
         })
 }
 
-fn sortformer_rms_gating_enabled() -> bool {
-    env_flag("IZWI_SORTFORMER_ENABLE_RMS_GATING").unwrap_or(false)
+fn sortformer_vad_gating_enabled() -> bool {
+    env_flag("IZWI_SORTFORMER_ENABLE_VAD_GATING")
+        .or_else(|| env_flag("IZWI_SORTFORMER_ENABLE_RMS_GATING"))
+        .unwrap_or(false)
 }
 
 fn select_speaker_channels(
@@ -2285,80 +2283,36 @@ fn average_speaker_probability_for_range(
     (count > 0).then_some((sum / count as f32).clamp(0.0, 1.0))
 }
 
-fn realtime_voice_vad_frame_mask(
+fn sortformer_vad_frame_mask(
     samples: &[f32],
     frame_count: usize,
     frame_stride_samples: usize,
-    vad_threshold: f32,
+    min_speech_ms: f32,
+    min_silence_ms: f32,
 ) -> Vec<bool> {
     if frame_count == 0 || frame_stride_samples == 0 {
         return Vec::new();
     }
 
-    let threshold = vad_threshold.clamp(0.001, 1.0);
-    let mut mask = vec![false; frame_count];
-    for (frame_idx, active) in mask.iter_mut().enumerate().take(frame_count) {
-        let start = frame_idx * frame_stride_samples;
-        if start >= samples.len() {
-            break;
-        }
-        let end = ((frame_idx + 1) * frame_stride_samples).min(samples.len());
-        *active = rms_f32(&samples[start..end]) >= threshold;
-    }
-    mask
+    let vad_config = VadRegionConfig {
+        min_speech_ms: ms_f32_to_u32(min_speech_ms),
+        min_silence_ms: ms_f32_to_u32(min_silence_ms),
+        speech_pad_ms: 0,
+        merge_gap_ms: ms_f32_to_u32(min_silence_ms),
+        ..VadRegionConfig::default()
+    };
+    speech_mask_for_frames_f32(
+        samples,
+        TARGET_SAMPLE_RATE,
+        frame_count,
+        frame_stride_samples,
+        &vad_config,
+    )
+    .unwrap_or_else(|_| vec![true; frame_count])
 }
 
-fn rms_f32(samples: &[f32]) -> f32 {
-    if samples.is_empty() {
-        return 0.0;
-    }
-    let sum_squares: f32 = samples.iter().map(|s| s * s).sum();
-    (sum_squares / samples.len() as f32).sqrt()
-}
-
-fn smooth_activity_mask(active: &mut [bool], min_speech_frames: usize, min_silence_frames: usize) {
-    if active.is_empty() {
-        return;
-    }
-
-    let mut idx = 0usize;
-    while idx < active.len() {
-        if active[idx] {
-            idx += 1;
-            continue;
-        }
-        let start = idx;
-        while idx < active.len() && !active[idx] {
-            idx += 1;
-        }
-        let end = idx;
-        let gap_len = end - start;
-        let has_left_speech = start > 0 && active[start - 1];
-        let has_right_speech = end < active.len() && active[end];
-        if has_left_speech && has_right_speech && gap_len <= min_silence_frames {
-            for value in &mut active[start..end] {
-                *value = true;
-            }
-        }
-    }
-
-    idx = 0;
-    while idx < active.len() {
-        if !active[idx] {
-            idx += 1;
-            continue;
-        }
-        let start = idx;
-        while idx < active.len() && active[idx] {
-            idx += 1;
-        }
-        let end = idx;
-        if end - start < min_speech_frames {
-            for value in &mut active[start..end] {
-                *value = false;
-            }
-        }
-    }
+fn ms_f32_to_u32(ms: f32) -> u32 {
+    ms.round().max(1.0) as u32
 }
 
 fn collect_active_regions(active: &[bool]) -> Vec<(usize, usize)> {
@@ -2689,15 +2643,12 @@ mod tests {
     }
 
     #[test]
-    fn realtime_voice_vad_frame_mask_uses_rms_threshold() {
-        let samples = vec![
-            0.0, 0.0, 0.0, 0.0, // silence
-            0.3, 0.3, 0.3, 0.3, // speech
-            0.0, 0.0, 0.0, 0.0, // silence
-            0.4, 0.4, 0.4, 0.4, // speech
-        ];
-        let mask = realtime_voice_vad_frame_mask(&samples, 4, 4, 0.02);
-        assert_eq!(mask, vec![false, true, false, true]);
+    fn sortformer_vad_frame_mask_returns_silence_for_silent_audio() {
+        let samples = vec![0.0; TARGET_SAMPLE_RATE as usize];
+        let mask = sortformer_vad_frame_mask(&samples, 100, 160, 240.0, 200.0);
+
+        assert_eq!(mask.len(), 100);
+        assert!(mask.iter().all(|active| !active));
     }
 
     #[test]
@@ -2983,18 +2934,6 @@ mod tests {
 
         assert!(filtering(&segments, &speech_first).is_empty());
         assert_eq!(filtering(&segments, &nonspeech_first), vec![(0.0, 0.22)]);
-    }
-
-    #[test]
-    fn smooth_activity_mask_fills_gaps_and_removes_short_bursts() {
-        let mut active = vec![
-            true, true, false, true, true, false, false, false, true, false, false,
-        ];
-        smooth_activity_mask(&mut active, 2, 1);
-        assert_eq!(
-            active,
-            vec![true, true, true, true, true, false, false, false, false, false, false]
-        );
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/sortformer/diarization/mod.rs
+++ b/crates/izwi-core/src/models/architectures/sortformer/diarization/mod.rs
@@ -338,21 +338,19 @@ impl SortformerDiarizerModel {
             );
 
         let mut gated_probs = speaker_probs;
-        if sortformer_vad_gating_enabled() {
-            let frame_count = gated_probs.len();
-            let vad_mask = sortformer_vad_frame_mask(
-                &samples,
-                frame_count,
-                frame_stride_samples,
-                min_speech_ms,
-                min_silence_ms,
-            );
+        let frame_count = gated_probs.len();
+        let vad_mask = sortformer_vad_frame_mask(
+            &samples,
+            frame_count,
+            frame_stride_samples,
+            min_speech_ms,
+            min_silence_ms,
+        );
 
-            for (frame_idx, active) in vad_mask.iter().copied().enumerate() {
-                if !active {
-                    for spk in 0..MAX_SUPPORTED_SPEAKERS {
-                        gated_probs[frame_idx][spk] = 0.0;
-                    }
+        for (frame_idx, active) in vad_mask.iter().copied().enumerate() {
+            if !active {
+                for spk in 0..MAX_SUPPORTED_SPEAKERS {
+                    gated_probs[frame_idx][spk] = 0.0;
                 }
             }
         }
@@ -2053,12 +2051,6 @@ fn env_flag(key: &str) -> Option<bool> {
             "0" | "false" | "no" | "off" => Some(false),
             _ => None,
         })
-}
-
-fn sortformer_vad_gating_enabled() -> bool {
-    env_flag("IZWI_SORTFORMER_ENABLE_VAD_GATING")
-        .or_else(|| env_flag("IZWI_SORTFORMER_ENABLE_RMS_GATING"))
-        .unwrap_or(false)
 }
 
 fn select_speaker_channels(

--- a/crates/izwi-server/Cargo.toml
+++ b/crates/izwi-server/Cargo.toml
@@ -46,6 +46,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 async-trait = "0.1"
 izwi-hooks = { path = "../izwi-hooks" }
 izwi-agent = { path = "../izwi-agent" }
+izwi-vad = { path = "../izwi-vad" }
 
 config = { workspace = true }
 dirs = { workspace = true }

--- a/crates/izwi-server/src/app/voice_realtime.rs
+++ b/crates/izwi-server/src/app/voice_realtime.rs
@@ -26,6 +26,11 @@ use izwi_core::{
     parse_chat_model_variant, parse_model_variant, parse_tts_model_variant, ChatMessage, ChatRole,
     GenerationConfig, GenerationParams, GenerationRequest, VoiceSession,
 };
+use izwi_vad::{
+    legacy_rms_threshold_to_score_threshold, EndpointConfig, EndpointDetector, EndpointEndReason,
+    EndpointEvent, VadScorer, DEFAULT_MAX_UTTERANCE_MS, DEFAULT_MIN_SPEECH_MS, DEFAULT_PRE_ROLL_MS,
+    DEFAULT_SILENCE_MS, DEFAULT_SPEECH_THRESHOLD, VAD_FRAME_MS, VAD_SAMPLE_RATE,
+};
 use serde::Deserialize;
 use serde_json::json;
 use tokio::sync::mpsc;
@@ -47,11 +52,11 @@ const WS_BIN_KIND_CLIENT_PCM16: u8 = 1;
 const WS_BIN_KIND_ASSISTANT_PCM16: u8 = 2;
 const WS_BIN_CLIENT_HEADER_LEN: usize = 16;
 const WS_BIN_ASSISTANT_HEADER_LEN: usize = 24;
-const DEFAULT_STREAM_VAD_THRESHOLD: f32 = 0.02;
-const DEFAULT_STREAM_MIN_SPEECH_MS: u32 = 300;
-const DEFAULT_STREAM_SILENCE_MS: u32 = 900;
-const DEFAULT_STREAM_MAX_UTTERANCE_MS: u32 = 20_000;
-const DEFAULT_STREAM_PRE_ROLL_MS: u32 = 160;
+const DEFAULT_STREAM_VAD_THRESHOLD: f32 = DEFAULT_SPEECH_THRESHOLD;
+const DEFAULT_STREAM_MIN_SPEECH_MS: u32 = DEFAULT_MIN_SPEECH_MS;
+const DEFAULT_STREAM_SILENCE_MS: u32 = DEFAULT_SILENCE_MS;
+const DEFAULT_STREAM_MAX_UTTERANCE_MS: u32 = DEFAULT_MAX_UTTERANCE_MS;
+const DEFAULT_STREAM_PRE_ROLL_MS: u32 = DEFAULT_PRE_ROLL_MS;
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -167,6 +172,18 @@ struct StreamingInputConfig {
     input_sample_rate_hint: Option<u32>,
 }
 
+impl StreamingInputConfig {
+    fn endpoint_config(&self) -> EndpointConfig {
+        EndpointConfig {
+            start_threshold: self.vad_threshold,
+            end_threshold: (self.vad_threshold * 0.7).min(self.vad_threshold),
+            min_speech_ms: self.min_speech_ms,
+            silence_ms: self.silence_duration_ms,
+            max_utterance_ms: self.max_utterance_ms,
+        }
+    }
+}
+
 #[derive(Debug)]
 struct StreamingActiveUtterance {
     utterance_id: String,
@@ -177,9 +194,10 @@ struct StreamingActiveUtterance {
     silence_ms: f32,
 }
 
-#[derive(Debug)]
 struct StreamingInputState {
     config: StreamingInputConfig,
+    vad_scorer: VadScorer,
+    endpoint: EndpointDetector,
     next_utterance_seq: u64,
     frame_seq_last: Option<u32>,
     current_sample_rate: Option<u32>,
@@ -209,6 +227,16 @@ impl UtteranceEndReason {
             Self::Silence => "silence",
             Self::MaxDuration => "max_duration",
             Self::StreamStopped => "stream_stopped",
+        }
+    }
+}
+
+impl From<EndpointEndReason> for UtteranceEndReason {
+    fn from(reason: EndpointEndReason) -> Self {
+        match reason {
+            EndpointEndReason::Silence => Self::Silence,
+            EndpointEndReason::MaxDuration => Self::MaxDuration,
+            EndpointEndReason::StreamStopped => Self::StreamStopped,
         }
     }
 }
@@ -330,8 +358,11 @@ struct StreamingFrameResult {
 
 impl StreamingInputState {
     fn new(config: StreamingInputConfig) -> Self {
+        let endpoint = EndpointDetector::new(config.endpoint_config());
         Self {
             config,
+            vad_scorer: VadScorer::new(),
+            endpoint,
             next_utterance_seq: 0,
             frame_seq_last: None,
             current_sample_rate: None,
@@ -384,79 +415,100 @@ impl StreamingInputState {
             });
         }
 
-        let rms = rms_i16(&samples);
         let frame_ms = (samples.len() as f32 * 1000.0) / (sample_rate as f32);
-        let is_speech = rms >= self.config.vad_threshold;
+        let vad_frames = self
+            .vad_scorer
+            .push_i16(&samples, sample_rate)
+            .map_err(|err| format!("VAD scoring error: {err}"))?;
+        let mut chunk_has_speech = false;
+        let mut chunk_voiced_ms = 0.0f32;
+        let mut speech_started = false;
+        let mut end_reason: Option<UtteranceEndReason> = None;
+
+        for vad_frame in &vad_frames {
+            let decision = self.endpoint.process_score(vad_frame.score, VAD_FRAME_MS);
+            if decision.is_speech {
+                chunk_has_speech = true;
+                chunk_voiced_ms += VAD_FRAME_MS;
+            }
+            for event in decision.events {
+                match event {
+                    EndpointEvent::SpeechStart => speech_started = true,
+                    EndpointEvent::SpeechEnd(reason) => end_reason = Some(reason.into()),
+                    EndpointEvent::NoiseRejected => {}
+                }
+            }
+        }
 
         let mut result = StreamingFrameResult {
             speech_start: None,
             finalized_utterance: None,
         };
 
-        if is_speech {
-            if self.active.is_none() {
-                let utterance_seq = self.next_utterance_seq.saturating_add(1);
-                self.next_utterance_seq = utterance_seq;
-                let utterance_id = format!("utt-{utterance_seq}");
+        if speech_started && self.active.is_none() {
+            let utterance_seq = self.next_utterance_seq.saturating_add(1);
+            self.next_utterance_seq = utterance_seq;
+            let utterance_id = format!("utt-{utterance_seq}");
 
-                let mut capture = StreamingActiveUtterance {
-                    utterance_id: utterance_id.clone(),
-                    utterance_seq,
-                    samples_i16: Vec::new(),
-                    voiced_ms: 0.0,
-                    total_ms: 0.0,
-                    silence_ms: 0.0,
-                };
-                if !self.pre_roll.is_empty() {
-                    capture.samples_i16.extend_from_slice(&self.pre_roll);
-                }
-                capture.samples_i16.extend_from_slice(&samples);
-                capture.voiced_ms += frame_ms;
-                capture.total_ms += frame_ms;
-                self.active = Some(capture);
-
-                result.speech_start = Some(SpeechStartEvent {
-                    utterance_id,
-                    utterance_seq,
-                });
-            } else if let Some(active) = self.active.as_mut() {
-                active.samples_i16.extend_from_slice(&samples);
-                active.voiced_ms += frame_ms;
-                active.total_ms += frame_ms;
-                active.silence_ms = 0.0;
+            let mut capture = StreamingActiveUtterance {
+                utterance_id: utterance_id.clone(),
+                utterance_seq,
+                samples_i16: Vec::new(),
+                voiced_ms: 0.0,
+                total_ms: 0.0,
+                silence_ms: 0.0,
+            };
+            if !self.pre_roll.is_empty() {
+                capture.samples_i16.extend_from_slice(&self.pre_roll);
             }
+            capture.samples_i16.extend_from_slice(&samples);
+            self.active = Some(capture);
+
+            result.speech_start = Some(SpeechStartEvent {
+                utterance_id,
+                utterance_seq,
+            });
         } else if let Some(active) = self.active.as_mut() {
             active.samples_i16.extend_from_slice(&samples);
-            active.total_ms += frame_ms;
-            active.silence_ms += frame_ms;
         } else {
             self.push_pre_roll(&samples, sample_rate);
             return Ok(result);
         }
 
-        let should_finalize = if let Some(active) = self.active.as_ref() {
-            if active.total_ms >= self.config.max_utterance_ms as f32 {
-                Some(UtteranceEndReason::MaxDuration)
-            } else if active.voiced_ms >= self.config.min_speech_ms as f32
-                && active.silence_ms >= self.config.silence_duration_ms as f32
-            {
-                Some(UtteranceEndReason::Silence)
+        if let Some(active) = self.active.as_mut() {
+            active.voiced_ms += chunk_voiced_ms;
+            active.total_ms += frame_ms;
+            if chunk_has_speech {
+                active.silence_ms = 0.0;
             } else {
-                None
+                active.silence_ms += frame_ms;
             }
-        } else {
-            None
-        };
+        }
 
-        if let Some(reason) = should_finalize {
+        if let Some(reason) = end_reason {
             result.finalized_utterance = self.finalize_active_utterance(reason)?;
         }
 
-        if !is_speech {
+        if !chunk_has_speech {
             self.push_pre_roll(&samples, sample_rate);
         }
 
         Ok(result)
+    }
+
+    fn finish_stream(
+        &mut self,
+    ) -> Result<Option<(PendingAudioCommit, Vec<u8>, UtteranceEndReason)>, String> {
+        match self.endpoint.finish() {
+            Some(EndpointEvent::SpeechEnd(EndpointEndReason::StreamStopped)) => {
+                self.finalize_active_utterance(UtteranceEndReason::StreamStopped)
+            }
+            Some(EndpointEvent::NoiseRejected) => {
+                self.active = None;
+                Ok(None)
+            }
+            _ => self.finalize_active_utterance(UtteranceEndReason::StreamStopped),
+        }
     }
 
     fn finalize_active_utterance(
@@ -585,6 +637,13 @@ async fn finalize_stream_vad_utterance(
     Ok(())
 }
 
+fn normalize_stream_vad_threshold(value: Option<f32>) -> f32 {
+    value
+        .filter(|v| v.is_finite() && *v >= 0.0)
+        .map(legacy_rms_threshold_to_score_threshold)
+        .unwrap_or(DEFAULT_STREAM_VAD_THRESHOLD)
+}
+
 fn parse_binary_message(data: &[u8]) -> Result<BinaryMessageKind, String> {
     if data.len() < WS_BIN_CLIENT_HEADER_LEN || &data[..4] != WS_BIN_MAGIC {
         return Err("Unexpected binary message (missing voice realtime frame header)".to_string());
@@ -619,18 +678,6 @@ fn pcm16_bytes_to_i16(bytes: &[u8]) -> Vec<i16> {
         out.push(i16::from_le_bytes([chunk[0], chunk[1]]));
     }
     out
-}
-
-fn rms_i16(samples: &[i16]) -> f32 {
-    if samples.is_empty() {
-        return 0.0;
-    }
-    let mut sum = 0.0f64;
-    for &s in samples {
-        let v = s as f64 / 32768.0f64;
-        sum += v * v;
-    }
-    (sum / samples.len() as f64).sqrt() as f32
 }
 
 fn wav_bytes_from_pcm16_mono(samples_i16: &[i16], sample_rate: u32) -> Result<Vec<u8>, String> {
@@ -900,10 +947,7 @@ async fn handle_text_message(
 
             conn.streaming_input = Some(StreamingInputState::new(StreamingInputConfig {
                 turn_config,
-                vad_threshold: vad_threshold
-                    .filter(|v| v.is_finite() && *v >= 0.0)
-                    .unwrap_or(DEFAULT_STREAM_VAD_THRESHOLD)
-                    .clamp(0.0, 1.0),
+                vad_threshold: normalize_stream_vad_threshold(vad_threshold),
                 min_speech_ms: min_speech_ms
                     .unwrap_or(DEFAULT_STREAM_MIN_SPEECH_MS)
                     .clamp(50, 10_000),
@@ -926,7 +970,10 @@ async fn handle_text_message(
                 json!({
                     "type": "input_stream_ready",
                     "vad": {
+                        "backend": "earshot",
                         "threshold": conn.streaming_input.as_ref().map(|s| s.config.vad_threshold),
+                        "score_sample_rate": VAD_SAMPLE_RATE,
+                        "score_frame_ms": VAD_FRAME_MS,
                         "min_speech_ms": conn.streaming_input.as_ref().map(|s| s.config.min_speech_ms),
                         "silence_duration_ms": conn.streaming_input.as_ref().map(|s| s.config.silence_duration_ms),
                     }
@@ -935,9 +982,7 @@ async fn handle_text_message(
         }
         ClientEvent::InputStreamStop => {
             if let Some(mut streaming) = conn.streaming_input.take() {
-                if let Some((commit, wav_bytes, end_reason)) =
-                    streaming.finalize_active_utterance(UtteranceEndReason::StreamStopped)?
-                {
+                if let Some((commit, wav_bytes, end_reason)) = streaming.finish_stream()? {
                     send_json(
                         out_tx,
                         json!({
@@ -2109,5 +2154,23 @@ impl ModelBackend for IzwiRuntimeBackend {
             tokens_generated: generation.tokens_generated,
             generation_time_ms: generation.generation_time_ms,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_vad_threshold_maps_legacy_rms_default_to_score_default() {
+        assert_eq!(
+            normalize_stream_vad_threshold(Some(0.02)),
+            DEFAULT_STREAM_VAD_THRESHOLD
+        );
+    }
+
+    #[test]
+    fn stream_vad_threshold_accepts_score_values_directly() {
+        assert_eq!(normalize_stream_vad_threshold(Some(0.62)), 0.62);
     }
 }

--- a/crates/izwi-server/src/app/voice_realtime.rs
+++ b/crates/izwi-server/src/app/voice_realtime.rs
@@ -2,11 +2,12 @@
 //!
 //! Frontend responsibilities:
 //! - microphone capture
-//! - simple local VAD (speech start/stop)
+//! - level metering and audio framing
 //! - audio playback
 //!
 //! Backend responsibilities:
 //! - ASR -> agent -> TTS orchestration
+//! - shared VAD and endpointing
 //! - streaming assistant audio/text events
 //! - interruption / barge-in cancellation
 
@@ -27,8 +28,8 @@ use izwi_core::{
     GenerationConfig, GenerationParams, GenerationRequest, VoiceSession,
 };
 use izwi_vad::{
-    legacy_rms_threshold_to_score_threshold, EndpointConfig, EndpointDetector, EndpointEndReason,
-    EndpointEvent, VadScorer, DEFAULT_MAX_UTTERANCE_MS, DEFAULT_MIN_SPEECH_MS, DEFAULT_PRE_ROLL_MS,
+    sanitize_score_threshold, EndpointConfig, EndpointDetector, EndpointEndReason, EndpointEvent,
+    VadScorer, DEFAULT_MAX_UTTERANCE_MS, DEFAULT_MIN_SPEECH_MS, DEFAULT_PRE_ROLL_MS,
     DEFAULT_SILENCE_MS, DEFAULT_SPEECH_THRESHOLD, VAD_FRAME_MS, VAD_SAMPLE_RATE,
 };
 use serde::Deserialize;
@@ -655,7 +656,7 @@ async fn finalize_stream_vad_utterance(
 fn normalize_stream_vad_threshold(value: Option<f32>) -> f32 {
     value
         .filter(|v| v.is_finite() && *v >= 0.0)
-        .map(legacy_rms_threshold_to_score_threshold)
+        .map(sanitize_score_threshold)
         .unwrap_or(DEFAULT_STREAM_VAD_THRESHOLD)
 }
 
@@ -2188,11 +2189,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn stream_vad_threshold_maps_legacy_rms_default_to_score_default() {
-        assert_eq!(
-            normalize_stream_vad_threshold(Some(0.02)),
-            DEFAULT_STREAM_VAD_THRESHOLD
-        );
+    fn stream_vad_threshold_uses_score_values_directly() {
+        assert_eq!(normalize_stream_vad_threshold(Some(0.02)), 0.02);
     }
 
     #[test]

--- a/crates/izwi-server/src/app/voice_realtime.rs
+++ b/crates/izwi-server/src/app/voice_realtime.rs
@@ -353,6 +353,7 @@ struct SpeechStartEvent {
 #[derive(Debug)]
 struct StreamingFrameResult {
     speech_start: Option<SpeechStartEvent>,
+    speech_rejected: Option<SpeechStartEvent>,
     finalized_utterance: Option<(PendingAudioCommit, Vec<u8>, UtteranceEndReason)>,
 }
 
@@ -383,6 +384,7 @@ impl StreamingInputState {
         if payload.is_empty() {
             return Ok(StreamingFrameResult {
                 speech_start: None,
+                speech_rejected: None,
                 finalized_utterance: None,
             });
         }
@@ -411,6 +413,7 @@ impl StreamingInputState {
         if samples.is_empty() {
             return Ok(StreamingFrameResult {
                 speech_start: None,
+                speech_rejected: None,
                 finalized_utterance: None,
             });
         }
@@ -423,6 +426,7 @@ impl StreamingInputState {
         let mut chunk_has_speech = false;
         let mut chunk_voiced_ms = 0.0f32;
         let mut speech_started = false;
+        let mut noise_rejected = false;
         let mut end_reason: Option<UtteranceEndReason> = None;
 
         for vad_frame in &vad_frames {
@@ -435,13 +439,14 @@ impl StreamingInputState {
                 match event {
                     EndpointEvent::SpeechStart => speech_started = true,
                     EndpointEvent::SpeechEnd(reason) => end_reason = Some(reason.into()),
-                    EndpointEvent::NoiseRejected => {}
+                    EndpointEvent::NoiseRejected => noise_rejected = true,
                 }
             }
         }
 
         let mut result = StreamingFrameResult {
             speech_start: None,
+            speech_rejected: None,
             finalized_utterance: None,
         };
 
@@ -487,6 +492,8 @@ impl StreamingInputState {
 
         if let Some(reason) = end_reason {
             result.finalized_utterance = self.finalize_active_utterance(reason)?;
+        } else if noise_rejected {
+            result.speech_rejected = self.reject_active_utterance();
         }
 
         if !chunk_has_speech {
@@ -494,6 +501,14 @@ impl StreamingInputState {
         }
 
         Ok(result)
+    }
+
+    fn reject_active_utterance(&mut self) -> Option<SpeechStartEvent> {
+        let active = self.active.take()?;
+        Some(SpeechStartEvent {
+            utterance_id: active.utterance_id,
+            utterance_seq: active.utterance_seq,
+        })
     }
 
     fn finish_stream(
@@ -1098,6 +1113,17 @@ async fn handle_binary_message(
                     end_reason,
                 )
                 .await?;
+            }
+
+            if let Some(evt) = frame_result.speech_rejected {
+                send_json(
+                    out_tx,
+                    json!({
+                        "type": "user_speech_rejected",
+                        "utterance_id": evt.utterance_id,
+                        "utterance_seq": evt.utterance_seq,
+                    }),
+                );
             }
 
             return Ok(());

--- a/crates/izwi-vad/Cargo.toml
+++ b/crates/izwi-vad/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "izwi-vad"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+earshot = "1.1.0"

--- a/crates/izwi-vad/src/lib.rs
+++ b/crates/izwi-vad/src/lib.rs
@@ -289,6 +289,11 @@ impl EndpointDetector {
         if self.total_ms >= self.config.max_utterance_ms as f32 {
             events.push(EndpointEvent::SpeechEnd(EndpointEndReason::MaxDuration));
             self.reset();
+        } else if self.speech_ms < self.config.min_speech_ms as f32
+            && self.silence_ms >= self.config.silence_ms as f32
+        {
+            events.push(EndpointEvent::NoiseRejected);
+            self.reset();
         } else if self.speech_ms >= self.config.min_speech_ms as f32
             && self.silence_ms >= self.config.silence_ms as f32
         {
@@ -748,6 +753,25 @@ mod tests {
 
         detector.process_score(0.9, 16.0);
         assert_eq!(detector.finish(), Some(EndpointEvent::NoiseRejected));
+        assert!(!detector.is_active());
+    }
+
+    #[test]
+    fn endpoint_detector_rejects_too_short_speech_after_silence() {
+        let mut detector = EndpointDetector::new(EndpointConfig {
+            start_threshold: 0.5,
+            end_threshold: 0.35,
+            min_speech_ms: 100,
+            silence_ms: 32,
+            max_utterance_ms: 10_000,
+        });
+
+        detector.process_score(0.8, 16.0);
+        let quiet = detector.process_score(0.0, 16.0);
+        assert!(quiet.events.is_empty());
+        let rejected = detector.process_score(0.0, 16.0);
+
+        assert_eq!(rejected.events, vec![EndpointEvent::NoiseRejected]);
         assert!(!detector.is_active());
     }
 

--- a/crates/izwi-vad/src/lib.rs
+++ b/crates/izwi-vad/src/lib.rs
@@ -1,0 +1,799 @@
+#![forbid(unsafe_code)]
+
+use std::fmt;
+
+pub const VAD_SAMPLE_RATE: u32 = 16_000;
+pub const VAD_FRAME_SAMPLES: usize = 256;
+pub const VAD_FRAME_MS: f32 = 16.0;
+pub const DEFAULT_SPEECH_THRESHOLD: f32 = 0.5;
+pub const DEFAULT_EXIT_THRESHOLD: f32 = 0.35;
+pub const DEFAULT_MIN_SPEECH_MS: u32 = 300;
+pub const DEFAULT_SILENCE_MS: u32 = 900;
+pub const DEFAULT_MAX_UTTERANCE_MS: u32 = 20_000;
+pub const DEFAULT_PRE_ROLL_MS: u32 = 160;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct VadFrame {
+    pub index: usize,
+    pub score: f32,
+    pub start_vad_sample: usize,
+    pub end_vad_sample: usize,
+    pub start_ms: f32,
+    pub end_ms: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VadError {
+    InvalidSampleRate(u32),
+}
+
+impl fmt::Display for VadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidSampleRate(sample_rate) => {
+                write!(f, "invalid VAD input sample rate {sample_rate}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VadError {}
+
+pub struct VadScorer {
+    detector: Box<earshot::Detector>,
+    resampler: Option<StreamingLinearResampler>,
+    vad_buffer: Vec<f32>,
+    next_frame_index: usize,
+    processed_vad_samples: usize,
+}
+
+impl Default for VadScorer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VadScorer {
+    pub fn new() -> Self {
+        Self {
+            detector: earshot::Detector::default_boxed(),
+            resampler: None,
+            vad_buffer: Vec::with_capacity(VAD_FRAME_SAMPLES * 2),
+            next_frame_index: 0,
+            processed_vad_samples: 0,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.detector.reset();
+        self.resampler = None;
+        self.vad_buffer.clear();
+        self.next_frame_index = 0;
+        self.processed_vad_samples = 0;
+    }
+
+    pub fn push_i16(
+        &mut self,
+        samples: &[i16],
+        sample_rate: u32,
+    ) -> Result<Vec<VadFrame>, VadError> {
+        let samples = pcm16_to_f32(samples);
+        self.push_f32(&samples, sample_rate)
+    }
+
+    pub fn push_f32(
+        &mut self,
+        samples: &[f32],
+        sample_rate: u32,
+    ) -> Result<Vec<VadFrame>, VadError> {
+        validate_sample_rate(sample_rate)?;
+        if samples.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        if sample_rate == VAD_SAMPLE_RATE {
+            self.resampler = None;
+            self.vad_buffer
+                .extend(samples.iter().map(|s| sanitize_sample(*s)));
+        } else {
+            let resampler = self
+                .resampler
+                .get_or_insert_with(|| StreamingLinearResampler::new(sample_rate, VAD_SAMPLE_RATE));
+            if resampler.src_rate != sample_rate {
+                *resampler = StreamingLinearResampler::new(sample_rate, VAD_SAMPLE_RATE);
+                self.detector.reset();
+                self.vad_buffer.clear();
+                self.next_frame_index = 0;
+                self.processed_vad_samples = 0;
+            }
+            self.vad_buffer
+                .extend(resampler.push(samples).into_iter().map(sanitize_sample));
+        }
+
+        Ok(self.drain_ready_frames())
+    }
+
+    pub fn score_complete_f32(
+        samples: &[f32],
+        sample_rate: u32,
+    ) -> Result<Vec<VadFrame>, VadError> {
+        let mut scorer = Self::new();
+        scorer.push_f32(samples, sample_rate)
+    }
+
+    pub fn score_complete_i16(
+        samples: &[i16],
+        sample_rate: u32,
+    ) -> Result<Vec<VadFrame>, VadError> {
+        let mut scorer = Self::new();
+        scorer.push_i16(samples, sample_rate)
+    }
+
+    fn drain_ready_frames(&mut self) -> Vec<VadFrame> {
+        let frame_count = self.vad_buffer.len() / VAD_FRAME_SAMPLES;
+        if frame_count == 0 {
+            return Vec::new();
+        }
+
+        let mut frames = Vec::with_capacity(frame_count);
+        for frame in self.vad_buffer.chunks_exact(VAD_FRAME_SAMPLES) {
+            let score = self.detector.predict_f32(frame).clamp(0.0, 1.0);
+            let start_vad_sample = self.processed_vad_samples;
+            let end_vad_sample = start_vad_sample + VAD_FRAME_SAMPLES;
+            frames.push(VadFrame {
+                index: self.next_frame_index,
+                score,
+                start_vad_sample,
+                end_vad_sample,
+                start_ms: vad_sample_to_ms(start_vad_sample),
+                end_ms: vad_sample_to_ms(end_vad_sample),
+            });
+            self.next_frame_index += 1;
+            self.processed_vad_samples = end_vad_sample;
+        }
+
+        let consumed = frame_count * VAD_FRAME_SAMPLES;
+        self.vad_buffer.drain(0..consumed);
+        frames
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EndpointConfig {
+    pub start_threshold: f32,
+    pub end_threshold: f32,
+    pub min_speech_ms: u32,
+    pub silence_ms: u32,
+    pub max_utterance_ms: u32,
+}
+
+impl Default for EndpointConfig {
+    fn default() -> Self {
+        Self {
+            start_threshold: DEFAULT_SPEECH_THRESHOLD,
+            end_threshold: DEFAULT_EXIT_THRESHOLD,
+            min_speech_ms: DEFAULT_MIN_SPEECH_MS,
+            silence_ms: DEFAULT_SILENCE_MS,
+            max_utterance_ms: DEFAULT_MAX_UTTERANCE_MS,
+        }
+    }
+}
+
+impl EndpointConfig {
+    pub fn sanitized(mut self) -> Self {
+        self.start_threshold = sanitize_score_threshold(self.start_threshold);
+        self.end_threshold = sanitize_score_threshold(self.end_threshold).min(self.start_threshold);
+        self.min_speech_ms = self.min_speech_ms.max(1);
+        self.silence_ms = self.silence_ms.max(1);
+        self.max_utterance_ms = self.max_utterance_ms.max(self.min_speech_ms);
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EndpointEndReason {
+    Silence,
+    MaxDuration,
+    StreamStopped,
+}
+
+impl EndpointEndReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Silence => "silence",
+            Self::MaxDuration => "max_duration",
+            Self::StreamStopped => "stream_stopped",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EndpointEvent {
+    SpeechStart,
+    SpeechEnd(EndpointEndReason),
+    NoiseRejected,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EndpointDecision {
+    pub is_speech: bool,
+    pub events: Vec<EndpointEvent>,
+    pub speech_ms: f32,
+    pub silence_ms: f32,
+    pub total_ms: f32,
+}
+
+pub struct EndpointDetector {
+    config: EndpointConfig,
+    active: bool,
+    speech_ms: f32,
+    silence_ms: f32,
+    total_ms: f32,
+}
+
+impl EndpointDetector {
+    pub fn new(config: EndpointConfig) -> Self {
+        Self {
+            config: config.sanitized(),
+            active: false,
+            speech_ms: 0.0,
+            silence_ms: 0.0,
+            total_ms: 0.0,
+        }
+    }
+
+    pub fn config(&self) -> &EndpointConfig {
+        &self.config
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    pub fn reset(&mut self) {
+        self.active = false;
+        self.speech_ms = 0.0;
+        self.silence_ms = 0.0;
+        self.total_ms = 0.0;
+    }
+
+    pub fn process_score(&mut self, score: f32, frame_ms: f32) -> EndpointDecision {
+        let frame_ms = frame_ms.max(0.0);
+        let threshold = if self.active {
+            self.config.end_threshold
+        } else {
+            self.config.start_threshold
+        };
+        let is_speech = sanitize_score(score) >= threshold;
+        let mut events = Vec::new();
+
+        if !self.active {
+            if is_speech {
+                self.active = true;
+                self.speech_ms = frame_ms;
+                self.silence_ms = 0.0;
+                self.total_ms = frame_ms;
+                events.push(EndpointEvent::SpeechStart);
+            }
+            return self.decision(is_speech, events);
+        }
+
+        self.total_ms += frame_ms;
+        if is_speech {
+            self.speech_ms += frame_ms;
+            self.silence_ms = 0.0;
+        } else {
+            self.silence_ms += frame_ms;
+        }
+
+        if self.total_ms >= self.config.max_utterance_ms as f32 {
+            events.push(EndpointEvent::SpeechEnd(EndpointEndReason::MaxDuration));
+            self.reset();
+        } else if self.speech_ms >= self.config.min_speech_ms as f32
+            && self.silence_ms >= self.config.silence_ms as f32
+        {
+            events.push(EndpointEvent::SpeechEnd(EndpointEndReason::Silence));
+            self.reset();
+        }
+
+        self.decision(is_speech, events)
+    }
+
+    pub fn finish(&mut self) -> Option<EndpointEvent> {
+        if !self.active {
+            return None;
+        }
+        let event = if self.speech_ms >= self.config.min_speech_ms as f32 {
+            EndpointEvent::SpeechEnd(EndpointEndReason::StreamStopped)
+        } else {
+            EndpointEvent::NoiseRejected
+        };
+        self.reset();
+        Some(event)
+    }
+
+    fn decision(&self, is_speech: bool, events: Vec<EndpointEvent>) -> EndpointDecision {
+        EndpointDecision {
+            is_speech,
+            events,
+            speech_ms: self.speech_ms,
+            silence_ms: self.silence_ms,
+            total_ms: self.total_ms,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SpeechRegion {
+    pub start_sample: usize,
+    pub end_sample: usize,
+}
+
+impl SpeechRegion {
+    pub fn len_samples(self) -> usize {
+        self.end_sample.saturating_sub(self.start_sample)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct VadRegionConfig {
+    pub start_threshold: f32,
+    pub end_threshold: f32,
+    pub min_speech_ms: u32,
+    pub min_silence_ms: u32,
+    pub speech_pad_ms: u32,
+    pub merge_gap_ms: u32,
+}
+
+impl Default for VadRegionConfig {
+    fn default() -> Self {
+        Self {
+            start_threshold: DEFAULT_SPEECH_THRESHOLD,
+            end_threshold: DEFAULT_EXIT_THRESHOLD,
+            min_speech_ms: DEFAULT_MIN_SPEECH_MS,
+            min_silence_ms: 450,
+            speech_pad_ms: 200,
+            merge_gap_ms: 350,
+        }
+    }
+}
+
+impl VadRegionConfig {
+    pub fn sanitized(mut self) -> Self {
+        self.start_threshold = sanitize_score_threshold(self.start_threshold);
+        self.end_threshold = sanitize_score_threshold(self.end_threshold).min(self.start_threshold);
+        self.min_speech_ms = self.min_speech_ms.max(1);
+        self.min_silence_ms = self.min_silence_ms.max(1);
+        self
+    }
+}
+
+pub fn detect_speech_regions_f32(
+    samples: &[f32],
+    sample_rate: u32,
+    config: &VadRegionConfig,
+) -> Result<Vec<SpeechRegion>, VadError> {
+    validate_sample_rate(sample_rate)?;
+    if samples.is_empty() {
+        return Ok(Vec::new());
+    }
+    let frames = VadScorer::score_complete_f32(samples, sample_rate)?;
+    Ok(detect_speech_regions_from_frames(
+        &frames,
+        samples.len(),
+        sample_rate,
+        config,
+    ))
+}
+
+pub fn detect_speech_regions_i16(
+    samples: &[i16],
+    sample_rate: u32,
+    config: &VadRegionConfig,
+) -> Result<Vec<SpeechRegion>, VadError> {
+    let samples = pcm16_to_f32(samples);
+    detect_speech_regions_f32(&samples, sample_rate, config)
+}
+
+pub fn detect_speech_regions_from_frames(
+    frames: &[VadFrame],
+    total_samples: usize,
+    sample_rate: u32,
+    config: &VadRegionConfig,
+) -> Vec<SpeechRegion> {
+    if frames.is_empty() || total_samples == 0 || sample_rate == 0 {
+        return Vec::new();
+    }
+
+    let config = config.clone().sanitized();
+    let total_ms = samples_to_ms(total_samples, sample_rate);
+    let min_speech_samples = ms_to_samples(config.min_speech_ms, sample_rate);
+    let min_silence_ms = config.min_silence_ms as f32;
+    let mut regions_ms: Vec<(f32, f32)> = Vec::new();
+    let mut in_speech = false;
+    let mut speech_start_ms = 0.0f32;
+    let mut silence_start_ms: Option<f32> = None;
+
+    for frame in frames {
+        if !in_speech {
+            if frame.score >= config.start_threshold {
+                in_speech = true;
+                speech_start_ms = frame.start_ms;
+                silence_start_ms = None;
+            }
+            continue;
+        }
+
+        if frame.score < config.end_threshold {
+            let start = *silence_start_ms.get_or_insert(frame.start_ms);
+            if frame.end_ms - start >= min_silence_ms {
+                if start > speech_start_ms {
+                    regions_ms.push((speech_start_ms, start.min(total_ms)));
+                }
+                in_speech = false;
+                silence_start_ms = None;
+            }
+        } else {
+            silence_start_ms = None;
+        }
+    }
+
+    if in_speech && total_ms > speech_start_ms {
+        regions_ms.push((speech_start_ms, total_ms));
+    }
+
+    let mut regions: Vec<SpeechRegion> = regions_ms
+        .into_iter()
+        .filter_map(|(start_ms, end_ms)| {
+            let start_sample = ms_float_to_sample(start_ms, sample_rate).min(total_samples);
+            let end_sample = ms_float_to_sample(end_ms, sample_rate).min(total_samples);
+            (end_sample > start_sample).then_some(SpeechRegion {
+                start_sample,
+                end_sample,
+            })
+        })
+        .filter(|region| region.len_samples() >= min_speech_samples)
+        .collect();
+
+    let pad_samples = ms_to_samples(config.speech_pad_ms, sample_rate);
+    apply_padding(&mut regions, total_samples, pad_samples);
+    merge_regions(&regions, ms_to_samples(config.merge_gap_ms, sample_rate))
+}
+
+pub fn speech_mask_for_frames_f32(
+    samples: &[f32],
+    sample_rate: u32,
+    frame_count: usize,
+    frame_stride_samples: usize,
+    config: &VadRegionConfig,
+) -> Result<Vec<bool>, VadError> {
+    if frame_count == 0 || frame_stride_samples == 0 {
+        return Ok(Vec::new());
+    }
+
+    let regions = detect_speech_regions_f32(samples, sample_rate, config)?;
+    Ok(mask_from_regions(
+        &regions,
+        frame_count,
+        frame_stride_samples,
+        samples.len(),
+    ))
+}
+
+pub fn mask_from_regions(
+    regions: &[SpeechRegion],
+    frame_count: usize,
+    frame_stride_samples: usize,
+    total_samples: usize,
+) -> Vec<bool> {
+    if frame_count == 0 || frame_stride_samples == 0 {
+        return Vec::new();
+    }
+
+    let mut mask = vec![false; frame_count];
+    for (frame_idx, active) in mask.iter_mut().enumerate() {
+        let start = frame_idx * frame_stride_samples;
+        if start >= total_samples {
+            break;
+        }
+        let end = ((frame_idx + 1) * frame_stride_samples).min(total_samples);
+        *active = regions
+            .iter()
+            .any(|region| region.start_sample < end && region.end_sample > start);
+    }
+    mask
+}
+
+pub fn pcm16_to_f32(samples: &[i16]) -> Vec<f32> {
+    samples
+        .iter()
+        .map(|sample| sanitize_sample(*sample as f32 / 32768.0))
+        .collect()
+}
+
+pub fn resample_linear_f32(
+    samples: &[f32],
+    source_sample_rate: u32,
+    target_sample_rate: u32,
+) -> Result<Vec<f32>, VadError> {
+    validate_sample_rate(source_sample_rate)?;
+    validate_sample_rate(target_sample_rate)?;
+    if samples.is_empty() {
+        return Ok(Vec::new());
+    }
+    if source_sample_rate == target_sample_rate {
+        return Ok(samples.iter().map(|s| sanitize_sample(*s)).collect());
+    }
+    if samples.len() == 1 {
+        return Ok(vec![sanitize_sample(samples[0])]);
+    }
+
+    let target_len = ((samples.len() as f64) * target_sample_rate as f64
+        / source_sample_rate as f64)
+        .ceil()
+        .max(1.0) as usize;
+    let step = source_sample_rate as f64 / target_sample_rate as f64;
+    let mut out = Vec::with_capacity(target_len);
+    for idx in 0..target_len {
+        let src_pos = idx as f64 * step;
+        let src_idx = src_pos.floor() as usize;
+        if src_idx + 1 >= samples.len() {
+            out.push(sanitize_sample(*samples.last().unwrap_or(&0.0)));
+            continue;
+        }
+        let frac = (src_pos - src_idx as f64) as f32;
+        out.push(sanitize_sample(
+            samples[src_idx] * (1.0 - frac) + samples[src_idx + 1] * frac,
+        ));
+    }
+    Ok(out)
+}
+
+pub fn sanitize_score_threshold(value: f32) -> f32 {
+    if value.is_finite() {
+        value.clamp(0.01, 0.99)
+    } else {
+        DEFAULT_SPEECH_THRESHOLD
+    }
+}
+
+pub fn legacy_rms_threshold_to_score_threshold(value: f32) -> f32 {
+    if !value.is_finite() {
+        return DEFAULT_SPEECH_THRESHOLD;
+    }
+    if value <= 0.1 {
+        ((value.max(0.001) / 0.02) * DEFAULT_SPEECH_THRESHOLD).clamp(0.2, 0.8)
+    } else {
+        sanitize_score_threshold(value)
+    }
+}
+
+fn sanitize_score(value: f32) -> f32 {
+    if value.is_finite() {
+        value.clamp(0.0, 1.0)
+    } else {
+        0.0
+    }
+}
+
+fn sanitize_sample(value: f32) -> f32 {
+    if value.is_finite() {
+        value.clamp(-1.0, 1.0)
+    } else {
+        0.0
+    }
+}
+
+fn validate_sample_rate(sample_rate: u32) -> Result<(), VadError> {
+    if sample_rate == 0 {
+        Err(VadError::InvalidSampleRate(sample_rate))
+    } else {
+        Ok(())
+    }
+}
+
+fn vad_sample_to_ms(sample: usize) -> f32 {
+    samples_to_ms(sample, VAD_SAMPLE_RATE)
+}
+
+fn samples_to_ms(samples: usize, sample_rate: u32) -> f32 {
+    (samples as f32 * 1000.0) / sample_rate as f32
+}
+
+fn ms_to_samples(ms: u32, sample_rate: u32) -> usize {
+    ((sample_rate as u64 * ms as u64) / 1000) as usize
+}
+
+fn ms_float_to_sample(ms: f32, sample_rate: u32) -> usize {
+    ((ms.max(0.0) * sample_rate as f32) / 1000.0).round() as usize
+}
+
+fn apply_padding(regions: &mut [SpeechRegion], total_samples: usize, pad_samples: usize) {
+    for region in regions {
+        region.start_sample = region.start_sample.saturating_sub(pad_samples);
+        region.end_sample = region
+            .end_sample
+            .saturating_add(pad_samples)
+            .min(total_samples);
+    }
+}
+
+fn merge_regions(regions: &[SpeechRegion], merge_gap_samples: usize) -> Vec<SpeechRegion> {
+    let mut merged: Vec<SpeechRegion> = Vec::new();
+    for region in regions.iter().copied() {
+        if region.end_sample <= region.start_sample {
+            continue;
+        }
+        if let Some(last) = merged.last_mut() {
+            let gap = region.start_sample.saturating_sub(last.end_sample);
+            if gap <= merge_gap_samples {
+                last.end_sample = last.end_sample.max(region.end_sample);
+                continue;
+            }
+        }
+        merged.push(region);
+    }
+    merged
+}
+
+struct StreamingLinearResampler {
+    src_rate: u32,
+    dst_rate: u32,
+    input: Vec<f32>,
+    next_src_pos: f64,
+}
+
+impl StreamingLinearResampler {
+    fn new(src_rate: u32, dst_rate: u32) -> Self {
+        Self {
+            src_rate,
+            dst_rate,
+            input: Vec::new(),
+            next_src_pos: 0.0,
+        }
+    }
+
+    fn push(&mut self, samples: &[f32]) -> Vec<f32> {
+        self.input
+            .extend(samples.iter().map(|s| sanitize_sample(*s)));
+        if self.input.len() < 2 {
+            return Vec::new();
+        }
+
+        let step = self.src_rate as f64 / self.dst_rate as f64;
+        let mut out = Vec::new();
+        while self.next_src_pos + 1.0 < self.input.len() as f64 {
+            let src_idx = self.next_src_pos.floor() as usize;
+            let frac = (self.next_src_pos - src_idx as f64) as f32;
+            out.push(sanitize_sample(
+                self.input[src_idx] * (1.0 - frac) + self.input[src_idx + 1] * frac,
+            ));
+            self.next_src_pos += step;
+        }
+
+        let drain = self.next_src_pos.floor() as usize;
+        if drain > 0 {
+            self.input.drain(0..drain);
+            self.next_src_pos -= drain as f64;
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn frame(index: usize, score: f32) -> VadFrame {
+        let start_vad_sample = index * VAD_FRAME_SAMPLES;
+        let end_vad_sample = start_vad_sample + VAD_FRAME_SAMPLES;
+        VadFrame {
+            index,
+            score,
+            start_vad_sample,
+            end_vad_sample,
+            start_ms: vad_sample_to_ms(start_vad_sample),
+            end_ms: vad_sample_to_ms(end_vad_sample),
+        }
+    }
+
+    #[test]
+    fn scorer_emits_finite_silence_scores() {
+        let samples = vec![0.0f32; VAD_SAMPLE_RATE as usize];
+        let frames = VadScorer::score_complete_f32(&samples, VAD_SAMPLE_RATE).unwrap();
+
+        assert_eq!(frames.len(), samples.len() / VAD_FRAME_SAMPLES);
+        assert!(frames
+            .iter()
+            .all(|frame| frame.score.is_finite() && (0.0..=1.0).contains(&frame.score)));
+    }
+
+    #[test]
+    fn endpoint_detector_uses_hysteresis_and_silence_timeout() {
+        let mut detector = EndpointDetector::new(EndpointConfig {
+            start_threshold: 0.5,
+            end_threshold: 0.35,
+            min_speech_ms: 32,
+            silence_ms: 32,
+            max_utterance_ms: 10_000,
+        });
+
+        let first = detector.process_score(0.6, 16.0);
+        assert_eq!(first.events, vec![EndpointEvent::SpeechStart]);
+        assert!(first.is_speech);
+
+        let held = detector.process_score(0.4, 16.0);
+        assert!(held.is_speech);
+        assert!(held.events.is_empty());
+
+        let quiet = detector.process_score(0.1, 16.0);
+        assert!(!quiet.is_speech);
+        assert!(quiet.events.is_empty());
+
+        let ended = detector.process_score(0.1, 16.0);
+        assert_eq!(
+            ended.events,
+            vec![EndpointEvent::SpeechEnd(EndpointEndReason::Silence)]
+        );
+        assert!(!detector.is_active());
+    }
+
+    #[test]
+    fn endpoint_detector_rejects_too_short_speech_on_finish() {
+        let mut detector = EndpointDetector::new(EndpointConfig {
+            min_speech_ms: 100,
+            ..EndpointConfig::default()
+        });
+
+        detector.process_score(0.9, 16.0);
+        assert_eq!(detector.finish(), Some(EndpointEvent::NoiseRejected));
+        assert!(!detector.is_active());
+    }
+
+    #[test]
+    fn regions_from_scores_apply_min_speech_padding_and_merge() {
+        let mut frames = Vec::new();
+        for idx in 0..250 {
+            let score = if (20..50).contains(&idx) || (65..90).contains(&idx) {
+                0.8
+            } else {
+                0.0
+            };
+            frames.push(frame(idx, score));
+        }
+        let config = VadRegionConfig {
+            min_speech_ms: 100,
+            min_silence_ms: 80,
+            speech_pad_ms: 20,
+            merge_gap_ms: 400,
+            ..VadRegionConfig::default()
+        };
+
+        let regions = detect_speech_regions_from_frames(&frames, 64_000, VAD_SAMPLE_RATE, &config);
+
+        assert_eq!(regions.len(), 1);
+        assert!(regions[0].start_sample < 20 * VAD_FRAME_SAMPLES);
+        assert!(regions[0].end_sample > 90 * VAD_FRAME_SAMPLES);
+    }
+
+    #[test]
+    fn mask_from_regions_marks_overlapping_frames() {
+        let regions = vec![SpeechRegion {
+            start_sample: 100,
+            end_sample: 260,
+        }];
+
+        let mask = mask_from_regions(&regions, 4, 100, 400);
+
+        assert_eq!(mask, vec![false, true, true, false]);
+    }
+
+    #[test]
+    fn legacy_threshold_maps_existing_default_to_score_default() {
+        assert_eq!(
+            legacy_rms_threshold_to_score_threshold(0.02),
+            DEFAULT_SPEECH_THRESHOLD
+        );
+    }
+}

--- a/crates/izwi-vad/src/lib.rs
+++ b/crates/izwi-vad/src/lib.rs
@@ -566,7 +566,7 @@ pub fn legacy_rms_threshold_to_score_threshold(value: f32) -> f32 {
     if !value.is_finite() {
         return DEFAULT_SPEECH_THRESHOLD;
     }
-    if value <= 0.1 {
+    if value < 0.1 {
         ((value.max(0.001) / 0.02) * DEFAULT_SPEECH_THRESHOLD).clamp(0.2, 0.8)
     } else {
         sanitize_score_threshold(value)
@@ -819,5 +819,10 @@ mod tests {
             legacy_rms_threshold_to_score_threshold(0.02),
             DEFAULT_SPEECH_THRESHOLD
         );
+    }
+
+    #[test]
+    fn legacy_threshold_keeps_minimum_score_threshold_as_score() {
+        assert_eq!(legacy_rms_threshold_to_score_threshold(0.1), 0.1);
     }
 }

--- a/crates/izwi-vad/src/lib.rs
+++ b/crates/izwi-vad/src/lib.rs
@@ -562,17 +562,6 @@ pub fn sanitize_score_threshold(value: f32) -> f32 {
     }
 }
 
-pub fn legacy_rms_threshold_to_score_threshold(value: f32) -> f32 {
-    if !value.is_finite() {
-        return DEFAULT_SPEECH_THRESHOLD;
-    }
-    if value < 0.1 {
-        ((value.max(0.001) / 0.02) * DEFAULT_SPEECH_THRESHOLD).clamp(0.2, 0.8)
-    } else {
-        sanitize_score_threshold(value)
-    }
-}
-
 fn sanitize_score(value: f32) -> f32 {
     if value.is_finite() {
         value.clamp(0.0, 1.0)
@@ -811,18 +800,5 @@ mod tests {
         let mask = mask_from_regions(&regions, 4, 100, 400);
 
         assert_eq!(mask, vec![false, true, true, false]);
-    }
-
-    #[test]
-    fn legacy_threshold_maps_existing_default_to_score_default() {
-        assert_eq!(
-            legacy_rms_threshold_to_score_threshold(0.02),
-            DEFAULT_SPEECH_THRESHOLD
-        );
-    }
-
-    #[test]
-    fn legacy_threshold_keeps_minimum_score_threshold_as_score() {
-        assert_eq!(legacy_rms_threshold_to_score_threshold(0.1), 0.1);
     }
 }

--- a/docs/dev/INFERENCE_ENGINE.md
+++ b/docs/dev/INFERENCE_ENGINE.md
@@ -350,7 +350,7 @@ Converts raw logits from the executor into user-facing output:
 
 `signal_frontend.rs` handles audio pre-processing before tokens reach the scheduler:
 - Resampling, normalisation, mel-spectrogram extraction
-- **Voice Activity Detection (VAD):** current implementation uses a simple energy-based detector. Silero VAD integration is planned (marked `TODO` in source).
+- **Voice Activity Detection (VAD):** shared Rust-native Earshot scoring and endpointing from `izwi-vad`.
 
 ---
 
@@ -642,7 +642,6 @@ The following features are scaffolded or partially implemented but not yet activ
 | Feature | Status | Notes |
 |---|---|---|
 | **Speculative Decoding** | Stub only | Draft model infrastructure not wired |
-| **Silero VAD** | TODO | Energy-based VAD is active; Silero integration pending |
 | **KV Cache Quantization (Int8)** | Config flag exists | Quantization kernel not yet applied |
 | **Flash Attention** | Planned | Standard attention used; Flash Attention would reduce memory bandwidth |
 | **Prefix Caching** | Planned | Block sharing infrastructure exists; hash-based prefix lookup not implemented |
@@ -687,7 +686,7 @@ The following features are scaffolded or partially implemented but not yet activ
 | **Flash Attention** | 2–4× memory bandwidth reduction during decode; lower latency |
 | **Prefix Caching** | Eliminate redundant prefill for shared prompt prefixes (e.g., system prompts) |
 | **KV Int8 Quantization** | ~50% KV memory reduction; enable larger batches |
-| **Silero VAD** | More accurate silence detection; reduce wasted decode steps |
+| **VAD Calibration** | Tune Earshot score thresholds and endpoint durations against production speech/noise captures |
 
 ### Medium-Term
 

--- a/docs/user/api.md
+++ b/docs/user/api.md
@@ -957,7 +957,7 @@ Client JSON messages:
 | `speaker` | TTS speaker/voice. |
 | `asr_language` | Language hint. |
 | `max_output_tokens` | Text output budget. |
-| `vad_threshold` | Speech detection threshold. |
+| `vad_threshold` | Earshot speech score threshold, default `0.5`. Legacy RMS-style values such as `0.02` are accepted and mapped server-side for compatibility. |
 | `min_speech_ms` | Minimum speech duration. |
 | `silence_duration_ms` | Silence before utterance end. |
 | `max_utterance_ms` | Hard utterance duration cap. |
@@ -994,7 +994,7 @@ Server events:
 | Type | Notes |
 |------|-------|
 | `session_ready` | Voice session initialized. |
-| `input_stream_ready` | Includes resolved VAD settings. |
+| `input_stream_ready` | Includes resolved VAD settings, including backend, score sample rate, and score frame duration. |
 | `input_stream_stopped` | Input stream stopped. |
 | `listening` | Ready for an utterance. |
 | `user_speech_start`, `user_speech_end` | VAD utterance boundaries. |

--- a/docs/user/api.md
+++ b/docs/user/api.md
@@ -998,6 +998,7 @@ Server events:
 | `input_stream_stopped` | Input stream stopped. |
 | `listening` | Ready for an utterance. |
 | `user_speech_start`, `user_speech_end` | VAD utterance boundaries. |
+| `user_speech_rejected` | A too-short speech start was rejected as noise and the stream returned to listening. |
 | `turn_processing` | Turn started. |
 | `user_transcript_start`, `user_transcript_delta`, `user_transcript_final` | User transcript events. |
 | `assistant_text_start`, `assistant_text_delta`, `assistant_text_final` | Assistant text events. |

--- a/docs/user/api.md
+++ b/docs/user/api.md
@@ -957,7 +957,7 @@ Client JSON messages:
 | `speaker` | TTS speaker/voice. |
 | `asr_language` | Language hint. |
 | `max_output_tokens` | Text output budget. |
-| `vad_threshold` | Earshot speech score threshold, default `0.5`. Legacy RMS-style values such as `0.02` are accepted and mapped server-side for compatibility. |
+| `vad_threshold` | Earshot speech score threshold, default `0.5`. Values are clamped to the valid score range. |
 | `min_speech_ms` | Minimum speech duration. |
 | `silence_duration_ms` | Silence before utterance end. |
 | `max_utterance_ms` | Hard utterance duration cap. |

--- a/ui/src/features/voice/realtime/support.ts
+++ b/ui/src/features/voice/realtime/support.ts
@@ -17,7 +17,10 @@ export type VoiceRealtimeServerEvent =
   | {
       type: "input_stream_ready";
       vad?: {
+        backend?: string;
         threshold?: number;
+        score_sample_rate?: number;
+        score_frame_ms?: number;
         min_speech_ms?: number;
         silence_duration_ms?: number;
       };

--- a/ui/src/features/voice/realtime/support.ts
+++ b/ui/src/features/voice/realtime/support.ts
@@ -28,6 +28,7 @@ export type VoiceRealtimeServerEvent =
   | { type: "input_stream_stopped" }
   | { type: "listening"; utterance_id: string; utterance_seq: number }
   | { type: "user_speech_start"; utterance_id: string; utterance_seq: number }
+  | { type: "user_speech_rejected"; utterance_id: string; utterance_seq: number }
   | {
       type: "user_speech_end";
       utterance_id: string;

--- a/ui/src/features/voice/route.tsx
+++ b/ui/src/features/voice/route.tsx
@@ -17,7 +17,6 @@ import { cn } from "@/lib/utils";
 import { api, type ModelInfo, type VoiceObservation } from "@/api";
 import { PageShell } from "@/components/PageShell";
 import { Button } from "@/components/ui/button";
-import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import {
   Select,
@@ -98,9 +97,6 @@ export function VoicePage({
   const [selectedSpeaker, setSelectedSpeaker] = useState("Serena");
   const [voiceMode, setVoiceMode] = useState<VoiceRealtimeMode>("modular");
 
-  const [vadThreshold, setVadThreshold] = useState(0.5);
-  const [silenceDurationMs, setSilenceDurationMs] = useState(900);
-  const [minSpeechMs, setMinSpeechMs] = useState(300);
   const [isConfigOpen, setIsConfigOpen] = useState(false);
   const [configTab, setConfigTab] = useState<VoiceConfigTab>("setup");
   const [isLoadAllRequested, setIsLoadAllRequested] = useState(false);
@@ -1293,9 +1289,6 @@ export function VoicePage({
             s2s_model_id: selectedUnifiedModel,
             speaker: selectedSpeaker,
             max_output_tokens: 1536,
-            vad_threshold: vadThreshold,
-            min_speech_ms: minSpeechMs,
-            silence_duration_ms: silenceDurationMs,
             max_utterance_ms: 20_000,
             pre_roll_ms: 160,
             input_sample_rate: Math.round(inputSampleRate),
@@ -1315,9 +1308,6 @@ export function VoicePage({
             speaker: selectedSpeaker,
             asr_language: "Auto",
             max_output_tokens: 1536,
-            vad_threshold: vadThreshold,
-            min_speech_ms: minSpeechMs,
-            silence_duration_ms: silenceDurationMs,
             max_utterance_ms: 20_000,
             pre_roll_ms: 160,
             input_sample_rate: Math.round(inputSampleRate),
@@ -1336,15 +1326,12 @@ export function VoicePage({
     },
     [
       ensureVoiceRealtimeSocket,
-      minSpeechMs,
       selectedAsrModel,
       selectedSpeaker,
       selectedTextModel,
       selectedTtsModel,
       selectedUnifiedModel,
       sendVoiceRealtimeJson,
-      silenceDurationMs,
-      vadThreshold,
       voiceMode,
       waitForVoiceRealtimeInputStreamReady,
     ],
@@ -1693,7 +1680,7 @@ export function VoicePage({
     {
       value: "setup",
       label: "Setup",
-      description: "Runtime mode, voice, playback, and speech detection.",
+      description: "Runtime mode, voice, and playback.",
     },
     {
       value: "models",
@@ -1835,7 +1822,6 @@ export function VoicePage({
           )}
         </div>
       </section>
-      {renderAdvancedSpeechSettings()}
     </div>
   );
 
@@ -2228,79 +2214,6 @@ export function VoicePage({
           </div>
         ))}
       </div>
-    </section>
-  );
-
-  const renderAdvancedSpeechSettings = () => (
-    <section className="border-t border-[var(--border-muted)] pt-6">
-      <details>
-        <summary className="cursor-pointer text-sm font-semibold text-[var(--text-primary)]">
-          Advanced Speech Detection
-        </summary>
-        <p className="mt-1 text-sm text-[var(--text-muted)]">
-          Tune how aggressively the microphone detects the start and end of
-          speech.
-        </p>
-        <div className="mt-4 grid gap-5 md:grid-cols-3">
-          <div>
-            <label className="text-sm font-medium text-[var(--text-primary)]">
-              Speech Threshold ({vadThreshold.toFixed(2)})
-            </label>
-            <Slider
-              aria-label="Speech threshold"
-              min={0.1}
-              max={0.9}
-              step={0.01}
-              value={[vadThreshold]}
-              onValueChange={(value) => {
-                const next = value[0];
-                if (typeof next === "number") {
-                  setVadThreshold(next);
-                }
-              }}
-              className="mt-2"
-            />
-          </div>
-          <div>
-            <label className="text-sm font-medium text-[var(--text-primary)]">
-              End Silence (ms): {silenceDurationMs}
-            </label>
-            <Slider
-              aria-label="End silence duration"
-              min={400}
-              max={1800}
-              step={50}
-              value={[silenceDurationMs]}
-              onValueChange={(value) => {
-                const next = value[0];
-                if (typeof next === "number") {
-                  setSilenceDurationMs(next);
-                }
-              }}
-              className="mt-2"
-            />
-          </div>
-          <div>
-            <label className="text-sm font-medium text-[var(--text-primary)]">
-              Minimum Speech (ms): {minSpeechMs}
-            </label>
-            <Slider
-              aria-label="Minimum speech duration"
-              min={150}
-              max={1200}
-              step={50}
-              value={[minSpeechMs]}
-              onValueChange={(value) => {
-                const next = value[0];
-                if (typeof next === "number") {
-                  setMinSpeechMs(next);
-                }
-              }}
-              className="mt-2"
-            />
-          </div>
-        </div>
-      </details>
     </section>
   );
 

--- a/ui/src/features/voice/route.tsx
+++ b/ui/src/features/voice/route.tsx
@@ -98,7 +98,7 @@ export function VoicePage({
   const [selectedSpeaker, setSelectedSpeaker] = useState("Serena");
   const [voiceMode, setVoiceMode] = useState<VoiceRealtimeMode>("modular");
 
-  const [vadThreshold, setVadThreshold] = useState(0.02);
+  const [vadThreshold, setVadThreshold] = useState(0.5);
   const [silenceDurationMs, setSilenceDurationMs] = useState(900);
   const [minSpeechMs, setMinSpeechMs] = useState(300);
   const [isConfigOpen, setIsConfigOpen] = useState(false);
@@ -1552,22 +1552,6 @@ export function VoicePage({
         }
         const rms = Math.sqrt(sumSquares / data.length);
         setAudioLevel(rms);
-
-        const isSpeech = rms >= vadThreshold;
-        if (isSpeech && runtimeStatusRef.current === "assistant_speaking") {
-          const nextAccepted = (voiceWsPlaybackRef.current?.utteranceSeq ?? 0) + 1;
-          voiceMinAcceptedAssistantSeqRef.current = Math.max(
-            voiceMinAcceptedAssistantSeqRef.current,
-            nextAccepted,
-          );
-          try {
-            sendVoiceRealtimeJson({ type: "interrupt", reason: "barge_in" });
-          } catch {
-            // Best-effort; local playback is stopped immediately.
-          }
-          clearAudioPlayback();
-          setRuntimeStatus("listening");
-        }
       }, VAD_INTERVAL);
     } catch (err) {
       const message =
@@ -1579,7 +1563,6 @@ export function VoicePage({
       stopSession();
     }
   }, [
-    clearAudioPlayback,
     ensureVoiceRealtimeInputStreamStarted,
     hasRunnableConfig,
     onError,
@@ -1588,9 +1571,7 @@ export function VoicePage({
     selectedTextModel,
     selectedTtsModel,
     sendVoiceRealtimeBinary,
-    sendVoiceRealtimeJson,
     stopSession,
-    vadThreshold,
   ]);
 
   const toggleSession = useCallback(() => {
@@ -1653,7 +1634,7 @@ export function VoicePage({
 
   const vadPercent = Math.min(
     100,
-    Math.round((audioLevel / Math.max(vadThreshold, 0.001)) * 40),
+    Math.round(audioLevel * 250),
   );
 
   const getStatusClass = (status: ModelInfo["status"]) => {
@@ -2257,13 +2238,13 @@ export function VoicePage({
         <div className="mt-4 grid gap-5 md:grid-cols-3">
           <div>
             <label className="text-sm font-medium text-[var(--text-primary)]">
-              VAD Sensitivity ({vadThreshold.toFixed(3)})
+              Speech Threshold ({vadThreshold.toFixed(2)})
             </label>
             <Slider
-              aria-label="VAD sensitivity"
-              min={0.005}
-              max={0.08}
-              step={0.001}
+              aria-label="Speech threshold"
+              min={0.1}
+              max={0.9}
+              step={0.01}
               value={[vadThreshold]}
               onValueChange={(value) => {
                 const next = value[0];

--- a/ui/src/features/voice/route.tsx
+++ b/ui/src/features/voice/route.tsx
@@ -906,6 +906,12 @@ export function VoicePage({
             setRuntimeStatus("user_speaking");
           }
           return;
+        case "user_speech_rejected":
+          processingRef.current = false;
+          if (isSessionActiveRef.current) {
+            setRuntimeStatus("listening");
+          }
+          return;
         case "user_speech_end":
           processingRef.current = true;
           if (isSessionActiveRef.current) {


### PR DESCRIPTION
Makes shared Rust-native Earshot VAD the default across realtime voice, ASR chunking, and Sortformer gating, removes legacy/duplicate VAD paths, and cleans up voice UI tuning controls.