### PR TITLE
Add native Rust/Candle Nemotron 3.5 ASR transcription

### DIFF
--- a/crates/izwi-core/src/artifacts/downloader.rs
+++ b/crates/izwi-core/src/artifacts/downloader.rs
@@ -542,6 +542,7 @@ impl ModelDownloader {
                         .iter()
                         .all(|file| path.join(file).exists())
             }
+            ModelFamily::NemotronAsr => path.join("nemotron-3.5-asr-streaming-0.6b.nemo").exists(),
             ModelFamily::SortformerDiarization => path
                 .join("diar_streaming_sortformer_4spk-v2.1.nemo")
                 .exists(),
@@ -1103,6 +1104,9 @@ impl ModelDownloader {
                 );
                 files
             }
+            ModelFamily::NemotronAsr => {
+                vec!["nemotron-3.5-asr-streaming-0.6b.nemo".to_string()]
+            }
             ModelFamily::SortformerDiarization => vec![
                 "diar_streaming_sortformer_4spk-v2.1.nemo".to_string(),
                 "README.md".to_string(),
@@ -1629,6 +1633,7 @@ impl ModelDownloader {
         } else if file.ends_with(".nemo") {
             match variant {
                 ModelVariant::ParakeetTdt06BV3 => 10_036_761_167,
+                ModelVariant::Nemotron35AsrStreaming06B => 2_370_000_000,
                 ModelVariant::DiarStreamingSortformer4SpkV21 => 510_000_000,
                 _ => 4_000_000_000,
             }
@@ -1809,6 +1814,33 @@ mod tests {
         std::fs::create_dir_all(&model_dir).expect("model dir");
         assert!(!downloader.is_downloaded(variant));
         std::fs::write(model_dir.join("qwen3_asr_1.7b_q8_0.gguf"), [0u8]).expect("gguf");
+        assert!(downloader.is_downloaded(variant));
+        std::fs::remove_dir_all(temp_dir).ok();
+    }
+
+    #[test]
+    fn nemotron_asr_model_files_only_include_nemo_checkpoint() {
+        let (downloader, temp_dir) = test_downloader();
+        let files = downloader.get_model_files(ModelVariant::Nemotron35AsrStreaming06B);
+        assert_eq!(
+            files,
+            vec!["nemotron-3.5-asr-streaming-0.6b.nemo".to_string()]
+        );
+        std::fs::remove_dir_all(temp_dir).ok();
+    }
+
+    #[test]
+    fn nemotron_asr_is_downloaded_when_nemo_checkpoint_exists() {
+        let (downloader, temp_dir) = test_downloader();
+        let variant = ModelVariant::Nemotron35AsrStreaming06B;
+        let model_dir = downloader.model_path(variant);
+        std::fs::create_dir_all(&model_dir).expect("model dir");
+        assert!(!downloader.is_downloaded(variant));
+        std::fs::write(
+            model_dir.join("nemotron-3.5-asr-streaming-0.6b.nemo"),
+            [0u8],
+        )
+        .expect("nemo");
         assert!(downloader.is_downloaded(variant));
         std::fs::remove_dir_all(temp_dir).ok();
     }

--- a/crates/izwi-core/src/catalog/cuda_support.rs
+++ b/crates/izwi-core/src/catalog/cuda_support.rs
@@ -137,6 +137,10 @@ impl ModelVariant {
                 CudaSupportLevel::CandleCudaGeneric,
                 "VibeVoice TTS uses dense Candle CUDA tensor kernels for the Qwen decoder, continuous tokenizers, and diffusion head; long-form generation is final-only until chunked decode is proven",
             ),
+            ModelFamily::NemotronAsr => CudaSupportInfo::new(
+                CudaSupportLevel::CandleCudaGeneric,
+                "Nemotron ASR uses dense Candle CUDA tensor kernels once the native FastConformer-RNNT loader is selected; cache-aware streaming remains disabled until encoder cache state is proven",
+            ),
             ModelFamily::Qwen3Tts
             | ModelFamily::KokoroTts
             | ModelFamily::ParakeetAsr
@@ -180,6 +184,10 @@ impl ModelVariant {
             ModelFamily::VoxtralTts => CudaQuantizationInfo::new(
                 CudaQuantizationSupportLevel::Dense,
                 "Voxtral TTS checkpoint is dense safetensors; CUDA dtype policy, not quantization, controls memory/performance tradeoffs",
+            ),
+            ModelFamily::NemotronAsr => CudaQuantizationInfo::new(
+                CudaQuantizationSupportLevel::Dense,
+                "Nemotron ASR ships a dense .nemo checkpoint; CUDA dtype policy, not quantization, controls memory/performance tradeoffs",
             ),
             ModelFamily::VibeVoiceTts | ModelFamily::VibeVoiceAsr => CudaQuantizationInfo::new(
                 CudaQuantizationSupportLevel::Dense,
@@ -316,6 +324,12 @@ mod tests {
         );
         assert_eq!(
             ModelVariant::Voxtral4BTts2603.cuda_quantization().level,
+            CudaQuantizationSupportLevel::Dense
+        );
+        assert_eq!(
+            ModelVariant::Nemotron35AsrStreaming06B
+                .cuda_quantization()
+                .level,
             CudaQuantizationSupportLevel::Dense
         );
     }

--- a/crates/izwi-core/src/catalog/metadata.rs
+++ b/crates/izwi-core/src/catalog/metadata.rs
@@ -116,6 +116,14 @@ pub enum ModelVariant {
         alias = "vibevoice-asr"
     )]
     VibeVoiceAsr,
+    /// NVIDIA Nemotron 3.5 streaming multilingual ASR model (.nemo)
+    #[serde(
+        rename = "Nemotron-3.5-ASR-Streaming-0.6B",
+        alias = "nvidia/nemotron-3.5-asr-streaming-0.6b",
+        alias = "nemotron-3.5-asr-streaming-0.6b",
+        alias = "Nemotron 3.5 ASR Streaming 0.6B"
+    )]
+    Nemotron35AsrStreaming06B,
     /// Streaming Sortformer 4-speaker diarization model (.nemo)
     #[serde(rename = "diar_streaming_sortformer_4spk-v2.1")]
     DiarStreamingSortformer4SpkV21,
@@ -268,6 +276,7 @@ impl ModelVariant {
             Self::WhisperLargeV3Turbo => "openai/whisper-large-v3-turbo",
             Self::Qwen3Asr06BGguf | Self::Qwen3Asr17BGguf => "Alkd/qwen3-asr-gguf",
             Self::VibeVoiceAsr => "microsoft/VibeVoice-ASR",
+            Self::Nemotron35AsrStreaming06B => "nvidia/nemotron-3.5-asr-streaming-0.6b",
             Self::DiarStreamingSortformer4SpkV21 => "nvidia/diar_streaming_sortformer_4spk-v2.1",
             Self::Qwen306B => "Qwen/Qwen3-0.6B",
             Self::Qwen306B4Bit => "mlx-community/Qwen3-0.6B-4bit",
@@ -321,6 +330,7 @@ impl ModelVariant {
             Self::Qwen3Asr06BGguf => "Qwen3 ASR 0.6B GGUF",
             Self::Qwen3Asr17BGguf => "Qwen3 ASR 1.7B GGUF",
             Self::VibeVoiceAsr => "VibeVoice ASR",
+            Self::Nemotron35AsrStreaming06B => "Nemotron 3.5 ASR Streaming 0.6B",
             Self::DiarStreamingSortformer4SpkV21 => "Streaming Sortformer 4spk v2.1",
             Self::Qwen306B => "Qwen3 0.6B",
             Self::Qwen306B4Bit => "Qwen3 0.6B 4-bit",
@@ -374,6 +384,7 @@ impl ModelVariant {
             Self::Qwen3Asr06BGguf => "Qwen3-ASR-0.6B-GGUF",
             Self::Qwen3Asr17BGguf => "Qwen3-ASR-1.7B-GGUF",
             Self::VibeVoiceAsr => "VibeVoice-ASR",
+            Self::Nemotron35AsrStreaming06B => "Nemotron-3.5-ASR-Streaming-0.6B",
             Self::DiarStreamingSortformer4SpkV21 => "diar_streaming_sortformer_4spk-v2.1",
             Self::Qwen306B => "Qwen3-0.6B",
             Self::Qwen306B4Bit => "Qwen3-0.6B-4bit",
@@ -426,7 +437,8 @@ impl ModelVariant {
             Self::WhisperLargeV3Turbo => 1_617_824_864, // ~1.51 GB (HF x-linked-size)
             Self::Qwen3Asr06BGguf => 1_012_824_608,     // HF x-linked-size, Mar 2026
             Self::Qwen3Asr17BGguf => 2_512_740_320,     // HF x-linked-size, Mar 2026
-            Self::VibeVoiceAsr => 17_348_198_410, // safetensors index metadata total_size
+            Self::VibeVoiceAsr => 17_348_198_410,       // safetensors index metadata total_size
+            Self::Nemotron35AsrStreaming06B => 2_370_000_000, // ~2.37 GB .nemo, HF tree, Jun 2026
             Self::DiarStreamingSortformer4SpkV21 => 510_000_000, // ~0.47 GB (est)
             Self::Qwen306B => 1_520_000_000,            // ~1.42 GB (est)
             Self::Qwen306B4Bit => 900_000_000,          // ~0.84 GB (est)
@@ -479,6 +491,7 @@ impl ModelVariant {
             Self::Qwen3Asr06BGguf => 4.0,
             Self::Qwen3Asr17BGguf => 8.0,
             Self::VibeVoiceAsr => 36.0,
+            Self::Nemotron35AsrStreaming06B => 6.0,
             Self::DiarStreamingSortformer4SpkV21 => 3.0,
             Self::Qwen306B => 3.0,
             Self::Qwen306B4Bit => 2.0,
@@ -521,6 +534,7 @@ impl ModelVariant {
                 | crate::catalog::ModelFamily::WhisperAsr
                 | crate::catalog::ModelFamily::Qwen3Asr
                 | crate::catalog::ModelFamily::VibeVoiceAsr
+                | crate::catalog::ModelFamily::NemotronAsr
         )
     }
 
@@ -572,6 +586,7 @@ impl ModelVariant {
         match self {
             Self::Voxtral4BTts2603 => Some("CC BY-NC 4.0"),
             Self::VibeVoiceAsr | Self::VibeVoice15BTts => Some("MIT"),
+            Self::Nemotron35AsrStreaming06B => Some("OpenMDW-1.1"),
             _ => None,
         }
     }
@@ -885,6 +900,7 @@ impl ModelVariant {
             Self::Qwen3Asr06BGguf,
             Self::Qwen3Asr17BGguf,
             Self::VibeVoiceAsr,
+            Self::Nemotron35AsrStreaming06B,
             Self::DiarStreamingSortformer4SpkV21,
             Self::Qwen306B,
             Self::Qwen306B4Bit,
@@ -1157,10 +1173,9 @@ mod tests {
             tts.tts_output_frame_rate_hz_hint(),
             Some(ModelVariant::VIBEVOICE_TTS_FRAME_RATE_HZ)
         );
-        assert!(
-            tts.tts_max_output_seconds_hint()
-                .is_some_and(|seconds| seconds >= 5_400.0)
-        );
+        assert!(tts
+            .tts_max_output_seconds_hint()
+            .is_some_and(|seconds| seconds >= 5_400.0));
         assert_eq!(
             tts.speech_capabilities(),
             Some(SpeechModelCapabilities {
@@ -1173,6 +1188,18 @@ mod tests {
                 supports_auto_long_form: true,
             })
         );
+    }
+
+    #[test]
+    fn nemotron_asr_catalog_contract_matches_hf_artifact() {
+        let variant = ModelVariant::Nemotron35AsrStreaming06B;
+        assert!(variant.is_asr());
+        assert_eq!(variant.primary_task(), ModelTask::Asr);
+        assert_eq!(variant.repo_id(), "nvidia/nemotron-3.5-asr-streaming-0.6b");
+        assert_eq!(variant.dir_name(), "Nemotron-3.5-ASR-Streaming-0.6B");
+        assert_eq!(variant.license_label(), Some("OpenMDW-1.1"));
+        assert!(!variant.is_quantized());
+        assert_eq!(variant.memory_required_gb(), 6.0);
     }
 
     #[test]

--- a/crates/izwi-core/src/catalog/variant.rs
+++ b/crates/izwi-core/src/catalog/variant.rs
@@ -14,6 +14,7 @@ pub enum ModelFamily {
     WhisperAsr,
     Qwen3Asr,
     VibeVoiceAsr,
+    NemotronAsr,
     SortformerDiarization,
     Qwen3Chat,
     Qwen35Chat,
@@ -109,6 +110,7 @@ impl ModelVariant {
             WhisperLargeV3Turbo => ModelFamily::WhisperAsr,
             Qwen3Asr06BGguf | Qwen3Asr17BGguf => ModelFamily::Qwen3Asr,
             VibeVoiceAsr => ModelFamily::VibeVoiceAsr,
+            Nemotron35AsrStreaming06B => ModelFamily::NemotronAsr,
             DiarStreamingSortformer4SpkV21 => ModelFamily::SortformerDiarization,
             Qwen306B | Qwen306B4Bit | Qwen306BGguf | Qwen317B | Qwen317B4Bit | Qwen317BGguf
             | Qwen34BGguf | Qwen38BGguf | Qwen314BGguf => ModelFamily::Qwen3Chat,
@@ -130,7 +132,8 @@ impl ModelVariant {
             ModelFamily::ParakeetAsr
             | ModelFamily::WhisperAsr
             | ModelFamily::Qwen3Asr
-            | ModelFamily::VibeVoiceAsr => ModelTask::Asr,
+            | ModelFamily::VibeVoiceAsr
+            | ModelFamily::NemotronAsr => ModelTask::Asr,
             ModelFamily::SortformerDiarization => ModelTask::Diarization,
             ModelFamily::Qwen3Chat
             | ModelFamily::Qwen35Chat
@@ -224,6 +227,8 @@ pub fn resolve_asr_model_variant(input: Option<&str>) -> ModelVariant {
             let normalized = normalize_identifier(raw);
             if normalized.contains("voxtral") {
                 VoxtralMini4BRealtime2602
+            } else if normalized.contains("nemotron") && normalized.contains("asr") {
+                Nemotron35AsrStreaming06B
             } else if normalized.contains("vibevoice") && normalized.contains("asr") {
                 VibeVoiceAsr
             } else if normalized.contains("whisper")
@@ -287,6 +292,10 @@ fn resolve_by_heuristic(normalized: &str) -> Option<ModelVariant> {
         {
             return Some(VibeVoice15BTts);
         }
+    }
+
+    if normalized.contains("nemotron") && normalized.contains("asr") {
+        return Some(Nemotron35AsrStreaming06B);
     }
 
     if normalized.contains("sortformer") && normalized.contains("diar") {
@@ -641,6 +650,19 @@ mod tests {
         let resolved = resolve_asr_model_variant(Some("microsoft/VibeVoice-ASR"));
         assert_eq!(resolved, ModelVariant::VibeVoiceAsr);
         assert_eq!(resolved.family(), ModelFamily::VibeVoiceAsr);
+    }
+
+    #[test]
+    fn parse_nemotron_asr_repo_alias() {
+        let parsed = parse_model_variant("nvidia/nemotron-3.5-asr-streaming-0.6b").unwrap();
+        assert_eq!(parsed, ModelVariant::Nemotron35AsrStreaming06B);
+        assert_eq!(parsed.family(), ModelFamily::NemotronAsr);
+    }
+
+    #[test]
+    fn resolve_asr_accepts_nemotron_family_alias() {
+        let resolved = resolve_asr_model_variant(Some("nemotron asr streaming"));
+        assert_eq!(resolved, ModelVariant::Nemotron35AsrStreaming06B);
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/mod.rs
+++ b/crates/izwi-core/src/models/architectures/mod.rs
@@ -9,6 +9,7 @@ pub mod gemma3;
 pub mod kokoro;
 pub mod lfm2;
 pub mod lfm25_audio;
+pub mod nemotron;
 pub mod parakeet;
 pub mod qwen3;
 pub mod qwen35;

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/config.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/config.rs
@@ -1,0 +1,227 @@
+use serde_yaml::Value;
+
+use crate::error::{Error, Result};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct NemotronConfigInventory {
+    pub sample_rate: Option<usize>,
+    pub features: Option<usize>,
+    pub encoder_layers: Option<usize>,
+    pub encoder_dim: Option<usize>,
+    pub encoder_heads: Option<usize>,
+    pub predictor_hidden: Option<usize>,
+    pub joint_hidden: Option<usize>,
+    pub vocab_size: Option<usize>,
+    pub prompt_dim: Option<usize>,
+    pub left_context_frames: Option<usize>,
+    pub right_context_frames: Vec<usize>,
+    pub model_target: Option<String>,
+}
+
+impl NemotronConfigInventory {
+    pub fn from_yaml_str(contents: &str) -> Result<Self> {
+        let value: Value = serde_yaml::from_str(contents).map_err(|e| {
+            Error::ModelLoadError(format!("Failed parsing Nemotron model_config.yaml: {e}"))
+        })?;
+
+        Ok(Self {
+            sample_rate: find_usize_by_keys(&value, &["sample_rate", "sample_rate_hz"]),
+            features: find_usize_by_keys(&value, &["features", "n_mels", "num_mels"]),
+            encoder_layers: find_usize_by_keys(&value, &["n_layers", "num_layers", "layers"]),
+            encoder_dim: find_usize_by_keys(&value, &["d_model", "feat_out", "encoder_dim"]),
+            encoder_heads: find_usize_by_keys(&value, &["n_heads", "num_heads"]),
+            predictor_hidden: find_usize_by_keys(
+                &value,
+                &["pred_hidden", "prediction_hidden", "pred_hidden_dim"],
+            ),
+            joint_hidden: find_usize_by_keys(&value, &["joint_hidden", "joint_hidden_dim"]),
+            vocab_size: find_usize_by_keys(&value, &["vocab_size", "num_classes"]),
+            prompt_dim: find_usize_by_keys(&value, &["prompt_dim", "prompt_size", "lang_dim"]),
+            left_context_frames: att_context_size(&value).and_then(|pair| pair.first().copied()),
+            right_context_frames: collect_right_context_frames(&value),
+            model_target: find_string_by_keys(&value, &["_target_", "target"]),
+        })
+    }
+}
+
+fn collect_right_context_frames(value: &Value) -> Vec<usize> {
+    let mut contexts = Vec::new();
+    if let Some(pair) = att_context_size(value) {
+        if let Some(right) = pair.get(1).copied() {
+            contexts.push(right);
+        }
+    }
+
+    collect_context_sequences(value, &mut contexts);
+    contexts.sort_unstable();
+    contexts.dedup();
+    contexts
+}
+
+fn att_context_size(value: &Value) -> Option<Vec<usize>> {
+    find_sequence_by_key(value, "att_context_size")
+        .or_else(|| find_sequence_by_key(value, "att_context_size_all"))
+        .map(|seq| seq.iter().filter_map(value_to_usize).collect())
+}
+
+fn collect_context_sequences(value: &Value, contexts: &mut Vec<usize>) {
+    match value {
+        Value::Sequence(items) => {
+            if items.len() == 2 {
+                let maybe_pair: Vec<_> = items.iter().filter_map(value_to_usize).collect();
+                if maybe_pair.len() == 2 {
+                    contexts.push(maybe_pair[1]);
+                }
+            }
+            for item in items {
+                collect_context_sequences(item, contexts);
+            }
+        }
+        Value::Mapping(map) => {
+            for (key, value) in map {
+                if scalar_key(key)
+                    .map(|key| key.contains("att_context_size"))
+                    .unwrap_or(false)
+                {
+                    if let Some(seq) = value.as_sequence() {
+                        if seq.len() == 2 {
+                            if let Some(right) = seq.get(1).and_then(value_to_usize) {
+                                contexts.push(right);
+                            }
+                        } else {
+                            for child in seq {
+                                collect_context_sequences(child, contexts);
+                            }
+                        }
+                    }
+                }
+                collect_context_sequences(value, contexts);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn find_sequence_by_key(value: &Value, target: &str) -> Option<Vec<Value>> {
+    match value {
+        Value::Mapping(map) => {
+            for (key, child) in map {
+                if scalar_key(key).is_some_and(|key| key == target) {
+                    return child.as_sequence().cloned();
+                }
+                if let Some(found) = find_sequence_by_key(child, target) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Value::Sequence(items) => items
+            .iter()
+            .find_map(|item| find_sequence_by_key(item, target)),
+        _ => None,
+    }
+}
+
+fn find_usize_by_keys(value: &Value, keys: &[&str]) -> Option<usize> {
+    match value {
+        Value::Mapping(map) => {
+            for (key, child) in map {
+                if let Some(name) = scalar_key(key) {
+                    if keys.iter().any(|candidate| *candidate == name) {
+                        if let Some(value) = value_to_usize(child) {
+                            return Some(value);
+                        }
+                    }
+                }
+            }
+            map.values()
+                .find_map(|child| find_usize_by_keys(child, keys))
+        }
+        Value::Sequence(items) => items.iter().find_map(|item| find_usize_by_keys(item, keys)),
+        _ => None,
+    }
+}
+
+fn find_string_by_keys(value: &Value, keys: &[&str]) -> Option<String> {
+    match value {
+        Value::Mapping(map) => {
+            for (key, child) in map {
+                if let Some(name) = scalar_key(key) {
+                    if keys.iter().any(|candidate| *candidate == name) {
+                        if let Some(value) = child.as_str() {
+                            return Some(value.to_string());
+                        }
+                    }
+                }
+            }
+            map.values()
+                .find_map(|child| find_string_by_keys(child, keys))
+        }
+        Value::Sequence(items) => items
+            .iter()
+            .find_map(|item| find_string_by_keys(item, keys)),
+        _ => None,
+    }
+}
+
+fn value_to_usize(value: &Value) -> Option<usize> {
+    if let Some(num) = value.as_u64() {
+        return usize::try_from(num).ok();
+    }
+    if let Some(num) = value.as_i64() {
+        return usize::try_from(num).ok();
+    }
+    value.as_str()?.parse::<usize>().ok()
+}
+
+fn scalar_key(value: &Value) -> Option<&str> {
+    value.as_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_inventory_extracts_nemotron_style_fields() {
+        let yaml = r#"
+model:
+  _target_: nemo.collections.asr.models.EncDecRNNTBPEModel
+  preprocessor:
+    sample_rate: 16000
+    features: 128
+  encoder:
+    n_layers: 24
+    d_model: 512
+    n_heads: 8
+    att_context_size: [56, 13]
+    att_context_size_all:
+      - [56, 0]
+      - [56, 1]
+      - [56, 3]
+      - [56, 6]
+      - [56, 13]
+  decoder:
+    pred_hidden: 640
+    vocab_size: 1024
+  joint:
+    joint_hidden: 512
+  prompt:
+    prompt_dim: 128
+"#;
+
+        let inventory = NemotronConfigInventory::from_yaml_str(yaml).unwrap();
+
+        assert_eq!(inventory.sample_rate, Some(16_000));
+        assert_eq!(inventory.features, Some(128));
+        assert_eq!(inventory.encoder_layers, Some(24));
+        assert_eq!(inventory.encoder_dim, Some(512));
+        assert_eq!(inventory.encoder_heads, Some(8));
+        assert_eq!(inventory.predictor_hidden, Some(640));
+        assert_eq!(inventory.joint_hidden, Some(512));
+        assert_eq!(inventory.vocab_size, Some(1024));
+        assert_eq!(inventory.prompt_dim, Some(128));
+        assert_eq!(inventory.left_context_frames, Some(56));
+        assert_eq!(inventory.right_context_frames, vec![0, 1, 3, 6, 13]);
+    }
+}

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/config.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/config.rs
@@ -6,13 +6,22 @@ use crate::error::{Error, Result};
 pub struct NemotronConfigInventory {
     pub sample_rate: Option<usize>,
     pub features: Option<usize>,
+    pub n_fft: Option<usize>,
+    pub window_length: Option<usize>,
+    pub hop_length: Option<usize>,
     pub encoder_layers: Option<usize>,
     pub encoder_dim: Option<usize>,
     pub encoder_heads: Option<usize>,
+    pub subsampling_factor: Option<usize>,
+    pub subsampling_conv_channels: Option<usize>,
+    pub ff_expansion_factor: Option<usize>,
+    pub conv_kernel_size: Option<usize>,
     pub predictor_hidden: Option<usize>,
+    pub predictor_layers: Option<usize>,
     pub joint_hidden: Option<usize>,
     pub vocab_size: Option<usize>,
     pub prompt_dim: Option<usize>,
+    pub prompt_dictionary: Vec<(String, usize)>,
     pub left_context_frames: Option<usize>,
     pub right_context_frames: Vec<usize>,
     pub model_target: Option<String>,
@@ -25,25 +34,43 @@ impl NemotronConfigInventory {
             Error::ModelLoadError(format!("Failed parsing Nemotron model_config.yaml: {e}"))
         })?;
 
+        let sample_rate = find_usize_by_keys(&value, &["sample_rate", "sample_rate_hz"]);
+
         Ok(Self {
-            sample_rate: find_usize_by_keys(&value, &["sample_rate", "sample_rate_hz"]),
+            sample_rate,
             features: find_usize_by_keys(&value, &["features", "n_mels", "num_mels"]),
+            n_fft: find_usize_by_keys(&value, &["n_fft", "fft_length"]),
+            window_length: find_frame_samples(&value, sample_rate, &["win_length", "window_size"]),
+            hop_length: find_frame_samples(&value, sample_rate, &["hop_length", "window_stride"]),
             encoder_layers: find_usize_by_keys(&value, &["n_layers", "num_layers", "layers"]),
             encoder_dim: find_usize_by_keys(&value, &["d_model", "feat_out", "encoder_dim"]),
             encoder_heads: find_usize_by_keys(&value, &["n_heads", "num_heads"]),
+            subsampling_factor: find_usize_by_keys(&value, &["subsampling_factor"]),
+            subsampling_conv_channels: find_usize_by_keys(&value, &["subsampling_conv_channels"]),
+            ff_expansion_factor: find_usize_by_keys(&value, &["ff_expansion_factor"]),
+            conv_kernel_size: find_usize_by_keys(&value, &["conv_kernel_size"]),
             predictor_hidden: find_usize_by_keys(
                 &value,
                 &["pred_hidden", "prediction_hidden", "pred_hidden_dim"],
             ),
+            predictor_layers: find_usize_by_keys(&value, &["pred_rnn_layers", "prediction_layers"]),
             joint_hidden: find_usize_by_keys(&value, &["joint_hidden", "joint_hidden_dim"]),
             vocab_size: find_usize_by_keys(&value, &["vocab_size", "num_classes"]),
-            prompt_dim: find_usize_by_keys(&value, &["prompt_dim", "prompt_size", "lang_dim"]),
+            prompt_dim: find_usize_by_keys(&value, &["prompt_dim", "prompt_size", "lang_dim"])
+                .or_else(|| find_usize_by_keys(&value, &["num_prompts"])),
+            prompt_dictionary: prompt_dictionary(&value),
             left_context_frames: att_context_size(&value).and_then(|pair| pair.first().copied()),
             right_context_frames: collect_right_context_frames(&value),
             model_target: find_string_by_keys(&value, &["_target_", "target"]),
             output_vocabulary: output_vocabulary(&value),
         })
     }
+}
+
+fn prompt_dictionary(value: &Value) -> Vec<(String, usize)> {
+    let mut entries = find_usize_mapping_by_key(value, "prompt_dictionary").unwrap_or_default();
+    entries.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
+    entries
 }
 
 fn output_vocabulary(value: &Value) -> Vec<String> {
@@ -179,6 +206,65 @@ fn find_usize_by_keys(value: &Value, keys: &[&str]) -> Option<usize> {
     }
 }
 
+fn find_frame_samples(value: &Value, sample_rate: Option<usize>, keys: &[&str]) -> Option<usize> {
+    let raw = find_value_by_keys(value, keys)?;
+    if let Some(samples) = value_to_usize(raw) {
+        return Some(samples);
+    }
+    let seconds = value_to_f64(raw)?;
+    let sample_rate = sample_rate?;
+    Some((seconds * sample_rate as f64).round().max(1.0) as usize)
+}
+
+fn find_value_by_keys<'a>(value: &'a Value, keys: &[&str]) -> Option<&'a Value> {
+    match value {
+        Value::Mapping(map) => {
+            for (key, child) in map {
+                if let Some(name) = scalar_key(key) {
+                    if keys.iter().any(|candidate| *candidate == name) {
+                        return Some(child);
+                    }
+                }
+            }
+            map.values()
+                .find_map(|child| find_value_by_keys(child, keys))
+        }
+        Value::Sequence(items) => items.iter().find_map(|item| find_value_by_keys(item, keys)),
+        _ => None,
+    }
+}
+
+fn find_usize_mapping_by_key(value: &Value, target: &str) -> Option<Vec<(String, usize)>> {
+    match value {
+        Value::Mapping(map) => {
+            for (key, child) in map {
+                if scalar_key(key).is_some_and(|key| key == target) {
+                    if let Value::Mapping(child_map) = child {
+                        let entries = child_map
+                            .iter()
+                            .filter_map(|(key, value)| {
+                                Some((scalar_key(key)?.to_string(), value_to_usize(value)?))
+                            })
+                            .collect::<Vec<_>>();
+                        if !entries.is_empty() {
+                            return Some(entries);
+                        }
+                    }
+                }
+
+                if let Some(found) = find_usize_mapping_by_key(child, target) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Value::Sequence(items) => items
+            .iter()
+            .find_map(|item| find_usize_mapping_by_key(item, target)),
+        _ => None,
+    }
+}
+
 fn find_string_by_keys(value: &Value, keys: &[&str]) -> Option<String> {
     match value {
         Value::Mapping(map) => {
@@ -209,6 +295,19 @@ fn value_to_usize(value: &Value) -> Option<usize> {
         return usize::try_from(num).ok();
     }
     value.as_str()?.parse::<usize>().ok()
+}
+
+fn value_to_f64(value: &Value) -> Option<f64> {
+    if let Some(num) = value.as_f64() {
+        return Some(num);
+    }
+    if let Some(num) = value.as_u64() {
+        return Some(num as f64);
+    }
+    if let Some(num) = value.as_i64() {
+        return Some(num as f64);
+    }
+    value.as_str()?.parse::<f64>().ok()
 }
 
 fn value_to_string_scalar(value: &Value) -> Option<String> {
@@ -246,10 +345,17 @@ model:
   preprocessor:
     sample_rate: 16000
     features: 128
+    n_fft: 512
+    window_size: 0.025
+    window_stride: 0.01
   encoder:
     n_layers: 24
     d_model: 512
     n_heads: 8
+    subsampling_factor: 8
+    subsampling_conv_channels: 256
+    ff_expansion_factor: 4
+    conv_kernel_size: 9
     att_context_size: [56, 13]
     att_context_size_all:
       - [56, 0]
@@ -258,15 +364,21 @@ model:
       - [56, 6]
       - [56, 13]
   decoder:
-    pred_hidden: 640
+    prednet:
+      pred_hidden: 640
+      pred_rnn_layers: 2
     vocab_size: 1024
   joint:
-    joint_hidden: 512
+    jointnet:
+      joint_hidden: 512
     vocabulary:
       - <unk>
       - ▁joint
-  prompt:
-    prompt_dim: 128
+  model_defaults:
+    num_prompts: 128
+    prompt_dictionary:
+      en-US: 0
+      auto: 101
 labels:
   - <unk>
   - <en-US>
@@ -278,13 +390,25 @@ labels:
 
         assert_eq!(inventory.sample_rate, Some(16_000));
         assert_eq!(inventory.features, Some(128));
+        assert_eq!(inventory.n_fft, Some(512));
+        assert_eq!(inventory.window_length, Some(400));
+        assert_eq!(inventory.hop_length, Some(160));
         assert_eq!(inventory.encoder_layers, Some(24));
         assert_eq!(inventory.encoder_dim, Some(512));
         assert_eq!(inventory.encoder_heads, Some(8));
+        assert_eq!(inventory.subsampling_factor, Some(8));
+        assert_eq!(inventory.subsampling_conv_channels, Some(256));
+        assert_eq!(inventory.ff_expansion_factor, Some(4));
+        assert_eq!(inventory.conv_kernel_size, Some(9));
         assert_eq!(inventory.predictor_hidden, Some(640));
+        assert_eq!(inventory.predictor_layers, Some(2));
         assert_eq!(inventory.joint_hidden, Some(512));
         assert_eq!(inventory.vocab_size, Some(1024));
         assert_eq!(inventory.prompt_dim, Some(128));
+        assert_eq!(
+            inventory.prompt_dictionary,
+            vec![("en-US".to_string(), 0), ("auto".to_string(), 101)]
+        );
         assert_eq!(inventory.left_context_frames, Some(56));
         assert_eq!(inventory.right_context_frames, vec![0, 1, 3, 6, 13]);
         assert_eq!(

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/config.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/config.rs
@@ -16,6 +16,7 @@ pub struct NemotronConfigInventory {
     pub left_context_frames: Option<usize>,
     pub right_context_frames: Vec<usize>,
     pub model_target: Option<String>,
+    pub output_vocabulary: Vec<String>,
 }
 
 impl NemotronConfigInventory {
@@ -40,8 +41,15 @@ impl NemotronConfigInventory {
             left_context_frames: att_context_size(&value).and_then(|pair| pair.first().copied()),
             right_context_frames: collect_right_context_frames(&value),
             model_target: find_string_by_keys(&value, &["_target_", "target"]),
+            output_vocabulary: output_vocabulary(&value),
         })
     }
+}
+
+fn output_vocabulary(value: &Value) -> Vec<String> {
+    find_non_empty_string_sequence_by_key(value, "labels")
+        .or_else(|| find_non_empty_string_sequence_by_key(value, "vocabulary"))
+        .unwrap_or_default()
 }
 
 fn collect_right_context_frames(value: &Value) -> Vec<usize> {
@@ -122,6 +130,35 @@ fn find_sequence_by_key(value: &Value, target: &str) -> Option<Vec<Value>> {
     }
 }
 
+fn find_non_empty_string_sequence_by_key(value: &Value, target: &str) -> Option<Vec<String>> {
+    match value {
+        Value::Mapping(map) => {
+            for (key, child) in map {
+                if scalar_key(key).is_some_and(|key| key == target) {
+                    if let Some(seq) = child.as_sequence() {
+                        let tokens = seq
+                            .iter()
+                            .filter_map(value_to_string_scalar)
+                            .collect::<Vec<_>>();
+                        if !tokens.is_empty() {
+                            return Some(tokens);
+                        }
+                    }
+                }
+
+                if let Some(found) = find_non_empty_string_sequence_by_key(child, target) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Value::Sequence(items) => items
+            .iter()
+            .find_map(|item| find_non_empty_string_sequence_by_key(item, target)),
+        _ => None,
+    }
+}
+
 fn find_usize_by_keys(value: &Value, keys: &[&str]) -> Option<usize> {
     match value {
         Value::Mapping(map) => {
@@ -174,6 +211,25 @@ fn value_to_usize(value: &Value) -> Option<usize> {
     value.as_str()?.parse::<usize>().ok()
 }
 
+fn value_to_string_scalar(value: &Value) -> Option<String> {
+    if let Some(value) = value.as_str() {
+        return Some(value.to_string());
+    }
+    if let Some(value) = value.as_u64() {
+        return Some(value.to_string());
+    }
+    if let Some(value) = value.as_i64() {
+        return Some(value.to_string());
+    }
+    if let Some(value) = value.as_f64() {
+        return Some(value.to_string());
+    }
+    if let Some(value) = value.as_bool() {
+        return Some(value.to_string());
+    }
+    None
+}
+
 fn scalar_key(value: &Value) -> Option<&str> {
     value.as_str()
 }
@@ -206,8 +262,16 @@ model:
     vocab_size: 1024
   joint:
     joint_hidden: 512
+    vocabulary:
+      - <unk>
+      - ▁joint
   prompt:
     prompt_dim: 128
+labels:
+  - <unk>
+  - <en-US>
+  - ▁Hello
+  - world
 "#;
 
         let inventory = NemotronConfigInventory::from_yaml_str(yaml).unwrap();
@@ -223,5 +287,29 @@ model:
         assert_eq!(inventory.prompt_dim, Some(128));
         assert_eq!(inventory.left_context_frames, Some(56));
         assert_eq!(inventory.right_context_frames, vec![0, 1, 3, 6, 13]);
+        assert_eq!(
+            inventory.output_vocabulary,
+            vec!["<unk>", "<en-US>", "▁Hello", "world"]
+        );
+    }
+
+    #[test]
+    fn config_inventory_falls_back_to_non_empty_joint_vocabulary() {
+        let yaml = r#"
+model:
+  tokenizer:
+    vocabulary: []
+  joint:
+    num_classes: 3
+    vocabulary:
+      - <unk>
+      - hello
+      - world
+"#;
+
+        let inventory = NemotronConfigInventory::from_yaml_str(yaml).unwrap();
+
+        assert_eq!(inventory.vocab_size, Some(3));
+        assert_eq!(inventory.output_vocabulary, vec!["<unk>", "hello", "world"]);
     }
 }

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/config.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/config.rs
@@ -9,6 +9,7 @@ pub struct NemotronConfigInventory {
     pub n_fft: Option<usize>,
     pub window_length: Option<usize>,
     pub hop_length: Option<usize>,
+    pub normalize: Option<String>,
     pub encoder_layers: Option<usize>,
     pub encoder_dim: Option<usize>,
     pub encoder_heads: Option<usize>,
@@ -42,6 +43,7 @@ impl NemotronConfigInventory {
             n_fft: find_usize_by_keys(&value, &["n_fft", "fft_length"]),
             window_length: find_frame_samples(&value, sample_rate, &["win_length", "window_size"]),
             hop_length: find_frame_samples(&value, sample_rate, &["hop_length", "window_stride"]),
+            normalize: find_string_by_keys(&value, &["normalize"]),
             encoder_layers: find_usize_by_keys(&value, &["n_layers", "num_layers", "layers"]),
             encoder_dim: find_usize_by_keys(&value, &["d_model", "feat_out", "encoder_dim"]),
             encoder_heads: find_usize_by_keys(&value, &["n_heads", "num_heads"]),
@@ -348,6 +350,7 @@ model:
     n_fft: 512
     window_size: 0.025
     window_stride: 0.01
+    normalize: NA
   encoder:
     n_layers: 24
     d_model: 512
@@ -393,6 +396,7 @@ labels:
         assert_eq!(inventory.n_fft, Some(512));
         assert_eq!(inventory.window_length, Some(400));
         assert_eq!(inventory.hop_length, Some(160));
+        assert_eq!(inventory.normalize.as_deref(), Some("NA"));
         assert_eq!(inventory.encoder_layers, Some(24));
         assert_eq!(inventory.encoder_dim, Some(512));
         assert_eq!(inventory.encoder_heads, Some(8));

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
@@ -1,0 +1,10 @@
+//! Nemotron 3.5 ASR artifact and native inference support.
+//!
+//! Phase 1 intentionally exposes only artifact extraction and config inventory.
+//! The FastConformer-RNNT network loader is added in later phases.
+
+pub mod config;
+pub mod nemo;
+
+pub use config::NemotronConfigInventory;
+pub use nemo::{ensure_nemotron_artifacts, NemotronArtifacts, NEMOTRON_NEMO_FILENAME};

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
@@ -1,10 +1,603 @@
 //! Nemotron 3.5 ASR artifact and native inference support.
-//!
-//! Phase 1 intentionally exposes only artifact extraction and config inventory.
-//! The FastConformer-RNNT network loader is added in later phases.
 
 pub mod config;
 pub mod nemo;
 
+use std::fs;
+use std::path::Path;
+
+use serde_json::json;
+
+use crate::backends::DeviceProfile;
+use crate::error::{Error, Result};
+use crate::model::ModelVariant;
+use crate::tokenizer::Tokenizer;
+
 pub use config::NemotronConfigInventory;
 pub use nemo::{ensure_nemotron_artifacts, NemotronArtifacts, NEMOTRON_NEMO_FILENAME};
+
+const SAMPLE_RATE: u32 = 16_000;
+const DEFAULT_STRIP_LANG_TAGS: bool = true;
+const DEFAULT_MAX_AUDIO_SECONDS_HINT: f32 = 30.0;
+const SUPPORTED_TARGET_LANGS: &[&str] = &[
+    "auto", "en-US", "en-GB", "es-US", "es-ES", "fr-FR", "fr-CA", "it-IT", "pt-BR", "pt-PT",
+    "nl-NL", "de-DE", "tr-TR", "ru-RU", "ar-AR", "hi-IN", "ja-JP", "ko-KR", "vi-VN", "uk-UA",
+    "pl-PL", "sv-SE", "cs-CZ", "nb-NO", "da-DK", "bg-BG", "fi-FI", "hr-HR", "sk-SK", "zh-CN",
+    "hu-HU", "ro-RO", "et-EE", "el-GR", "lt-LT", "lv-LV", "mt-MT", "sl-SI", "he-IL", "th-TH",
+    "nn-NO",
+];
+
+#[derive(Debug, Clone)]
+pub struct NemotronAsrTranscriptionOutput {
+    pub text: String,
+    pub language: Option<String>,
+    pub diagnostics: Option<serde_json::Value>,
+}
+
+pub struct NemotronAsrModel {
+    variant: ModelVariant,
+    artifacts: NemotronArtifacts,
+    decoder: NemotronDecoder,
+    runtime_plan: NemotronRuntimePlan,
+    device_profile: DeviceProfile,
+}
+
+enum NemotronDecoder {
+    HfTokenizer(Tokenizer),
+    Vocab(Vec<String>),
+}
+
+impl NemotronDecoder {
+    fn load(artifacts: &NemotronArtifacts) -> Result<Self> {
+        if let Ok(tokenizer) = Tokenizer::from_path(&artifacts.extracted_dir) {
+            return Ok(Self::HfTokenizer(tokenizer));
+        }
+
+        for path in &artifacts.tokenizer_paths {
+            if path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name == "tokenizer.vocab" || name == "vocab.txt")
+            {
+                return Ok(Self::Vocab(load_tokenizer_vocab(path)?));
+            }
+        }
+
+        let asset_list = artifacts
+            .tokenizer_paths
+            .iter()
+            .filter_map(|path| path.file_name().and_then(|name| name.to_str()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        Err(Error::ModelLoadError(format!(
+            "Nemotron tokenizer assets do not include a supported decoder at {} (found: {})",
+            artifacts.extracted_dir.display(),
+            if asset_list.is_empty() {
+                "none"
+            } else {
+                &asset_list
+            }
+        )))
+    }
+
+    fn decode(&self, ids: &[usize]) -> String {
+        match self {
+            Self::HfTokenizer(tokenizer) => {
+                let ids = ids.iter().map(|id| *id as u32).collect::<Vec<_>>();
+                tokenizer.decode(&ids).unwrap_or_default()
+            }
+            Self::Vocab(vocab) => decode_vocab_tokens(ids, vocab),
+        }
+    }
+
+    fn vocab_size(&self) -> usize {
+        match self {
+            Self::HfTokenizer(tokenizer) => tokenizer.vocab_size(),
+            Self::Vocab(vocab) => vocab.len(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NemotronRuntimePlan {
+    sample_rate: u32,
+    feature_bins: Option<usize>,
+    encoder_layers: Option<usize>,
+    encoder_dim: Option<usize>,
+    encoder_heads: Option<usize>,
+    predictor_hidden: Option<usize>,
+    joint_hidden: Option<usize>,
+    prompt_dim: Option<usize>,
+    vocab_size: Option<usize>,
+    default_streaming_profile: NemotronStreamingProfile,
+}
+
+impl NemotronRuntimePlan {
+    fn from_inventory(inventory: &NemotronConfigInventory) -> Result<Self> {
+        let sample_rate = inventory.sample_rate.unwrap_or(SAMPLE_RATE as usize);
+        if sample_rate != SAMPLE_RATE as usize {
+            return Err(Error::ModelLoadError(format!(
+                "Nemotron config advertises sample_rate={sample_rate}, expected {SAMPLE_RATE}"
+            )));
+        }
+
+        Ok(Self {
+            sample_rate: SAMPLE_RATE,
+            feature_bins: inventory.features,
+            encoder_layers: inventory.encoder_layers,
+            encoder_dim: inventory.encoder_dim,
+            encoder_heads: inventory.encoder_heads,
+            predictor_hidden: inventory.predictor_hidden,
+            joint_hidden: inventory.joint_hidden,
+            prompt_dim: inventory.prompt_dim,
+            vocab_size: inventory.vocab_size,
+            default_streaming_profile: NemotronStreamingProfile::from_inventory(inventory)?,
+        })
+    }
+
+    fn diagnostics(&self) -> serde_json::Value {
+        json!({
+            "sample_rate": self.sample_rate,
+            "feature_bins": self.feature_bins,
+            "encoder_layers": self.encoder_layers,
+            "encoder_dim": self.encoder_dim,
+            "encoder_heads": self.encoder_heads,
+            "predictor_hidden": self.predictor_hidden,
+            "joint_hidden": self.joint_hidden,
+            "prompt_dim": self.prompt_dim,
+            "vocab_size": self.vocab_size,
+            "streaming_profile": self.default_streaming_profile.diagnostics(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NemotronStreamingProfile {
+    pub left_context_frames: usize,
+    pub right_context_frames: usize,
+    pub chunk_frames: usize,
+    pub chunk_ms: usize,
+}
+
+impl NemotronStreamingProfile {
+    fn from_inventory(inventory: &NemotronConfigInventory) -> Result<Self> {
+        let left_context_frames = inventory.left_context_frames.unwrap_or(56);
+        let right_context_frames = inventory
+            .right_context_frames
+            .iter()
+            .copied()
+            .max()
+            .unwrap_or(13);
+        Self::new(left_context_frames, right_context_frames)
+    }
+
+    pub fn new(left_context_frames: usize, right_context_frames: usize) -> Result<Self> {
+        if left_context_frames != 56 {
+            return Err(Error::ModelLoadError(format!(
+                "Nemotron 3.5 ASR currently expects 56 left-context frames, got {left_context_frames}"
+            )));
+        }
+        if !matches!(right_context_frames, 0 | 1 | 3 | 6 | 13) {
+            return Err(Error::ModelLoadError(format!(
+                "Unsupported Nemotron right-context profile {right_context_frames}; expected one of 0, 1, 3, 6, 13"
+            )));
+        }
+
+        let chunk_frames = right_context_frames + 1;
+        Ok(Self {
+            left_context_frames,
+            right_context_frames,
+            chunk_frames,
+            chunk_ms: chunk_frames * 80,
+        })
+    }
+
+    fn diagnostics(&self) -> serde_json::Value {
+        json!({
+            "att_context_size": [self.left_context_frames, self.right_context_frames],
+            "chunk_frames": self.chunk_frames,
+            "chunk_ms": self.chunk_ms,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NemotronPromptCondition {
+    target_lang: String,
+    strip_lang_tags: bool,
+    context_prompt: Option<String>,
+}
+
+impl NemotronPromptCondition {
+    fn resolve(language: Option<&str>, prompt: Option<&str>) -> Result<Self> {
+        let language_hint = language
+            .and_then(non_empty_trimmed)
+            .or_else(|| prompt.and_then(non_empty_trimmed).filter(|value| looks_like_lang(value)));
+        let target_lang = normalize_target_lang(language_hint.unwrap_or("auto"))?;
+        let context_prompt = prompt
+            .and_then(non_empty_trimmed)
+            .filter(|value| !looks_like_lang(value))
+            .map(ToOwned::to_owned);
+
+        Ok(Self {
+            target_lang,
+            strip_lang_tags: DEFAULT_STRIP_LANG_TAGS,
+            context_prompt,
+        })
+    }
+
+    fn diagnostics(&self) -> serde_json::Value {
+        json!({
+            "target_lang": self.target_lang,
+            "strip_lang_tags": self.strip_lang_tags,
+            "context_prompt_present": self.context_prompt.is_some(),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct NemotronDecodeRequest {
+    samples: usize,
+    input_sample_rate: u32,
+    target_sample_rate: u32,
+    prompt: NemotronPromptCondition,
+}
+
+impl NemotronDecodeRequest {
+    fn diagnostics(&self) -> serde_json::Value {
+        json!({
+            "samples": self.samples,
+            "input_sample_rate": self.input_sample_rate,
+            "target_sample_rate": self.target_sample_rate,
+            "prompt": self.prompt.diagnostics(),
+        })
+    }
+}
+
+impl NemotronAsrModel {
+    pub fn load(
+        model_dir: &Path,
+        variant: ModelVariant,
+        device_profile: DeviceProfile,
+    ) -> Result<Self> {
+        if variant != ModelVariant::Nemotron35AsrStreaming06B {
+            return Err(Error::InvalidInput(format!(
+                "Variant {} is not a Nemotron 3.5 ASR model",
+                variant.dir_name()
+            )));
+        }
+
+        let artifacts = ensure_nemotron_artifacts(model_dir, variant)?;
+        let runtime_plan = NemotronRuntimePlan::from_inventory(&artifacts.config_inventory)?;
+        let decoder = NemotronDecoder::load(&artifacts)?;
+        if let Some(expected) = runtime_plan.vocab_size {
+            let actual = decoder.vocab_size();
+            if actual < expected {
+                return Err(Error::ModelLoadError(format!(
+                    "Nemotron tokenizer vocabulary is smaller than config: tokenizer={actual}, config={expected}"
+                )));
+            }
+        }
+
+        Ok(Self {
+            variant,
+            artifacts,
+            decoder,
+            runtime_plan,
+            device_profile,
+        })
+    }
+
+    pub fn transcribe(
+        &self,
+        audio: &[f32],
+        sample_rate: u32,
+        language: Option<&str>,
+    ) -> Result<String> {
+        let mut no_op = |_delta: &str| {};
+        self.transcribe_with_callback_and_prompt(audio, sample_rate, language, None, &mut no_op)
+    }
+
+    pub fn transcribe_with_callback(
+        &self,
+        audio: &[f32],
+        sample_rate: u32,
+        language: Option<&str>,
+        on_delta: &mut dyn FnMut(&str),
+    ) -> Result<String> {
+        self.transcribe_with_callback_and_prompt(audio, sample_rate, language, None, on_delta)
+    }
+
+    pub fn transcribe_with_callback_and_prompt(
+        &self,
+        audio: &[f32],
+        sample_rate: u32,
+        language: Option<&str>,
+        prompt: Option<&str>,
+        _on_delta: &mut dyn FnMut(&str),
+    ) -> Result<String> {
+        let request = self.prepare_decode_request(audio, sample_rate, language, prompt)?;
+        Err(self.native_forward_not_ready_error(&request))
+    }
+
+    pub fn transcribe_with_details_and_prompt(
+        &self,
+        audio: &[f32],
+        sample_rate: u32,
+        language: Option<&str>,
+        prompt: Option<&str>,
+    ) -> Result<NemotronAsrTranscriptionOutput> {
+        let request = self.prepare_decode_request(audio, sample_rate, language, prompt)?;
+        Err(self.native_forward_not_ready_error(&request))
+    }
+
+    pub fn max_audio_seconds_hint(&self) -> Option<f32> {
+        Some(DEFAULT_MAX_AUDIO_SECONDS_HINT)
+    }
+
+    pub fn diagnostics_for_prompt(
+        &self,
+        language: Option<&str>,
+        prompt: Option<&str>,
+    ) -> Result<serde_json::Value> {
+        let prompt = NemotronPromptCondition::resolve(language, prompt)?;
+        Ok(json!({
+            "variant": self.variant.dir_name(),
+            "repo_id": self.variant.repo_id(),
+            "device": format!("{:?}", self.device_profile.kind),
+            "nemo_path": self.artifacts.nemo_path.display().to_string(),
+            "checkpoint_path": self.artifacts.checkpoint_path.display().to_string(),
+            "model_config_path": self.artifacts.model_config_path.display().to_string(),
+            "tokenizer_vocab_size": self.decoder.vocab_size(),
+            "runtime": self.runtime_plan.diagnostics(),
+            "prompt": prompt.diagnostics(),
+            "native_forward_status": "pending_fastconformer_rnnt_weight_mapping",
+        }))
+    }
+
+    fn prepare_decode_request(
+        &self,
+        audio: &[f32],
+        sample_rate: u32,
+        language: Option<&str>,
+        prompt: Option<&str>,
+    ) -> Result<NemotronDecodeRequest> {
+        if audio.is_empty() {
+            return Err(Error::InvalidInput("Empty audio input".to_string()));
+        }
+        if sample_rate == 0 {
+            return Err(Error::InvalidInput(
+                "Audio sample rate must be greater than zero".to_string(),
+            ));
+        }
+
+        Ok(NemotronDecodeRequest {
+            samples: audio.len(),
+            input_sample_rate: sample_rate,
+            target_sample_rate: self.runtime_plan.sample_rate,
+            prompt: NemotronPromptCondition::resolve(language, prompt)?,
+        })
+    }
+
+    fn native_forward_not_ready_error(&self, request: &NemotronDecodeRequest) -> Error {
+        Error::InferenceError(format!(
+            "Nemotron 3.5 ASR native FastConformer-RNNT forward pass is not enabled yet; loaded artifacts and prompt diagnostics: {}",
+            request.diagnostics()
+        ))
+    }
+}
+
+fn normalize_target_lang(value: &str) -> Result<String> {
+    let normalized = value.trim().replace('_', "-");
+    if normalized.eq_ignore_ascii_case("auto") {
+        return Ok("auto".to_string());
+    }
+
+    if let Some(locale) = SUPPORTED_TARGET_LANGS
+        .iter()
+        .copied()
+        .find(|candidate| candidate.eq_ignore_ascii_case(&normalized))
+    {
+        return Ok(locale.to_string());
+    }
+
+    if let Some(locale) = default_locale_for_short_code(&normalized.to_ascii_lowercase()) {
+        return Ok(locale.to_string());
+    }
+
+    Err(Error::InvalidInput(format!(
+        "Unsupported Nemotron target_lang '{value}'. Use 'auto' or one of: {}",
+        SUPPORTED_TARGET_LANGS.join(", ")
+    )))
+}
+
+fn default_locale_for_short_code(code: &str) -> Option<&'static str> {
+    match code {
+        "en" => Some("en-US"),
+        "es" => Some("es-ES"),
+        "fr" => Some("fr-FR"),
+        "it" => Some("it-IT"),
+        "pt" => Some("pt-BR"),
+        "nl" => Some("nl-NL"),
+        "de" => Some("de-DE"),
+        "tr" => Some("tr-TR"),
+        "ru" => Some("ru-RU"),
+        "ar" => Some("ar-AR"),
+        "hi" => Some("hi-IN"),
+        "ja" => Some("ja-JP"),
+        "ko" => Some("ko-KR"),
+        "vi" => Some("vi-VN"),
+        "uk" => Some("uk-UA"),
+        "pl" => Some("pl-PL"),
+        "sv" => Some("sv-SE"),
+        "cs" => Some("cs-CZ"),
+        "no" | "nb" => Some("nb-NO"),
+        "da" => Some("da-DK"),
+        "bg" => Some("bg-BG"),
+        "fi" => Some("fi-FI"),
+        "hr" => Some("hr-HR"),
+        "sk" => Some("sk-SK"),
+        "zh" => Some("zh-CN"),
+        "hu" => Some("hu-HU"),
+        "ro" => Some("ro-RO"),
+        "et" => Some("et-EE"),
+        "el" => Some("el-GR"),
+        "lt" => Some("lt-LT"),
+        "lv" => Some("lv-LV"),
+        "mt" => Some("mt-MT"),
+        "sl" => Some("sl-SI"),
+        "he" => Some("he-IL"),
+        "th" => Some("th-TH"),
+        "nn" => Some("nn-NO"),
+        _ => None,
+    }
+}
+
+fn looks_like_lang(value: &str) -> bool {
+    let trimmed = value.trim();
+    trimmed.eq_ignore_ascii_case("auto")
+        || trimmed.len() == 2
+        || (trimmed.len() == 5
+            && trimmed
+                .as_bytes()
+                .get(2)
+                .is_some_and(|separator| *separator == b'-' || *separator == b'_'))
+}
+
+fn non_empty_trimmed(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then_some(trimmed)
+}
+
+fn load_tokenizer_vocab(path: &Path) -> Result<Vec<String>> {
+    let raw = fs::read_to_string(path).map_err(|e| {
+        Error::ModelLoadError(format!(
+            "Failed to read Nemotron tokenizer vocab {}: {}",
+            path.display(),
+            e
+        ))
+    })?;
+
+    let vocab = raw
+        .lines()
+        .filter_map(|line| line.split('\t').next())
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    if vocab.is_empty() {
+        return Err(Error::ModelLoadError(format!(
+            "Nemotron tokenizer vocab at {} is empty",
+            path.display()
+        )));
+    }
+    Ok(vocab)
+}
+
+fn decode_vocab_tokens(ids: &[usize], vocab: &[String]) -> String {
+    let mut out = String::new();
+
+    for &id in ids {
+        let Some(token) = vocab.get(id) else {
+            continue;
+        };
+        if should_skip_token(token) {
+            continue;
+        }
+        if token.starts_with('<') && token.ends_with('>') {
+            continue;
+        }
+        if token.starts_with('▁') {
+            let piece = token.trim_start_matches('▁');
+            if !out.is_empty() && !out.ends_with(' ') {
+                out.push(' ');
+            }
+            out.push_str(piece);
+            continue;
+        }
+        if let Some(piece) = token.strip_prefix("##") {
+            out.push_str(piece);
+            continue;
+        }
+        out.push_str(token);
+    }
+
+    normalize_decoded_text(out)
+}
+
+fn should_skip_token(token: &str) -> bool {
+    matches!(
+        token,
+        "<unk>" | "<pad>" | "<blank>" | "<s>" | "</s>" | "[UNK]" | "[PAD]" | "[BLANK]"
+    )
+}
+
+fn normalize_decoded_text(mut text: String) -> String {
+    text = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    for punct in [".", ",", "!", "?", ":", ";"] {
+        text = text.replace(&format!(" {punct}"), punct);
+    }
+    text.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_condition_defaults_to_auto_language() {
+        let prompt = NemotronPromptCondition::resolve(None, None).unwrap();
+
+        assert_eq!(prompt.target_lang, "auto");
+        assert!(prompt.strip_lang_tags);
+        assert!(prompt.context_prompt.is_none());
+    }
+
+    #[test]
+    fn prompt_condition_accepts_short_language_aliases() {
+        let prompt = NemotronPromptCondition::resolve(Some("de"), None).unwrap();
+        assert_eq!(prompt.target_lang, "de-DE");
+
+        let prompt = NemotronPromptCondition::resolve(None, Some("en_US")).unwrap();
+        assert_eq!(prompt.target_lang, "en-US");
+        assert!(prompt.context_prompt.is_none());
+    }
+
+    #[test]
+    fn prompt_condition_preserves_non_language_prompt_as_context() {
+        let prompt = NemotronPromptCondition::resolve(Some("fr-CA"), Some("medical dictation"))
+            .unwrap();
+
+        assert_eq!(prompt.target_lang, "fr-CA");
+        assert_eq!(prompt.context_prompt.as_deref(), Some("medical dictation"));
+    }
+
+    #[test]
+    fn prompt_condition_rejects_unknown_language() {
+        let err = NemotronPromptCondition::resolve(Some("xx-YY"), None).unwrap_err();
+
+        assert!(err.to_string().contains("Unsupported Nemotron target_lang"));
+    }
+
+    #[test]
+    fn streaming_profile_maps_right_context_to_chunk_ms() {
+        let profile = NemotronStreamingProfile::new(56, 13).unwrap();
+
+        assert_eq!(profile.chunk_frames, 14);
+        assert_eq!(profile.chunk_ms, 1120);
+    }
+
+    #[test]
+    fn vocab_decoder_skips_control_and_language_tags() {
+        let vocab = vec![
+            "<blank>".to_string(),
+            "▁Hello".to_string(),
+            ",".to_string(),
+            "▁world".to_string(),
+            "!".to_string(),
+            "<en-US>".to_string(),
+        ];
+
+        assert_eq!(decode_vocab_tokens(&[0, 1, 2, 3, 4, 5], &vocab), "Hello, world!");
+    }
+}

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
@@ -967,6 +967,9 @@ fn ms_to_samples(ms: usize, sample_rate: u32) -> usize {
 mod tests {
     use super::*;
 
+    use std::path::PathBuf;
+
+    use crate::backends::{DeviceKind, DeviceSelector};
     use uuid::Uuid;
 
     #[test]
@@ -1161,5 +1164,58 @@ mod tests {
             decode_vocab_tokens(&[0, 1, 2, 3, 4, 5], &vocab),
             "Hello, world!"
         );
+    }
+
+    #[test]
+    #[ignore = "requires local Nemotron-3.5-ASR-Streaming-0.6B assets and loads a 2.4 GB checkpoint"]
+    fn nemotron_local_silence_forward_smoke_if_available() {
+        let models_root = std::env::var("IZWI_MODELS_DIR")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                dirs::data_local_dir()
+                    .unwrap_or_else(|| PathBuf::from("."))
+                    .join("izwi")
+                    .join("models")
+            });
+        let model_dir = models_root.join(ModelVariant::Nemotron35AsrStreaming06B.dir_name());
+        let ckpt_path = model_dir.join("nemotron-native").join("model_weights.ckpt");
+        if !ckpt_path.exists() {
+            eprintln!(
+                "Skipping local Nemotron smoke test, checkpoint not found at {}",
+                ckpt_path.display()
+            );
+            return;
+        }
+
+        let backend = std::env::var("IZWI_NEMOTRON_ASR_SMOKE_BACKEND")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "cpu".to_string());
+        let device =
+            DeviceSelector::detect_with_preference(Some(&backend)).expect("requested device");
+        if backend.eq_ignore_ascii_case("metal") && device.kind != DeviceKind::Metal {
+            eprintln!("Skipping local Nemotron Metal smoke test, Metal device was not selected");
+            return;
+        }
+        let model =
+            NemotronAsrModel::load(&model_dir, ModelVariant::Nemotron35AsrStreaming06B, device)
+                .expect("Nemotron ASR model should load");
+        let silence = vec![0.0f32; 1_600];
+        let output = model
+            .transcribe_with_details_and_prompt(&silence, 16_000, Some("English"), None)
+            .expect("Nemotron silent forward should run");
+
+        assert_eq!(output.language.as_deref(), Some("en-US"));
+        let diagnostics = output.diagnostics.expect("diagnostics");
+        assert_eq!(
+            diagnostics["native_forward_status"],
+            "enabled_offline_fastconformer_rnnt"
+        );
+        assert_eq!(diagnostics["prompt_id"], 0);
+        assert!(diagnostics["decode"]["encoded_frames"]
+            .as_u64()
+            .is_some_and(|frames| frames > 0));
     }
 }

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
@@ -19,6 +19,7 @@ pub use nemo::{ensure_nemotron_artifacts, NemotronArtifacts, NEMOTRON_NEMO_FILEN
 const SAMPLE_RATE: u32 = 16_000;
 const DEFAULT_STRIP_LANG_TAGS: bool = true;
 const DEFAULT_MAX_AUDIO_SECONDS_HINT: f32 = 30.0;
+const STREAMING_FRAME_MS: usize = 80;
 const SUPPORTED_TARGET_LANGS: &[&str] = &[
     "auto", "en-US", "en-GB", "es-US", "es-ES", "fr-FR", "fr-CA", "it-IT", "pt-BR", "pt-PT",
     "nl-NL", "de-DE", "tr-TR", "ru-RU", "ar-AR", "hi-IN", "ja-JP", "ko-KR", "vi-VN", "uk-UA",
@@ -110,6 +111,7 @@ struct NemotronRuntimePlan {
     prompt_dim: Option<usize>,
     vocab_size: Option<usize>,
     default_streaming_profile: NemotronStreamingProfile,
+    streaming_profiles: Vec<NemotronStreamingProfile>,
 }
 
 impl NemotronRuntimePlan {
@@ -121,6 +123,14 @@ impl NemotronRuntimePlan {
             )));
         }
 
+        let streaming_profiles = NemotronStreamingProfile::profiles_from_inventory(inventory)?;
+        let default_streaming_profile = streaming_profiles
+            .last()
+            .cloned()
+            .ok_or_else(|| {
+                Error::ModelLoadError("Nemotron config did not yield a streaming profile".to_string())
+            })?;
+
         Ok(Self {
             sample_rate: SAMPLE_RATE,
             feature_bins: inventory.features,
@@ -131,7 +141,8 @@ impl NemotronRuntimePlan {
             joint_hidden: inventory.joint_hidden,
             prompt_dim: inventory.prompt_dim,
             vocab_size: inventory.vocab_size,
-            default_streaming_profile: NemotronStreamingProfile::from_inventory(inventory)?,
+            default_streaming_profile,
+            streaming_profiles,
         })
     }
 
@@ -147,6 +158,7 @@ impl NemotronRuntimePlan {
             "prompt_dim": self.prompt_dim,
             "vocab_size": self.vocab_size,
             "streaming_profile": self.default_streaming_profile.diagnostics(),
+            "streaming_profiles": self.streaming_profiles.iter().map(|profile| profile.diagnostics()).collect::<Vec<_>>(),
         })
     }
 }
@@ -160,15 +172,19 @@ pub struct NemotronStreamingProfile {
 }
 
 impl NemotronStreamingProfile {
-    fn from_inventory(inventory: &NemotronConfigInventory) -> Result<Self> {
+    fn profiles_from_inventory(inventory: &NemotronConfigInventory) -> Result<Vec<Self>> {
         let left_context_frames = inventory.left_context_frames.unwrap_or(56);
-        let right_context_frames = inventory
-            .right_context_frames
-            .iter()
-            .copied()
-            .max()
-            .unwrap_or(13);
-        Self::new(left_context_frames, right_context_frames)
+        let mut right_context_frames = if inventory.right_context_frames.is_empty() {
+            vec![0, 1, 3, 6, 13]
+        } else {
+            inventory.right_context_frames.clone()
+        };
+        right_context_frames.sort_unstable();
+        right_context_frames.dedup();
+        right_context_frames
+            .into_iter()
+            .map(|right| Self::new(left_context_frames, right))
+            .collect()
     }
 
     pub fn new(left_context_frames: usize, right_context_frames: usize) -> Result<Self> {
@@ -188,8 +204,20 @@ impl NemotronStreamingProfile {
             left_context_frames,
             right_context_frames,
             chunk_frames,
-            chunk_ms: chunk_frames * 80,
+            chunk_ms: chunk_frames * STREAMING_FRAME_MS,
         })
+    }
+
+    pub fn chunk_samples(&self, sample_rate: u32) -> usize {
+        ms_to_samples(self.chunk_ms, sample_rate)
+    }
+
+    pub fn left_context_samples(&self, sample_rate: u32) -> usize {
+        ms_to_samples(self.left_context_frames * STREAMING_FRAME_MS, sample_rate)
+    }
+
+    pub fn right_context_samples(&self, sample_rate: u32) -> usize {
+        ms_to_samples(self.right_context_frames * STREAMING_FRAME_MS, sample_rate)
     }
 
     fn diagnostics(&self) -> serde_json::Value {
@@ -197,6 +225,151 @@ impl NemotronStreamingProfile {
             "att_context_size": [self.left_context_frames, self.right_context_frames],
             "chunk_frames": self.chunk_frames,
             "chunk_ms": self.chunk_ms,
+            "cache_reuse_ready": false,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NemotronStreamChunkRange {
+    pub chunk_index: usize,
+    pub start_sample: usize,
+    pub end_sample: usize,
+    pub is_final: bool,
+}
+
+impl NemotronStreamChunkRange {
+    pub fn len_samples(&self) -> usize {
+        self.end_sample.saturating_sub(self.start_sample)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NemotronStreamingCacheStatus {
+    PendingNativeCacheImplementation,
+}
+
+#[derive(Debug, Clone)]
+pub struct NemotronStreamingState {
+    profile: NemotronStreamingProfile,
+    prompt: NemotronPromptCondition,
+    sample_rate: u32,
+    buffered_samples: usize,
+    consumed_samples: usize,
+    chunks_processed: usize,
+    input_finished: bool,
+    cache_status: NemotronStreamingCacheStatus,
+}
+
+impl NemotronStreamingState {
+    fn new(
+        profile: NemotronStreamingProfile,
+        prompt: NemotronPromptCondition,
+        sample_rate: u32,
+    ) -> Self {
+        Self {
+            profile,
+            prompt,
+            sample_rate,
+            buffered_samples: 0,
+            consumed_samples: 0,
+            chunks_processed: 0,
+            input_finished: false,
+            cache_status: NemotronStreamingCacheStatus::PendingNativeCacheImplementation,
+        }
+    }
+
+    pub fn profile(&self) -> &NemotronStreamingProfile {
+        &self.profile
+    }
+
+    pub fn sample_rate(&self) -> u32 {
+        self.sample_rate
+    }
+
+    pub fn buffered_samples(&self) -> usize {
+        self.buffered_samples
+    }
+
+    pub fn consumed_samples(&self) -> usize {
+        self.consumed_samples
+    }
+
+    pub fn chunks_processed(&self) -> usize {
+        self.chunks_processed
+    }
+
+    pub fn push_samples(&mut self, samples: &[f32]) -> Result<()> {
+        if self.input_finished {
+            return Err(Error::InvalidInput(
+                "Cannot push audio into a finalized Nemotron streaming state".to_string(),
+            ));
+        }
+        self.buffered_samples = self.buffered_samples.saturating_add(samples.len());
+        Ok(())
+    }
+
+    pub fn finish_input(&mut self) {
+        self.input_finished = true;
+    }
+
+    pub fn next_ready_chunk(&self) -> Option<NemotronStreamChunkRange> {
+        if self.consumed_samples >= self.buffered_samples {
+            return None;
+        }
+
+        let chunk_samples = self.profile.chunk_samples(self.sample_rate);
+        let planned_end = self.consumed_samples.saturating_add(chunk_samples);
+        if planned_end <= self.buffered_samples {
+            return Some(NemotronStreamChunkRange {
+                chunk_index: self.chunks_processed,
+                start_sample: self.consumed_samples,
+                end_sample: planned_end,
+                is_final: self.input_finished && planned_end == self.buffered_samples,
+            });
+        }
+
+        self.input_finished.then_some(NemotronStreamChunkRange {
+            chunk_index: self.chunks_processed,
+            start_sample: self.consumed_samples,
+            end_sample: self.buffered_samples,
+            is_final: true,
+        })
+    }
+
+    pub fn mark_chunk_consumed(&mut self, chunk: &NemotronStreamChunkRange) -> Result<()> {
+        if chunk.chunk_index != self.chunks_processed {
+            return Err(Error::InvalidInput(format!(
+                "Nemotron stream chunk index mismatch: got {}, expected {}",
+                chunk.chunk_index, self.chunks_processed
+            )));
+        }
+        if chunk.start_sample != self.consumed_samples
+            || chunk.end_sample <= chunk.start_sample
+            || chunk.end_sample > self.buffered_samples
+        {
+            return Err(Error::InvalidInput(format!(
+                "Invalid Nemotron stream chunk range {}..{} for consumed={} buffered={}",
+                chunk.start_sample, chunk.end_sample, self.consumed_samples, self.buffered_samples
+            )));
+        }
+
+        self.consumed_samples = chunk.end_sample;
+        self.chunks_processed = self.chunks_processed.saturating_add(1);
+        Ok(())
+    }
+
+    pub fn diagnostics(&self) -> serde_json::Value {
+        json!({
+            "profile": self.profile.diagnostics(),
+            "prompt": self.prompt.diagnostics(),
+            "sample_rate": self.sample_rate,
+            "buffered_samples": self.buffered_samples,
+            "consumed_samples": self.consumed_samples,
+            "chunks_processed": self.chunks_processed,
+            "input_finished": self.input_finished,
+            "cache_status": format!("{:?}", self.cache_status),
+            "supports_realtime_cache_decode": false,
         })
     }
 }
@@ -333,6 +506,39 @@ impl NemotronAsrModel {
 
     pub fn max_audio_seconds_hint(&self) -> Option<f32> {
         Some(DEFAULT_MAX_AUDIO_SECONDS_HINT)
+    }
+
+    pub fn available_streaming_profiles(&self) -> &[NemotronStreamingProfile] {
+        &self.runtime_plan.streaming_profiles
+    }
+
+    pub fn start_stream_state(
+        &self,
+        language: Option<&str>,
+        prompt: Option<&str>,
+        right_context_frames: Option<usize>,
+    ) -> Result<NemotronStreamingState> {
+        let prompt = NemotronPromptCondition::resolve(language, prompt)?;
+        let profile = match right_context_frames {
+            Some(right_context_frames) => self
+                .runtime_plan
+                .streaming_profiles
+                .iter()
+                .find(|profile| profile.right_context_frames == right_context_frames)
+                .cloned()
+                .ok_or_else(|| {
+                    Error::InvalidInput(format!(
+                        "Nemotron streaming profile with right-context {right_context_frames} is not available"
+                    ))
+                })?,
+            None => self.runtime_plan.default_streaming_profile.clone(),
+        };
+
+        Ok(NemotronStreamingState::new(
+            profile,
+            prompt,
+            self.runtime_plan.sample_rate,
+        ))
     }
 
     pub fn diagnostics_for_prompt(
@@ -540,6 +746,10 @@ fn normalize_decoded_text(mut text: String) -> String {
     text.trim().to_string()
 }
 
+fn ms_to_samples(ms: usize, sample_rate: u32) -> usize {
+    ((sample_rate as usize).saturating_mul(ms)) / 1000
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -585,6 +795,61 @@ mod tests {
 
         assert_eq!(profile.chunk_frames, 14);
         assert_eq!(profile.chunk_ms, 1120);
+        assert_eq!(profile.chunk_samples(16_000), 17_920);
+        assert_eq!(profile.right_context_samples(16_000), 16_640);
+    }
+
+    #[test]
+    fn streaming_profiles_from_inventory_cover_all_model_card_profiles() {
+        let inventory = NemotronConfigInventory {
+            left_context_frames: Some(56),
+            right_context_frames: vec![13, 0, 6, 1, 3],
+            ..Default::default()
+        };
+
+        let profiles = NemotronStreamingProfile::profiles_from_inventory(&inventory).unwrap();
+        let chunk_ms = profiles
+            .iter()
+            .map(|profile| profile.chunk_ms)
+            .collect::<Vec<_>>();
+
+        assert_eq!(chunk_ms, vec![80, 160, 320, 560, 1120]);
+    }
+
+    #[test]
+    fn streaming_state_emits_non_overlapping_ready_chunks() {
+        let profile = NemotronStreamingProfile::new(56, 1).unwrap();
+        let prompt = NemotronPromptCondition::resolve(Some("en-US"), None).unwrap();
+        let mut state = NemotronStreamingState::new(profile, prompt, 16_000);
+
+        state.push_samples(&vec![0.0; 2_560]).unwrap();
+        let first = state.next_ready_chunk().expect("first chunk");
+        assert_eq!(first.start_sample, 0);
+        assert_eq!(first.end_sample, 2_560);
+        assert!(!first.is_final);
+        state.mark_chunk_consumed(&first).unwrap();
+
+        state.push_samples(&vec![0.0; 1_280]).unwrap();
+        assert!(state.next_ready_chunk().is_none());
+        state.finish_input();
+        let tail = state.next_ready_chunk().expect("final tail chunk");
+        assert_eq!(tail.start_sample, 2_560);
+        assert_eq!(tail.end_sample, 3_840);
+        assert!(tail.is_final);
+    }
+
+    #[test]
+    fn streaming_state_rejects_out_of_order_chunk_accounting() {
+        let profile = NemotronStreamingProfile::new(56, 0).unwrap();
+        let prompt = NemotronPromptCondition::resolve(None, None).unwrap();
+        let mut state = NemotronStreamingState::new(profile, prompt, 16_000);
+        state.push_samples(&vec![0.0; 1_280]).unwrap();
+
+        let mut chunk = state.next_ready_chunk().unwrap();
+        chunk.chunk_index = 3;
+        let err = state.mark_chunk_consumed(&chunk).unwrap_err();
+
+        assert!(err.to_string().contains("chunk index mismatch"));
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
@@ -120,12 +120,21 @@ impl NemotronDecoder {
 struct NemotronRuntimePlan {
     sample_rate: u32,
     feature_bins: Option<usize>,
+    n_fft: Option<usize>,
+    window_length: Option<usize>,
+    hop_length: Option<usize>,
     encoder_layers: Option<usize>,
     encoder_dim: Option<usize>,
     encoder_heads: Option<usize>,
+    subsampling_factor: Option<usize>,
+    subsampling_conv_channels: Option<usize>,
+    ff_expansion_factor: Option<usize>,
+    conv_kernel_size: Option<usize>,
     predictor_hidden: Option<usize>,
+    predictor_layers: Option<usize>,
     joint_hidden: Option<usize>,
     prompt_dim: Option<usize>,
+    prompt_dictionary_size: usize,
     vocab_size: Option<usize>,
     default_streaming_profile: NemotronStreamingProfile,
     streaming_profiles: Vec<NemotronStreamingProfile>,
@@ -141,22 +150,28 @@ impl NemotronRuntimePlan {
         }
 
         let streaming_profiles = NemotronStreamingProfile::profiles_from_inventory(inventory)?;
-        let default_streaming_profile = streaming_profiles
-            .last()
-            .cloned()
-            .ok_or_else(|| {
-                Error::ModelLoadError("Nemotron config did not yield a streaming profile".to_string())
-            })?;
+        let default_streaming_profile = streaming_profiles.last().cloned().ok_or_else(|| {
+            Error::ModelLoadError("Nemotron config did not yield a streaming profile".to_string())
+        })?;
 
         Ok(Self {
             sample_rate: SAMPLE_RATE,
             feature_bins: inventory.features,
+            n_fft: inventory.n_fft,
+            window_length: inventory.window_length,
+            hop_length: inventory.hop_length,
             encoder_layers: inventory.encoder_layers,
             encoder_dim: inventory.encoder_dim,
             encoder_heads: inventory.encoder_heads,
+            subsampling_factor: inventory.subsampling_factor,
+            subsampling_conv_channels: inventory.subsampling_conv_channels,
+            ff_expansion_factor: inventory.ff_expansion_factor,
+            conv_kernel_size: inventory.conv_kernel_size,
             predictor_hidden: inventory.predictor_hidden,
+            predictor_layers: inventory.predictor_layers,
             joint_hidden: inventory.joint_hidden,
             prompt_dim: inventory.prompt_dim,
+            prompt_dictionary_size: inventory.prompt_dictionary.len(),
             vocab_size: inventory.vocab_size,
             default_streaming_profile,
             streaming_profiles,
@@ -167,12 +182,21 @@ impl NemotronRuntimePlan {
         json!({
             "sample_rate": self.sample_rate,
             "feature_bins": self.feature_bins,
+            "n_fft": self.n_fft,
+            "window_length": self.window_length,
+            "hop_length": self.hop_length,
             "encoder_layers": self.encoder_layers,
             "encoder_dim": self.encoder_dim,
             "encoder_heads": self.encoder_heads,
+            "subsampling_factor": self.subsampling_factor,
+            "subsampling_conv_channels": self.subsampling_conv_channels,
+            "ff_expansion_factor": self.ff_expansion_factor,
+            "conv_kernel_size": self.conv_kernel_size,
             "predictor_hidden": self.predictor_hidden,
+            "predictor_layers": self.predictor_layers,
             "joint_hidden": self.joint_hidden,
             "prompt_dim": self.prompt_dim,
+            "prompt_dictionary_size": self.prompt_dictionary_size,
             "vocab_size": self.vocab_size,
             "streaming_profile": self.default_streaming_profile.diagnostics(),
             "streaming_profiles": self.streaming_profiles.iter().map(|profile| profile.diagnostics()).collect::<Vec<_>>(),
@@ -400,9 +424,11 @@ struct NemotronPromptCondition {
 
 impl NemotronPromptCondition {
     fn resolve(language: Option<&str>, prompt: Option<&str>) -> Result<Self> {
-        let language_hint = language
-            .and_then(non_empty_trimmed)
-            .or_else(|| prompt.and_then(non_empty_trimmed).filter(|value| looks_like_lang(value)));
+        let language_hint = language.and_then(non_empty_trimmed).or_else(|| {
+            prompt
+                .and_then(non_empty_trimmed)
+                .filter(|value| looks_like_lang(value))
+        });
         let target_lang = normalize_target_lang(language_hint.unwrap_or("auto"))?;
         let context_prompt = prompt
             .and_then(non_empty_trimmed)
@@ -668,8 +694,9 @@ fn language_alias_key(value: &str) -> String {
 
 fn default_locale_for_language_name(name: &str) -> Option<&'static str> {
     match name {
-        "english" | "american english" | "us english" | "u s english"
-        | "united states english" => Some("en-US"),
+        "english" | "american english" | "us english" | "u s english" | "united states english" => {
+            Some("en-US")
+        }
         "british english" | "uk english" | "u k english" | "united kingdom english" => {
             Some("en-GB")
         }
@@ -898,8 +925,8 @@ mod tests {
 
     #[test]
     fn prompt_condition_preserves_non_language_prompt_as_context() {
-        let prompt = NemotronPromptCondition::resolve(Some("fr-CA"), Some("medical dictation"))
-            .unwrap();
+        let prompt =
+            NemotronPromptCondition::resolve(Some("fr-CA"), Some("medical dictation")).unwrap();
 
         assert_eq!(prompt.target_lang, "fr-CA");
         assert_eq!(prompt.context_prompt.as_deref(), Some("medical dictation"));
@@ -1044,6 +1071,9 @@ mod tests {
             "<en-US>".to_string(),
         ];
 
-        assert_eq!(decode_vocab_tokens(&[0, 1, 2, 3, 4, 5], &vocab), "Hello, world!");
+        assert_eq!(
+            decode_vocab_tokens(&[0, 1, 2, 3, 4, 5], &vocab),
+            "Hello, world!"
+        );
     }
 }

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod config;
 pub mod nemo;
+mod network;
 
 use std::fs;
 use std::path::Path;
@@ -123,6 +124,7 @@ struct NemotronRuntimePlan {
     n_fft: Option<usize>,
     window_length: Option<usize>,
     hop_length: Option<usize>,
+    normalize: Option<String>,
     encoder_layers: Option<usize>,
     encoder_dim: Option<usize>,
     encoder_heads: Option<usize>,
@@ -160,6 +162,7 @@ impl NemotronRuntimePlan {
             n_fft: inventory.n_fft,
             window_length: inventory.window_length,
             hop_length: inventory.hop_length,
+            normalize: inventory.normalize.clone(),
             encoder_layers: inventory.encoder_layers,
             encoder_dim: inventory.encoder_dim,
             encoder_heads: inventory.encoder_heads,
@@ -185,6 +188,7 @@ impl NemotronRuntimePlan {
             "n_fft": self.n_fft,
             "window_length": self.window_length,
             "hop_length": self.hop_length,
+            "normalize": self.normalize,
             "encoder_layers": self.encoder_layers,
             "encoder_dim": self.encoder_dim,
             "encoder_heads": self.encoder_heads,

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
@@ -7,6 +7,8 @@ mod network;
 use std::fs;
 use std::path::Path;
 
+use candle_core::{DType, Device};
+use candle_nn::VarBuilder;
 use serde_json::json;
 
 use crate::backends::DeviceProfile;
@@ -16,6 +18,7 @@ use crate::tokenizer::Tokenizer;
 
 pub use config::NemotronConfigInventory;
 pub use nemo::{ensure_nemotron_artifacts, NemotronArtifacts, NEMOTRON_NEMO_FILENAME};
+use network::{resample_linear, NemotronNetwork};
 
 const SAMPLE_RATE: u32 = 16_000;
 const DEFAULT_STRIP_LANG_TAGS: bool = true;
@@ -40,6 +43,7 @@ pub struct NemotronAsrModel {
     variant: ModelVariant,
     artifacts: NemotronArtifacts,
     decoder: NemotronDecoder,
+    network: NemotronNetwork,
     runtime_plan: NemotronRuntimePlan,
     device_profile: DeviceProfile,
 }
@@ -491,11 +495,22 @@ impl NemotronAsrModel {
         let runtime_plan = NemotronRuntimePlan::from_inventory(&artifacts.config_inventory)?;
         validate_config_output_vocabulary(&artifacts.config_inventory)?;
         let decoder = NemotronDecoder::load(&artifacts)?;
+        let device = select_device_for_nemotron(&device_profile);
+        let vb =
+            VarBuilder::from_pth(&artifacts.checkpoint_path, DType::F32, &device).map_err(|e| {
+                Error::ModelLoadError(format!(
+                    "Failed to load Nemotron checkpoint {}: {}",
+                    artifacts.checkpoint_path.display(),
+                    e
+                ))
+            })?;
+        let network = NemotronNetwork::load(&vb, &artifacts.config_inventory)?;
 
         Ok(Self {
             variant,
             artifacts,
             decoder,
+            network,
             runtime_plan,
             device_profile,
         })
@@ -527,10 +542,11 @@ impl NemotronAsrModel {
         sample_rate: u32,
         language: Option<&str>,
         prompt: Option<&str>,
-        _on_delta: &mut dyn FnMut(&str),
+        on_delta: &mut dyn FnMut(&str),
     ) -> Result<String> {
         let request = self.prepare_decode_request(audio, sample_rate, language, prompt)?;
-        Err(self.native_forward_not_ready_error(&request))
+        let output = self.decode_offline(audio, &request, on_delta)?;
+        Ok(output.text)
     }
 
     pub fn transcribe_with_details_and_prompt(
@@ -541,7 +557,8 @@ impl NemotronAsrModel {
         prompt: Option<&str>,
     ) -> Result<NemotronAsrTranscriptionOutput> {
         let request = self.prepare_decode_request(audio, sample_rate, language, prompt)?;
-        Err(self.native_forward_not_ready_error(&request))
+        let mut no_op = |_delta: &str| {};
+        self.decode_offline(audio, &request, &mut no_op)
     }
 
     pub fn max_audio_seconds_hint(&self) -> Option<f32> {
@@ -587,6 +604,7 @@ impl NemotronAsrModel {
         prompt: Option<&str>,
     ) -> Result<serde_json::Value> {
         let prompt = NemotronPromptCondition::resolve(language, prompt)?;
+        let prompt_id = self.network.prompt_id(&prompt.target_lang)?;
         Ok(json!({
             "variant": self.variant.dir_name(),
             "repo_id": self.variant.repo_id(),
@@ -599,7 +617,10 @@ impl NemotronAsrModel {
             "decoder_source": self.decoder.source(),
             "runtime": self.runtime_plan.diagnostics(),
             "prompt": prompt.diagnostics(),
-            "native_forward_status": "pending_fastconformer_rnnt_weight_mapping",
+            "prompt_id": prompt_id,
+            "blank_id": self.network.blank_idx(),
+            "native_forward_status": "enabled_offline_fastconformer_rnnt",
+            "supports_realtime_cache_decode": false,
         }))
     }
 
@@ -627,12 +648,61 @@ impl NemotronAsrModel {
         })
     }
 
-    fn native_forward_not_ready_error(&self, request: &NemotronDecodeRequest) -> Error {
-        Error::InferenceError(format!(
-            "Nemotron 3.5 ASR native FastConformer-RNNT forward pass is not enabled yet; loaded artifacts and prompt diagnostics: {}",
-            request.diagnostics()
-        ))
+    fn decode_offline(
+        &self,
+        audio: &[f32],
+        request: &NemotronDecodeRequest,
+        on_delta: &mut dyn FnMut(&str),
+    ) -> Result<NemotronAsrTranscriptionOutput> {
+        let audio_16khz = if request.input_sample_rate == request.target_sample_rate {
+            audio.to_vec()
+        } else {
+            resample_linear(audio, request.input_sample_rate, request.target_sample_rate)
+        };
+        let prompt_id = self.network.prompt_id(&request.prompt.target_lang)?;
+        let (encoded, encoded_len) = self.network.encode_with_prompt(&audio_16khz, prompt_id)?;
+
+        let mut token_ids = Vec::<usize>::new();
+        let mut assembled = String::new();
+        let mut on_token = |token_id: usize| {
+            token_ids.push(token_id);
+            let decoded = self.decoder.decode(&token_ids);
+            let delta = text_delta(&assembled, &decoded);
+            if !delta.is_empty() {
+                on_delta(delta.as_str());
+            }
+            assembled = decoded;
+        };
+        let decoded = self
+            .network
+            .decode_rnnt_greedy(&encoded, encoded_len, &mut on_token)?;
+        if assembled.is_empty() {
+            assembled = self.decoder.decode(&decoded.token_ids);
+        }
+
+        Ok(NemotronAsrTranscriptionOutput {
+            text: assembled,
+            language: Some(request.prompt.target_lang.clone()),
+            diagnostics: Some(json!({
+                "audio": {
+                    "input_sample_rate": request.input_sample_rate,
+                    "target_sample_rate": request.target_sample_rate,
+                    "input_samples": request.samples,
+                    "resampled_samples": audio_16khz.len(),
+                },
+                "prompt": request.prompt.diagnostics(),
+                "prompt_id": prompt_id,
+                "blank_id": self.network.blank_idx(),
+                "native_forward_status": "enabled_offline_fastconformer_rnnt",
+                "decode": decoded.stats.diagnostics(),
+                "supports_realtime_cache_decode": false,
+            })),
+        })
     }
+}
+
+fn select_device_for_nemotron(device_profile: &DeviceProfile) -> Device {
+    device_profile.device.clone()
 }
 
 fn validate_config_output_vocabulary(inventory: &NemotronConfigInventory) -> Result<()> {
@@ -860,6 +930,18 @@ fn decode_vocab_tokens(ids: &[usize], vocab: &[String]) -> String {
     }
 
     normalize_decoded_text(out)
+}
+
+fn text_delta(previous: &str, current: &str) -> String {
+    if let Some(delta) = current.strip_prefix(previous) {
+        return delta.to_string();
+    }
+    let common = previous
+        .chars()
+        .zip(current.chars())
+        .take_while(|(a, b)| a == b)
+        .count();
+    current.chars().skip(common).collect()
 }
 
 fn should_skip_token(token: &str) -> bool {

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
@@ -45,11 +45,18 @@ pub struct NemotronAsrModel {
 
 enum NemotronDecoder {
     HfTokenizer(Tokenizer),
+    ConfigLabels(Vec<String>),
     Vocab(Vec<String>),
 }
 
 impl NemotronDecoder {
     fn load(artifacts: &NemotronArtifacts) -> Result<Self> {
+        if !artifacts.config_inventory.output_vocabulary.is_empty() {
+            return Ok(Self::ConfigLabels(
+                artifacts.config_inventory.output_vocabulary.clone(),
+            ));
+        }
+
         if let Ok(tokenizer) = Tokenizer::from_path(&artifacts.extracted_dir) {
             return Ok(Self::HfTokenizer(tokenizer));
         }
@@ -87,6 +94,7 @@ impl NemotronDecoder {
                 let ids = ids.iter().map(|id| *id as u32).collect::<Vec<_>>();
                 tokenizer.decode(&ids).unwrap_or_default()
             }
+            Self::ConfigLabels(vocab) => decode_vocab_tokens(ids, vocab),
             Self::Vocab(vocab) => decode_vocab_tokens(ids, vocab),
         }
     }
@@ -94,7 +102,16 @@ impl NemotronDecoder {
     fn vocab_size(&self) -> usize {
         match self {
             Self::HfTokenizer(tokenizer) => tokenizer.vocab_size(),
+            Self::ConfigLabels(vocab) => vocab.len(),
             Self::Vocab(vocab) => vocab.len(),
+        }
+    }
+
+    fn source(&self) -> &'static str {
+        match self {
+            Self::HfTokenizer(_) => "huggingface_tokenizer",
+            Self::ConfigLabels(_) => "config_labels",
+            Self::Vocab(_) => "vocab_file",
         }
     }
 }
@@ -442,15 +459,8 @@ impl NemotronAsrModel {
 
         let artifacts = ensure_nemotron_artifacts(model_dir, variant)?;
         let runtime_plan = NemotronRuntimePlan::from_inventory(&artifacts.config_inventory)?;
+        validate_config_output_vocabulary(&artifacts.config_inventory)?;
         let decoder = NemotronDecoder::load(&artifacts)?;
-        if let Some(expected) = runtime_plan.vocab_size {
-            let actual = decoder.vocab_size();
-            if actual < expected {
-                return Err(Error::ModelLoadError(format!(
-                    "Nemotron tokenizer vocabulary is smaller than config: tokenizer={actual}, config={expected}"
-                )));
-            }
-        }
 
         Ok(Self {
             variant,
@@ -555,6 +565,8 @@ impl NemotronAsrModel {
             "checkpoint_path": self.artifacts.checkpoint_path.display().to_string(),
             "model_config_path": self.artifacts.model_config_path.display().to_string(),
             "tokenizer_vocab_size": self.decoder.vocab_size(),
+            "decoder_vocabulary_size": self.decoder.vocab_size(),
+            "decoder_source": self.decoder.source(),
             "runtime": self.runtime_plan.diagnostics(),
             "prompt": prompt.diagnostics(),
             "native_forward_status": "pending_fastconformer_rnnt_weight_mapping",
@@ -591,6 +603,23 @@ impl NemotronAsrModel {
             request.diagnostics()
         ))
     }
+}
+
+fn validate_config_output_vocabulary(inventory: &NemotronConfigInventory) -> Result<()> {
+    let Some(expected) = inventory.vocab_size else {
+        return Ok(());
+    };
+    if inventory.output_vocabulary.is_empty() {
+        return Ok(());
+    }
+
+    let actual = inventory.output_vocabulary.len();
+    if actual != expected {
+        return Err(Error::ModelLoadError(format!(
+            "Nemotron output vocabulary length does not match config: labels={actual}, config={expected}"
+        )));
+    }
+    Ok(())
 }
 
 fn normalize_target_lang(value: &str) -> Result<String> {
@@ -754,6 +783,8 @@ fn ms_to_samples(ms: usize, sample_rate: u32) -> usize {
 mod tests {
     use super::*;
 
+    use uuid::Uuid;
+
     #[test]
     fn prompt_condition_defaults_to_auto_language() {
         let prompt = NemotronPromptCondition::resolve(None, None).unwrap();
@@ -850,6 +881,55 @@ mod tests {
         let err = state.mark_chunk_consumed(&chunk).unwrap_err();
 
         assert!(err.to_string().contains("chunk index mismatch"));
+    }
+
+    #[test]
+    fn decoder_prefers_config_labels_over_short_vocab_txt() {
+        let temp_dir = std::env::temp_dir().join(format!("nemotron-decoder-{}", Uuid::new_v4()));
+        fs::create_dir_all(&temp_dir).unwrap();
+        let vocab_path = temp_dir.join("vocab.txt");
+        fs::write(&vocab_path, "##hello\n##world\n").unwrap();
+        let artifacts = NemotronArtifacts {
+            nemo_path: temp_dir.join("model.nemo"),
+            extracted_dir: temp_dir.clone(),
+            model_config_path: temp_dir.join("model_config.yaml"),
+            checkpoint_path: temp_dir.join("model_weights.ckpt"),
+            tokenizer_paths: vec![vocab_path],
+            config_inventory: NemotronConfigInventory {
+                vocab_size: Some(4),
+                output_vocabulary: vec![
+                    "<unk>".to_string(),
+                    "<en-US>".to_string(),
+                    "▁hello".to_string(),
+                    "▁world".to_string(),
+                ],
+                ..Default::default()
+            },
+        };
+
+        validate_config_output_vocabulary(&artifacts.config_inventory).unwrap();
+        let decoder = NemotronDecoder::load(&artifacts).unwrap();
+
+        assert_eq!(decoder.source(), "config_labels");
+        assert_eq!(decoder.vocab_size(), 4);
+        assert_eq!(decoder.decode(&[0, 1, 2, 3]), "hello world");
+
+        fs::remove_dir_all(temp_dir).unwrap();
+    }
+
+    #[test]
+    fn config_output_vocabulary_must_match_config_vocab_size() {
+        let inventory = NemotronConfigInventory {
+            vocab_size: Some(3),
+            output_vocabulary: vec!["<unk>".to_string(), "hello".to_string()],
+            ..Default::default()
+        };
+
+        let err = validate_config_output_vocabulary(&inventory).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("output vocabulary length does not match config"));
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
@@ -636,14 +636,85 @@ fn normalize_target_lang(value: &str) -> Result<String> {
         return Ok(locale.to_string());
     }
 
+    let alias_key = language_alias_key(&normalized);
+    if let Some(locale) = default_locale_for_language_name(&alias_key) {
+        return Ok(locale.to_string());
+    }
+
     if let Some(locale) = default_locale_for_short_code(&normalized.to_ascii_lowercase()) {
         return Ok(locale.to_string());
     }
 
     Err(Error::InvalidInput(format!(
-        "Unsupported Nemotron target_lang '{value}'. Use 'auto' or one of: {}",
+        "Unsupported Nemotron target_lang '{value}'. Use 'auto', a supported language name, or one of: {}",
         SUPPORTED_TARGET_LANGS.join(", ")
     )))
+}
+
+fn language_alias_key(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut last_was_space = true;
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            last_was_space = false;
+        } else if !last_was_space {
+            out.push(' ');
+            last_was_space = true;
+        }
+    }
+    out.trim().to_string()
+}
+
+fn default_locale_for_language_name(name: &str) -> Option<&'static str> {
+    match name {
+        "english" | "american english" | "us english" | "u s english"
+        | "united states english" => Some("en-US"),
+        "british english" | "uk english" | "u k english" | "united kingdom english" => {
+            Some("en-GB")
+        }
+        "spanish" | "castilian" | "european spanish" | "spain spanish" => Some("es-ES"),
+        "us spanish" | "u s spanish" | "united states spanish" | "american spanish" => {
+            Some("es-US")
+        }
+        "french" | "european french" | "france french" => Some("fr-FR"),
+        "canadian french" | "canada french" => Some("fr-CA"),
+        "italian" => Some("it-IT"),
+        "portuguese" | "brazilian portuguese" | "brazil portuguese" => Some("pt-BR"),
+        "european portuguese" | "portugal portuguese" => Some("pt-PT"),
+        "dutch" => Some("nl-NL"),
+        "german" => Some("de-DE"),
+        "turkish" => Some("tr-TR"),
+        "russian" => Some("ru-RU"),
+        "arabic" => Some("ar-AR"),
+        "hindi" => Some("hi-IN"),
+        "japanese" => Some("ja-JP"),
+        "korean" => Some("ko-KR"),
+        "vietnamese" => Some("vi-VN"),
+        "ukrainian" => Some("uk-UA"),
+        "polish" => Some("pl-PL"),
+        "swedish" => Some("sv-SE"),
+        "czech" => Some("cs-CZ"),
+        "norwegian" | "norwegian bokmal" | "bokmal" => Some("nb-NO"),
+        "norwegian nynorsk" | "nynorsk" => Some("nn-NO"),
+        "danish" => Some("da-DK"),
+        "bulgarian" => Some("bg-BG"),
+        "finnish" => Some("fi-FI"),
+        "croatian" => Some("hr-HR"),
+        "slovak" => Some("sk-SK"),
+        "chinese" | "mandarin" | "mandarin chinese" | "simplified chinese" => Some("zh-CN"),
+        "hungarian" => Some("hu-HU"),
+        "romanian" => Some("ro-RO"),
+        "estonian" => Some("et-EE"),
+        "greek" => Some("el-GR"),
+        "lithuanian" => Some("lt-LT"),
+        "latvian" => Some("lv-LV"),
+        "maltese" => Some("mt-MT"),
+        "slovenian" | "slovene" => Some("sl-SI"),
+        "hebrew" => Some("he-IL"),
+        "thai" => Some("th-TH"),
+        _ => None,
+    }
 }
 
 fn default_locale_for_short_code(code: &str) -> Option<&'static str> {
@@ -805,6 +876,27 @@ mod tests {
     }
 
     #[test]
+    fn prompt_condition_accepts_public_language_names() {
+        let prompt = NemotronPromptCondition::resolve(Some("English"), None).unwrap();
+        assert_eq!(prompt.target_lang, "en-US");
+
+        let prompt = NemotronPromptCondition::resolve(Some("Auto"), None).unwrap();
+        assert_eq!(prompt.target_lang, "auto");
+
+        let prompt = NemotronPromptCondition::resolve(Some("British English"), None).unwrap();
+        assert_eq!(prompt.target_lang, "en-GB");
+
+        let prompt = NemotronPromptCondition::resolve(Some("Canadian French"), None).unwrap();
+        assert_eq!(prompt.target_lang, "fr-CA");
+
+        let prompt = NemotronPromptCondition::resolve(Some("European Portuguese"), None).unwrap();
+        assert_eq!(prompt.target_lang, "pt-PT");
+
+        let prompt = NemotronPromptCondition::resolve(Some("Mandarin"), None).unwrap();
+        assert_eq!(prompt.target_lang, "zh-CN");
+    }
+
+    #[test]
     fn prompt_condition_preserves_non_language_prompt_as_context() {
         let prompt = NemotronPromptCondition::resolve(Some("fr-CA"), Some("medical dictation"))
             .unwrap();
@@ -818,6 +910,15 @@ mod tests {
         let err = NemotronPromptCondition::resolve(Some("xx-YY"), None).unwrap_err();
 
         assert!(err.to_string().contains("Unsupported Nemotron target_lang"));
+    }
+
+    #[test]
+    fn prompt_condition_rejects_unsupported_public_language_name() {
+        let err = NemotronPromptCondition::resolve(Some("Cantonese"), None).unwrap_err();
+        let msg = err.to_string();
+
+        assert!(msg.contains("Unsupported Nemotron target_lang 'Cantonese'"));
+        assert!(msg.contains("supported language name"));
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/nemo.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/nemo.rs
@@ -1,0 +1,343 @@
+use std::fs::{self, File};
+use std::io::{self, Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+use flate2::read::GzDecoder;
+use tar::Archive;
+
+use crate::error::{Error, Result};
+use crate::model::ModelVariant;
+
+use super::config::NemotronConfigInventory;
+
+pub const NEMOTRON_NEMO_FILENAME: &str = "nemotron-3.5-asr-streaming-0.6b.nemo";
+
+const OPTIONAL_TOKENIZER_SUFFIXES: &[&str] = &[
+    "tokenizer.model",
+    "tokenizer.vocab",
+    "vocab.txt",
+    "vocab.json",
+    "merges.txt",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+];
+
+#[derive(Debug, Clone)]
+pub struct NemotronArtifacts {
+    pub nemo_path: PathBuf,
+    pub extracted_dir: PathBuf,
+    pub model_config_path: PathBuf,
+    pub checkpoint_path: PathBuf,
+    pub tokenizer_paths: Vec<PathBuf>,
+    pub config_inventory: NemotronConfigInventory,
+}
+
+pub fn ensure_nemotron_artifacts(
+    model_dir: &Path,
+    variant: ModelVariant,
+) -> Result<NemotronArtifacts> {
+    if variant != ModelVariant::Nemotron35AsrStreaming06B {
+        return Err(Error::InvalidInput(format!(
+            "Unsupported Nemotron ASR variant: {}",
+            variant.dir_name()
+        )));
+    }
+
+    let nemo_path = model_dir.join(NEMOTRON_NEMO_FILENAME);
+    if !nemo_path.exists() {
+        return Err(Error::ModelNotFound(format!(
+            "Missing .nemo checkpoint for {} at {}",
+            variant.dir_name(),
+            nemo_path.display()
+        )));
+    }
+
+    let extracted_dir = model_dir.join("nemotron-native");
+    fs::create_dir_all(&extracted_dir).map_err(|e| {
+        Error::ModelLoadError(format!(
+            "Failed to create Nemotron cache directory {}: {}",
+            extracted_dir.display(),
+            e
+        ))
+    })?;
+
+    let model_config_path = extracted_dir.join("model_config.yaml");
+    let checkpoint_path = extracted_dir.join("model_weights.ckpt");
+
+    if !model_config_path.exists() || !checkpoint_path.exists() {
+        extract_nemotron_entries(
+            &nemo_path,
+            &extracted_dir,
+            &model_config_path,
+            &checkpoint_path,
+        )?;
+    }
+
+    let tokenizer_paths = discover_tokenizer_paths(&extracted_dir)?;
+    let config_contents = fs::read_to_string(&model_config_path).map_err(|e| {
+        Error::ModelLoadError(format!(
+            "Failed reading Nemotron config {}: {}",
+            model_config_path.display(),
+            e
+        ))
+    })?;
+    let config_inventory = NemotronConfigInventory::from_yaml_str(&config_contents)?;
+
+    Ok(NemotronArtifacts {
+        nemo_path,
+        extracted_dir,
+        model_config_path,
+        checkpoint_path,
+        tokenizer_paths,
+        config_inventory,
+    })
+}
+
+fn extract_nemotron_entries(
+    nemo_path: &Path,
+    extracted_dir: &Path,
+    model_config_path: &Path,
+    checkpoint_path: &Path,
+) -> Result<()> {
+    let mut archive = open_nemo_archive(nemo_path)?;
+    let mut found_config = false;
+    let mut found_checkpoint = false;
+
+    for entry in archive.entries().map_err(|e| {
+        Error::ModelLoadError(format!(
+            "Failed reading .nemo archive {}: {}",
+            nemo_path.display(),
+            e
+        ))
+    })? {
+        let mut entry = entry.map_err(|e| {
+            Error::ModelLoadError(format!(
+                "Failed iterating .nemo archive {}: {}",
+                nemo_path.display(),
+                e
+            ))
+        })?;
+        let entry_path = entry
+            .path()
+            .map_err(|e| {
+                Error::ModelLoadError(format!(
+                    "Failed reading archive entry path in {}: {}",
+                    nemo_path.display(),
+                    e
+                ))
+            })?
+            .to_string_lossy()
+            .into_owned();
+
+        if entry_path.ends_with("model_config.yaml") {
+            extract_entry_to_file(&mut entry, model_config_path)?;
+            found_config = true;
+            continue;
+        }
+
+        if entry_path.ends_with("model_weights.ckpt") {
+            extract_entry_to_file(&mut entry, checkpoint_path)?;
+            found_checkpoint = true;
+            continue;
+        }
+
+        if let Some(filename) = tokenizer_asset_filename(&entry_path) {
+            extract_entry_to_file(&mut entry, &extracted_dir.join(filename))?;
+        }
+    }
+
+    let mut missing = Vec::new();
+    if !found_config {
+        missing.push("model_config.yaml");
+    }
+    if !found_checkpoint {
+        missing.push("model_weights.ckpt");
+    }
+    if !missing.is_empty() {
+        return Err(Error::ModelLoadError(format!(
+            "Missing required files in .nemo archive {}: {}",
+            nemo_path.display(),
+            missing.join(", ")
+        )));
+    }
+
+    Ok(())
+}
+
+fn tokenizer_asset_filename(entry_path: &str) -> Option<&'static str> {
+    OPTIONAL_TOKENIZER_SUFFIXES
+        .iter()
+        .copied()
+        .find(|suffix| entry_path.ends_with(suffix))
+}
+
+fn discover_tokenizer_paths(extracted_dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    for suffix in OPTIONAL_TOKENIZER_SUFFIXES {
+        let path = extracted_dir.join(suffix);
+        if path.exists() {
+            paths.push(path);
+        }
+    }
+    Ok(paths)
+}
+
+fn open_nemo_archive(nemo_path: &Path) -> Result<Archive<Box<dyn Read>>> {
+    let mut file = File::open(nemo_path).map_err(|e| {
+        Error::ModelLoadError(format!(
+            "Failed opening .nemo archive {}: {}",
+            nemo_path.display(),
+            e
+        ))
+    })?;
+    let mut magic = [0u8; 2];
+    let read = file.read(&mut magic).map_err(|e| {
+        Error::ModelLoadError(format!(
+            "Failed reading .nemo archive header {}: {}",
+            nemo_path.display(),
+            e
+        ))
+    })?;
+    file.seek(SeekFrom::Start(0)).map_err(|e| {
+        Error::ModelLoadError(format!(
+            "Failed rewinding .nemo archive {}: {}",
+            nemo_path.display(),
+            e
+        ))
+    })?;
+
+    let reader: Box<dyn Read> = if read == 2 && magic == [0x1f, 0x8b] {
+        Box::new(GzDecoder::new(file))
+    } else {
+        Box::new(file)
+    };
+    Ok(Archive::new(reader))
+}
+
+fn extract_entry_to_file<R: Read>(entry: &mut tar::Entry<'_, R>, dest: &Path) -> Result<()> {
+    let tmp_path = dest.with_extension("tmp");
+    let mut tmp_file = File::create(&tmp_path).map_err(|e| {
+        Error::ModelLoadError(format!(
+            "Failed creating temp extraction file {}: {}",
+            tmp_path.display(),
+            e
+        ))
+    })?;
+
+    io::copy(entry, &mut tmp_file).map_err(|e| {
+        Error::ModelLoadError(format!(
+            "Failed writing extracted .nemo entry to {}: {}",
+            tmp_path.display(),
+            e
+        ))
+    })?;
+
+    fs::rename(&tmp_path, dest).map_err(|e| {
+        Error::ModelLoadError(format!(
+            "Failed moving extracted artifact into {}: {}",
+            dest.display(),
+            e
+        ))
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+    use std::io::Write;
+    use tar::Builder;
+    use uuid::Uuid;
+
+    #[test]
+    fn ensure_nemotron_artifacts_extracts_required_files_and_tokenizer_assets() {
+        let temp_dir = std::env::temp_dir().join(format!("nemotron-nemo-{}", Uuid::new_v4()));
+        fs::create_dir_all(&temp_dir).unwrap();
+        let model_dir = temp_dir.join(ModelVariant::Nemotron35AsrStreaming06B.dir_name());
+        fs::create_dir_all(&model_dir).unwrap();
+
+        let nemo_path = model_dir.join(NEMOTRON_NEMO_FILENAME);
+        let nemo_file = File::create(&nemo_path).unwrap();
+        let encoder = GzEncoder::new(nemo_file, Compression::default());
+        let mut builder = Builder::new(encoder);
+
+        add_archive_file(
+            &mut builder,
+            "nested/model_config.yaml",
+            br#"
+model:
+  _target_: nemo.collections.asr.models.EncDecRNNTBPEModel
+  preprocessor:
+    sample_rate: 16000
+    features: 128
+  encoder:
+    n_layers: 24
+    d_model: 512
+    n_heads: 8
+    att_context_size: [56, 13]
+  prompt:
+    prompt_dim: 128
+"#,
+        );
+        add_archive_file(&mut builder, "nested/model_weights.ckpt", b"checkpoint");
+        add_archive_file(&mut builder, "nested/tokenizer.vocab", b"<blank>\nhello\n");
+        let encoder = builder.into_inner().unwrap();
+        encoder.finish().unwrap();
+
+        let artifacts =
+            ensure_nemotron_artifacts(&model_dir, ModelVariant::Nemotron35AsrStreaming06B).unwrap();
+
+        assert!(artifacts.model_config_path.exists());
+        assert_eq!(fs::read(artifacts.checkpoint_path).unwrap(), b"checkpoint");
+        assert_eq!(artifacts.config_inventory.sample_rate, Some(16_000));
+        assert_eq!(artifacts.config_inventory.encoder_layers, Some(24));
+        assert_eq!(artifacts.config_inventory.prompt_dim, Some(128));
+        assert_eq!(artifacts.config_inventory.left_context_frames, Some(56));
+        assert_eq!(artifacts.config_inventory.right_context_frames, vec![13]);
+        assert_eq!(artifacts.tokenizer_paths.len(), 1);
+        assert_eq!(
+            fs::read_to_string(&artifacts.tokenizer_paths[0]).unwrap(),
+            "<blank>\nhello\n"
+        );
+
+        fs::remove_dir_all(temp_dir).unwrap();
+    }
+
+    #[test]
+    fn ensure_nemotron_artifacts_rejects_missing_checkpoint() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("nemotron-nemo-missing-{}", Uuid::new_v4()));
+        fs::create_dir_all(&temp_dir).unwrap();
+        let model_dir = temp_dir.join(ModelVariant::Nemotron35AsrStreaming06B.dir_name());
+        fs::create_dir_all(&model_dir).unwrap();
+
+        let nemo_path = model_dir.join(NEMOTRON_NEMO_FILENAME);
+        let mut builder = Builder::new(File::create(&nemo_path).unwrap());
+        add_archive_file(
+            &mut builder,
+            "model_config.yaml",
+            b"model:\n  preprocessor:\n    sample_rate: 16000\n",
+        );
+        builder.finish().unwrap();
+
+        let err = ensure_nemotron_artifacts(&model_dir, ModelVariant::Nemotron35AsrStreaming06B)
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("model_weights.ckpt"), "{msg}");
+
+        fs::remove_dir_all(temp_dir).unwrap();
+    }
+
+    fn add_archive_file<W: Write>(builder: &mut Builder<W>, path: &str, contents: &[u8]) {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append_data(&mut header, path, contents).unwrap();
+    }
+}

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
@@ -1,0 +1,1092 @@
+use std::collections::HashMap;
+
+use candle_core::{DType, Device, IndexOp, Tensor};
+use candle_nn::ops;
+use candle_nn::{
+    batch_norm, layer_norm, Conv1d, Conv1dConfig, Conv2d, Conv2dConfig, LayerNorm, Linear, Module,
+    ModuleT, VarBuilder,
+};
+use rustfft::num_complex::Complex;
+use rustfft::FftPlanner;
+use serde_json::json;
+
+use super::config::NemotronConfigInventory;
+use crate::error::{Error, Result};
+use crate::models::shared::weights::mlx;
+
+const SAMPLE_RATE: u32 = 16_000;
+const ENCODER_LAYERS: usize = 24;
+const ENCODER_DIM: usize = 1024;
+const ENCODER_HEADS: usize = 8;
+const ENCODER_HEAD_DIM: usize = ENCODER_DIM / ENCODER_HEADS;
+const FF_DIM: usize = ENCODER_DIM * 4;
+const PRED_HIDDEN: usize = 640;
+const JOINT_HIDDEN: usize = 640;
+const PROMPT_DIM: usize = 128;
+const PROMPT_HIDDEN: usize = 2048;
+const CONV_SUB_CHANNELS: usize = 256;
+const CONV_KERNEL_1D: usize = 9;
+const SUBSAMPLING_FACTOR: usize = 8;
+const N_FFT: usize = 512;
+const WIN_LENGTH: usize = 400;
+const HOP_LENGTH: usize = 160;
+const N_MELS: usize = 128;
+const PREEMPH: f32 = 0.97;
+const LOG_GUARD: f32 = 5.960_464_5e-8;
+const NORMALIZE_EPS: f32 = 1e-5;
+const DEFAULT_MAX_SYMBOLS_PER_FRAME: usize = 10;
+
+#[derive(Debug, Clone)]
+pub(super) struct NemotronDecodeStats {
+    pub encoded_frames: usize,
+    pub emitted_tokens: usize,
+    pub blank_frames: usize,
+    pub guard_exits: usize,
+    pub max_symbols_per_frame: usize,
+}
+
+impl NemotronDecodeStats {
+    pub(super) fn diagnostics(&self) -> serde_json::Value {
+        json!({
+            "encoded_frames": self.encoded_frames,
+            "emitted_tokens": self.emitted_tokens,
+            "blank_frames": self.blank_frames,
+            "guard_exits": self.guard_exits,
+            "max_symbols_per_frame": self.max_symbols_per_frame,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct NemotronDecodedTokens {
+    pub token_ids: Vec<usize>,
+    pub stats: NemotronDecodeStats,
+}
+
+pub(super) struct NemotronNetwork {
+    preprocessor: NemotronPreprocessor,
+    pre_encode: ConvSubsamplingDw,
+    layers: Vec<ConformerLayer>,
+    predictor: Predictor,
+    joint: Joint,
+    prompt_kernel: PromptKernel,
+    prompt_dictionary: HashMap<String, usize>,
+    left_context_frames: usize,
+    right_context_frames: usize,
+    blank_idx: usize,
+    max_symbols_per_frame: usize,
+}
+
+impl NemotronNetwork {
+    pub(super) fn load(vb: &VarBuilder, inventory: &NemotronConfigInventory) -> Result<Self> {
+        validate_inventory_for_forward(inventory)?;
+
+        let preprocessor = NemotronPreprocessor::load(vb, inventory)?;
+        let pre_encode = ConvSubsamplingDw::load(vb.pp("encoder.pre_encode"))?;
+
+        let mut layers = Vec::with_capacity(ENCODER_LAYERS);
+        for idx in 0..ENCODER_LAYERS {
+            layers.push(ConformerLayer::load(
+                vb.pp(format!("encoder.layers.{idx}")),
+            )?);
+        }
+
+        let predictor = Predictor::load(vb.pp("decoder.prediction"))?;
+        let blank_idx = inventory
+            .vocab_size
+            .unwrap_or_else(|| predictor.blank_idx.saturating_sub(0));
+        if predictor.blank_idx != blank_idx {
+            return Err(Error::ModelLoadError(format!(
+                "Nemotron predictor blank index mismatch: embed_blank={}, config_blank={blank_idx}",
+                predictor.blank_idx
+            )));
+        }
+
+        let joint = Joint::load(vb.pp("joint"), ENCODER_DIM, blank_idx + 1)?;
+        let prompt_kernel = PromptKernel::load(vb.pp("prompt_kernel"))?;
+        let prompt_dictionary = inventory
+            .prompt_dictionary
+            .iter()
+            .cloned()
+            .collect::<HashMap<_, _>>();
+        if prompt_dictionary.is_empty() {
+            return Err(Error::ModelLoadError(
+                "Nemotron config does not include prompt_dictionary entries".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            preprocessor,
+            pre_encode,
+            layers,
+            predictor,
+            joint,
+            prompt_kernel,
+            prompt_dictionary,
+            left_context_frames: inventory.left_context_frames.unwrap_or(56),
+            right_context_frames: inventory
+                .right_context_frames
+                .iter()
+                .copied()
+                .max()
+                .unwrap_or(13),
+            blank_idx,
+            max_symbols_per_frame: DEFAULT_MAX_SYMBOLS_PER_FRAME,
+        })
+    }
+
+    pub(super) fn prompt_id(&self, target_lang: &str) -> Result<usize> {
+        self.prompt_dictionary
+            .get(target_lang)
+            .copied()
+            .ok_or_else(|| {
+                Error::InvalidInput(format!(
+                    "Nemotron prompt dictionary does not contain target_lang '{target_lang}'"
+                ))
+            })
+    }
+
+    pub(super) fn encode_with_prompt(
+        &self,
+        audio_16khz: &[f32],
+        prompt_id: usize,
+    ) -> Result<(Tensor, usize)> {
+        let (features, feature_frames) = self.preprocessor.compute_features(audio_16khz)?;
+        let (mut x, encoded_len) = self.pre_encode.forward(&features, feature_frames)?;
+        if encoded_len == 0 {
+            return Err(Error::InferenceError(
+                "Nemotron encoder produced zero frames".to_string(),
+            ));
+        }
+
+        let pos_len = x.dim(1)?;
+        let pos_emb = build_rel_positional_embedding(pos_len, ENCODER_DIM, x.device())?;
+        let att_mask = build_limited_context_mask(
+            pos_len,
+            self.left_context_frames,
+            self.right_context_frames,
+            x.device(),
+        )?;
+        for layer in &self.layers {
+            x = layer.forward(&x, &pos_emb, &att_mask)?;
+        }
+
+        let x = self.prompt_kernel.forward(&x, prompt_id)?;
+        Ok((x, encoded_len.min(pos_len)))
+    }
+
+    pub(super) fn decode_rnnt_greedy(
+        &self,
+        encoded: &Tensor,
+        encoded_len: usize,
+        on_token: &mut dyn FnMut(usize),
+    ) -> Result<NemotronDecodedTokens> {
+        let encoded = encoded.i((0, ..encoded_len, ..))?; // [T, D]
+        let mut predictor_state = self.predictor.initial_state(1, encoded.device())?;
+        let mut predictor_out =
+            self.predictor
+                .step(self.blank_idx, &mut predictor_state, encoded.device())?;
+
+        let mut token_ids = Vec::new();
+        let mut blank_frames = 0usize;
+        let mut guard_exits = 0usize;
+
+        for t in 0..encoded_len {
+            let enc_t = encoded.i((t, ..))?.unsqueeze(0)?.unsqueeze(0)?; // [1, 1, D]
+            let mut symbols_this_frame = 0usize;
+
+            loop {
+                let logits = self
+                    .joint
+                    .joint_after_projection(&enc_t, &predictor_out)?
+                    .squeeze(0)?
+                    .squeeze(0)?
+                    .squeeze(0)?; // [V + blank]
+                let label = argmax_1d(&logits)?;
+
+                if label == self.blank_idx {
+                    blank_frames = blank_frames.saturating_add(1);
+                    break;
+                }
+                if label > self.blank_idx {
+                    return Err(Error::InferenceError(format!(
+                        "Nemotron RNNT emitted invalid label {label}; blank_idx={}",
+                        self.blank_idx
+                    )));
+                }
+
+                token_ids.push(label);
+                on_token(label);
+                symbols_this_frame = symbols_this_frame.saturating_add(1);
+                if symbols_this_frame >= self.max_symbols_per_frame {
+                    guard_exits = guard_exits.saturating_add(1);
+                    break;
+                }
+
+                predictor_out =
+                    self.predictor
+                        .step(label, &mut predictor_state, encoded.device())?;
+            }
+        }
+
+        Ok(NemotronDecodedTokens {
+            stats: NemotronDecodeStats {
+                encoded_frames: encoded_len,
+                emitted_tokens: token_ids.len(),
+                blank_frames,
+                guard_exits,
+                max_symbols_per_frame: self.max_symbols_per_frame,
+            },
+            token_ids,
+        })
+    }
+
+    pub(super) fn blank_idx(&self) -> usize {
+        self.blank_idx
+    }
+}
+
+fn validate_inventory_for_forward(inventory: &NemotronConfigInventory) -> Result<()> {
+    expect_dim("sample_rate", inventory.sample_rate, SAMPLE_RATE as usize)?;
+    expect_dim("features", inventory.features, N_MELS)?;
+    expect_dim("n_fft", inventory.n_fft, N_FFT)?;
+    expect_dim("window_length", inventory.window_length, WIN_LENGTH)?;
+    expect_dim("hop_length", inventory.hop_length, HOP_LENGTH)?;
+    expect_dim("encoder_layers", inventory.encoder_layers, ENCODER_LAYERS)?;
+    expect_dim("encoder_dim", inventory.encoder_dim, ENCODER_DIM)?;
+    expect_dim("encoder_heads", inventory.encoder_heads, ENCODER_HEADS)?;
+    expect_dim(
+        "subsampling_factor",
+        inventory.subsampling_factor,
+        SUBSAMPLING_FACTOR,
+    )?;
+    expect_dim(
+        "subsampling_conv_channels",
+        inventory.subsampling_conv_channels,
+        CONV_SUB_CHANNELS,
+    )?;
+    expect_dim("ff_expansion_factor", inventory.ff_expansion_factor, 4)?;
+    expect_dim(
+        "conv_kernel_size",
+        inventory.conv_kernel_size,
+        CONV_KERNEL_1D,
+    )?;
+    expect_dim("predictor_hidden", inventory.predictor_hidden, PRED_HIDDEN)?;
+    expect_dim("predictor_layers", inventory.predictor_layers, 2)?;
+    expect_dim("joint_hidden", inventory.joint_hidden, JOINT_HIDDEN)?;
+    expect_dim("prompt_dim", inventory.prompt_dim, PROMPT_DIM)?;
+    if inventory.vocab_size.is_none() {
+        return Err(Error::ModelLoadError(
+            "Nemotron config is missing vocab_size/num_classes".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn expect_dim(name: &str, actual: Option<usize>, expected: usize) -> Result<()> {
+    if actual.is_some_and(|actual| actual != expected) {
+        return Err(Error::ModelLoadError(format!(
+            "Nemotron config {name} mismatch: expected {expected}, got {}",
+            actual.unwrap()
+        )));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FeatureNormalize {
+    None,
+    PerFeature,
+}
+
+impl FeatureNormalize {
+    fn from_config(value: Option<&str>) -> Self {
+        match value
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| value.to_ascii_lowercase())
+            .as_deref()
+        {
+            Some("per_feature") | Some("true") => Self::PerFeature,
+            _ => Self::None,
+        }
+    }
+}
+
+struct NemotronPreprocessor {
+    device: Device,
+    padded_window: Vec<f32>,
+    fb: Vec<f32>,
+    normalize: FeatureNormalize,
+}
+
+impl NemotronPreprocessor {
+    fn load(vb: &VarBuilder, inventory: &NemotronConfigInventory) -> Result<Self> {
+        let device = vb.device().clone();
+        let preproc_vb = vb.pp("preprocessor.featurizer");
+
+        let window_tensor = preproc_vb
+            .get_unchecked_dtype("window", DType::F32)
+            .map_err(|e| {
+                Error::ModelLoadError(format!(
+                    "Failed to load Nemotron preprocessor window tensor: {e}"
+                ))
+            })?;
+        let window = window_tensor.to_vec1::<f32>()?;
+        if window.len() != WIN_LENGTH {
+            return Err(Error::ModelLoadError(format!(
+                "Unexpected Nemotron window length: expected {WIN_LENGTH}, got {}",
+                window.len()
+            )));
+        }
+
+        let fb_tensor = preproc_vb
+            .get_unchecked_dtype("fb", DType::F32)
+            .map_err(|e| {
+                Error::ModelLoadError(format!(
+                    "Failed to load Nemotron preprocessor filterbank tensor: {e}"
+                ))
+            })?;
+        let (_, n_mels, n_freqs) = fb_tensor.dims3().map_err(|e| {
+            Error::ModelLoadError(format!("Unexpected Nemotron filterbank tensor shape: {e}"))
+        })?;
+        if n_mels != N_MELS || n_freqs != N_FFT / 2 + 1 {
+            return Err(Error::ModelLoadError(format!(
+                "Unexpected Nemotron filterbank shape: expected (1,{N_MELS},{}), got (1,{n_mels},{n_freqs})",
+                N_FFT / 2 + 1
+            )));
+        }
+        let fb = fb_tensor.squeeze(0)?.flatten_all()?.to_vec1::<f32>()?;
+
+        let mut padded_window = vec![0f32; N_FFT];
+        let offset = (N_FFT - WIN_LENGTH) / 2;
+        padded_window[offset..offset + WIN_LENGTH].copy_from_slice(&window);
+
+        Ok(Self {
+            device,
+            padded_window,
+            fb,
+            normalize: FeatureNormalize::from_config(inventory.normalize.as_deref()),
+        })
+    }
+
+    fn compute_features(&self, audio: &[f32]) -> Result<(Tensor, usize)> {
+        if audio.is_empty() {
+            return Err(Error::InvalidInput("Empty audio input".to_string()));
+        }
+
+        let mut x = audio.to_vec();
+        preemphasis(&mut x, PREEMPH);
+
+        let center_pad = N_FFT / 2;
+        let mut padded = Vec::with_capacity(x.len() + center_pad * 2);
+        padded.extend(std::iter::repeat(0.0).take(center_pad));
+        padded.extend_from_slice(&x);
+        padded.extend(std::iter::repeat(0.0).take(center_pad));
+
+        let frame_count = if padded.len() >= N_FFT {
+            (padded.len() - N_FFT) / HOP_LENGTH + 1
+        } else {
+            1
+        };
+
+        let mut planner = FftPlanner::<f32>::new();
+        let fft = planner.plan_fft_forward(N_FFT);
+        let mut spectrum = vec![0f32; frame_count * (N_FFT / 2 + 1)];
+        let mut buffer = vec![Complex::<f32>::new(0.0, 0.0); N_FFT];
+
+        for frame_idx in 0..frame_count {
+            let start = frame_idx * HOP_LENGTH;
+            let slice = &padded[start..start + N_FFT];
+            for i in 0..N_FFT {
+                buffer[i].re = slice[i] * self.padded_window[i];
+                buffer[i].im = 0.0;
+            }
+
+            fft.process(&mut buffer);
+
+            for k in 0..(N_FFT / 2 + 1) {
+                let mag = (buffer[k].re * buffer[k].re + buffer[k].im * buffer[k].im).sqrt();
+                spectrum[frame_idx * (N_FFT / 2 + 1) + k] = mag * mag;
+            }
+        }
+
+        let n_freqs = N_FFT / 2 + 1;
+        let mut mel = vec![0f32; N_MELS * frame_count];
+        for m in 0..N_MELS {
+            for t in 0..frame_count {
+                let mut acc = 0f32;
+                let spec_row = &spectrum[t * n_freqs..(t + 1) * n_freqs];
+                let fb_row = &self.fb[m * n_freqs..(m + 1) * n_freqs];
+                for f in 0..n_freqs {
+                    acc += spec_row[f] * fb_row[f];
+                }
+                mel[m * frame_count + t] = (acc + LOG_GUARD).ln();
+            }
+        }
+
+        let valid_frames = ((audio.len() + HOP_LENGTH - 1) / HOP_LENGTH)
+            .max(1)
+            .min(frame_count);
+        if self.normalize == FeatureNormalize::PerFeature {
+            normalize_per_feature(&mut mel, N_MELS, frame_count, valid_frames);
+        }
+
+        if valid_frames < frame_count {
+            for m in 0..N_MELS {
+                for t in valid_frames..frame_count {
+                    mel[m * frame_count + t] = 0.0;
+                }
+            }
+        }
+
+        let features = Tensor::from_vec(mel, (1, N_MELS, frame_count), &self.device)?;
+        Ok((features, valid_frames))
+    }
+}
+
+struct ConvSubsamplingDw {
+    conv0: Conv2d,
+    conv2: Conv2d,
+    conv3: Conv2d,
+    conv5: Conv2d,
+    conv6: Conv2d,
+    out: Linear,
+}
+
+impl ConvSubsamplingDw {
+    fn load(vb: VarBuilder) -> Result<Self> {
+        let stride_cfg = Conv2dConfig {
+            stride: 2,
+            padding: 1,
+            ..Default::default()
+        };
+        let point_cfg = Conv2dConfig {
+            stride: 1,
+            padding: 0,
+            ..Default::default()
+        };
+
+        let conv0 = mlx::load_conv2d(1, CONV_SUB_CHANNELS, 3, stride_cfg, vb.pp("conv.0"))?;
+
+        let mut dw_stride_cfg = stride_cfg;
+        dw_stride_cfg.groups = CONV_SUB_CHANNELS;
+        let conv2 = mlx::load_conv2d(1, CONV_SUB_CHANNELS, 3, dw_stride_cfg, vb.pp("conv.2"))?;
+        let conv3 = mlx::load_conv2d(
+            CONV_SUB_CHANNELS,
+            CONV_SUB_CHANNELS,
+            1,
+            point_cfg,
+            vb.pp("conv.3"),
+        )?;
+        let conv5 = mlx::load_conv2d(1, CONV_SUB_CHANNELS, 3, dw_stride_cfg, vb.pp("conv.5"))?;
+        let conv6 = mlx::load_conv2d(
+            CONV_SUB_CHANNELS,
+            CONV_SUB_CHANNELS,
+            1,
+            point_cfg,
+            vb.pp("conv.6"),
+        )?;
+        let out = mlx::load_linear(CONV_SUB_CHANNELS * 16, ENCODER_DIM, vb.pp("out"))?;
+
+        Ok(Self {
+            conv0,
+            conv2,
+            conv3,
+            conv5,
+            conv6,
+            out,
+        })
+    }
+
+    fn forward(&self, features: &Tensor, feature_frames: usize) -> Result<(Tensor, usize)> {
+        let mut x = features.transpose(1, 2)?.unsqueeze(1)?;
+
+        x = self.conv0.forward(&x)?.relu()?;
+        x = self.conv2.forward(&x)?;
+        x = self.conv3.forward(&x)?.relu()?;
+        x = self.conv5.forward(&x)?;
+        x = self.conv6.forward(&x)?.relu()?;
+
+        let (b, c, t, f) = x.dims4()?;
+        let x = x
+            .transpose(1, 2)?
+            .reshape((b, t, c * f))?
+            .apply(&self.out)?;
+        let encoded_len = subsampled_len_3x(feature_frames).min(t).max(1);
+        Ok((x, encoded_len))
+    }
+}
+
+fn subsampled_len_3x(mut len: usize) -> usize {
+    for _ in 0..3 {
+        len = len.div_ceil(2);
+    }
+    len
+}
+
+struct ConformerLayer {
+    norm_ff1: LayerNorm,
+    ff1: FeedForward,
+    norm_self_att: LayerNorm,
+    self_attn: RelPosSelfAttention,
+    norm_conv: LayerNorm,
+    conv: ConformerConv,
+    norm_ff2: LayerNorm,
+    ff2: FeedForward,
+    norm_out: LayerNorm,
+}
+
+impl ConformerLayer {
+    fn load(vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            norm_ff1: layer_norm(ENCODER_DIM, 1e-5, vb.pp("norm_feed_forward1"))?,
+            ff1: FeedForward::load(vb.pp("feed_forward1"))?,
+            norm_self_att: layer_norm(ENCODER_DIM, 1e-5, vb.pp("norm_self_att"))?,
+            self_attn: RelPosSelfAttention::load(vb.pp("self_attn"))?,
+            norm_conv: layer_norm(ENCODER_DIM, 1e-5, vb.pp("norm_conv"))?,
+            conv: ConformerConv::load(vb.pp("conv"))?,
+            norm_ff2: layer_norm(ENCODER_DIM, 1e-5, vb.pp("norm_feed_forward2"))?,
+            ff2: FeedForward::load(vb.pp("feed_forward2"))?,
+            norm_out: layer_norm(ENCODER_DIM, 1e-5, vb.pp("norm_out"))?,
+        })
+    }
+
+    fn forward(&self, x: &Tensor, pos_emb: &Tensor, att_mask: &Tensor) -> Result<Tensor> {
+        let mut residual = x.clone();
+
+        let ff1 = self.ff1.forward(&self.norm_ff1.forward(&residual)?)?;
+        residual = residual.broadcast_add(&ff1.affine(0.5, 0.0)?)?;
+
+        let attn =
+            self.self_attn
+                .forward(&self.norm_self_att.forward(&residual)?, pos_emb, att_mask)?;
+        residual = residual.broadcast_add(&attn)?;
+
+        let conv = self.conv.forward(&self.norm_conv.forward(&residual)?)?;
+        residual = residual.broadcast_add(&conv)?;
+
+        let ff2 = self.ff2.forward(&self.norm_ff2.forward(&residual)?)?;
+        residual = residual.broadcast_add(&ff2.affine(0.5, 0.0)?)?;
+
+        self.norm_out
+            .forward(&residual)
+            .map_err(|e| Error::InferenceError(e.to_string()))
+    }
+}
+
+struct FeedForward {
+    linear1: Linear,
+    linear2: Linear,
+}
+
+impl FeedForward {
+    fn load(vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            linear1: mlx::load_linear_no_bias(ENCODER_DIM, FF_DIM, vb.pp("linear1"))?,
+            linear2: mlx::load_linear_no_bias(FF_DIM, ENCODER_DIM, vb.pp("linear2"))?,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let x = self.linear1.forward(x)?;
+        let x = swish(&x)?;
+        self.linear2
+            .forward(&x)
+            .map_err(|e| Error::InferenceError(e.to_string()))
+    }
+}
+
+struct ConformerConv {
+    pointwise_conv1: Conv1d,
+    depthwise_conv: Conv1d,
+    batch_norm: candle_nn::BatchNorm,
+    pointwise_conv2: Conv1d,
+}
+
+impl ConformerConv {
+    fn load(vb: VarBuilder) -> Result<Self> {
+        let pointwise_conv1 = mlx::load_conv1d_no_bias(
+            ENCODER_DIM,
+            ENCODER_DIM * 2,
+            1,
+            Conv1dConfig::default(),
+            vb.pp("pointwise_conv1"),
+        )?;
+
+        let depthwise_conv = mlx::load_conv1d_no_bias(
+            ENCODER_DIM,
+            ENCODER_DIM,
+            CONV_KERNEL_1D,
+            Conv1dConfig {
+                padding: 0,
+                groups: ENCODER_DIM,
+                ..Default::default()
+            },
+            vb.pp("depthwise_conv"),
+        )?;
+
+        Ok(Self {
+            pointwise_conv1,
+            depthwise_conv,
+            batch_norm: batch_norm(ENCODER_DIM, 1e-5, vb.pp("batch_norm"))?,
+            pointwise_conv2: mlx::load_conv1d_no_bias(
+                ENCODER_DIM,
+                ENCODER_DIM,
+                1,
+                Conv1dConfig::default(),
+                vb.pp("pointwise_conv2"),
+            )?,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let mut x = x.transpose(1, 2)?;
+        x = self.pointwise_conv1.forward(&x)?;
+        let x_a = x.i((.., ..ENCODER_DIM, ..))?;
+        let x_b = x.i((.., ENCODER_DIM.., ..))?;
+        x = x_a.broadcast_mul(&ops::sigmoid(&x_b)?)?;
+
+        x = x.pad_with_zeros(2, CONV_KERNEL_1D - 1, 0)?;
+        x = self.depthwise_conv.forward(&x)?;
+        x = self.batch_norm.forward_t(&x, false)?;
+        x = swish(&x)?;
+        x = self.pointwise_conv2.forward(&x)?;
+
+        x.transpose(1, 2).map_err(Error::from)
+    }
+}
+
+struct RelPosSelfAttention {
+    linear_q: Linear,
+    linear_k: Linear,
+    linear_v: Linear,
+    linear_out: Linear,
+    linear_pos: Linear,
+    pos_bias_u: Tensor,
+    pos_bias_v: Tensor,
+}
+
+impl RelPosSelfAttention {
+    fn load(vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            linear_q: mlx::load_linear_no_bias(ENCODER_DIM, ENCODER_DIM, vb.pp("linear_q"))?,
+            linear_k: mlx::load_linear_no_bias(ENCODER_DIM, ENCODER_DIM, vb.pp("linear_k"))?,
+            linear_v: mlx::load_linear_no_bias(ENCODER_DIM, ENCODER_DIM, vb.pp("linear_v"))?,
+            linear_out: mlx::load_linear_no_bias(ENCODER_DIM, ENCODER_DIM, vb.pp("linear_out"))?,
+            linear_pos: mlx::load_linear_no_bias(ENCODER_DIM, ENCODER_DIM, vb.pp("linear_pos"))?,
+            pos_bias_u: vb.get((ENCODER_HEADS, ENCODER_HEAD_DIM), "pos_bias_u")?,
+            pos_bias_v: vb.get((ENCODER_HEADS, ENCODER_HEAD_DIM), "pos_bias_v")?,
+        })
+    }
+
+    fn forward(&self, x: &Tensor, pos_emb: &Tensor, att_mask: &Tensor) -> Result<Tensor> {
+        let (b, t, _d) = x.dims3()?;
+
+        let q = self
+            .linear_q
+            .forward(x)?
+            .reshape((b, t, ENCODER_HEADS, ENCODER_HEAD_DIM))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let k = self
+            .linear_k
+            .forward(x)?
+            .reshape((b, t, ENCODER_HEADS, ENCODER_HEAD_DIM))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let v = self
+            .linear_v
+            .forward(x)?
+            .reshape((b, t, ENCODER_HEADS, ENCODER_HEAD_DIM))?
+            .transpose(1, 2)?
+            .contiguous()?;
+
+        let p = self
+            .linear_pos
+            .forward(pos_emb)?
+            .reshape((1, 2 * t - 1, ENCODER_HEADS, ENCODER_HEAD_DIM))?
+            .transpose(1, 2)?;
+
+        let pos_bias_u = self
+            .pos_bias_u
+            .reshape((1, ENCODER_HEADS, 1, ENCODER_HEAD_DIM))?;
+        let pos_bias_v = self
+            .pos_bias_v
+            .reshape((1, ENCODER_HEADS, 1, ENCODER_HEAD_DIM))?;
+        let matrix_ac = q
+            .broadcast_add(&pos_bias_u)?
+            .matmul(&k.transpose(2, 3)?.contiguous()?)?;
+        let matrix_bd = rel_shift(
+            &q.broadcast_add(&pos_bias_v)?
+                .matmul(&p.transpose(2, 3)?.contiguous()?)?,
+        )?
+        .narrow(3, 0, t)?;
+
+        let scores = matrix_ac
+            .broadcast_add(&matrix_bd)?
+            .affine(1.0 / (ENCODER_HEAD_DIM as f64).sqrt(), 0.0)?
+            .broadcast_add(att_mask)?;
+        let attn = ops::softmax(&scores, 3)?;
+        let out = attn.matmul(&v)?;
+        let out = out.transpose(1, 2)?.reshape((b, t, ENCODER_DIM))?;
+
+        self.linear_out
+            .forward(&out)
+            .map_err(|e| Error::InferenceError(e.to_string()))
+    }
+}
+
+fn rel_shift(x: &Tensor) -> Result<Tensor> {
+    let (b, h, qlen, pos_len) = x.dims4()?;
+    let x = x.pad_with_zeros(3, 1, 0)?;
+    let x = x.reshape((b, h, pos_len + 1, qlen))?;
+    let x = x.narrow(2, 1, pos_len)?;
+    x.reshape((b, h, qlen, pos_len)).map_err(Error::from)
+}
+
+struct PromptKernel {
+    linear0: Linear,
+    linear2: Linear,
+}
+
+impl PromptKernel {
+    fn load(vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            linear0: mlx::load_linear(ENCODER_DIM + PROMPT_DIM, PROMPT_HIDDEN, vb.pp("0"))?,
+            linear2: mlx::load_linear(PROMPT_HIDDEN, ENCODER_DIM, vb.pp("2"))?,
+        })
+    }
+
+    fn forward(&self, encoded: &Tensor, prompt_id: usize) -> Result<Tensor> {
+        if prompt_id >= PROMPT_DIM {
+            return Err(Error::InvalidInput(format!(
+                "Nemotron prompt id {prompt_id} exceeds prompt feature dimension {PROMPT_DIM}"
+            )));
+        }
+
+        let (b, t, _d) = encoded.dims3()?;
+        let mut prompt = vec![0f32; b * t * PROMPT_DIM];
+        for bi in 0..b {
+            for ti in 0..t {
+                prompt[(bi * t + ti) * PROMPT_DIM + prompt_id] = 1.0;
+            }
+        }
+        let prompt = Tensor::from_vec(prompt, (b, t, PROMPT_DIM), encoded.device())?;
+        let x = Tensor::cat(&[encoded, &prompt], 2)?;
+        let x = self.linear0.forward(&x)?.relu()?;
+        self.linear2
+            .forward(&x)
+            .map_err(|e| Error::InferenceError(e.to_string()))
+    }
+}
+
+struct Predictor {
+    embed: Tensor,
+    lstm_l0: LstmCell,
+    lstm_l1: LstmCell,
+    blank_idx: usize,
+}
+
+#[derive(Clone)]
+struct PredictorState {
+    h0: Tensor,
+    c0: Tensor,
+    h1: Tensor,
+    c1: Tensor,
+}
+
+impl Predictor {
+    fn load(vb: VarBuilder) -> Result<Self> {
+        let embed = vb.pp("embed").get_unchecked_dtype("weight", DType::F32)?;
+        let vocab_plus_blank = embed.dim(0)?;
+        let hidden = embed.dim(1)?;
+        if hidden != PRED_HIDDEN {
+            return Err(Error::ModelLoadError(format!(
+                "Unexpected Nemotron predictor embedding hidden size: expected {PRED_HIDDEN}, got {hidden}"
+            )));
+        }
+
+        Ok(Self {
+            embed,
+            lstm_l0: LstmCell::load(vb.pp("dec_rnn.lstm"), 0)?,
+            lstm_l1: LstmCell::load(vb.pp("dec_rnn.lstm"), 1)?,
+            blank_idx: vocab_plus_blank.saturating_sub(1),
+        })
+    }
+
+    fn initial_state(&self, batch: usize, device: &Device) -> Result<PredictorState> {
+        let zeros = |dim| Tensor::zeros((batch, dim), DType::F32, device).map_err(Error::from);
+        Ok(PredictorState {
+            h0: zeros(PRED_HIDDEN)?,
+            c0: zeros(PRED_HIDDEN)?,
+            h1: zeros(PRED_HIDDEN)?,
+            c1: zeros(PRED_HIDDEN)?,
+        })
+    }
+
+    fn step(&self, label: usize, state: &mut PredictorState, device: &Device) -> Result<Tensor> {
+        let x = if label == self.blank_idx {
+            Tensor::zeros((1, PRED_HIDDEN), DType::F32, device)?
+        } else {
+            self.embed.i((label, ..))?.unsqueeze(0)?
+        };
+
+        let (h0, c0) = self.lstm_l0.step(&x, &state.h0, &state.c0)?;
+        state.h0 = h0;
+        state.c0 = c0;
+
+        let (h1, c1) = self.lstm_l1.step(&state.h0, &state.h1, &state.c1)?;
+        state.h1 = h1;
+        state.c1 = c1;
+
+        Ok(state.h1.unsqueeze(1)?)
+    }
+}
+
+struct LstmCell {
+    w_ih: Tensor,
+    w_hh: Tensor,
+    b_ih: Tensor,
+    b_hh: Tensor,
+}
+
+impl LstmCell {
+    fn load(vb: VarBuilder, layer: usize) -> Result<Self> {
+        let w_ih_name = format!("weight_ih_l{layer}");
+        let w_hh_name = format!("weight_hh_l{layer}");
+        let b_ih_name = format!("bias_ih_l{layer}");
+        let b_hh_name = format!("bias_hh_l{layer}");
+
+        Ok(Self {
+            w_ih: vb.get((PRED_HIDDEN * 4, PRED_HIDDEN), &w_ih_name)?,
+            w_hh: vb.get((PRED_HIDDEN * 4, PRED_HIDDEN), &w_hh_name)?,
+            b_ih: vb.get(PRED_HIDDEN * 4, &b_ih_name)?,
+            b_hh: vb.get(PRED_HIDDEN * 4, &b_hh_name)?,
+        })
+    }
+
+    fn step(&self, x: &Tensor, h_prev: &Tensor, c_prev: &Tensor) -> Result<(Tensor, Tensor)> {
+        let gates = x
+            .matmul(&self.w_ih.transpose(0, 1)?)?
+            .broadcast_add(&self.b_ih.unsqueeze(0)?)?
+            .broadcast_add(&h_prev.matmul(&self.w_hh.transpose(0, 1)?)?)?
+            .broadcast_add(&self.b_hh.unsqueeze(0)?)?;
+
+        let i = ops::sigmoid(&gates.i((.., 0..PRED_HIDDEN))?)?;
+        let f = ops::sigmoid(&gates.i((.., PRED_HIDDEN..(PRED_HIDDEN * 2)))?)?;
+        let g = gates
+            .i((.., (PRED_HIDDEN * 2)..(PRED_HIDDEN * 3)))?
+            .tanh()?;
+        let o = ops::sigmoid(&gates.i((.., (PRED_HIDDEN * 3)..))?)?;
+
+        let c = f
+            .broadcast_mul(c_prev)?
+            .broadcast_add(&i.broadcast_mul(&g)?)?;
+        let h = o.broadcast_mul(&c.tanh()?)?;
+
+        Ok((h, c))
+    }
+}
+
+struct Joint {
+    pred: Linear,
+    enc: Linear,
+    out: Linear,
+}
+
+impl Joint {
+    fn load(vb: VarBuilder, enc_hidden: usize, num_classes_with_blank: usize) -> Result<Self> {
+        let pred = mlx::load_linear(PRED_HIDDEN, JOINT_HIDDEN, vb.pp("pred"))?;
+        let enc = mlx::load_linear(enc_hidden, JOINT_HIDDEN, vb.pp("enc"))?;
+        let out_bias = vb
+            .pp("joint_net.2")
+            .get_unchecked_dtype("bias", DType::F32)?;
+        let out_dim = out_bias.dim(0)?;
+        if out_dim != num_classes_with_blank {
+            return Err(Error::ModelLoadError(format!(
+                "Nemotron RNNT joint output mismatch: out_dim={out_dim}, expected classes_with_blank={num_classes_with_blank}"
+            )));
+        }
+        let out = mlx::load_linear(JOINT_HIDDEN, out_dim, vb.pp("joint_net.2"))?;
+        Ok(Self { pred, enc, out })
+    }
+
+    fn joint_after_projection(&self, f: &Tensor, g: &Tensor) -> Result<Tensor> {
+        let f = self.enc.forward(f)?;
+        let g = self.pred.forward(g)?;
+        let inp = f.unsqueeze(2)?.broadcast_add(&g.unsqueeze(1)?)?;
+        let inp = inp.relu()?;
+        self.out
+            .forward(&inp)
+            .map_err(|e| Error::InferenceError(e.to_string()))
+    }
+}
+
+pub(super) fn resample_linear(audio: &[f32], src_rate: u32, dst_rate: u32) -> Vec<f32> {
+    if src_rate == dst_rate || audio.len() < 2 {
+        return audio.to_vec();
+    }
+
+    let ratio = dst_rate as f64 / src_rate as f64;
+    let out_len = ((audio.len() as f64) * ratio).round().max(1.0) as usize;
+    let mut out = Vec::with_capacity(out_len);
+    for i in 0..out_len {
+        let src_pos = (i as f64) / ratio;
+        let left = src_pos.floor() as usize;
+        let right = left.saturating_add(1).min(audio.len() - 1);
+        let frac = (src_pos - left as f64) as f32;
+        out.push(audio[left] * (1.0 - frac) + audio[right] * frac);
+    }
+    out
+}
+
+fn build_rel_positional_embedding(len: usize, d_model: usize, device: &Device) -> Result<Tensor> {
+    if len == 0 {
+        return Err(Error::InvalidInput(
+            "Cannot build positional embedding for empty sequence".to_string(),
+        ));
+    }
+
+    let pos_len = 2 * len - 1;
+    let mut emb = vec![0f32; pos_len * d_model];
+    let denom = (10_000f32).ln() / d_model as f32;
+
+    for (pi, p) in (-(len as isize - 1)..=(len as isize - 1)).enumerate() {
+        let p = (-p) as f32;
+        for i in (0..d_model).step_by(2) {
+            let div = (-denom * i as f32).exp();
+            let angle = p * div;
+            emb[pi * d_model + i] = angle.sin();
+            if i + 1 < d_model {
+                emb[pi * d_model + i + 1] = angle.cos();
+            }
+        }
+    }
+
+    Tensor::from_vec(emb, (1, pos_len, d_model), device).map_err(Error::from)
+}
+
+fn build_limited_context_mask(
+    len: usize,
+    left_context: usize,
+    right_context: usize,
+    device: &Device,
+) -> Result<Tensor> {
+    let mut mask = vec![0f32; len * len];
+    for q in 0..len {
+        for k in 0..len {
+            if k + left_context < q || k > q.saturating_add(right_context) {
+                mask[q * len + k] = -1.0e9;
+            }
+        }
+    }
+    Tensor::from_vec(mask, (1, 1, len, len), device).map_err(Error::from)
+}
+
+fn swish(x: &Tensor) -> Result<Tensor> {
+    x.broadcast_mul(&ops::sigmoid(x)?).map_err(Error::from)
+}
+
+fn argmax_1d(x: &Tensor) -> Result<usize> {
+    let v = x.to_vec1::<f32>()?;
+    let mut best_idx = 0usize;
+    let mut best_val = f32::NEG_INFINITY;
+    for (i, &val) in v.iter().enumerate() {
+        if val > best_val {
+            best_val = val;
+            best_idx = i;
+        }
+    }
+    Ok(best_idx)
+}
+
+fn preemphasis(x: &mut [f32], preemph: f32) {
+    if x.len() < 2 {
+        return;
+    }
+    let mut prev = x[0];
+    for sample in x.iter_mut().skip(1) {
+        let cur = *sample;
+        *sample = cur - preemph * prev;
+        prev = cur;
+    }
+}
+
+fn normalize_per_feature(mel: &mut [f32], n_mels: usize, frames: usize, valid_frames: usize) {
+    if valid_frames == 0 {
+        return;
+    }
+    for m in 0..n_mels {
+        let row = &mut mel[m * frames..(m + 1) * frames];
+        let mean = row[..valid_frames].iter().copied().sum::<f32>() / valid_frames as f32;
+        let var = if valid_frames > 1 {
+            row[..valid_frames]
+                .iter()
+                .map(|v| {
+                    let d = *v - mean;
+                    d * d
+                })
+                .sum::<f32>()
+                / (valid_frames as f32 - 1.0)
+        } else {
+            0.0
+        };
+        let std = var.sqrt() + NORMALIZE_EPS;
+        for v in row[..valid_frames].iter_mut() {
+            *v = (*v - mean) / std;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resample_linear_downsamples_24khz_to_16khz_length() {
+        let audio = vec![0.0f32; 24_000];
+        let out = resample_linear(&audio, 24_000, 16_000);
+
+        assert_eq!(out.len(), 16_000);
+    }
+
+    #[test]
+    fn subsampled_length_matches_three_stride_two_layers() {
+        assert_eq!(subsampled_len_3x(1), 1);
+        assert_eq!(subsampled_len_3x(8), 1);
+        assert_eq!(subsampled_len_3x(9), 2);
+        assert_eq!(subsampled_len_3x(100), 13);
+    }
+
+    #[test]
+    fn limited_context_mask_blocks_out_of_window_positions() {
+        let mask = build_limited_context_mask(4, 1, 1, &Device::Cpu).unwrap();
+        let values = mask
+            .squeeze(0)
+            .unwrap()
+            .squeeze(0)
+            .unwrap()
+            .to_vec2::<f32>()
+            .unwrap();
+
+        assert_eq!(values[0][0], 0.0);
+        assert_eq!(values[0][1], 0.0);
+        assert!(values[0][2] < -1.0e8);
+        assert_eq!(values[2][1], 0.0);
+        assert_eq!(values[2][3], 0.0);
+        assert!(values[3][1] < -1.0e8);
+    }
+
+    #[test]
+    fn normalize_mode_respects_nemo_na_value() {
+        assert_eq!(
+            FeatureNormalize::from_config(Some("NA")),
+            FeatureNormalize::None
+        );
+        assert_eq!(
+            FeatureNormalize::from_config(Some("per_feature")),
+            FeatureNormalize::PerFeature
+        );
+    }
+}

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
@@ -3,8 +3,7 @@ use std::collections::HashMap;
 use candle_core::{DType, Device, IndexOp, Tensor};
 use candle_nn::ops;
 use candle_nn::{
-    batch_norm, layer_norm, Conv1d, Conv1dConfig, Conv2d, Conv2dConfig, LayerNorm, Linear, Module,
-    ModuleT, VarBuilder,
+    layer_norm, Conv1d, Conv1dConfig, Conv2d, Conv2dConfig, LayerNorm, Linear, Module, VarBuilder,
 };
 use rustfft::num_complex::Complex;
 use rustfft::FftPlanner;
@@ -452,6 +451,7 @@ struct ConvSubsamplingDw {
     conv5: Conv2d,
     conv6: Conv2d,
     out: Linear,
+    out_feature_bins: usize,
 }
 
 impl ConvSubsamplingDw {
@@ -487,7 +487,7 @@ impl ConvSubsamplingDw {
             point_cfg,
             vb.pp("conv.6"),
         )?;
-        let out = mlx::load_linear(CONV_SUB_CHANNELS * 16, ENCODER_DIM, vb.pp("out"))?;
+        let (out, out_feature_bins) = load_subsampling_out_projection(vb.pp("out"))?;
 
         Ok(Self {
             conv0,
@@ -496,6 +496,7 @@ impl ConvSubsamplingDw {
             conv5,
             conv6,
             out,
+            out_feature_bins,
         })
     }
 
@@ -508,7 +509,19 @@ impl ConvSubsamplingDw {
         x = self.conv5.forward(&x)?;
         x = self.conv6.forward(&x)?.relu()?;
 
-        let (b, c, t, f) = x.dims4()?;
+        let (b, c, t, mut f) = x.dims4()?;
+        if c != CONV_SUB_CHANNELS {
+            return Err(Error::InferenceError(format!(
+                "Nemotron subsampling channel mismatch: expected {CONV_SUB_CHANNELS}, got {c}"
+            )));
+        }
+        if f < self.out_feature_bins {
+            x = x.pad_with_zeros(3, 0, self.out_feature_bins - f)?;
+            f = self.out_feature_bins;
+        } else if f > self.out_feature_bins {
+            x = x.narrow(3, 0, self.out_feature_bins)?;
+            f = self.out_feature_bins;
+        }
         let x = x
             .transpose(1, 2)?
             .reshape((b, t, c * f))?
@@ -516,6 +529,22 @@ impl ConvSubsamplingDw {
         let encoded_len = subsampled_len_3x(feature_frames).min(t).max(1);
         Ok((x, encoded_len))
     }
+}
+
+fn load_subsampling_out_projection(vb: VarBuilder) -> Result<(Linear, usize)> {
+    let ws = vb.get_unchecked_dtype("weight", DType::F32)?;
+    let (out_dim, in_dim) = ws.dims2()?;
+    if out_dim != ENCODER_DIM || in_dim % CONV_SUB_CHANNELS != 0 {
+        return Err(Error::ModelLoadError(format!(
+            "Unexpected Nemotron subsampling projection shape: expected out_dim={ENCODER_DIM} and input multiple of {CONV_SUB_CHANNELS}, got ({out_dim},{in_dim})"
+        )));
+    }
+    let bias = if vb.contains_tensor("bias") {
+        Some(vb.get(out_dim, "bias")?)
+    } else {
+        None
+    };
+    Ok((Linear::new(ws, bias), in_dim / CONV_SUB_CHANNELS))
 }
 
 fn subsampled_len_3x(mut len: usize) -> usize {
@@ -600,7 +629,7 @@ impl FeedForward {
 struct ConformerConv {
     pointwise_conv1: Conv1d,
     depthwise_conv: Conv1d,
-    batch_norm: candle_nn::BatchNorm,
+    conv_norm: LayerNorm,
     pointwise_conv2: Conv1d,
 }
 
@@ -629,7 +658,7 @@ impl ConformerConv {
         Ok(Self {
             pointwise_conv1,
             depthwise_conv,
-            batch_norm: batch_norm(ENCODER_DIM, 1e-5, vb.pp("batch_norm"))?,
+            conv_norm: load_conv_channel_layer_norm(vb.pp("batch_norm"))?,
             pointwise_conv2: mlx::load_conv1d_no_bias(
                 ENCODER_DIM,
                 ENCODER_DIM,
@@ -649,12 +678,21 @@ impl ConformerConv {
 
         x = x.pad_with_zeros(2, CONV_KERNEL_1D - 1, 0)?;
         x = self.depthwise_conv.forward(&x)?;
-        x = self.batch_norm.forward_t(&x, false)?;
+        x = self
+            .conv_norm
+            .forward(&x.transpose(1, 2)?)?
+            .transpose(1, 2)?;
         x = swish(&x)?;
         x = self.pointwise_conv2.forward(&x)?;
 
         x.transpose(1, 2).map_err(Error::from)
     }
+}
+
+fn load_conv_channel_layer_norm(vb: VarBuilder) -> Result<LayerNorm> {
+    let weight = vb.get(ENCODER_DIM, "weight")?;
+    let bias = vb.get(ENCODER_DIM, "bias")?;
+    Ok(LayerNorm::new(weight, bias, 1e-5))
 }
 
 struct RelPosSelfAttention {

--- a/crates/izwi-core/src/models/architectures/nemotron/mod.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/mod.rs
@@ -1,0 +1,3 @@
+//! NVIDIA Nemotron model family implementations.
+
+pub mod asr;

--- a/crates/izwi-core/src/models/families/mod.rs
+++ b/crates/izwi-core/src/models/families/mod.rs
@@ -48,6 +48,7 @@ const WHISPER_ASR_VARIANTS: &[ModelVariant] = &[ModelVariant::WhisperLargeV3Turb
 const QWEN3_ASR_VARIANTS: &[ModelVariant] =
     &[ModelVariant::Qwen3Asr06BGguf, ModelVariant::Qwen3Asr17BGguf];
 const VIBEVOICE_ASR_VARIANTS: &[ModelVariant] = &[ModelVariant::VibeVoiceAsr];
+const NEMOTRON_ASR_VARIANTS: &[ModelVariant] = &[ModelVariant::Nemotron35AsrStreaming06B];
 const SORTFORMER_DIARIZATION_VARIANTS: &[ModelVariant] =
     &[ModelVariant::DiarStreamingSortformer4SpkV21];
 const QWEN3_CHAT_VARIANTS: &[ModelVariant] = &[
@@ -167,6 +168,13 @@ pub const MODEL_FAMILY_REGISTRATIONS: &[FamilyRegistration] = &[
         family: ModelFamily::VibeVoiceAsr,
         module_path: "crate::models::architectures::vibevoice::asr",
         variants: VIBEVOICE_ASR_VARIANTS,
+        capabilities: ASR_CAPABILITIES,
+        fixture_ids: ASR_FIXTURES,
+    },
+    FamilyRegistration {
+        family: ModelFamily::NemotronAsr,
+        module_path: "crate::models::architectures::nemotron::asr",
+        variants: NEMOTRON_ASR_VARIANTS,
         capabilities: ASR_CAPABILITIES,
         fixture_ids: ASR_FIXTURES,
     },

--- a/crates/izwi-core/src/models/registry.rs
+++ b/crates/izwi-core/src/models/registry.rs
@@ -16,6 +16,9 @@ use crate::models::architectures::lfm2::chat::Lfm2ChatModel;
 use crate::models::architectures::lfm25_audio::{
     Lfm25AudioGenerationConfig, Lfm25AudioModel, Lfm25AudioStreamConfig,
 };
+use crate::models::architectures::nemotron::asr::{
+    NemotronAsrModel, NemotronAsrTranscriptionOutput,
+};
 use crate::models::architectures::parakeet::asr::ParakeetAsrModel;
 use crate::models::architectures::qwen3::asr::{
     AsrDecodeState as Qwen3AsrDecodeState, AsrDecodeStep as Qwen3AsrDecodeStep,
@@ -131,6 +134,16 @@ fn load_parakeet_asr_model(
     device: DeviceProfile,
 ) -> Result<NativeAsrModel> {
     Ok(NativeAsrModel::Parakeet(ParakeetAsrModel::load(
+        model_dir, variant, device,
+    )?))
+}
+
+fn load_nemotron_asr_model(
+    model_dir: &Path,
+    variant: ModelVariant,
+    device: DeviceProfile,
+) -> Result<NativeAsrModel> {
+    Ok(NativeAsrModel::Nemotron(NemotronAsrModel::load(
         model_dir, variant, device,
     )?))
 }
@@ -264,6 +277,11 @@ const ASR_LOADER_REGISTRY: &[AsrLoaderRegistration] = &[
         loader: load_parakeet_asr_model,
     },
     AsrLoaderRegistration {
+        name: "nemotron_asr",
+        family: ModelFamily::NemotronAsr,
+        loader: load_nemotron_asr_model,
+    },
+    AsrLoaderRegistration {
         name: "whisper_asr",
         family: ModelFamily::WhisperAsr,
         loader: load_whisper_asr_model,
@@ -360,6 +378,7 @@ fn resolve_asr_loader_registration(
         ModelFamily::Qwen3Asr => ModelFamily::Qwen3Asr,
         ModelFamily::Qwen3ForcedAligner => ModelFamily::Qwen3ForcedAligner,
         ModelFamily::ParakeetAsr => ModelFamily::ParakeetAsr,
+        ModelFamily::NemotronAsr => ModelFamily::NemotronAsr,
         ModelFamily::WhisperAsr => ModelFamily::WhisperAsr,
         ModelFamily::VibeVoiceAsr => ModelFamily::VibeVoiceAsr,
         _ => return None,
@@ -445,6 +464,7 @@ fn resolve_kokoro_loader_registration(
 pub enum NativeAsrModel {
     Qwen3(Qwen3AsrModel),
     Parakeet(ParakeetAsrModel),
+    Nemotron(NemotronAsrModel),
     WhisperTurbo(WhisperTurboAsrModel),
     VibeVoice(VibeVoiceAsrModel),
 }
@@ -561,6 +581,13 @@ impl NativeAsrModel {
             Self::Parakeet(model) => {
                 model.transcribe_with_callback(audio, sample_rate, language, on_delta)
             }
+            Self::Nemotron(model) => model.transcribe_with_callback_and_prompt(
+                audio,
+                sample_rate,
+                language,
+                prompt,
+                on_delta,
+            ),
             Self::WhisperTurbo(model) => model.transcribe_with_callback_and_prompt(
                 audio,
                 sample_rate,
@@ -645,6 +672,23 @@ impl NativeAsrModel {
                 language: language.map(|value| value.to_string()),
                 diagnostics: None,
             }),
+            Self::Nemotron(model) => {
+                let NemotronAsrTranscriptionOutput {
+                    text,
+                    language,
+                    diagnostics,
+                } = model.transcribe_with_details_and_prompt(
+                    audio,
+                    sample_rate,
+                    language,
+                    prompt,
+                )?;
+                Ok(NativeAsrTranscription {
+                    text,
+                    language,
+                    diagnostics,
+                })
+            }
             Self::WhisperTurbo(model) => {
                 let WhisperAsrTranscriptionOutput {
                     text,
@@ -725,6 +769,9 @@ impl NativeAsrModel {
             Self::Parakeet(_) => Err(Error::InvalidInput(
                 "Forced alignment is only available for Qwen3-ForcedAligner models".to_string(),
             )),
+            Self::Nemotron(_) => Err(Error::InvalidInput(
+                "Forced alignment is only available for Qwen3-ForcedAligner models".to_string(),
+            )),
             Self::WhisperTurbo(_) => Err(Error::InvalidInput(
                 "Forced alignment is only available for Qwen3-ForcedAligner models".to_string(),
             )),
@@ -742,6 +789,7 @@ impl NativeAsrModel {
         match self {
             Self::Qwen3(model) => model.max_audio_seconds_hint(),
             Self::Parakeet(_) => None,
+            Self::Nemotron(model) => model.max_audio_seconds_hint(),
             Self::WhisperTurbo(model) => model.max_audio_seconds_hint(),
             Self::VibeVoice(model) => model.max_audio_seconds_hint(),
         }
@@ -776,6 +824,9 @@ impl NativeAsrModel {
                 )?,
             )),
             Self::Parakeet(_) => Err(Error::InvalidInput(
+                "Incremental decode state is not available for this ASR model".to_string(),
+            )),
+            Self::Nemotron(_) => Err(Error::InvalidInput(
                 "Incremental decode state is not available for this ASR model".to_string(),
             )),
             Self::WhisperTurbo(_) => Err(Error::InvalidInput(
@@ -1687,6 +1738,16 @@ mod tests {
 
         assert_eq!(registration.name, "vibevoice_asr");
         assert_eq!(registration.family, ModelFamily::VibeVoiceAsr);
+    }
+
+    #[test]
+    fn resolves_nemotron_asr_loader_registration() {
+        let registration =
+            resolve_asr_loader_registration(ModelVariant::Nemotron35AsrStreaming06B)
+                .expect("Nemotron ASR loader should be registered");
+
+        assert_eq!(registration.name, "nemotron_asr");
+        assert_eq!(registration.family, ModelFamily::NemotronAsr);
     }
 
     #[test]

--- a/crates/izwi-core/src/runtime/lifecycle/instantiate.rs
+++ b/crates/izwi-core/src/runtime/lifecycle/instantiate.rs
@@ -35,6 +35,7 @@ impl RuntimeService {
             | ModelFamily::WhisperAsr
             | ModelFamily::Qwen3Asr
             | ModelFamily::VibeVoiceAsr
+            | ModelFamily::NemotronAsr
             | ModelFamily::Qwen3ForcedAligner => {
                 self.model_registry.load_asr(variant, &model_path).await?;
                 InstantiatedPayload::None

--- a/crates/izwi-core/src/runtime/lifecycle/publish.rs
+++ b/crates/izwi-core/src/runtime/lifecycle/publish.rs
@@ -27,6 +27,7 @@ impl RuntimeService {
             | ModelFamily::Gemma3Chat
             | ModelFamily::Voxtral
             | ModelFamily::VibeVoiceAsr
+            | ModelFamily::NemotronAsr
             | ModelFamily::Lfm25Audio
             | ModelFamily::Qwen3Tts
             | ModelFamily::KokoroTts

--- a/crates/izwi-core/src/runtime/lifecycle/unload.rs
+++ b/crates/izwi-core/src/runtime/lifecycle/unload.rs
@@ -22,6 +22,7 @@ impl RuntimeService {
             | ModelFamily::WhisperAsr
             | ModelFamily::Qwen3Asr
             | ModelFamily::VibeVoiceAsr
+            | ModelFamily::NemotronAsr
             | ModelFamily::Qwen3ForcedAligner => {
                 self.model_registry.unload_asr(variant).await;
             }

--- a/docs/dev/INFERENCE_CAPABILITY_INVENTORY.md
+++ b/docs/dev/INFERENCE_CAPABILITY_INVENTORY.md
@@ -63,6 +63,7 @@ phases can verify registry coverage without changing public behavior.
 | `WhisperLargeV3Turbo` | WhisperAsr | ASR | `asr` | Yes |
 | `Qwen3Asr06BGguf` | Qwen3Asr | ASR | `asr` | Yes |
 | `Qwen3Asr17BGguf` | Qwen3Asr | ASR | `asr` | Yes |
+| `Nemotron35AsrStreaming06B` | NemotronAsr | ASR | `asr` | Yes |
 | `DiarStreamingSortformer4SpkV21` | SortformerDiarization | Diarization | `diarization` | Yes |
 | `Qwen306B` | Qwen3Chat | Chat | `chat` | No |
 | `Qwen306B4Bit` | Qwen3Chat | Chat | `chat` | No |

--- a/docs/user/cli/pull.md
+++ b/docs/user/cli/pull.md
@@ -71,6 +71,7 @@ Common models:
 | `Voxtral-4B-TTS-2603` | TTS (20 preset voices, CC BY-NC 4.0) | ~8.1 GB |
 | `Parakeet-TDT-0.6B-v3` | ASR (default) | ~9.4 GB |
 | `Qwen3-ASR-0.6B-GGUF` | ASR (compact) | ~1.0 GB |
+| `Nemotron-3.5-ASR-Streaming-0.6B` | ASR (NVIDIA multilingual `.nemo`) | ~2.37 GB |
 | `Voxtral-Mini-4B-Realtime-2602` | ASR (offline transcription; realtime planned) | ~8 GB |
 | `Qwen3-8B-GGUF` | Chat | ~5.2 GB |
 | `Qwen3.5-4B` | Chat | ~3.4 GB |

--- a/docs/user/cli/transcribe.md
+++ b/docs/user/cli/transcribe.md
@@ -141,6 +141,7 @@ the option.
 | `Whisper-Large-v3-Turbo` | 1.5 GB | Medium | Strong multilingual baseline |
 | `Qwen3-ASR-0.6B-GGUF` | 1.0 GB | Fast | Good |
 | `Qwen3-ASR-1.7B-GGUF` | 2.5 GB | Medium | Better |
+| `Nemotron-3.5-ASR-Streaming-0.6B` | 2.37 GB | Medium | 40-locale NVIDIA FastConformer-RNNT; native forward path pending final weight-map work |
 | `Voxtral-Mini-4B-Realtime-2602` | 8 GB | Medium | Rust/Candle offline transcription; realtime planned |
 
 ---

--- a/docs/user/cli/transcribe.md
+++ b/docs/user/cli/transcribe.md
@@ -141,7 +141,7 @@ the option.
 | `Whisper-Large-v3-Turbo` | 1.5 GB | Medium | Strong multilingual baseline |
 | `Qwen3-ASR-0.6B-GGUF` | 1.0 GB | Fast | Good |
 | `Qwen3-ASR-1.7B-GGUF` | 2.5 GB | Medium | Better |
-| `Nemotron-3.5-ASR-Streaming-0.6B` | 2.37 GB | Medium | 40-locale NVIDIA FastConformer-RNNT; native forward path pending final weight-map work |
+| `Nemotron-3.5-ASR-Streaming-0.6B` | 2.37 GB | Medium | 40-locale NVIDIA FastConformer-RNNT; native offline transcription with prompt-conditioned language control |
 | `Voxtral-Mini-4B-Realtime-2602` | 8 GB | Medium | Rust/Candle offline transcription; realtime planned |
 
 ---

--- a/docs/user/features/transcription.md
+++ b/docs/user/features/transcription.md
@@ -181,6 +181,7 @@ streaming events, upload limits, and exact response shapes.
 | `Whisper-Large-v3-Turbo` | 1.5 GB | Strong multilingual baseline | Medium |
 | `Qwen3-ASR-0.6B-GGUF` | 1.0 GB | Good | Fast |
 | `Qwen3-ASR-1.7B-GGUF` | 2.5 GB | Better | Medium |
+| `Nemotron-3.5-ASR-Streaming-0.6B` | 2.37 GB | 40-locale NVIDIA FastConformer-RNNT; native forward path pending final weight-map work | Medium |
 | `LFM2.5-Audio-1.5B-GGUF` | 1.2 GB | Good integrated speech model | Medium |
 | `Voxtral-Mini-4B-Realtime-2602` | 8 GB | Rust/Candle offline transcription; realtime planned | Medium |
 

--- a/docs/user/features/transcription.md
+++ b/docs/user/features/transcription.md
@@ -181,7 +181,7 @@ streaming events, upload limits, and exact response shapes.
 | `Whisper-Large-v3-Turbo` | 1.5 GB | Strong multilingual baseline | Medium |
 | `Qwen3-ASR-0.6B-GGUF` | 1.0 GB | Good | Fast |
 | `Qwen3-ASR-1.7B-GGUF` | 2.5 GB | Better | Medium |
-| `Nemotron-3.5-ASR-Streaming-0.6B` | 2.37 GB | 40-locale NVIDIA FastConformer-RNNT; native forward path pending final weight-map work | Medium |
+| `Nemotron-3.5-ASR-Streaming-0.6B` | 2.37 GB | 40-locale NVIDIA FastConformer-RNNT; native offline transcription with prompt-conditioned language control | Medium |
 | `LFM2.5-Audio-1.5B-GGUF` | 1.2 GB | Good integrated speech model | Medium |
 | `Voxtral-Mini-4B-Realtime-2602` | 8 GB | Rust/Candle offline transcription; realtime planned | Medium |
 

--- a/docs/user/models/index.md
+++ b/docs/user/models/index.md
@@ -37,6 +37,7 @@ Those endpoints only show variants that are enabled for download/use.
 | `Whisper-Large-v3-Turbo` | Whisper ASR option |
 | `Qwen3-ASR-0.6B-GGUF` | Smaller Qwen3 ASR |
 | `Qwen3-ASR-1.7B-GGUF` | Higher-accuracy Qwen3 ASR |
+| `Nemotron-3.5-ASR-Streaming-0.6B` | NVIDIA multilingual FastConformer-RNNT `.nemo`; native artifact/config/tokenizer and streaming-state support |
 | `LFM2.5-Audio-1.5B-GGUF` | Unified audio model (ASR + speech generation) |
 | `Voxtral-Mini-4B-Realtime-2602` | Mistral Voxtral offline transcription; realtime support planned |
 
@@ -79,6 +80,9 @@ izwi pull Qwen3-TTS-12Hz-0.6B-Base
 
 # Download an ASR model
 izwi pull Qwen3-ASR-0.6B-GGUF
+
+# Download NVIDIA Nemotron 3.5 ASR
+izwi pull Nemotron-3.5-ASR-Streaming-0.6B
 ```
 
 ### Via Web UI

--- a/scripts/ci/nemotron-asr-smoke.sh
+++ b/scripts/ci/nemotron-asr-smoke.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Nemotron-ASR scaffold smoke verification against a running izwi server.
+
+Optional environment:
+  IZWI_NEMOTRON_ASR_SMOKE_SERVER       Default: http://127.0.0.1:8080
+  IZWI_NEMOTRON_ASR_SMOKE_MODEL        Default: Nemotron-3.5-ASR-Streaming-0.6B
+  IZWI_NEMOTRON_ASR_SMOKE_AUDIO        WAV/FLAC/MP3 fixture. If unset, a short silent WAV is generated.
+  IZWI_NEMOTRON_ASR_SMOKE_OUT_DIR      Default: target/nemotron-asr-smoke
+  IZWI_NEMOTRON_ASR_SMOKE_TIMEOUT_SECS Default: 900
+
+This script validates the current native Rust scaffold: model artifacts should
+load, and transcription should fail with the expected pending FastConformer-RNNT
+forward-pass diagnostic until the tensor mapping is completed.
+
+Start the server separately, for example:
+  IZWI_BACKEND=cpu izwi serve --backend cpu
+USAGE
+}
+
+SERVER="${IZWI_NEMOTRON_ASR_SMOKE_SERVER:-http://127.0.0.1:8080}"
+MODEL="${IZWI_NEMOTRON_ASR_SMOKE_MODEL:-Nemotron-3.5-ASR-Streaming-0.6B}"
+OUT_DIR="${IZWI_NEMOTRON_ASR_SMOKE_OUT_DIR:-target/nemotron-asr-smoke}"
+TIMEOUT="${IZWI_NEMOTRON_ASR_SMOKE_TIMEOUT_SECS:-900}"
+mkdir -p "$OUT_DIR"
+
+AUDIO_PATH="${IZWI_NEMOTRON_ASR_SMOKE_AUDIO:-$OUT_DIR/silence.wav}"
+if [[ -z "${IZWI_NEMOTRON_ASR_SMOKE_AUDIO:-}" ]]; then
+  python3 - "$AUDIO_PATH" <<'PY'
+import struct
+import sys
+import wave
+
+path = sys.argv[1]
+sample_rate = 16000
+samples = [0] * (sample_rate // 2)
+with wave.open(path, "wb") as wav:
+    wav.setnchannels(1)
+    wav.setsampwidth(2)
+    wav.setframerate(sample_rate)
+    wav.writeframes(b"".join(struct.pack("<h", sample) for sample in samples))
+PY
+fi
+
+if [[ ! -r "$AUDIO_PATH" ]]; then
+  echo "audio fixture is not readable: $AUDIO_PATH" >&2
+  usage >&2
+  exit 2
+fi
+
+python3 - "$SERVER" "$MODEL" "$AUDIO_PATH" "$OUT_DIR" "$TIMEOUT" <<'PY'
+import base64
+import json
+from pathlib import Path
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+server, model, audio_path, out_dir, timeout_s = sys.argv[1:]
+timeout = int(timeout_s)
+server = server.rstrip("/")
+encoded_model = urllib.parse.quote(model, safe="")
+
+def post_json(path, payload):
+    request = urllib.request.Request(
+        f"{server}{path}",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status, response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8", errors="replace")
+
+status, body = post_json(f"/v1/admin/models/{encoded_model}/load", {})
+Path(out_dir, "load.json").write_text(body)
+if status >= 400:
+    raise SystemExit(f"load failed with HTTP {status}: {body[:500]}")
+
+payload = {
+    "model": model,
+    "audio_base64": base64.b64encode(Path(audio_path).read_bytes()).decode("ascii"),
+    "response_format": "json",
+    "language": "auto",
+}
+status, body = post_json("/v1/audio/transcriptions", payload)
+Path(out_dir, "transcription.json").write_text(body)
+
+expected = "native FastConformer-RNNT forward pass is not enabled yet"
+if status < 400:
+    raise SystemExit(
+        "Nemotron transcription unexpectedly succeeded before native forward mapping was completed"
+    )
+if expected not in body:
+    raise SystemExit(
+        f"Nemotron scaffold error did not contain expected diagnostic {expected!r}: {body[:500]}"
+    )
+
+print("Nemotron ASR scaffold smoke passed.")
+PY

--- a/scripts/ci/nemotron-asr-smoke.sh
+++ b/scripts/ci/nemotron-asr-smoke.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-Nemotron-ASR scaffold smoke verification against a running izwi server.
+Nemotron-ASR native offline smoke verification against a running izwi server.
 
 Optional environment:
   IZWI_NEMOTRON_ASR_SMOKE_SERVER       Default: http://127.0.0.1:8080
@@ -12,9 +12,10 @@ Optional environment:
   IZWI_NEMOTRON_ASR_SMOKE_OUT_DIR      Default: target/nemotron-asr-smoke
   IZWI_NEMOTRON_ASR_SMOKE_TIMEOUT_SECS Default: 900
 
-This script validates the current native Rust scaffold: model artifacts should
-load, and transcription should fail with the expected pending FastConformer-RNNT
-forward-pass diagnostic until the tensor mapping is completed.
+This script validates the native Rust/Candle offline path: model artifacts
+should load, and transcription should reach the enabled FastConformer-RNNT
+forward pass. A generated silent WAV is enough to catch loader/tensor-shape
+regressions; set IZWI_NEMOTRON_ASR_SMOKE_AUDIO for a content fixture.
 
 Start the server separately, for example:
   IZWI_BACKEND=cpu izwi serve --backend cpu
@@ -87,20 +88,23 @@ payload = {
     "model": model,
     "audio_base64": base64.b64encode(Path(audio_path).read_bytes()).decode("ascii"),
     "response_format": "json",
-    "language": "auto",
+    "language": "English",
 }
 status, body = post_json("/v1/audio/transcriptions", payload)
 Path(out_dir, "transcription.json").write_text(body)
 
-expected = "native FastConformer-RNNT forward pass is not enabled yet"
-if status < 400:
-    raise SystemExit(
-        "Nemotron transcription unexpectedly succeeded before native forward mapping was completed"
-    )
-if expected not in body:
-    raise SystemExit(
-        f"Nemotron scaffold error did not contain expected diagnostic {expected!r}: {body[:500]}"
-    )
+if status >= 400:
+    raise SystemExit(f"transcription failed with HTTP {status}: {body[:500]}")
+if "forward pass is not enabled yet" in body:
+    raise SystemExit(f"Nemotron transcription returned stale scaffold diagnostic: {body[:500]}")
 
-print("Nemotron ASR scaffold smoke passed.")
+try:
+    parsed = json.loads(body)
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"transcription response is not JSON: {exc}: {body[:500]}")
+
+if "text" not in parsed:
+    raise SystemExit(f"transcription response did not include text field: {body[:500]}")
+
+print("Nemotron ASR native offline smoke passed.")
 PY

--- a/ui/src/features/models/catalog/modelMetadata.ts
+++ b/ui/src/features/models/catalog/modelMetadata.ts
@@ -360,7 +360,7 @@ export const MODEL_DETAILS: Record<string, ModelDetail> = {
     shortName: "Nemotron 3.5 ASR",
     fullName: "NVIDIA Nemotron 3.5 ASR Streaming 0.6B",
     description:
-      "Multilingual cache-aware FastConformer-RNNT ASR model with language-ID prompt conditioning; native Rust loader and streaming state are scaffolded",
+      "Multilingual cache-aware FastConformer-RNNT ASR model with native Rust/Candle offline transcription and language-ID prompt conditioning",
     category: "asr",
     capabilities: [
       "Transcription",

--- a/ui/src/features/models/catalog/modelMetadata.ts
+++ b/ui/src/features/models/catalog/modelMetadata.ts
@@ -25,6 +25,8 @@ export function getModelProviderLabel(variant: string): string {
   if (variant.startsWith("Gemma-")) return "Google";
   if (
     variant.startsWith("Parakeet-") ||
+    variant.startsWith("Nemotron-") ||
+    variant.startsWith("nvidia/nemotron-") ||
     variant.startsWith("diar_streaming_sortformer")
   ) {
     return "NVIDIA";
@@ -353,6 +355,21 @@ export const MODEL_DETAILS: Record<string, ModelDetail> = {
     category: "asr",
     capabilities: ["Transcription", "Long-form", "24 kHz"],
     size: "16.16 GB",
+  },
+  "Nemotron-3.5-ASR-Streaming-0.6B": {
+    shortName: "Nemotron 3.5 ASR",
+    fullName: "NVIDIA Nemotron 3.5 ASR Streaming 0.6B",
+    description:
+      "Multilingual cache-aware FastConformer-RNNT ASR model with language-ID prompt conditioning; native Rust loader and streaming state are scaffolded",
+    category: "asr",
+    capabilities: [
+      "Transcription",
+      "40 locales",
+      "16 kHz",
+      "RNNT",
+      "Streaming profiles",
+    ],
+    size: "2.37 GB",
   },
   "Qwen3-ForcedAligner-0.6B": {
     shortName: "ForcedAligner 0.6B",

--- a/ui/src/features/models/catalog/routeModelCatalog.test.ts
+++ b/ui/src/features/models/catalog/routeModelCatalog.test.ts
@@ -5,6 +5,7 @@ import {
   DIARIZATION_PREFERRED_ASR_MODELS,
   DIARIZATION_PREFERRED_MODELS,
   DIARIZATION_PREFERRED_SUMMARY_MODELS,
+  TRANSCRIPTION_PREFERRED_MODELS,
   getChatRouteModelLabel,
   isThinkingChatModel,
   resolvePreferredRouteModel,
@@ -95,6 +96,13 @@ describe("route model catalog", () => {
     });
 
     expect(selected).toBe("Whisper-Large-v3-Turbo");
+  });
+
+  it("keeps Nemotron discoverable without making it the default transcription pick", () => {
+    expect(TRANSCRIPTION_PREFERRED_MODELS).toContain(
+      "Nemotron-3.5-ASR-Streaming-0.6B",
+    );
+    expect(TRANSCRIPTION_PREFERRED_MODELS[0]).toBe("Qwen3-ASR-0.6B-GGUF");
   });
 
   it("treats Qwen3.5 models as thinking-capable chat models", () => {

--- a/ui/src/features/models/catalog/routeModelCatalog.ts
+++ b/ui/src/features/models/catalog/routeModelCatalog.ts
@@ -34,6 +34,7 @@ export const TRANSCRIPTION_PREFERRED_MODELS = [
   "Qwen3-ASR-1.7B-GGUF",
   "Parakeet-TDT-0.6B-v3",
   "Whisper-Large-v3-Turbo",
+  "Nemotron-3.5-ASR-Streaming-0.6B",
 ] as const;
 
 export const DIARIZATION_PREFERRED_MODELS = [

--- a/ui/src/types.test.ts
+++ b/ui/src/types.test.ts
@@ -35,6 +35,19 @@ describe("speech route model filters", () => {
     ).toBe(true);
   });
 
+  it("includes nemotron asr on transcription routes", () => {
+    expect(
+      VIEW_CONFIGS.transcription.modelFilter(
+        "Nemotron-3.5-ASR-Streaming-0.6B",
+      ),
+    ).toBe(true);
+    expect(
+      VIEW_CONFIGS.transcription.modelFilter(
+        "nvidia/nemotron-3.5-asr-streaming-0.6b",
+      ),
+    ).toBe(true);
+  });
+
   it("includes lfm25 audio on transcription routes", () => {
     expect(VIEW_CONFIGS.transcription.modelFilter("LFM2.5-Audio-1.5B-GGUF")).toBe(
       true,

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -65,6 +65,15 @@ function isVibeVoiceAsrVariant(variant: string): boolean {
   );
 }
 
+function isNemotronAsrVariant(variant: string): boolean {
+  const normalized = variant.trim().toLowerCase();
+  return (
+    normalized === "nemotron-3.5-asr-streaming-0.6b" ||
+    normalized === "nvidia/nemotron-3.5-asr-streaming-0.6b" ||
+    normalized === "nemotron 3.5 asr streaming 0.6b"
+  );
+}
+
 function isQwenAsrVariant(variant: string): boolean {
   const normalized = variant.trim().toLowerCase();
   return (
@@ -137,10 +146,11 @@ export const VIEW_CONFIGS: Record<ViewMode, ViewConfig> = {
     id: "transcription",
     label: "Transcription",
     description:
-      "Speech-to-text with Qwen3-ASR, VibeVoice-ASR, Whisper, Parakeet-TDT, Voxtral, and LFM2.5 Audio models",
+      "Speech-to-text with Qwen3-ASR, Nemotron ASR, VibeVoice-ASR, Whisper, Parakeet-TDT, Voxtral, and LFM2.5 Audio models",
     icon: "FileText",
     modelFilter: (variant) =>
       isQwenAsrVariant(variant) ||
+      isNemotronAsrVariant(variant) ||
       isVibeVoiceAsrVariant(variant) ||
       variant.includes("Whisper-Large-v3-Turbo") ||
       variant.includes("Parakeet-TDT") ||
@@ -148,7 +158,7 @@ export const VIEW_CONFIGS: Record<ViewMode, ViewConfig> = {
       isLfm25AudioVariant(variant),
     emptyStateTitle: "No ASR Model Loaded",
     emptyStateDescription:
-      "Download and load a Qwen3-ASR, VibeVoice-ASR, Whisper, Parakeet-TDT, Voxtral, or LFM2.5 Audio model for speech transcription",
+      "Download and load a Qwen3-ASR, Nemotron ASR, VibeVoice-ASR, Whisper, Parakeet-TDT, Voxtral, or LFM2.5 Audio model for speech transcription",
   },
   chat: {
     id: "chat",


### PR DESCRIPTION
Adds Nemotron ASR catalog support, config-label decoding, language aliases, native Candle FastConformer-RNNT offline transcription, prompt conditioning, diagnostics, smoke coverage, and UI/docs updates.