### PR TITLE
Optimize Nemotron ASR CUDA decode and realtime streaming

### DIFF
--- a/crates/izwi-core/src/backends/device.rs
+++ b/crates/izwi-core/src/backends/device.rs
@@ -521,6 +521,26 @@ impl DeviceProfile {
                     })
                 }
             }
+            ModelFamily::NemotronAsr => {
+                if self.capabilities.supports_bf16 {
+                    Some(DTypeSelection {
+                        dtype: DType::BF16,
+                        reason: "Nemotron ASR CUDA policy defaults dense FastConformer/RNNT stages to BF16 when supported".into(),
+                    })
+                } else if self.capabilities.supports_f16 {
+                    Some(DTypeSelection {
+                        dtype: DType::F16,
+                        reason:
+                            "Nemotron ASR CUDA policy falls back to F16 when BF16 is unavailable"
+                                .into(),
+                    })
+                } else {
+                    Some(DTypeSelection {
+                        dtype: DType::F32,
+                        reason: "Nemotron ASR CUDA policy falls back to F32 without reported half precision support".into(),
+                    })
+                }
+            }
             _ => None,
         }
     }
@@ -970,6 +990,10 @@ mod tests {
             cuda_profile.select_model_dtype(ModelFamily::VibeVoiceAsr, None),
             DType::BF16
         );
+        assert_eq!(
+            cuda_profile.select_model_dtype(ModelFamily::NemotronAsr, None),
+            DType::BF16
+        );
     }
 
     #[test]
@@ -1175,6 +1199,48 @@ mod tests {
     }
 
     #[test]
+    fn cpu_and_metal_nemotron_model_dtype_stays_f32() {
+        let cpu_profile = DeviceProfile {
+            device: Device::Cpu,
+            kind: DeviceKind::Cpu,
+            capabilities: DeviceCapabilities::default(),
+            memory_pool: None,
+        };
+        let metal_profile = DeviceProfile {
+            device: Device::Cpu,
+            kind: DeviceKind::Metal,
+            capabilities: DeviceCapabilities {
+                prefers_f32: true,
+                supports_f16: true,
+                supports_bf16: true,
+                ..Default::default()
+            },
+            memory_pool: None,
+        };
+
+        assert_eq!(
+            cpu_profile.select_model_dtype(ModelFamily::NemotronAsr, None),
+            DType::F32
+        );
+        assert_eq!(
+            cpu_profile
+                .select_model_dtype_checked(ModelFamily::NemotronAsr, Some("bf16"), "Nemotron ASR")
+                .unwrap(),
+            DType::F32
+        );
+        assert_eq!(
+            metal_profile.select_model_dtype(ModelFamily::NemotronAsr, None),
+            DType::F32
+        );
+        assert_eq!(
+            metal_profile
+                .select_model_dtype_checked(ModelFamily::NemotronAsr, Some("f16"), "Nemotron ASR")
+                .unwrap(),
+            DType::F32
+        );
+    }
+
+    #[test]
     fn cuda_vibevoice_dtype_falls_back_by_capability() {
         let cuda_f16_profile = DeviceProfile {
             device: Device::Cpu,
@@ -1203,6 +1269,53 @@ mod tests {
         );
         assert_eq!(
             cuda_f32_profile.select_model_dtype(ModelFamily::VibeVoiceTts, None),
+            DType::F32
+        );
+    }
+
+    #[test]
+    fn cuda_nemotron_dtype_falls_back_by_capability() {
+        let cuda_bf16_profile = DeviceProfile {
+            device: Device::Cpu,
+            kind: DeviceKind::Cuda,
+            capabilities: DeviceCapabilities {
+                supports_bf16: true,
+                supports_f16: true,
+                ..Default::default()
+            },
+            memory_pool: None,
+        };
+        let cuda_f16_profile = DeviceProfile {
+            device: Device::Cpu,
+            kind: DeviceKind::Cuda,
+            capabilities: DeviceCapabilities {
+                supports_bf16: false,
+                supports_f16: true,
+                ..Default::default()
+            },
+            memory_pool: None,
+        };
+        let cuda_f32_profile = DeviceProfile {
+            device: Device::Cpu,
+            kind: DeviceKind::Cuda,
+            capabilities: DeviceCapabilities {
+                supports_bf16: false,
+                supports_f16: false,
+                ..Default::default()
+            },
+            memory_pool: None,
+        };
+
+        assert_eq!(
+            cuda_bf16_profile.select_model_dtype(ModelFamily::NemotronAsr, None),
+            DType::BF16
+        );
+        assert_eq!(
+            cuda_f16_profile.select_model_dtype(ModelFamily::NemotronAsr, None),
+            DType::F16
+        );
+        assert_eq!(
+            cuda_f32_profile.select_model_dtype(ModelFamily::NemotronAsr, None),
             DType::F32
         );
     }

--- a/crates/izwi-core/src/lib.rs
+++ b/crates/izwi-core/src/lib.rs
@@ -74,8 +74,9 @@ pub use runtime::{
 pub use runtime::{
     AudioChunk, EngineRuntimeTelemetrySnapshot, GenerationConfig,
     InferenceBrokerRuntimeTelemetrySnapshot, InferenceOptions, PipelineRuntimeTelemetrySnapshot,
-    ReplayRedaction, RuntimeReplayRecord, RuntimeService, RuntimeTelemetrySnapshot,
-    RuntimeTraceContract, RuntimeTracePhase, SpeechToSpeechGeneration,
+    ReplayRedaction, RuntimeAsrRealtimeEvent, RuntimeAsrRealtimeStream, RuntimeReplayRecord,
+    RuntimeService, RuntimeTelemetrySnapshot, RuntimeTraceContract, RuntimeTracePhase,
+    SpeechToSpeechGeneration,
     VoiceRuntimeTelemetrySnapshot, VoiceSession, VoiceSessionPhase, RUNTIME_REPLAY_REDACTION,
     RUNTIME_TRACE_CONTRACTS, TRACE_CAPABILITY, TRACE_CORRELATION_ID, TRACE_ERROR_KIND,
     TRACE_EXECUTION_TARGET, TRACE_MODEL_VARIANT, TRACE_PIPELINE_KIND, TRACE_PIPELINE_STAGE,

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
@@ -6,6 +6,7 @@ mod network;
 
 use std::fs;
 use std::path::Path;
+use std::time::{Duration, Instant};
 
 use candle_core::{DType, Device};
 use candle_nn::VarBuilder;
@@ -471,6 +472,25 @@ struct NemotronDecodeRequest {
     prompt: NemotronPromptCondition,
 }
 
+#[derive(Debug, Clone, Default)]
+struct NemotronStageTimings {
+    resample: Duration,
+    encode: Duration,
+    rnnt_decode: Duration,
+    text_assembly: Duration,
+}
+
+impl NemotronStageTimings {
+    fn diagnostics(&self) -> serde_json::Value {
+        json!({
+            "resample_ms": duration_ms(self.resample),
+            "encode_ms": duration_ms(self.encode),
+            "rnnt_decode_ms": duration_ms(self.rnnt_decode),
+            "text_assembly_ms": duration_ms(self.text_assembly),
+        })
+    }
+}
+
 impl NemotronDecodeRequest {
     fn diagnostics(&self) -> serde_json::Value {
         json!({
@@ -541,8 +561,9 @@ impl NemotronAsrModel {
         sample_rate: u32,
         language: Option<&str>,
     ) -> Result<String> {
-        let mut no_op = |_delta: &str| {};
-        self.transcribe_with_callback_and_prompt(audio, sample_rate, language, None, &mut no_op)
+        let request = self.prepare_decode_request(audio, sample_rate, language, None)?;
+        let output = self.decode_offline_final(audio, &request)?;
+        Ok(output.text)
     }
 
     pub fn transcribe_with_callback(
@@ -576,8 +597,7 @@ impl NemotronAsrModel {
         prompt: Option<&str>,
     ) -> Result<NemotronAsrTranscriptionOutput> {
         let request = self.prepare_decode_request(audio, sample_rate, language, prompt)?;
-        let mut no_op = |_delta: &str| {};
-        self.decode_offline(audio, &request, &mut no_op)
+        self.decode_offline_final(audio, &request)
     }
 
     pub fn max_audio_seconds_hint(&self) -> Option<f32> {
@@ -674,51 +694,129 @@ impl NemotronAsrModel {
         request: &NemotronDecodeRequest,
         on_delta: &mut dyn FnMut(&str),
     ) -> Result<NemotronAsrTranscriptionOutput> {
+        let mut timings = NemotronStageTimings::default();
+        let resample_start = Instant::now();
         let audio_16khz = if request.input_sample_rate == request.target_sample_rate {
             audio.to_vec()
         } else {
             resample_linear(audio, request.input_sample_rate, request.target_sample_rate)
         };
+        timings.resample = resample_start.elapsed();
         let prompt_id = self.network.prompt_id(&request.prompt.target_lang)?;
+        let encode_start = Instant::now();
         let (encoded, encoded_len) = self.network.encode_with_prompt(&audio_16khz, prompt_id)?;
+        timings.encode = encode_start.elapsed();
 
         let mut token_ids = Vec::<usize>::new();
         let mut assembled = String::new();
-        let mut on_token = |token_id: usize| {
-            token_ids.push(token_id);
-            let decoded = self.decoder.decode(&token_ids);
-            let delta = text_delta(&assembled, &decoded);
-            if !delta.is_empty() {
-                on_delta(delta.as_str());
-            }
-            assembled = decoded;
+        let decoded = {
+            let mut on_token = |token_id: usize| {
+                token_ids.push(token_id);
+                let text_start = Instant::now();
+                let decoded = self.decoder.decode(&token_ids);
+                let delta = text_delta(&assembled, &decoded);
+                if !delta.is_empty() {
+                    on_delta(delta.as_str());
+                }
+                assembled = decoded;
+                timings.text_assembly += text_start.elapsed();
+            };
+            let decode_start = Instant::now();
+            let decoded = self
+                .network
+                .decode_rnnt_greedy(&encoded, encoded_len, &mut on_token)?;
+            timings.rnnt_decode = decode_start.elapsed();
+            decoded
         };
-        let decoded = self
-            .network
-            .decode_rnnt_greedy(&encoded, encoded_len, &mut on_token)?;
         if assembled.is_empty() {
+            let text_start = Instant::now();
             assembled = self.decoder.decode(&decoded.token_ids);
+            timings.text_assembly += text_start.elapsed();
         }
 
-        Ok(NemotronAsrTranscriptionOutput {
-            text: assembled,
+        Ok(self.build_decode_output(
+            assembled,
+            request,
+            prompt_id,
+            audio_16khz.len(),
+            decoded,
+            timings,
+            "callback_delta",
+        ))
+    }
+
+    fn decode_offline_final(
+        &self,
+        audio: &[f32],
+        request: &NemotronDecodeRequest,
+    ) -> Result<NemotronAsrTranscriptionOutput> {
+        let mut timings = NemotronStageTimings::default();
+        let resample_start = Instant::now();
+        let audio_16khz = if request.input_sample_rate == request.target_sample_rate {
+            audio.to_vec()
+        } else {
+            resample_linear(audio, request.input_sample_rate, request.target_sample_rate)
+        };
+        timings.resample = resample_start.elapsed();
+
+        let prompt_id = self.network.prompt_id(&request.prompt.target_lang)?;
+        let encode_start = Instant::now();
+        let (encoded, encoded_len) = self.network.encode_with_prompt(&audio_16khz, prompt_id)?;
+        timings.encode = encode_start.elapsed();
+
+        let mut no_op = |_token_id: usize| {};
+        let decode_start = Instant::now();
+        let decoded = self
+            .network
+            .decode_rnnt_greedy(&encoded, encoded_len, &mut no_op)?;
+        timings.rnnt_decode = decode_start.elapsed();
+
+        let text_start = Instant::now();
+        let assembled = self.decoder.decode(&decoded.token_ids);
+        timings.text_assembly = text_start.elapsed();
+
+        Ok(self.build_decode_output(
+            assembled,
+            request,
+            prompt_id,
+            audio_16khz.len(),
+            decoded,
+            timings,
+            "final_only",
+        ))
+    }
+
+    fn build_decode_output(
+        &self,
+        text: String,
+        request: &NemotronDecodeRequest,
+        prompt_id: usize,
+        resampled_samples: usize,
+        decoded: network::NemotronDecodedTokens,
+        timings: NemotronStageTimings,
+        decode_mode: &'static str,
+    ) -> NemotronAsrTranscriptionOutput {
+        NemotronAsrTranscriptionOutput {
+            text,
             language: Some(request.prompt.target_lang.clone()),
             diagnostics: Some(json!({
                 "audio": {
                     "input_sample_rate": request.input_sample_rate,
                     "target_sample_rate": request.target_sample_rate,
                     "input_samples": request.samples,
-                    "resampled_samples": audio_16khz.len(),
+                    "resampled_samples": resampled_samples,
                 },
                 "prompt": request.prompt.diagnostics(),
                 "prompt_id": prompt_id,
                 "blank_id": self.network.blank_idx(),
                 "dtype_plan": nemotron_dtype_diagnostics(&self.dtype_selection, &self.device_profile, self.network.dtype()),
                 "native_forward_status": "enabled_offline_fastconformer_rnnt",
+                "decode_mode": decode_mode,
                 "decode": decoded.stats.diagnostics(),
+                "timings_ms": timings.diagnostics(),
                 "supports_realtime_cache_decode": false,
             })),
-        })
+        }
     }
 }
 
@@ -1026,6 +1124,10 @@ fn ms_to_samples(ms: usize, sample_rate: u32) -> usize {
     ((sample_rate as usize).saturating_mul(ms)) / 1000
 }
 
+fn duration_ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1000.0
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1123,6 +1225,22 @@ mod tests {
 
         let err = select_nemotron_asr_dtype(&cuda, Some("float8")).unwrap_err();
         assert!(err.to_string().contains("expected one of"));
+    }
+
+    #[test]
+    fn stage_timings_diagnostics_report_milliseconds() {
+        let timings = NemotronStageTimings {
+            resample: Duration::from_micros(1_500),
+            encode: Duration::from_millis(2),
+            rnnt_decode: Duration::from_micros(3_250),
+            text_assembly: Duration::from_millis(4),
+        };
+        let diagnostics = timings.diagnostics();
+
+        assert_eq!(diagnostics["resample_ms"], 1.5);
+        assert_eq!(diagnostics["encode_ms"], 2.0);
+        assert_eq!(diagnostics["rnnt_decode_ms"], 3.25);
+        assert_eq!(diagnostics["text_assembly_ms"], 4.0);
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
@@ -1693,6 +1693,22 @@ mod tests {
     }
 
     #[test]
+    fn streaming_state_retains_audio_samples_for_native_pipeline() {
+        let profile = NemotronStreamingProfile::new(56, 0).unwrap();
+        let prompt = NemotronPromptCondition::resolve(Some("en-US"), None).unwrap();
+        let mut state = NemotronStreamingState::new(profile, prompt, 16_000);
+
+        state.push_samples(&[0.1, 0.2, 0.3]).unwrap();
+        state.push_samples(&[0.4]).unwrap();
+
+        assert_eq!(state.buffered_samples(), 4);
+        assert_eq!(state.samples, vec![0.1, 0.2, 0.3, 0.4]);
+        assert_eq!(state.text(), "");
+        assert_eq!(state.emitted_tokens(), 0);
+        assert_eq!(state.diagnostics()["supports_realtime_stream_decode"], false);
+    }
+
+    #[test]
     fn streaming_state_emits_non_overlapping_ready_chunks() {
         let profile = NemotronStreamingProfile::new(56, 1).unwrap();
         let prompt = NemotronPromptCondition::resolve(Some("en-US"), None).unwrap();

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
@@ -10,8 +10,10 @@ use std::path::Path;
 use candle_core::{DType, Device};
 use candle_nn::VarBuilder;
 use serde_json::json;
+use tracing::info;
 
-use crate::backends::DeviceProfile;
+use crate::backends::{DTypeSelection, DTypeSelectionRequest, DeviceProfile};
+use crate::catalog::ModelFamily;
 use crate::error::{Error, Result};
 use crate::model::ModelVariant;
 use crate::tokenizer::Tokenizer;
@@ -24,6 +26,7 @@ const SAMPLE_RATE: u32 = 16_000;
 const DEFAULT_STRIP_LANG_TAGS: bool = true;
 const DEFAULT_MAX_AUDIO_SECONDS_HINT: f32 = 30.0;
 const STREAMING_FRAME_MS: usize = 80;
+const NEMOTRON_ASR_DTYPE_ENV: &str = "IZWI_NEMOTRON_ASR_DTYPE";
 const SUPPORTED_TARGET_LANGS: &[&str] = &[
     "auto", "en-US", "en-GB", "es-US", "es-ES", "fr-FR", "fr-CA", "it-IT", "pt-BR", "pt-PT",
     "nl-NL", "de-DE", "tr-TR", "ru-RU", "ar-AR", "hi-IN", "ja-JP", "ko-KR", "vi-VN", "uk-UA",
@@ -46,6 +49,7 @@ pub struct NemotronAsrModel {
     network: NemotronNetwork,
     runtime_plan: NemotronRuntimePlan,
     device_profile: DeviceProfile,
+    dtype_selection: DTypeSelection,
 }
 
 enum NemotronDecoder {
@@ -496,15 +500,29 @@ impl NemotronAsrModel {
         validate_config_output_vocabulary(&artifacts.config_inventory)?;
         let decoder = NemotronDecoder::load(&artifacts)?;
         let device = select_device_for_nemotron(&device_profile);
-        let vb =
-            VarBuilder::from_pth(&artifacts.checkpoint_path, DType::F32, &device).map_err(|e| {
-                Error::ModelLoadError(format!(
-                    "Failed to load Nemotron checkpoint {}: {}",
-                    artifacts.checkpoint_path.display(),
-                    e
-                ))
-            })?;
+        let dtype_override = std::env::var(NEMOTRON_ASR_DTYPE_ENV).ok();
+        let dtype_selection =
+            select_nemotron_asr_dtype(&device_profile, dtype_override.as_deref())?;
+        let checkpoint_display = artifacts.checkpoint_path.display();
+        let vb = match VarBuilder::from_pth(
+            &artifacts.checkpoint_path,
+            dtype_selection.dtype,
+            &device,
+        ) {
+            Ok(vb) => vb,
+            Err(e) => {
+                return Err(Error::ModelLoadError(format!(
+                    "Failed to load Nemotron checkpoint {checkpoint_display}: {e}"
+                )));
+            }
+        };
         let network = NemotronNetwork::load(&vb, &artifacts.config_inventory)?;
+        info!(
+            "Loaded Nemotron ASR model on {:?} with dtype {:?} ({})",
+            device_profile.kind,
+            dtype_selection.dtype,
+            dtype_selection.reason.as_ref()
+        );
 
         Ok(Self {
             variant,
@@ -513,6 +531,7 @@ impl NemotronAsrModel {
             network,
             runtime_plan,
             device_profile,
+            dtype_selection,
         })
     }
 
@@ -616,6 +635,7 @@ impl NemotronAsrModel {
             "decoder_vocabulary_size": self.decoder.vocab_size(),
             "decoder_source": self.decoder.source(),
             "runtime": self.runtime_plan.diagnostics(),
+            "dtype_plan": nemotron_dtype_diagnostics(&self.dtype_selection, &self.device_profile, self.network.dtype()),
             "prompt": prompt.diagnostics(),
             "prompt_id": prompt_id,
             "blank_id": self.network.blank_idx(),
@@ -693,6 +713,7 @@ impl NemotronAsrModel {
                 "prompt": request.prompt.diagnostics(),
                 "prompt_id": prompt_id,
                 "blank_id": self.network.blank_idx(),
+                "dtype_plan": nemotron_dtype_diagnostics(&self.dtype_selection, &self.device_profile, self.network.dtype()),
                 "native_forward_status": "enabled_offline_fastconformer_rnnt",
                 "decode": decoded.stats.diagnostics(),
                 "supports_realtime_cache_decode": false,
@@ -703,6 +724,48 @@ impl NemotronAsrModel {
 
 fn select_device_for_nemotron(device_profile: &DeviceProfile) -> Device {
     device_profile.device.clone()
+}
+
+fn select_nemotron_asr_dtype(
+    device_profile: &DeviceProfile,
+    dtype_override: Option<&str>,
+) -> Result<DTypeSelection> {
+    let requested = dtype_override.map(str::trim).filter(|raw| !raw.is_empty());
+    let request = DTypeSelectionRequest::new(if device_profile.kind.is_cuda() {
+        requested
+    } else {
+        None
+    })
+    .with_model_family(ModelFamily::NemotronAsr);
+
+    if device_profile.kind.is_cuda() && requested.is_some() {
+        return device_profile.try_resolve_dtype(request).map_err(|err| {
+            Error::InvalidInput(format!("Invalid CUDA Nemotron ASR dtype override: {err}"))
+        });
+    }
+
+    Ok(device_profile.resolve_dtype(request))
+}
+
+fn nemotron_dtype_diagnostics(
+    selection: &DTypeSelection,
+    device_profile: &DeviceProfile,
+    actual_network_dtype: DType,
+) -> serde_json::Value {
+    let cuda_compute_capability = device_profile
+        .capabilities
+        .cuda_compute_capability
+        .map(|(major, minor)| format!("{major}.{minor}"));
+    json!({
+        "model_weights": format!("{:?}", selection.dtype),
+        "activations": format!("{:?}", actual_network_dtype),
+        "reason": selection.reason.to_string(),
+        "device": format!("{:?}", device_profile.kind),
+        "supports_bf16": device_profile.capabilities.supports_bf16,
+        "supports_f16": device_profile.capabilities.supports_f16,
+        "cuda_compute_capability": cuda_compute_capability,
+        "cuda_device_name": device_profile.capabilities.cuda_device_name.as_deref(),
+    })
 }
 
 fn validate_config_output_vocabulary(inventory: &NemotronConfigInventory) -> Result<()> {
@@ -969,7 +1032,7 @@ mod tests {
 
     use std::path::PathBuf;
 
-    use crate::backends::{DeviceKind, DeviceSelector};
+    use crate::backends::{DeviceCapabilities, DeviceKind, DeviceProfile, DeviceSelector};
     use uuid::Uuid;
 
     #[test]
@@ -979,6 +1042,87 @@ mod tests {
         assert_eq!(prompt.target_lang, "auto");
         assert!(prompt.strip_lang_tags);
         assert!(prompt.context_prompt.is_none());
+    }
+
+    fn test_device_profile(
+        kind: DeviceKind,
+        supports_bf16: bool,
+        supports_f16: bool,
+    ) -> DeviceProfile {
+        DeviceProfile {
+            device: Device::Cpu,
+            kind,
+            capabilities: DeviceCapabilities {
+                prefers_f32: kind.is_metal(),
+                supports_bf16,
+                supports_f16,
+                cuda_compute_capability: kind.is_cuda().then_some((8, 9)),
+                cuda_device_name: kind.is_cuda().then_some("test-cuda".to_string()),
+                ..Default::default()
+            },
+            memory_pool: None,
+        }
+    }
+
+    #[test]
+    fn nemotron_dtype_plan_keeps_cpu_and_metal_f32() {
+        let cpu = test_device_profile(DeviceKind::Cpu, true, true);
+        let metal = test_device_profile(DeviceKind::Metal, true, true);
+
+        assert_eq!(
+            select_nemotron_asr_dtype(&cpu, None).unwrap().dtype,
+            DType::F32
+        );
+        assert_eq!(
+            select_nemotron_asr_dtype(&cpu, Some("bf16")).unwrap().dtype,
+            DType::F32
+        );
+        assert_eq!(
+            select_nemotron_asr_dtype(&metal, None).unwrap().dtype,
+            DType::F32
+        );
+        assert_eq!(
+            select_nemotron_asr_dtype(&metal, Some("f16"))
+                .unwrap()
+                .dtype,
+            DType::F32
+        );
+    }
+
+    #[test]
+    fn nemotron_dtype_plan_uses_cuda_capability_order_and_diagnostics() {
+        let cuda_bf16 = test_device_profile(DeviceKind::Cuda, true, true);
+        let cuda_f16 = test_device_profile(DeviceKind::Cuda, false, true);
+        let cuda_f32 = test_device_profile(DeviceKind::Cuda, false, false);
+
+        let selection = select_nemotron_asr_dtype(&cuda_bf16, None).unwrap();
+        assert_eq!(selection.dtype, DType::BF16);
+        assert_eq!(
+            select_nemotron_asr_dtype(&cuda_f16, None).unwrap().dtype,
+            DType::F16
+        );
+        assert_eq!(
+            select_nemotron_asr_dtype(&cuda_f32, None).unwrap().dtype,
+            DType::F32
+        );
+
+        let diagnostics = nemotron_dtype_diagnostics(&selection, &cuda_bf16, DType::BF16);
+        assert_eq!(diagnostics["model_weights"], "BF16");
+        assert_eq!(diagnostics["activations"], "BF16");
+        assert_eq!(diagnostics["device"], "Cuda");
+        assert_eq!(diagnostics["cuda_compute_capability"], "8.9");
+        assert_eq!(diagnostics["cuda_device_name"], "test-cuda");
+    }
+
+    #[test]
+    fn nemotron_dtype_plan_rejects_bad_cuda_overrides() {
+        let cuda = test_device_profile(DeviceKind::Cuda, false, true);
+
+        let err = select_nemotron_asr_dtype(&cuda, Some("bf16")).unwrap_err();
+        assert!(err.to_string().contains("Invalid CUDA Nemotron ASR"));
+
+        let err = select_nemotron_asr_dtype(&cuda, Some("float8")).unwrap_err();
+        assert!(err.to_string().contains("expected one of"));
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
@@ -299,6 +299,90 @@ impl NemotronStreamChunkRange {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NemotronRealtimeStreamConfig {
+    pub language: Option<String>,
+    pub prompt: Option<String>,
+    pub right_context_frames: Option<usize>,
+    pub emit_partials: bool,
+}
+
+impl Default for NemotronRealtimeStreamConfig {
+    fn default() -> Self {
+        Self {
+            language: None,
+            prompt: None,
+            right_context_frames: None,
+            emit_partials: true,
+        }
+    }
+}
+
+impl NemotronRealtimeStreamConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_language(mut self, language: impl Into<String>) -> Self {
+        self.language = Some(language.into());
+        self
+    }
+
+    fn with_optional_language(mut self, language: Option<&str>) -> Self {
+        self.language = language.map(ToOwned::to_owned);
+        self
+    }
+
+    pub fn with_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.prompt = Some(prompt.into());
+        self
+    }
+
+    fn with_optional_prompt(mut self, prompt: Option<&str>) -> Self {
+        self.prompt = prompt.map(ToOwned::to_owned);
+        self
+    }
+
+    pub fn with_right_context_frames(mut self, right_context_frames: usize) -> Self {
+        self.right_context_frames = Some(right_context_frames);
+        self
+    }
+
+    fn with_optional_right_context_frames(mut self, right_context_frames: Option<usize>) -> Self {
+        self.right_context_frames = right_context_frames;
+        self
+    }
+
+    pub fn with_emit_partials(mut self, emit_partials: bool) -> Self {
+        self.emit_partials = emit_partials;
+        self
+    }
+
+    fn prompt_condition(&self) -> Result<NemotronPromptCondition> {
+        NemotronPromptCondition::resolve(self.language.as_deref(), self.prompt.as_deref())
+    }
+
+    fn diagnostics(&self) -> serde_json::Value {
+        let prompt = self.prompt_condition().ok();
+        json!({
+            "target_lang": prompt.as_ref().map(|prompt| prompt.target_lang.as_str()).unwrap_or("auto"),
+            "context_prompt_present": prompt
+                .as_ref()
+                .is_some_and(|prompt| prompt.context_prompt.is_some()),
+            "right_context_frames": self.right_context_frames,
+            "emit_partials": self.emit_partials,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NemotronRealtimeStreamEvent {
+    pub text: String,
+    pub delta: String,
+    pub is_final: bool,
+    pub chunk_index: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NemotronStreamingCacheStatus {
     PendingNativeCacheImplementation,
 }
@@ -614,8 +698,34 @@ impl NemotronAsrModel {
         prompt: Option<&str>,
         right_context_frames: Option<usize>,
     ) -> Result<NemotronStreamingState> {
-        let prompt = NemotronPromptCondition::resolve(language, prompt)?;
-        let profile = match right_context_frames {
+        self.start_stream_state_with_config(
+            &NemotronRealtimeStreamConfig::new()
+                .with_emit_partials(true)
+                .with_optional_language(language)
+                .with_optional_prompt(prompt)
+                .with_optional_right_context_frames(right_context_frames),
+        )
+    }
+
+    pub fn start_stream_state_with_config(
+        &self,
+        config: &NemotronRealtimeStreamConfig,
+    ) -> Result<NemotronStreamingState> {
+        let prompt = config.prompt_condition()?;
+        let profile = self.resolve_streaming_profile(config.right_context_frames)?;
+
+        Ok(NemotronStreamingState::new(
+            profile,
+            prompt,
+            self.runtime_plan.sample_rate,
+        ))
+    }
+
+    fn resolve_streaming_profile(
+        &self,
+        right_context_frames: Option<usize>,
+    ) -> Result<NemotronStreamingProfile> {
+        Ok(match right_context_frames {
             Some(right_context_frames) => self
                 .runtime_plan
                 .streaming_profiles
@@ -628,13 +738,7 @@ impl NemotronAsrModel {
                     ))
                 })?,
             None => self.runtime_plan.default_streaming_profile.clone(),
-        };
-
-        Ok(NemotronStreamingState::new(
-            profile,
-            prompt,
-            self.runtime_plan.sample_rate,
-        ))
+        })
     }
 
     pub fn diagnostics_for_prompt(
@@ -1324,6 +1428,39 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(chunk_ms, vec![80, 160, 320, 560, 1120]);
+    }
+
+    #[test]
+    fn realtime_stream_config_resolves_prompt_and_profile_contract() {
+        let config = NemotronRealtimeStreamConfig::new()
+            .with_language("German")
+            .with_prompt("medical dictation")
+            .with_right_context_frames(3);
+
+        let prompt = config.prompt_condition().unwrap();
+        let diagnostics = config.diagnostics();
+
+        assert_eq!(prompt.target_lang, "de-DE");
+        assert_eq!(prompt.context_prompt.as_deref(), Some("medical dictation"));
+        assert_eq!(config.right_context_frames, Some(3));
+        assert_eq!(diagnostics["target_lang"], "de-DE");
+        assert_eq!(diagnostics["right_context_frames"], 3);
+        assert_eq!(diagnostics["emit_partials"], true);
+    }
+
+    #[test]
+    fn streaming_state_contract_does_not_claim_native_cache_before_wiring() {
+        let profile = NemotronStreamingProfile::new(56, 3).unwrap();
+        let prompt = NemotronPromptCondition::resolve(Some("auto"), None).unwrap();
+        let state = NemotronStreamingState::new(profile, prompt, 16_000);
+        let diagnostics = state.diagnostics();
+
+        assert_eq!(diagnostics["supports_realtime_cache_decode"], false);
+        assert_eq!(
+            diagnostics["cache_status"],
+            "PendingNativeCacheImplementation"
+        );
+        assert_eq!(diagnostics["profile"]["cache_reuse_ready"], false);
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
@@ -21,7 +21,10 @@ use crate::tokenizer::Tokenizer;
 
 pub use config::NemotronConfigInventory;
 pub use nemo::{ensure_nemotron_artifacts, NemotronArtifacts, NEMOTRON_NEMO_FILENAME};
-use network::{resample_linear, NemotronNetwork};
+use network::{
+    resample_linear, NemotronNetwork, NemotronRnntStreamState, NemotronStreamingEncoderState,
+    NemotronStreamingFeatureState, NemotronStreamingPreEncodeState,
+};
 
 const SAMPLE_RATE: u32 = 16_000;
 const DEFAULT_STRIP_LANG_TAGS: bool = true;
@@ -41,6 +44,14 @@ pub struct NemotronAsrTranscriptionOutput {
     pub text: String,
     pub language: Option<String>,
     pub diagnostics: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NemotronAsrDecodeStep {
+    pub delta: String,
+    pub text: String,
+    pub tokens_generated: usize,
+    pub finished: bool,
 }
 
 pub struct NemotronAsrModel {
@@ -387,16 +398,24 @@ pub enum NemotronStreamingCacheStatus {
     PendingNativeCacheImplementation,
 }
 
-#[derive(Debug, Clone)]
 pub struct NemotronStreamingState {
     profile: NemotronStreamingProfile,
     prompt: NemotronPromptCondition,
     sample_rate: u32,
+    samples: Vec<f32>,
     buffered_samples: usize,
     consumed_samples: usize,
     chunks_processed: usize,
+    events_emitted: usize,
     input_finished: bool,
+    final_event_emitted: bool,
     cache_status: NemotronStreamingCacheStatus,
+    feature_state: NemotronStreamingFeatureState,
+    pre_encode_state: NemotronStreamingPreEncodeState,
+    encoder_state: NemotronStreamingEncoderState,
+    rnnt_state: Option<NemotronRnntStreamState>,
+    assembled_text: String,
+    emitted_tokens: usize,
 }
 
 impl NemotronStreamingState {
@@ -405,16 +424,33 @@ impl NemotronStreamingState {
         prompt: NemotronPromptCondition,
         sample_rate: u32,
     ) -> Self {
+        let encoder_state = NemotronStreamingEncoderState::new(
+            profile.left_context_frames,
+            profile.right_context_frames,
+        );
         Self {
             profile,
             prompt,
             sample_rate,
+            samples: Vec::new(),
             buffered_samples: 0,
             consumed_samples: 0,
             chunks_processed: 0,
+            events_emitted: 0,
             input_finished: false,
+            final_event_emitted: false,
             cache_status: NemotronStreamingCacheStatus::PendingNativeCacheImplementation,
+            feature_state: NemotronStreamingFeatureState::new(),
+            pre_encode_state: NemotronStreamingPreEncodeState::new(),
+            encoder_state,
+            rnnt_state: None,
+            assembled_text: String::new(),
+            emitted_tokens: 0,
         }
+    }
+
+    fn attach_rnnt_state(&mut self, rnnt_state: NemotronRnntStreamState) {
+        self.rnnt_state = Some(rnnt_state);
     }
 
     pub fn profile(&self) -> &NemotronStreamingProfile {
@@ -437,12 +473,21 @@ impl NemotronStreamingState {
         self.chunks_processed
     }
 
+    pub fn text(&self) -> &str {
+        &self.assembled_text
+    }
+
+    pub fn emitted_tokens(&self) -> usize {
+        self.emitted_tokens
+    }
+
     pub fn push_samples(&mut self, samples: &[f32]) -> Result<()> {
         if self.input_finished {
             return Err(Error::InvalidInput(
                 "Cannot push audio into a finalized Nemotron streaming state".to_string(),
             ));
         }
+        self.samples.extend_from_slice(samples);
         self.buffered_samples = self.buffered_samples.saturating_add(samples.len());
         Ok(())
     }
@@ -505,9 +550,13 @@ impl NemotronStreamingState {
             "buffered_samples": self.buffered_samples,
             "consumed_samples": self.consumed_samples,
             "chunks_processed": self.chunks_processed,
+            "events_emitted": self.events_emitted,
             "input_finished": self.input_finished,
+            "final_event_emitted": self.final_event_emitted,
+            "emitted_tokens": self.emitted_tokens,
             "cache_status": format!("{:?}", self.cache_status),
             "supports_realtime_cache_decode": false,
+            "supports_realtime_stream_decode": self.rnnt_state.is_some(),
         })
     }
 }
@@ -713,12 +762,11 @@ impl NemotronAsrModel {
     ) -> Result<NemotronStreamingState> {
         let prompt = config.prompt_condition()?;
         let profile = self.resolve_streaming_profile(config.right_context_frames)?;
+        let rnnt_state = self.network.start_rnnt_stream()?;
 
-        Ok(NemotronStreamingState::new(
-            profile,
-            prompt,
-            self.runtime_plan.sample_rate,
-        ))
+        let mut state = NemotronStreamingState::new(profile, prompt, self.runtime_plan.sample_rate);
+        state.attach_rnnt_state(rnnt_state);
+        Ok(state)
     }
 
     fn resolve_streaming_profile(
@@ -739,6 +787,187 @@ impl NemotronAsrModel {
                 })?,
             None => self.runtime_plan.default_streaming_profile.clone(),
         })
+    }
+
+    pub fn push_stream_samples(
+        &self,
+        state: &mut NemotronStreamingState,
+        samples: &[f32],
+        sample_rate: u32,
+    ) -> Result<Vec<NemotronRealtimeStreamEvent>> {
+        if samples.is_empty() {
+            return Ok(Vec::new());
+        }
+        if sample_rate == 0 {
+            return Err(Error::InvalidInput(
+                "Audio sample rate must be greater than zero".to_string(),
+            ));
+        }
+        let samples = if sample_rate == state.sample_rate {
+            samples.to_vec()
+        } else {
+            resample_linear(samples, sample_rate, state.sample_rate)
+        };
+        state.push_samples(&samples)?;
+        self.decode_ready_stream_chunks(state)
+    }
+
+    pub fn finish_stream(
+        &self,
+        state: &mut NemotronStreamingState,
+    ) -> Result<Vec<NemotronRealtimeStreamEvent>> {
+        state.finish_input();
+        let mut events = self.decode_ready_stream_chunks(state)?;
+        if !state.final_event_emitted {
+            state.final_event_emitted = true;
+            let event = NemotronRealtimeStreamEvent {
+                text: state.assembled_text.clone(),
+                delta: String::new(),
+                is_final: true,
+                chunk_index: state.events_emitted,
+            };
+            state.events_emitted = state.events_emitted.saturating_add(1);
+            events.push(event);
+        }
+        Ok(events)
+    }
+
+    pub fn start_decode_with_prompt(
+        &self,
+        audio: &[f32],
+        sample_rate: u32,
+        language: Option<&str>,
+        prompt: Option<&str>,
+        _max_new_tokens: usize,
+    ) -> Result<NemotronStreamingState> {
+        let mut state = self.start_stream_state(language, prompt, None)?;
+        let audio_16khz = if sample_rate == self.runtime_plan.sample_rate {
+            audio.to_vec()
+        } else {
+            resample_linear(audio, sample_rate, self.runtime_plan.sample_rate)
+        };
+        state.push_samples(&audio_16khz)?;
+        state.finish_input();
+        Ok(state)
+    }
+
+    pub fn decode_step(&self, state: &mut NemotronStreamingState) -> Result<NemotronAsrDecodeStep> {
+        let events = self.decode_next_stream_chunk(state)?;
+        let mut delta = String::new();
+        let mut finished = false;
+        for event in events {
+            delta.push_str(&event.delta);
+            finished |= event.is_final;
+        }
+        if state.input_finished && state.consumed_samples >= state.buffered_samples && !finished {
+            let final_events = self.finish_stream(state)?;
+            for event in final_events {
+                delta.push_str(&event.delta);
+                finished |= event.is_final;
+            }
+        }
+        Ok(NemotronAsrDecodeStep {
+            delta,
+            text: state.assembled_text.clone(),
+            tokens_generated: state.emitted_tokens,
+            finished,
+        })
+    }
+
+    fn decode_ready_stream_chunks(
+        &self,
+        state: &mut NemotronStreamingState,
+    ) -> Result<Vec<NemotronRealtimeStreamEvent>> {
+        let mut events = Vec::new();
+        while state.next_ready_chunk().is_some() {
+            events.extend(self.decode_next_stream_chunk(state)?);
+        }
+        Ok(events)
+    }
+
+    fn decode_next_stream_chunk(
+        &self,
+        state: &mut NemotronStreamingState,
+    ) -> Result<Vec<NemotronRealtimeStreamEvent>> {
+        let Some(chunk) = state.next_ready_chunk() else {
+            return Ok(Vec::new());
+        };
+        let chunk_samples = state.samples[chunk.start_sample..chunk.end_sample].to_vec();
+        state.feature_state.push_samples(&chunk_samples)?;
+        if chunk.is_final {
+            state.feature_state.finish_input();
+        }
+        state.mark_chunk_consumed(&chunk)?;
+        let prompt_id = self.network.prompt_id(&state.prompt.target_lang)?;
+        self.drain_streaming_network(state, prompt_id)
+    }
+
+    fn drain_streaming_network(
+        &self,
+        state: &mut NemotronStreamingState,
+        prompt_id: usize,
+    ) -> Result<Vec<NemotronRealtimeStreamEvent>> {
+        let mut events = Vec::new();
+        loop {
+            let mut progressed = false;
+
+            if let Some(feature_chunk) = self
+                .network
+                .compute_streaming_features(&mut state.feature_state)?
+            {
+                state.pre_encode_state.push_features(feature_chunk)?;
+                progressed = true;
+            } else if state.input_finished {
+                state.pre_encode_state.finish_input();
+            }
+
+            if let Some(pre_encoded) = self
+                .network
+                .pre_encode_streaming_chunk(&mut state.pre_encode_state)?
+            {
+                state.encoder_state.push_pre_encoded(pre_encoded)?;
+                progressed = true;
+            } else if state.input_finished {
+                state.encoder_state.finish_input();
+            }
+
+            if let Some(encoder_chunk) = self
+                .network
+                .encode_streaming_chunk(&mut state.encoder_state, prompt_id)?
+            {
+                let rnnt_state = state.rnnt_state.as_mut().ok_or_else(|| {
+                    Error::InferenceError("Nemotron stream is missing RNNT state".to_string())
+                })?;
+                let mut ignored = |_token_id: usize| {};
+                let decoded = self.network.decode_rnnt_streaming_chunk(
+                    rnnt_state,
+                    &encoder_chunk.encoded,
+                    encoder_chunk.frames,
+                    &mut ignored,
+                )?;
+                state.emitted_tokens = decoded.stats.emitted_tokens;
+                let text = self.decoder.decode(&decoded.token_ids);
+                let delta = text_delta(&state.assembled_text, &text);
+                state.assembled_text = text.clone();
+                if !delta.is_empty() || encoder_chunk.is_final {
+                    let is_final = encoder_chunk.is_final;
+                    state.final_event_emitted |= is_final;
+                    events.push(NemotronRealtimeStreamEvent {
+                        text,
+                        delta,
+                        is_final,
+                        chunk_index: state.events_emitted,
+                    });
+                    state.events_emitted = state.events_emitted.saturating_add(1);
+                }
+                progressed = true;
+            }
+
+            if !progressed {
+                break;
+            }
+        }
+        Ok(events)
     }
 
     pub fn diagnostics_for_prompt(

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
@@ -77,6 +77,7 @@ pub(super) struct NemotronNetwork {
     max_symbols_per_frame: usize,
     rel_pos_cache: Mutex<HashMap<RelPosCacheKey, Tensor>>,
     att_mask_cache: Mutex<HashMap<LimitedMaskCacheKey, Tensor>>,
+    dtype: DType,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -150,6 +151,7 @@ impl NemotronNetwork {
             max_symbols_per_frame: DEFAULT_MAX_SYMBOLS_PER_FRAME,
             rel_pos_cache: Mutex::new(HashMap::new()),
             att_mask_cache: Mutex::new(HashMap::new()),
+            dtype: vb.dtype(),
         })
     }
 
@@ -170,6 +172,11 @@ impl NemotronNetwork {
         prompt_id: usize,
     ) -> Result<(Tensor, usize)> {
         let (features, feature_frames) = self.preprocessor.compute_features(audio_16khz)?;
+        let features = if features.dtype() == self.dtype {
+            features
+        } else {
+            features.to_dtype(self.dtype)?
+        };
         let (mut x, encoded_len) = self.pre_encode.forward(&features, feature_frames)?;
         if encoded_len == 0 {
             return Err(Error::InferenceError(
@@ -335,6 +342,10 @@ impl NemotronNetwork {
 
     pub(super) fn blank_idx(&self) -> usize {
         self.blank_idx
+    }
+
+    pub(super) fn dtype(&self) -> DType {
+        self.dtype
     }
 
     fn rel_positional_embedding(
@@ -691,7 +702,7 @@ impl ConvSubsamplingDw {
 }
 
 fn load_subsampling_out_projection(vb: VarBuilder) -> Result<(Linear, usize)> {
-    let ws = vb.get_unchecked_dtype("weight", DType::F32)?;
+    let ws = vb.get_unchecked_dtype("weight", vb.dtype())?;
     let (out_dim, in_dim) = ws.dims2()?;
     if out_dim != ENCODER_DIM || in_dim % CONV_SUB_CHANNELS != 0 {
         return Err(Error::ModelLoadError(format!(
@@ -905,12 +916,18 @@ impl RelPosSelfAttention {
             .reshape((1, 2 * t - 1, ENCODER_HEADS, ENCODER_HEAD_DIM))?
             .transpose(1, 2)?;
 
-        let pos_bias_u = self
-            .pos_bias_u
-            .reshape((1, ENCODER_HEADS, 1, ENCODER_HEAD_DIM))?;
-        let pos_bias_v = self
-            .pos_bias_v
-            .reshape((1, ENCODER_HEADS, 1, ENCODER_HEAD_DIM))?;
+        let pos_bias_u = self.pos_bias_u.to_dtype(q.dtype())?.reshape((
+            1,
+            ENCODER_HEADS,
+            1,
+            ENCODER_HEAD_DIM,
+        ))?;
+        let pos_bias_v = self.pos_bias_v.to_dtype(q.dtype())?.reshape((
+            1,
+            ENCODER_HEADS,
+            1,
+            ENCODER_HEAD_DIM,
+        ))?;
         let matrix_ac = q
             .broadcast_add(&pos_bias_u)?
             .matmul(&k.transpose(2, 3)?.contiguous()?)?;
@@ -1038,7 +1055,7 @@ struct PredictorState {
 
 impl Predictor {
     fn load(vb: VarBuilder) -> Result<Self> {
-        let embed = vb.pp("embed").get_unchecked_dtype("weight", DType::F32)?;
+        let embed = vb.pp("embed").get_unchecked_dtype("weight", vb.dtype())?;
         let vocab_plus_blank = embed.dim(0)?;
         let hidden = embed.dim(1)?;
         if hidden != PRED_HIDDEN {
@@ -1056,7 +1073,8 @@ impl Predictor {
     }
 
     fn initial_state(&self, batch: usize, device: &Device) -> Result<PredictorState> {
-        let zeros = |dim| Tensor::zeros((batch, dim), DType::F32, device).map_err(Error::from);
+        let dtype = self.embed.dtype();
+        let zeros = |dim| Tensor::zeros((batch, dim), dtype, device).map_err(Error::from);
         Ok(PredictorState {
             h0: zeros(PRED_HIDDEN)?,
             c0: zeros(PRED_HIDDEN)?,
@@ -1067,7 +1085,7 @@ impl Predictor {
 
     fn step(&self, label: usize, state: &mut PredictorState, device: &Device) -> Result<Tensor> {
         let x = if label == self.blank_idx {
-            Tensor::zeros((1, PRED_HIDDEN), DType::F32, device)?
+            Tensor::zeros((1, PRED_HIDDEN), self.embed.dtype(), device)?
         } else {
             self.embed.i((label, ..))?.unsqueeze(0)?
         };
@@ -1171,7 +1189,7 @@ impl Joint {
         let enc = mlx::load_linear(enc_hidden, JOINT_HIDDEN, vb.pp("enc"))?;
         let out_bias = vb
             .pp("joint_net.2")
-            .get_unchecked_dtype("bias", DType::F32)?;
+            .get_unchecked_dtype("bias", vb.dtype())?;
         let out_dim = out_bias.dim(0)?;
         if out_dim != num_classes_with_blank {
             return Err(Error::ModelLoadError(format!(

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
@@ -180,6 +180,10 @@ impl NemotronNetwork {
         encoded_len: usize,
         on_token: &mut dyn FnMut(usize),
     ) -> Result<NemotronDecodedTokens> {
+        if encoded.device().is_cuda() {
+            return self.decode_rnnt_greedy_cuda_cached(encoded, encoded_len, on_token);
+        }
+
         let encoded = encoded.i((0, ..encoded_len, ..))?; // [T, D]
         let mut predictor_state = self.predictor.initial_state(1, encoded.device())?;
         let mut predictor_out =
@@ -225,6 +229,75 @@ impl NemotronNetwork {
                 predictor_out =
                     self.predictor
                         .step(label, &mut predictor_state, encoded.device())?;
+            }
+        }
+
+        Ok(NemotronDecodedTokens {
+            stats: NemotronDecodeStats {
+                encoded_frames: encoded_len,
+                emitted_tokens: token_ids.len(),
+                blank_frames,
+                guard_exits,
+                max_symbols_per_frame: self.max_symbols_per_frame,
+            },
+            token_ids,
+        })
+    }
+
+    fn decode_rnnt_greedy_cuda_cached(
+        &self,
+        encoded: &Tensor,
+        encoded_len: usize,
+        on_token: &mut dyn FnMut(usize),
+    ) -> Result<NemotronDecodedTokens> {
+        let encoded = encoded.i((0, ..encoded_len, ..))?; // [T, D]
+        let encoded_projection = self.joint.project_encoder(&encoded)?; // [T, H]
+        let mut predictor_state = self.predictor.initial_state(1, encoded.device())?;
+        let mut predictor_out =
+            self.predictor
+                .step(self.blank_idx, &mut predictor_state, encoded.device())?;
+        let mut predictor_projection = self.joint.project_predictor(&predictor_out)?;
+
+        let mut token_ids = Vec::new();
+        let mut blank_frames = 0usize;
+        let mut guard_exits = 0usize;
+
+        for t in 0..encoded_len {
+            let enc_t = encoded_projection.i((t, ..))?.unsqueeze(0)?.unsqueeze(0)?;
+            let mut symbols_this_frame = 0usize;
+
+            loop {
+                let logits = self
+                    .joint
+                    .joint_from_projections(&enc_t, &predictor_projection)?
+                    .squeeze(0)?
+                    .squeeze(0)?
+                    .squeeze(0)?;
+                let label = argmax_1d(&logits)?;
+
+                if label == self.blank_idx {
+                    blank_frames = blank_frames.saturating_add(1);
+                    break;
+                }
+                if label > self.blank_idx {
+                    return Err(Error::InferenceError(format!(
+                        "Nemotron RNNT emitted invalid label {label}; blank_idx={}",
+                        self.blank_idx
+                    )));
+                }
+
+                token_ids.push(label);
+                on_token(label);
+                symbols_this_frame = symbols_this_frame.saturating_add(1);
+                if symbols_this_frame >= self.max_symbols_per_frame {
+                    guard_exits = guard_exits.saturating_add(1);
+                    break;
+                }
+
+                predictor_out =
+                    self.predictor
+                        .step(label, &mut predictor_state, encoded.device())?;
+                predictor_projection = self.joint.project_predictor(&predictor_out)?;
             }
         }
 
@@ -887,6 +960,14 @@ struct LstmCell {
     w_hh: Tensor,
     b_ih: Tensor,
     b_hh: Tensor,
+    cuda_views: Option<LstmCellCudaViews>,
+}
+
+struct LstmCellCudaViews {
+    w_ih_t: Tensor,
+    w_hh_t: Tensor,
+    b_ih_batched: Tensor,
+    b_hh_batched: Tensor,
 }
 
 impl LstmCell {
@@ -896,20 +977,42 @@ impl LstmCell {
         let b_ih_name = format!("bias_ih_l{layer}");
         let b_hh_name = format!("bias_hh_l{layer}");
 
+        let w_ih = vb.get((PRED_HIDDEN * 4, PRED_HIDDEN), &w_ih_name)?;
+        let w_hh = vb.get((PRED_HIDDEN * 4, PRED_HIDDEN), &w_hh_name)?;
+        let b_ih = vb.get(PRED_HIDDEN * 4, &b_ih_name)?;
+        let b_hh = vb.get(PRED_HIDDEN * 4, &b_hh_name)?;
+        let cuda_views = if w_ih.device().is_cuda() {
+            Some(LstmCellCudaViews {
+                w_ih_t: w_ih.transpose(0, 1)?.contiguous()?,
+                w_hh_t: w_hh.transpose(0, 1)?.contiguous()?,
+                b_ih_batched: b_ih.unsqueeze(0)?,
+                b_hh_batched: b_hh.unsqueeze(0)?,
+            })
+        } else {
+            None
+        };
+
         Ok(Self {
-            w_ih: vb.get((PRED_HIDDEN * 4, PRED_HIDDEN), &w_ih_name)?,
-            w_hh: vb.get((PRED_HIDDEN * 4, PRED_HIDDEN), &w_hh_name)?,
-            b_ih: vb.get(PRED_HIDDEN * 4, &b_ih_name)?,
-            b_hh: vb.get(PRED_HIDDEN * 4, &b_hh_name)?,
+            w_ih,
+            w_hh,
+            b_ih,
+            b_hh,
+            cuda_views,
         })
     }
 
     fn step(&self, x: &Tensor, h_prev: &Tensor, c_prev: &Tensor) -> Result<(Tensor, Tensor)> {
-        let gates = x
-            .matmul(&self.w_ih.transpose(0, 1)?)?
-            .broadcast_add(&self.b_ih.unsqueeze(0)?)?
-            .broadcast_add(&h_prev.matmul(&self.w_hh.transpose(0, 1)?)?)?
-            .broadcast_add(&self.b_hh.unsqueeze(0)?)?;
+        let gates = if let Some(views) = &self.cuda_views {
+            x.matmul(&views.w_ih_t)?
+                .broadcast_add(&views.b_ih_batched)?
+                .broadcast_add(&h_prev.matmul(&views.w_hh_t)?)?
+                .broadcast_add(&views.b_hh_batched)?
+        } else {
+            x.matmul(&self.w_ih.transpose(0, 1)?)?
+                .broadcast_add(&self.b_ih.unsqueeze(0)?)?
+                .broadcast_add(&h_prev.matmul(&self.w_hh.transpose(0, 1)?)?)?
+                .broadcast_add(&self.b_hh.unsqueeze(0)?)?
+        };
 
         let i = ops::sigmoid(&gates.i((.., 0..PRED_HIDDEN))?)?;
         let f = ops::sigmoid(&gates.i((.., PRED_HIDDEN..(PRED_HIDDEN * 2)))?)?;
@@ -951,8 +1054,24 @@ impl Joint {
     }
 
     fn joint_after_projection(&self, f: &Tensor, g: &Tensor) -> Result<Tensor> {
-        let f = self.enc.forward(f)?;
-        let g = self.pred.forward(g)?;
+        let f = self.project_encoder(f)?;
+        let g = self.project_predictor(g)?;
+        self.joint_from_projections(&f, &g)
+    }
+
+    fn project_encoder(&self, f: &Tensor) -> Result<Tensor> {
+        self.enc
+            .forward(f)
+            .map_err(|e| Error::InferenceError(e.to_string()))
+    }
+
+    fn project_predictor(&self, g: &Tensor) -> Result<Tensor> {
+        self.pred
+            .forward(g)
+            .map_err(|e| Error::InferenceError(e.to_string()))
+    }
+
+    fn joint_from_projections(&self, f: &Tensor, g: &Tensor) -> Result<Tensor> {
         let inp = f.unsqueeze(2)?.broadcast_add(&g.unsqueeze(1)?)?;
         let inp = inp.relu()?;
         self.out
@@ -1168,5 +1287,46 @@ mod tests {
         let err = argmax_1d(&logits).expect_err("rank-2 logits should fail");
 
         assert!(err.to_string().contains("expected rank-1 logits"));
+    }
+
+    #[test]
+    fn joint_projection_helpers_match_uncached_joint_logits() {
+        let device = Device::Cpu;
+        let joint = Joint {
+            pred: Linear::new(
+                Tensor::ones((JOINT_HIDDEN, PRED_HIDDEN), DType::F32, &device).unwrap(),
+                Some(Tensor::zeros(JOINT_HIDDEN, DType::F32, &device).unwrap()),
+            ),
+            enc: Linear::new(
+                Tensor::ones((JOINT_HIDDEN, ENCODER_DIM), DType::F32, &device).unwrap(),
+                Some(Tensor::zeros(JOINT_HIDDEN, DType::F32, &device).unwrap()),
+            ),
+            out: Linear::new(
+                Tensor::ones((4, JOINT_HIDDEN), DType::F32, &device).unwrap(),
+                Some(Tensor::from_vec(vec![0.0f32, 1.0, 2.0, 3.0], 4, &device).unwrap()),
+            ),
+        };
+        let enc = Tensor::ones((1, 1, ENCODER_DIM), DType::F32, &device).unwrap();
+        let pred = Tensor::ones((1, 1, PRED_HIDDEN), DType::F32, &device).unwrap();
+
+        let uncached = joint
+            .joint_after_projection(&enc, &pred)
+            .unwrap()
+            .flatten_all()
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap();
+        let cached = joint
+            .joint_from_projections(
+                &joint.project_encoder(&enc).unwrap(),
+                &joint.project_predictor(&pred).unwrap(),
+            )
+            .unwrap()
+            .flatten_all()
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap();
+
+        assert_eq!(cached, uncached);
     }
 }

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
@@ -77,6 +77,8 @@ pub(super) struct NemotronNetwork {
     max_symbols_per_frame: usize,
     rel_pos_cache: Mutex<HashMap<RelPosCacheKey, Tensor>>,
     att_mask_cache: Mutex<HashMap<LimitedMaskCacheKey, Tensor>>,
+    stream_rel_pos_cache: Mutex<HashMap<StreamingRelPosCacheKey, Tensor>>,
+    stream_att_mask_cache: Mutex<HashMap<StreamingMaskCacheKey, Tensor>>,
     dtype: DType,
 }
 
@@ -89,6 +91,24 @@ struct RelPosCacheKey {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct LimitedMaskCacheKey {
     len: usize,
+    left_context: usize,
+    right_context: usize,
+    dtype: DType,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct StreamingRelPosCacheKey {
+    q_len: usize,
+    key_len: usize,
+    query_offset: usize,
+    dtype: DType,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct StreamingMaskCacheKey {
+    q_len: usize,
+    key_len: usize,
+    query_offset: usize,
     left_context: usize,
     right_context: usize,
     dtype: DType,
@@ -151,6 +171,8 @@ impl NemotronNetwork {
             max_symbols_per_frame: DEFAULT_MAX_SYMBOLS_PER_FRAME,
             rel_pos_cache: Mutex::new(HashMap::new()),
             att_mask_cache: Mutex::new(HashMap::new()),
+            stream_rel_pos_cache: Mutex::new(HashMap::new()),
+            stream_att_mask_cache: Mutex::new(HashMap::new()),
             dtype: vb.dtype(),
         })
     }
@@ -223,37 +245,47 @@ impl NemotronNetwork {
         state: &mut NemotronStreamingEncoderState,
         prompt_id: usize,
     ) -> Result<Option<NemotronStreamingEncoderChunk>> {
-        let Some(pre_encoded) = state.pre_encoded.as_ref() else {
+        let Some(mut x) = state.take_ready_pre_encoded_chunk()? else {
             return Ok(None);
         };
-        let ready_frames = state.ready_frames();
-        if ready_frames <= state.emitted_frames {
-            return Ok(None);
-        }
-
-        let (encoded, encoded_len) = self.encode_preencoded_with_prompt(
-            pre_encoded.clone(),
-            state.encoded_frames,
-            prompt_id,
+        let frames = x.dim(1)?;
+        let cache_len = state.attention_cache_len();
+        let key_len = cache_len.saturating_add(frames);
+        let pos_pair = self.streaming_rel_positional_embedding(
+            frames,
+            key_len,
+            cache_len,
+            x.dtype(),
+            x.device(),
+        )?;
+        let att_mask = self.streaming_limited_context_mask(
+            frames,
+            key_len,
+            cache_len,
             state.left_context_frames,
             state.right_context_frames,
+            x.dtype(),
+            x.device(),
         )?;
-        let ready_frames = ready_frames.min(encoded_len);
-        if ready_frames <= state.emitted_frames {
-            return Ok(None);
+
+        for (layer, layer_state) in self.layers.iter().zip(state.layer_states.iter_mut()) {
+            x = layer.forward_streaming(
+                &x,
+                layer_state,
+                &pos_pair,
+                &att_mask,
+                state.left_context_frames,
+            )?;
         }
 
-        let start_frame = state.emitted_frames;
-        let frames = ready_frames - start_frame;
-        let encoded = encoded.narrow(1, start_frame, frames)?.contiguous()?;
-        state.emitted_frames = ready_frames;
+        let encoded = self.prompt_kernel.forward(&x, prompt_id)?;
 
         Ok(Some(NemotronStreamingEncoderChunk {
             encoded,
-            start_frame,
+            start_frame: state.last_chunk_start_frame,
             frames,
-            total_ready_frames: ready_frames,
-            is_final: state.input_finished && ready_frames == encoded_len,
+            total_ready_frames: state.processed_frames,
+            is_final: state.input_finished && state.pending_frames()? == 0,
         }))
     }
 
@@ -593,6 +625,89 @@ impl NemotronNetwork {
             .insert(key, tensor.clone());
         Ok(tensor)
     }
+
+    fn streaming_rel_positional_embedding(
+        &self,
+        q_len: usize,
+        key_len: usize,
+        query_offset: usize,
+        dtype: DType,
+        device: &Device,
+    ) -> Result<Tensor> {
+        let key = StreamingRelPosCacheKey {
+            q_len,
+            key_len,
+            query_offset,
+            dtype,
+        };
+        if let Some(cached) = self
+            .stream_rel_pos_cache
+            .lock()
+            .map_err(|_| Error::InferenceError("Nemotron stream rel-pos cache lock poisoned".into()))?
+            .get(&key)
+            .cloned()
+        {
+            return Ok(cached);
+        }
+
+        let tensor = build_streaming_rel_positional_embedding_for_dtype(
+            q_len,
+            key_len,
+            query_offset,
+            ENCODER_DIM,
+            device,
+            dtype,
+        )?;
+        self.stream_rel_pos_cache
+            .lock()
+            .map_err(|_| Error::InferenceError("Nemotron stream rel-pos cache lock poisoned".into()))?
+            .insert(key, tensor.clone());
+        Ok(tensor)
+    }
+
+    fn streaming_limited_context_mask(
+        &self,
+        q_len: usize,
+        key_len: usize,
+        query_offset: usize,
+        left_context: usize,
+        right_context: usize,
+        dtype: DType,
+        device: &Device,
+    ) -> Result<Tensor> {
+        let key = StreamingMaskCacheKey {
+            q_len,
+            key_len,
+            query_offset,
+            left_context,
+            right_context,
+            dtype,
+        };
+        if let Some(cached) = self
+            .stream_att_mask_cache
+            .lock()
+            .map_err(|_| Error::InferenceError("Nemotron stream mask cache lock poisoned".into()))?
+            .get(&key)
+            .cloned()
+        {
+            return Ok(cached);
+        }
+
+        let tensor = build_streaming_limited_context_mask_for_dtype(
+            q_len,
+            key_len,
+            query_offset,
+            left_context,
+            right_context,
+            device,
+            dtype,
+        )?;
+        self.stream_att_mask_cache
+            .lock()
+            .map_err(|_| Error::InferenceError("Nemotron stream mask cache lock poisoned".into()))?
+            .insert(key, tensor.clone());
+        Ok(tensor)
+    }
 }
 
 fn validate_inventory_for_forward(inventory: &NemotronConfigInventory) -> Result<()> {
@@ -701,12 +816,16 @@ pub(super) struct NemotronStreamingEncodedChunk {
 }
 
 pub(super) struct NemotronStreamingEncoderState {
-    pre_encoded: Option<Tensor>,
-    encoded_frames: usize,
-    emitted_frames: usize,
+    pending_pre_encoded: Option<Tensor>,
+    pending_start_frame: usize,
+    received_frames: usize,
+    processed_frames: usize,
+    last_chunk_start_frame: usize,
     left_context_frames: usize,
     right_context_frames: usize,
+    chunk_frames: usize,
     input_finished: bool,
+    layer_states: Vec<ConformerLayerStreamState>,
 }
 
 pub(super) struct NemotronStreamingEncoderChunk {
@@ -729,6 +848,11 @@ pub(super) struct NemotronRnntStreamStep {
     pub token_ids: Vec<usize>,
     pub new_token_ids: Vec<usize>,
     pub stats: NemotronDecodeStats,
+}
+
+struct ConformerLayerStreamState {
+    attn_cache: Option<Tensor>,
+    conv_cache: Option<Tensor>,
 }
 
 impl NemotronStreamingFeatureState {
@@ -828,12 +952,18 @@ impl NemotronStreamingPreEncodeState {
 impl NemotronStreamingEncoderState {
     pub(super) fn new(left_context_frames: usize, right_context_frames: usize) -> Self {
         Self {
-            pre_encoded: None,
-            encoded_frames: 0,
-            emitted_frames: 0,
+            pending_pre_encoded: None,
+            pending_start_frame: 0,
+            received_frames: 0,
+            processed_frames: 0,
+            last_chunk_start_frame: 0,
             left_context_frames,
             right_context_frames,
+            chunk_frames: right_context_frames.saturating_add(1).max(1),
             input_finished: false,
+            layer_states: (0..ENCODER_LAYERS)
+                .map(|_| ConformerLayerStreamState::new())
+                .collect(),
         }
     }
 
@@ -843,22 +973,25 @@ impl NemotronStreamingEncoderState {
                 "Cannot push encoder frames into a finalized Nemotron encoder stream".to_string(),
             ));
         }
-        if chunk.start_frame != self.encoded_frames {
+        if chunk.start_frame != self.received_frames {
             return Err(Error::InvalidInput(format!(
                 "Nemotron encoder stream expected start frame {}, got {}",
-                self.encoded_frames, chunk.start_frame
+                self.received_frames, chunk.start_frame
             )));
         }
         if chunk.frames == 0 {
             return Ok(());
         }
 
-        self.pre_encoded = Some(if let Some(existing) = self.pre_encoded.as_ref() {
+        if self.pending_pre_encoded.is_none() {
+            self.pending_start_frame = chunk.start_frame;
+        }
+        self.pending_pre_encoded = Some(if let Some(existing) = self.pending_pre_encoded.as_ref() {
             Tensor::cat(&[existing, &chunk.encoded], 1)?
         } else {
             chunk.encoded
         });
-        self.encoded_frames = self.encoded_frames.saturating_add(chunk.frames);
+        self.received_frames = self.received_frames.saturating_add(chunk.frames);
         self.input_finished = chunk.is_final;
         Ok(())
     }
@@ -867,19 +1000,70 @@ impl NemotronStreamingEncoderState {
         self.input_finished = true;
     }
 
+    fn pending_frames(&self) -> Result<usize> {
+        self.pending_pre_encoded
+            .as_ref()
+            .map(|tensor| tensor.dim(1).map_err(Error::from))
+            .unwrap_or(Ok(0))
+    }
+
+    fn attention_cache_len(&self) -> usize {
+        self.layer_states
+            .first()
+            .and_then(|state| state.attn_cache.as_ref())
+            .and_then(|cache| cache.dim(1).ok())
+            .unwrap_or(0)
+    }
+
     fn ready_frames(&self) -> usize {
-        if self.input_finished {
-            self.encoded_frames
+        let pending = self.pending_frames().unwrap_or(0);
+        if pending >= self.chunk_frames || (self.input_finished && pending > 0) {
+            self.processed_frames + pending.min(self.chunk_frames)
         } else {
-            self.encoded_frames
-                .saturating_sub(self.right_context_frames)
+            self.processed_frames
         }
+    }
+
+    fn take_ready_pre_encoded_chunk(&mut self) -> Result<Option<Tensor>> {
+        let pending_frames = self.pending_frames()?;
+        if pending_frames == 0 {
+            return Ok(None);
+        }
+        if pending_frames < self.chunk_frames && !self.input_finished {
+            return Ok(None);
+        }
+
+        let frames = pending_frames.min(self.chunk_frames);
+        let pending = self
+            .pending_pre_encoded
+            .take()
+            .ok_or_else(|| Error::InferenceError("Nemotron encoder stream lost pending frames".into()))?;
+        let chunk = pending.narrow(1, 0, frames)?.contiguous()?;
+        let remaining = pending_frames - frames;
+        self.last_chunk_start_frame = self.pending_start_frame;
+        self.pending_start_frame = self.pending_start_frame.saturating_add(frames);
+        self.processed_frames = self.processed_frames.saturating_add(frames);
+        self.pending_pre_encoded = if remaining > 0 {
+            Some(pending.narrow(1, frames, remaining)?.contiguous()?)
+        } else {
+            None
+        };
+        Ok(Some(chunk))
     }
 }
 
 impl NemotronRnntStreamState {
     fn token_ids(&self) -> &[usize] {
         &self.token_ids
+    }
+}
+
+impl ConformerLayerStreamState {
+    fn new() -> Self {
+        Self {
+            attn_cache: None,
+            conv_cache: None,
+        }
     }
 }
 
@@ -1313,6 +1497,46 @@ impl ConformerLayer {
             .forward(&residual)
             .map_err(|e| Error::InferenceError(e.to_string()))
     }
+
+    fn forward_streaming(
+        &self,
+        x: &Tensor,
+        state: &mut ConformerLayerStreamState,
+        pos_pair: &Tensor,
+        att_mask: &Tensor,
+        left_context_frames: usize,
+    ) -> Result<Tensor> {
+        let mut residual = x.clone();
+
+        let ff1 = self.ff1.forward(&self.norm_ff1.forward(&residual)?)?;
+        residual = residual.broadcast_add(&ff1.affine(0.5, 0.0)?)?;
+
+        let att_input = self.norm_self_att.forward(&residual)?;
+        let attn = self.self_attn.forward_streaming(
+            &att_input,
+            state.attn_cache.as_ref(),
+            pos_pair,
+            att_mask,
+        )?;
+        state.attn_cache = update_time_cache_dim1(
+            state.attn_cache.take(),
+            &att_input,
+            left_context_frames,
+        )?;
+        residual = residual.broadcast_add(&attn)?;
+
+        let conv =
+            self.conv
+                .forward_streaming(&self.norm_conv.forward(&residual)?, &mut state.conv_cache)?;
+        residual = residual.broadcast_add(&conv)?;
+
+        let ff2 = self.ff2.forward(&self.norm_ff2.forward(&residual)?)?;
+        residual = residual.broadcast_add(&ff2.affine(0.5, 0.0)?)?;
+
+        self.norm_out
+            .forward(&residual)
+            .map_err(|e| Error::InferenceError(e.to_string()))
+    }
 }
 
 struct FeedForward {
@@ -1389,6 +1613,37 @@ impl ConformerConv {
 
         x = x.pad_with_zeros(2, CONV_KERNEL_1D - 1, 0)?;
         x = self.depthwise_conv.forward(&x)?;
+        x = self
+            .conv_norm
+            .forward(&x.transpose(1, 2)?)?
+            .transpose(1, 2)?;
+        x = swish(&x)?;
+        x = self.pointwise_conv2.forward(&x)?;
+
+        x.transpose(1, 2).map_err(Error::from)
+    }
+
+    fn forward_streaming(&self, x: &Tensor, cache: &mut Option<Tensor>) -> Result<Tensor> {
+        let mut x = x.transpose(1, 2)?;
+        x = self.pointwise_conv1.forward(&x)?;
+        let x_a = x.i((.., ..ENCODER_DIM, ..))?;
+        let x_b = x.i((.., ENCODER_DIM.., ..))?;
+        let x = x_a.broadcast_mul(&ops::sigmoid(&x_b)?)?;
+
+        let cache_len = cache.as_ref().and_then(|cache| cache.dim(2).ok()).unwrap_or(0);
+        let cached_and_current = if let Some(existing) = cache.as_ref() {
+            Tensor::cat(&[existing, &x], 2)?
+        } else {
+            x.clone()
+        };
+        let conv_input = if cache_len < CONV_KERNEL_1D - 1 {
+            cached_and_current.pad_with_zeros(2, CONV_KERNEL_1D - 1 - cache_len, 0)?
+        } else {
+            cached_and_current.clone()
+        };
+        *cache = update_time_cache_dim2(None, &cached_and_current, CONV_KERNEL_1D - 1)?;
+
+        let mut x = self.depthwise_conv.forward(&conv_input)?;
         x = self
             .conv_norm
             .forward(&x.transpose(1, 2)?)?
@@ -1485,6 +1740,81 @@ impl RelPosSelfAttention {
         let attn = ops::softmax(&scores, 3)?;
         let out = attn.matmul(&v)?;
         let out = out.transpose(1, 2)?.reshape((b, t, ENCODER_DIM))?;
+
+        self.linear_out
+            .forward(&out)
+            .map_err(|e| Error::InferenceError(e.to_string()))
+    }
+
+    fn forward_streaming(
+        &self,
+        x: &Tensor,
+        cache: Option<&Tensor>,
+        pos_pair: &Tensor,
+        att_mask: &Tensor,
+    ) -> Result<Tensor> {
+        let (b, q_len, _d) = x.dims3()?;
+        let key_value = if let Some(cache) = cache {
+            Tensor::cat(&[cache, x], 1)?
+        } else {
+            x.clone()
+        };
+        let key_len = key_value.dim(1)?;
+
+        let q = self
+            .linear_q
+            .forward(x)?
+            .reshape((b, q_len, ENCODER_HEADS, ENCODER_HEAD_DIM))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let k = self
+            .linear_k
+            .forward(&key_value)?
+            .reshape((b, key_len, ENCODER_HEADS, ENCODER_HEAD_DIM))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let v = self
+            .linear_v
+            .forward(&key_value)?
+            .reshape((b, key_len, ENCODER_HEADS, ENCODER_HEAD_DIM))?
+            .transpose(1, 2)?
+            .contiguous()?;
+
+        let p = self
+            .linear_pos
+            .forward(pos_pair)?
+            .reshape((1, q_len, key_len, ENCODER_HEADS, ENCODER_HEAD_DIM))?
+            .permute((0, 3, 1, 2, 4))?
+            .contiguous()?;
+
+        let pos_bias_u = self.pos_bias_u.to_dtype(q.dtype())?.reshape((
+            1,
+            ENCODER_HEADS,
+            1,
+            ENCODER_HEAD_DIM,
+        ))?;
+        let pos_bias_v = self.pos_bias_v.to_dtype(q.dtype())?.reshape((
+            1,
+            ENCODER_HEADS,
+            1,
+            ENCODER_HEAD_DIM,
+        ))?;
+        let matrix_ac = q
+            .broadcast_add(&pos_bias_u)?
+            .matmul(&k.transpose(2, 3)?.contiguous()?)?;
+        let matrix_bd = q
+            .broadcast_add(&pos_bias_v)?
+            .unsqueeze(3)?
+            .broadcast_mul(&p)?
+            .sum(D::Minus1)?;
+
+        let scores = matrix_ac
+            .broadcast_add(&matrix_bd)?
+            .affine(1.0 / (ENCODER_HEAD_DIM as f64).sqrt(), 0.0)?
+            .broadcast_add(att_mask)?;
+        let attn = ops::softmax(&scores, 3)?;
+        let out = attn.matmul(&v)?;
+        let out = out.transpose(1, 2)?.reshape((b, q_len, ENCODER_DIM))?;
 
         self.linear_out
             .forward(&out)
@@ -1823,6 +2153,58 @@ fn build_rel_positional_embedding_for_dtype(
         .map_err(Error::from)
 }
 
+fn build_streaming_rel_positional_embedding(
+    q_len: usize,
+    key_len: usize,
+    query_offset: usize,
+    d_model: usize,
+    device: &Device,
+) -> Result<Tensor> {
+    if q_len == 0 || key_len == 0 {
+        return Err(Error::InvalidInput(
+            "Cannot build streaming positional embedding for an empty attention window".to_string(),
+        ));
+    }
+    if query_offset.saturating_add(q_len) > key_len {
+        return Err(Error::InvalidInput(format!(
+            "Invalid Nemotron streaming attention window: q_len={q_len}, key_len={key_len}, query_offset={query_offset}"
+        )));
+    }
+
+    let mut emb = vec![0f32; q_len * key_len * d_model];
+    let denom = (10_000f32).ln() / d_model as f32;
+    for q in 0..q_len {
+        let query_pos = query_offset + q;
+        for k in 0..key_len {
+            let distance = query_pos as isize - k as isize;
+            let base = (q * key_len + k) * d_model;
+            for i in (0..d_model).step_by(2) {
+                let div = (-denom * i as f32).exp();
+                let angle = distance as f32 * div;
+                emb[base + i] = angle.sin();
+                if i + 1 < d_model {
+                    emb[base + i + 1] = angle.cos();
+                }
+            }
+        }
+    }
+
+    Tensor::from_vec(emb, (1, q_len * key_len, d_model), device).map_err(Error::from)
+}
+
+fn build_streaming_rel_positional_embedding_for_dtype(
+    q_len: usize,
+    key_len: usize,
+    query_offset: usize,
+    d_model: usize,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    build_streaming_rel_positional_embedding(q_len, key_len, query_offset, d_model, device)?
+        .to_dtype(dtype)
+        .map_err(Error::from)
+}
+
 fn build_limited_context_mask(
     len: usize,
     left_context: usize,
@@ -1852,6 +2234,58 @@ fn build_limited_context_mask_for_dtype(
         .map_err(Error::from)
 }
 
+fn build_streaming_limited_context_mask(
+    q_len: usize,
+    key_len: usize,
+    query_offset: usize,
+    left_context: usize,
+    right_context: usize,
+    device: &Device,
+) -> Result<Tensor> {
+    if q_len == 0 || key_len == 0 {
+        return Err(Error::InvalidInput(
+            "Cannot build streaming attention mask for an empty attention window".to_string(),
+        ));
+    }
+    if query_offset.saturating_add(q_len) > key_len {
+        return Err(Error::InvalidInput(format!(
+            "Invalid Nemotron streaming attention mask window: q_len={q_len}, key_len={key_len}, query_offset={query_offset}"
+        )));
+    }
+
+    let mut mask = vec![0f32; q_len * key_len];
+    for q in 0..q_len {
+        let query_pos = query_offset + q;
+        for k in 0..key_len {
+            if k + left_context < query_pos || k > query_pos.saturating_add(right_context) {
+                mask[q * key_len + k] = -1.0e9;
+            }
+        }
+    }
+    Tensor::from_vec(mask, (1, 1, q_len, key_len), device).map_err(Error::from)
+}
+
+fn build_streaming_limited_context_mask_for_dtype(
+    q_len: usize,
+    key_len: usize,
+    query_offset: usize,
+    left_context: usize,
+    right_context: usize,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    build_streaming_limited_context_mask(
+        q_len,
+        key_len,
+        query_offset,
+        left_context,
+        right_context,
+        device,
+    )?
+    .to_dtype(dtype)
+    .map_err(Error::from)
+}
+
 fn build_prompt_one_hot(prompt_id: usize, device: &Device, dtype: DType) -> Result<Tensor> {
     if prompt_id >= PROMPT_DIM {
         return Err(Error::InvalidInput(format!(
@@ -1867,6 +2301,50 @@ fn build_prompt_one_hot(prompt_id: usize, device: &Device, dtype: DType) -> Resu
 
 fn swish(x: &Tensor) -> Result<Tensor> {
     x.broadcast_mul(&ops::sigmoid(x)?).map_err(Error::from)
+}
+
+fn update_time_cache_dim1(
+    existing: Option<Tensor>,
+    current: &Tensor,
+    max_frames: usize,
+) -> Result<Option<Tensor>> {
+    if max_frames == 0 {
+        return Ok(None);
+    }
+    let combined = if let Some(existing) = existing.as_ref() {
+        Tensor::cat(&[existing, current], 1)?
+    } else {
+        current.clone()
+    };
+    let len = combined.dim(1)?;
+    let start = len.saturating_sub(max_frames);
+    Ok(Some(
+        combined
+            .narrow(1, start, len.saturating_sub(start))?
+            .contiguous()?,
+    ))
+}
+
+fn update_time_cache_dim2(
+    existing: Option<Tensor>,
+    current: &Tensor,
+    max_frames: usize,
+) -> Result<Option<Tensor>> {
+    if max_frames == 0 {
+        return Ok(None);
+    }
+    let combined = if let Some(existing) = existing.as_ref() {
+        Tensor::cat(&[existing, current], 2)?
+    } else {
+        current.clone()
+    };
+    let len = combined.dim(2)?;
+    let start = len.saturating_sub(max_frames);
+    Ok(Some(
+        combined
+            .narrow(2, start, len.saturating_sub(start))?
+            .contiguous()?,
+    ))
 }
 
 fn argmax_1d(x: &Tensor) -> Result<usize> {
@@ -2110,6 +2588,8 @@ mod tests {
             max_symbols_per_frame,
             rel_pos_cache: Mutex::new(HashMap::new()),
             att_mask_cache: Mutex::new(HashMap::new()),
+            stream_rel_pos_cache: Mutex::new(HashMap::new()),
+            stream_att_mask_cache: Mutex::new(HashMap::new()),
             dtype: DType::F32,
         }
     }
@@ -2223,6 +2703,35 @@ mod tests {
 
         assert_eq!(pos.dtype(), DType::F32);
         assert_eq!(pos.dims(), &[1, 5, 8]);
+    }
+
+    #[test]
+    fn streaming_limited_context_mask_uses_bounded_key_window() {
+        let mask =
+            build_streaming_limited_context_mask(2, 5, 3, 2, 1, &Device::Cpu).unwrap();
+        let values = mask
+            .squeeze(0)
+            .unwrap()
+            .squeeze(0)
+            .unwrap()
+            .to_vec2::<f32>()
+            .unwrap();
+
+        assert_eq!(mask.dims(), &[1, 1, 2, 5]);
+        assert!(values[0][0] < -1.0e8, "query 3 cannot attend before left context");
+        assert_eq!(values[0][1], 0.0);
+        assert_eq!(values[0][4], 0.0, "query 3 can attend one frame right");
+        assert_eq!(values[1][2], 0.0);
+    }
+
+    #[test]
+    fn streaming_rel_positional_embedding_is_pairwise_bounded() {
+        let pos =
+            build_streaming_rel_positional_embedding_for_dtype(2, 5, 3, 8, &Device::Cpu, DType::F32)
+                .unwrap();
+
+        assert_eq!(pos.dtype(), DType::F32);
+        assert_eq!(pos.dims(), &[1, 10, 8]);
     }
 
     #[test]
@@ -2406,17 +2915,31 @@ mod tests {
     }
 
     #[test]
-    fn streaming_encoder_state_delays_until_right_context_is_available() {
+    fn streaming_encoder_state_groups_non_overlapping_model_card_chunks() {
         let mut state = NemotronStreamingEncoderState::new(56, 3);
 
         state.push_pre_encoded(encoded_chunk(0, 2, false)).unwrap();
         assert_eq!(state.ready_frames(), 0);
 
         state.push_pre_encoded(encoded_chunk(2, 2, false)).unwrap();
-        assert_eq!(state.ready_frames(), 1);
+        assert_eq!(state.ready_frames(), 4);
+        let first = state
+            .take_ready_pre_encoded_chunk()
+            .unwrap()
+            .expect("first model-card chunk");
+        assert_eq!(first.dim(1).unwrap(), 4);
+        assert_eq!(state.last_chunk_start_frame, 0);
+        assert_eq!(state.processed_frames, 4);
 
         state.push_pre_encoded(encoded_chunk(4, 4, false)).unwrap();
-        assert_eq!(state.ready_frames(), 5);
+        assert_eq!(state.ready_frames(), 8);
+        let second = state
+            .take_ready_pre_encoded_chunk()
+            .unwrap()
+            .expect("second model-card chunk");
+        assert_eq!(second.dim(1).unwrap(), 4);
+        assert_eq!(state.last_chunk_start_frame, 4);
+        assert_eq!(state.processed_frames, 8);
 
         state.finish_input();
         assert_eq!(state.ready_frames(), 8);

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use candle_core::{DType, Device, IndexOp, Tensor};
+use candle_core::{DType, Device, IndexOp, Tensor, D};
 use candle_nn::ops;
 use candle_nn::{
     layer_norm, Conv1d, Conv1dConfig, Conv2d, Conv2dConfig, LayerNorm, Linear, Module, VarBuilder,
@@ -1027,6 +1027,31 @@ fn swish(x: &Tensor) -> Result<Tensor> {
 }
 
 fn argmax_1d(x: &Tensor) -> Result<usize> {
+    if x.rank() != 1 {
+        return Err(Error::InferenceError(format!(
+            "Nemotron RNNT argmax expected rank-1 logits, got shape {:?}",
+            x.shape().dims()
+        )));
+    }
+    if x.device().is_cuda() {
+        return argmax_1d_device(x);
+    }
+
+    argmax_1d_host(x)
+}
+
+fn argmax_1d_device(x: &Tensor) -> Result<usize> {
+    let idx = x.argmax(D::Minus1)?;
+    let idx = if idx.rank() == 0 {
+        idx
+    } else {
+        idx.squeeze(0)?
+    };
+    Ok(idx.to_dtype(DType::U32)?.to_scalar::<u32>()? as usize)
+}
+
+fn argmax_1d_host(x: &Tensor) -> Result<usize> {
+    let x = x.to_dtype(DType::F32)?;
     let v = x.to_vec1::<f32>()?;
     let mut best_idx = 0usize;
     let mut best_val = f32::NEG_INFINITY;
@@ -1126,5 +1151,22 @@ mod tests {
             FeatureNormalize::from_config(Some("per_feature")),
             FeatureNormalize::PerFeature
         );
+    }
+
+    #[test]
+    fn argmax_1d_selects_max_from_rank1_logits() {
+        let logits =
+            Tensor::from_vec(vec![0.1f32, 3.2, -4.0, 2.7], 4, &Device::Cpu).expect("logits");
+
+        assert_eq!(argmax_1d(&logits).expect("argmax"), 1);
+    }
+
+    #[test]
+    fn argmax_1d_rejects_non_vector_logits() {
+        let logits =
+            Tensor::from_vec(vec![0.1f32; 8], (2, 4), &Device::Cpu).expect("batched logits");
+        let err = argmax_1d(&logits).expect_err("rank-2 logits should fail");
+
+        assert!(err.to_string().contains("expected rank-1 logits"));
     }
 }

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
@@ -505,6 +505,21 @@ pub(super) struct NemotronStreamingFeatureChunk {
     pub is_final: bool,
 }
 
+pub(super) struct NemotronStreamingPreEncodeState {
+    features: Option<Tensor>,
+    feature_frames: usize,
+    emitted_encoded_frames: usize,
+    input_finished: bool,
+}
+
+pub(super) struct NemotronStreamingEncodedChunk {
+    pub encoded: Tensor,
+    pub start_frame: usize,
+    pub frames: usize,
+    pub total_stable_frames: usize,
+    pub is_final: bool,
+}
+
 impl NemotronStreamingFeatureState {
     pub(super) fn new() -> Self {
         Self {
@@ -555,6 +570,50 @@ impl NemotronStreamingFeatureState {
             return 0;
         }
         ((self.preemphasized.len() - center_pad) / HOP_LENGTH) + 1
+    }
+}
+
+impl NemotronStreamingPreEncodeState {
+    pub(super) fn new() -> Self {
+        Self {
+            features: None,
+            feature_frames: 0,
+            emitted_encoded_frames: 0,
+            input_finished: false,
+        }
+    }
+
+    pub(super) fn push_features(
+        &mut self,
+        chunk: NemotronStreamingFeatureChunk,
+    ) -> Result<()> {
+        if self.input_finished {
+            return Err(Error::InvalidInput(
+                "Cannot push features into a finalized Nemotron pre-encode stream".to_string(),
+            ));
+        }
+        if chunk.start_frame != self.feature_frames {
+            return Err(Error::InvalidInput(format!(
+                "Nemotron feature stream expected start frame {}, got {}",
+                self.feature_frames, chunk.start_frame
+            )));
+        }
+        if chunk.frames == 0 {
+            return Ok(());
+        }
+
+        self.features = Some(if let Some(existing) = self.features.as_ref() {
+            Tensor::cat(&[existing, &chunk.features], 2)?
+        } else {
+            chunk.features
+        });
+        self.feature_frames = self.feature_frames.saturating_add(chunk.frames);
+        self.input_finished = chunk.is_final;
+        Ok(())
+    }
+
+    pub(super) fn finish_input(&mut self) {
+        self.input_finished = true;
     }
 }
 
@@ -864,6 +923,46 @@ impl ConvSubsamplingDw {
         let encoded_len = subsampled_len_3x(feature_frames).min(t).max(1);
         Ok((x, encoded_len))
     }
+
+    pub(super) fn forward_streaming_chunk(
+        &self,
+        state: &mut NemotronStreamingPreEncodeState,
+    ) -> Result<Option<NemotronStreamingEncodedChunk>> {
+        let Some(features) = state.features.as_ref() else {
+            return Ok(None);
+        };
+        if state.feature_frames == 0 {
+            return Ok(None);
+        }
+
+        let stable_frames = if state.input_finished {
+            subsampled_len_3x(state.feature_frames)
+        } else {
+            stable_subsampled_len_3x(state.feature_frames)
+        };
+        if stable_frames <= state.emitted_encoded_frames {
+            return Ok(None);
+        }
+
+        let (encoded, encoded_len) = self.forward(features, state.feature_frames)?;
+        let stable_frames = stable_frames.min(encoded_len);
+        if stable_frames <= state.emitted_encoded_frames {
+            return Ok(None);
+        }
+
+        let start_frame = state.emitted_encoded_frames;
+        let frames = stable_frames - start_frame;
+        let encoded = encoded.narrow(1, start_frame, frames)?.contiguous()?;
+        state.emitted_encoded_frames = stable_frames;
+
+        Ok(Some(NemotronStreamingEncodedChunk {
+            encoded,
+            start_frame,
+            frames,
+            total_stable_frames: stable_frames,
+            is_final: state.input_finished && stable_frames == encoded_len,
+        }))
+    }
 }
 
 fn load_subsampling_out_projection(vb: VarBuilder) -> Result<(Linear, usize)> {
@@ -887,6 +986,13 @@ fn subsampled_len_3x(mut len: usize) -> usize {
         len = len.div_ceil(2);
     }
     len
+}
+
+fn stable_subsampled_len_3x(feature_frames: usize) -> usize {
+    if feature_frames < SUBSAMPLING_FACTOR {
+        return 0;
+    }
+    ((feature_frames - SUBSAMPLING_FACTOR) / SUBSAMPLING_FACTOR) + 1
 }
 
 struct ConformerLayer {
@@ -1592,6 +1698,92 @@ mod tests {
         }
     }
 
+    fn zero_subsampling() -> ConvSubsamplingDw {
+        let device = Device::Cpu;
+        let stride_cfg = Conv2dConfig {
+            stride: 2,
+            padding: 1,
+            ..Default::default()
+        };
+        let mut dw_stride_cfg = stride_cfg;
+        dw_stride_cfg.groups = CONV_SUB_CHANNELS;
+        let point_cfg = Conv2dConfig {
+            stride: 1,
+            padding: 0,
+            ..Default::default()
+        };
+        let conv0 = Conv2d::new(
+            Tensor::zeros((CONV_SUB_CHANNELS, 1, 3, 3), DType::F32, &device).unwrap(),
+            None,
+            stride_cfg,
+        );
+        let conv2 = Conv2d::new(
+            Tensor::zeros((CONV_SUB_CHANNELS, 1, 3, 3), DType::F32, &device).unwrap(),
+            None,
+            dw_stride_cfg,
+        );
+        let conv3 = Conv2d::new(
+            Tensor::zeros(
+                (CONV_SUB_CHANNELS, CONV_SUB_CHANNELS, 1, 1),
+                DType::F32,
+                &device,
+            )
+            .unwrap(),
+            None,
+            point_cfg,
+        );
+        let conv5 = Conv2d::new(
+            Tensor::zeros((CONV_SUB_CHANNELS, 1, 3, 3), DType::F32, &device).unwrap(),
+            None,
+            dw_stride_cfg,
+        );
+        let conv6 = Conv2d::new(
+            Tensor::zeros(
+                (CONV_SUB_CHANNELS, CONV_SUB_CHANNELS, 1, 1),
+                DType::F32,
+                &device,
+            )
+            .unwrap(),
+            None,
+            point_cfg,
+        );
+        let out_feature_bins = 16;
+        let out = Linear::new(
+            Tensor::zeros(
+                (ENCODER_DIM, CONV_SUB_CHANNELS * out_feature_bins),
+                DType::F32,
+                &device,
+            )
+            .unwrap(),
+            Some(Tensor::zeros(ENCODER_DIM, DType::F32, &device).unwrap()),
+        );
+
+        ConvSubsamplingDw {
+            conv0,
+            conv2,
+            conv3,
+            conv5,
+            conv6,
+            out,
+            out_feature_bins,
+        }
+    }
+
+    fn feature_chunk(
+        features: &Tensor,
+        start_frame: usize,
+        frames: usize,
+        is_final: bool,
+    ) -> NemotronStreamingFeatureChunk {
+        NemotronStreamingFeatureChunk {
+            features: features.narrow(2, start_frame, frames).unwrap(),
+            start_frame,
+            frames,
+            total_ready_frames: start_frame + frames,
+            is_final,
+        }
+    }
+
     fn assert_tensor_close(lhs: &Tensor, rhs: &Tensor, tolerance: f32) {
         assert_eq!(lhs.dims(), rhs.dims());
         let lhs = lhs.flatten_all().unwrap().to_vec1::<f32>().unwrap();
@@ -1619,6 +1811,16 @@ mod tests {
         assert_eq!(subsampled_len_3x(8), 1);
         assert_eq!(subsampled_len_3x(9), 2);
         assert_eq!(subsampled_len_3x(100), 13);
+    }
+
+    #[test]
+    fn stable_subsampled_length_waits_for_full_stride_receptive_field() {
+        assert_eq!(stable_subsampled_len_3x(0), 0);
+        assert_eq!(stable_subsampled_len_3x(7), 0);
+        assert_eq!(stable_subsampled_len_3x(8), 1);
+        assert_eq!(stable_subsampled_len_3x(15), 1);
+        assert_eq!(stable_subsampled_len_3x(16), 2);
+        assert_eq!(stable_subsampled_len_3x(41), 5);
     }
 
     #[test]
@@ -1773,6 +1975,75 @@ mod tests {
 
         let err = state.push_samples(&[0.0]).unwrap_err();
         assert!(err.to_string().contains("finalized"));
+    }
+
+    #[test]
+    fn streaming_pre_encode_delays_tail_and_matches_full_output() {
+        let subsampling = zero_subsampling();
+        let device = Device::Cpu;
+        let feature_frames = 41usize;
+        let values = (0..(N_MELS * feature_frames))
+            .map(|idx| (idx as f32) / 1000.0)
+            .collect::<Vec<_>>();
+        let features = Tensor::from_vec(values, (1, N_MELS, feature_frames), &device).unwrap();
+        let (full, encoded_len) = subsampling.forward(&features, feature_frames).unwrap();
+
+        let mut state = NemotronStreamingPreEncodeState::new();
+        state
+            .push_features(feature_chunk(&features, 0, 7, false))
+            .unwrap();
+        assert!(subsampling
+            .forward_streaming_chunk(&mut state)
+            .unwrap()
+            .is_none());
+
+        state
+            .push_features(feature_chunk(&features, 7, 1, false))
+            .unwrap();
+        let first = subsampling
+            .forward_streaming_chunk(&mut state)
+            .unwrap()
+            .expect("first stable encoded frame");
+        assert_eq!(first.start_frame, 0);
+        assert_eq!(first.frames, 1);
+        assert_eq!(first.total_stable_frames, 1);
+        assert!(!first.is_final);
+
+        state
+            .push_features(feature_chunk(&features, 8, 24, false))
+            .unwrap();
+        let middle = subsampling
+            .forward_streaming_chunk(&mut state)
+            .unwrap()
+            .expect("middle stable frames");
+        assert_eq!(middle.start_frame, 1);
+        assert_eq!(middle.total_stable_frames, 4);
+
+        state
+            .push_features(feature_chunk(&features, 32, 9, false))
+            .unwrap();
+        state.finish_input();
+        let tail = subsampling
+            .forward_streaming_chunk(&mut state)
+            .unwrap()
+            .expect("final tail frames");
+        assert!(tail.is_final);
+        assert_eq!(tail.total_stable_frames, encoded_len);
+
+        let streamed = Tensor::cat(&[&first.encoded, &middle.encoded, &tail.encoded], 1).unwrap();
+        let full = full.narrow(1, 0, encoded_len).unwrap();
+        assert_tensor_close(&streamed, &full, 0.0);
+    }
+
+    #[test]
+    fn streaming_pre_encode_rejects_out_of_order_features() {
+        let features = Tensor::zeros((1, N_MELS, 2), DType::F32, &Device::Cpu).unwrap();
+        let mut state = NemotronStreamingPreEncodeState::new();
+
+        let err = state
+            .push_features(feature_chunk(&features, 1, 1, false))
+            .unwrap_err();
+        assert!(err.to_string().contains("expected start frame 0"));
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Mutex;
 
 use candle_core::{DType, Device, IndexOp, Tensor, D};
 use candle_nn::ops;
@@ -74,6 +75,22 @@ pub(super) struct NemotronNetwork {
     right_context_frames: usize,
     blank_idx: usize,
     max_symbols_per_frame: usize,
+    rel_pos_cache: Mutex<HashMap<RelPosCacheKey, Tensor>>,
+    att_mask_cache: Mutex<HashMap<LimitedMaskCacheKey, Tensor>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct RelPosCacheKey {
+    len: usize,
+    dtype: DType,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct LimitedMaskCacheKey {
+    len: usize,
+    left_context: usize,
+    right_context: usize,
+    dtype: DType,
 }
 
 impl NemotronNetwork {
@@ -131,6 +148,8 @@ impl NemotronNetwork {
                 .unwrap_or(13),
             blank_idx,
             max_symbols_per_frame: DEFAULT_MAX_SYMBOLS_PER_FRAME,
+            rel_pos_cache: Mutex::new(HashMap::new()),
+            att_mask_cache: Mutex::new(HashMap::new()),
         })
     }
 
@@ -159,11 +178,12 @@ impl NemotronNetwork {
         }
 
         let pos_len = x.dim(1)?;
-        let pos_emb = build_rel_positional_embedding(pos_len, ENCODER_DIM, x.device())?;
-        let att_mask = build_limited_context_mask(
+        let pos_emb = self.rel_positional_embedding(pos_len, x.dtype(), x.device())?;
+        let att_mask = self.limited_context_mask(
             pos_len,
             self.left_context_frames,
             self.right_context_frames,
+            x.dtype(),
             x.device(),
         )?;
         for layer in &self.layers {
@@ -315,6 +335,72 @@ impl NemotronNetwork {
 
     pub(super) fn blank_idx(&self) -> usize {
         self.blank_idx
+    }
+
+    fn rel_positional_embedding(
+        &self,
+        len: usize,
+        dtype: DType,
+        device: &Device,
+    ) -> Result<Tensor> {
+        if !device.is_cuda() {
+            return build_rel_positional_embedding(len, ENCODER_DIM, device);
+        }
+
+        let key = RelPosCacheKey { len, dtype };
+        if let Some(cached) = self
+            .rel_pos_cache
+            .lock()
+            .map_err(|_| Error::InferenceError("Nemotron rel-pos cache lock poisoned".into()))?
+            .get(&key)
+            .cloned()
+        {
+            return Ok(cached);
+        }
+
+        let tensor = build_rel_positional_embedding_for_dtype(len, ENCODER_DIM, device, dtype)?;
+        self.rel_pos_cache
+            .lock()
+            .map_err(|_| Error::InferenceError("Nemotron rel-pos cache lock poisoned".into()))?
+            .insert(key, tensor.clone());
+        Ok(tensor)
+    }
+
+    fn limited_context_mask(
+        &self,
+        len: usize,
+        left_context: usize,
+        right_context: usize,
+        dtype: DType,
+        device: &Device,
+    ) -> Result<Tensor> {
+        if !device.is_cuda() {
+            return build_limited_context_mask(len, left_context, right_context, device);
+        }
+
+        let key = LimitedMaskCacheKey {
+            len,
+            left_context,
+            right_context,
+            dtype,
+        };
+        if let Some(cached) = self
+            .att_mask_cache
+            .lock()
+            .map_err(|_| Error::InferenceError("Nemotron mask cache lock poisoned".into()))?
+            .get(&key)
+            .cloned()
+        {
+            return Ok(cached);
+        }
+
+        let tensor =
+            build_limited_context_mask_for_dtype(len, left_context, right_context, device, dtype)?;
+        self.att_mask_cache
+            .lock()
+            .map_err(|_| Error::InferenceError("Nemotron mask cache lock poisoned".into()))?
+            .insert(key, tensor.clone());
+        Ok(tensor)
     }
 }
 
@@ -859,6 +945,13 @@ fn rel_shift(x: &Tensor) -> Result<Tensor> {
 struct PromptKernel {
     linear0: Linear,
     linear2: Linear,
+    prompt_cache: Mutex<HashMap<PromptCacheKey, Tensor>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct PromptCacheKey {
+    prompt_id: usize,
+    dtype: DType,
 }
 
 impl PromptKernel {
@@ -866,6 +959,7 @@ impl PromptKernel {
         Ok(Self {
             linear0: mlx::load_linear(ENCODER_DIM + PROMPT_DIM, PROMPT_HIDDEN, vb.pp("0"))?,
             linear2: mlx::load_linear(PROMPT_HIDDEN, ENCODER_DIM, vb.pp("2"))?,
+            prompt_cache: Mutex::new(HashMap::new()),
         })
     }
 
@@ -877,18 +971,53 @@ impl PromptKernel {
         }
 
         let (b, t, _d) = encoded.dims3()?;
-        let mut prompt = vec![0f32; b * t * PROMPT_DIM];
-        for bi in 0..b {
-            for ti in 0..t {
-                prompt[(bi * t + ti) * PROMPT_DIM + prompt_id] = 1.0;
-            }
-        }
-        let prompt = Tensor::from_vec(prompt, (b, t, PROMPT_DIM), encoded.device())?;
+        let prompt = self.prompt_tensor(encoded, prompt_id, b, t)?;
         let x = Tensor::cat(&[encoded, &prompt], 2)?;
         let x = self.linear0.forward(&x)?.relu()?;
         self.linear2
             .forward(&x)
             .map_err(|e| Error::InferenceError(e.to_string()))
+    }
+
+    fn prompt_tensor(
+        &self,
+        encoded: &Tensor,
+        prompt_id: usize,
+        b: usize,
+        t: usize,
+    ) -> Result<Tensor> {
+        if !encoded.device().is_cuda() {
+            let mut prompt = vec![0f32; b * t * PROMPT_DIM];
+            for bi in 0..b {
+                for ti in 0..t {
+                    prompt[(bi * t + ti) * PROMPT_DIM + prompt_id] = 1.0;
+                }
+            }
+            return Tensor::from_vec(prompt, (b, t, PROMPT_DIM), encoded.device())
+                .map_err(Error::from);
+        }
+
+        let key = PromptCacheKey {
+            prompt_id,
+            dtype: encoded.dtype(),
+        };
+        let base = if let Some(cached) = self
+            .prompt_cache
+            .lock()
+            .map_err(|_| Error::InferenceError("Nemotron prompt cache lock poisoned".into()))?
+            .get(&key)
+            .cloned()
+        {
+            cached
+        } else {
+            let tensor = build_prompt_one_hot(prompt_id, encoded.device(), encoded.dtype())?;
+            self.prompt_cache
+                .lock()
+                .map_err(|_| Error::InferenceError("Nemotron prompt cache lock poisoned".into()))?
+                .insert(key, tensor.clone());
+            tensor
+        };
+        base.broadcast_as((b, t, PROMPT_DIM)).map_err(Error::from)
     }
 }
 
@@ -1124,6 +1253,17 @@ fn build_rel_positional_embedding(len: usize, d_model: usize, device: &Device) -
     Tensor::from_vec(emb, (1, pos_len, d_model), device).map_err(Error::from)
 }
 
+fn build_rel_positional_embedding_for_dtype(
+    len: usize,
+    d_model: usize,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    build_rel_positional_embedding(len, d_model, device)?
+        .to_dtype(dtype)
+        .map_err(Error::from)
+}
+
 fn build_limited_context_mask(
     len: usize,
     left_context: usize,
@@ -1139,6 +1279,31 @@ fn build_limited_context_mask(
         }
     }
     Tensor::from_vec(mask, (1, 1, len, len), device).map_err(Error::from)
+}
+
+fn build_limited_context_mask_for_dtype(
+    len: usize,
+    left_context: usize,
+    right_context: usize,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    build_limited_context_mask(len, left_context, right_context, device)?
+        .to_dtype(dtype)
+        .map_err(Error::from)
+}
+
+fn build_prompt_one_hot(prompt_id: usize, device: &Device, dtype: DType) -> Result<Tensor> {
+    if prompt_id >= PROMPT_DIM {
+        return Err(Error::InvalidInput(format!(
+            "Nemotron prompt id {prompt_id} exceeds prompt feature dimension {PROMPT_DIM}"
+        )));
+    }
+    let mut prompt = vec![0f32; PROMPT_DIM];
+    prompt[prompt_id] = 1.0;
+    Tensor::from_vec(prompt, (1, 1, PROMPT_DIM), device)?
+        .to_dtype(dtype)
+        .map_err(Error::from)
 }
 
 fn swish(x: &Tensor) -> Result<Tensor> {
@@ -1261,6 +1426,30 @@ mod tests {
     }
 
     #[test]
+    fn typed_limited_context_mask_matches_f32_builder_values() {
+        let mask = build_limited_context_mask_for_dtype(4, 1, 1, &Device::Cpu, DType::F32).unwrap();
+        let values = mask
+            .squeeze(0)
+            .unwrap()
+            .squeeze(0)
+            .unwrap()
+            .to_vec2::<f32>()
+            .unwrap();
+
+        assert_eq!(mask.dtype(), DType::F32);
+        assert_eq!(values[0][0], 0.0);
+        assert!(values[0][2] < -1.0e8);
+    }
+
+    #[test]
+    fn typed_rel_positional_embedding_matches_f32_builder_shape() {
+        let pos = build_rel_positional_embedding_for_dtype(3, 8, &Device::Cpu, DType::F32).unwrap();
+
+        assert_eq!(pos.dtype(), DType::F32);
+        assert_eq!(pos.dims(), &[1, 5, 8]);
+    }
+
+    #[test]
     fn normalize_mode_respects_nemo_na_value() {
         assert_eq!(
             FeatureNormalize::from_config(Some("NA")),
@@ -1287,6 +1476,16 @@ mod tests {
         let err = argmax_1d(&logits).expect_err("rank-2 logits should fail");
 
         assert!(err.to_string().contains("expected rank-1 logits"));
+    }
+
+    #[test]
+    fn prompt_one_hot_builder_sets_only_requested_prompt_id() {
+        let prompt = build_prompt_one_hot(3, &Device::Cpu, DType::F32).unwrap();
+        let values = prompt.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+
+        assert_eq!(prompt.dims(), &[1, 1, PROMPT_DIM]);
+        assert_eq!(values[3], 1.0);
+        assert_eq!(values.iter().filter(|value| **value == 1.0).count(), 1);
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
@@ -327,6 +327,114 @@ impl NemotronNetwork {
         })
     }
 
+    pub(super) fn start_rnnt_stream(&self) -> Result<NemotronRnntStreamState> {
+        let device = &self.preprocessor.device;
+        let mut predictor_state = self.predictor.initial_state(1, device)?;
+        let predictor_out = self
+            .predictor
+            .step(self.blank_idx, &mut predictor_state, device)?;
+        let predictor_projection = if device.is_cuda() {
+            Some(self.joint.project_predictor(&predictor_out)?)
+        } else {
+            None
+        };
+
+        Ok(NemotronRnntStreamState {
+            predictor_state,
+            predictor_out,
+            predictor_projection,
+            token_ids: Vec::new(),
+            stats: NemotronDecodeStats {
+                encoded_frames: 0,
+                emitted_tokens: 0,
+                blank_frames: 0,
+                guard_exits: 0,
+                max_symbols_per_frame: self.max_symbols_per_frame,
+            },
+        })
+    }
+
+    pub(super) fn decode_rnnt_streaming_chunk(
+        &self,
+        state: &mut NemotronRnntStreamState,
+        encoded: &Tensor,
+        encoded_len: usize,
+        on_token: &mut dyn FnMut(usize),
+    ) -> Result<NemotronRnntStreamStep> {
+        let encoded = encoded.i((0, ..encoded_len, ..))?;
+        let encoded_projection = if encoded.device().is_cuda() {
+            Some(self.joint.project_encoder(&encoded)?)
+        } else {
+            None
+        };
+        let mut new_token_ids = Vec::new();
+
+        for t in 0..encoded_len {
+            let enc_t = if let Some(projection) = encoded_projection.as_ref() {
+                projection.i((t, ..))?.unsqueeze(0)?.unsqueeze(0)?
+            } else {
+                encoded.i((t, ..))?.unsqueeze(0)?.unsqueeze(0)?
+            };
+            let mut symbols_this_frame = 0usize;
+
+            loop {
+                let logits = if encoded_projection.is_some() {
+                    let predictor_projection =
+                        state.predictor_projection.as_ref().ok_or_else(|| {
+                            Error::InferenceError(
+                                "Nemotron CUDA RNNT stream is missing predictor projection"
+                                    .to_string(),
+                            )
+                        })?;
+                    self.joint.joint_from_projections(&enc_t, predictor_projection)?
+                } else {
+                    self.joint.joint_after_projection(&enc_t, &state.predictor_out)?
+                }
+                .squeeze(0)?
+                .squeeze(0)?
+                .squeeze(0)?;
+                let label = argmax_1d(&logits)?;
+
+                if label == self.blank_idx {
+                    state.stats.blank_frames = state.stats.blank_frames.saturating_add(1);
+                    break;
+                }
+                if label > self.blank_idx {
+                    return Err(Error::InferenceError(format!(
+                        "Nemotron RNNT emitted invalid label {label}; blank_idx={}",
+                        self.blank_idx
+                    )));
+                }
+
+                state.token_ids.push(label);
+                new_token_ids.push(label);
+                on_token(label);
+                symbols_this_frame = symbols_this_frame.saturating_add(1);
+                if symbols_this_frame >= self.max_symbols_per_frame {
+                    state.stats.guard_exits = state.stats.guard_exits.saturating_add(1);
+                    break;
+                }
+
+                state.predictor_out =
+                    self.predictor
+                        .step(label, &mut state.predictor_state, encoded.device())?;
+                if encoded_projection.is_some() {
+                    state.predictor_projection =
+                        Some(self.joint.project_predictor(&state.predictor_out)?);
+                }
+            }
+        }
+
+        state.stats.encoded_frames = state.stats.encoded_frames.saturating_add(encoded_len);
+        state.stats.emitted_tokens = state.token_ids.len();
+
+        Ok(NemotronRnntStreamStep {
+            token_ids: state.token_ids.clone(),
+            new_token_ids,
+            stats: state.stats.clone(),
+        })
+    }
+
     fn decode_rnnt_greedy_cuda_cached(
         &self,
         encoded: &Tensor,
@@ -593,6 +701,20 @@ pub(super) struct NemotronStreamingEncoderChunk {
     pub is_final: bool,
 }
 
+pub(super) struct NemotronRnntStreamState {
+    predictor_state: PredictorState,
+    predictor_out: Tensor,
+    predictor_projection: Option<Tensor>,
+    token_ids: Vec<usize>,
+    stats: NemotronDecodeStats,
+}
+
+pub(super) struct NemotronRnntStreamStep {
+    pub token_ids: Vec<usize>,
+    pub new_token_ids: Vec<usize>,
+    pub stats: NemotronDecodeStats,
+}
+
 impl NemotronStreamingFeatureState {
     pub(super) fn new() -> Self {
         Self {
@@ -741,6 +863,12 @@ impl NemotronStreamingEncoderState {
         } else {
             self.encoded_frames.saturating_sub(self.right_context_frames)
         }
+    }
+}
+
+impl NemotronRnntStreamState {
+    fn token_ids(&self) -> &[usize] {
+        &self.token_ids
     }
 }
 
@@ -1896,6 +2024,77 @@ mod tests {
         }
     }
 
+    fn zero_lstm_cell() -> LstmCell {
+        let device = Device::Cpu;
+        LstmCell {
+            w_ih: Tensor::zeros((PRED_HIDDEN * 4, PRED_HIDDEN), DType::F32, &device).unwrap(),
+            w_hh: Tensor::zeros((PRED_HIDDEN * 4, PRED_HIDDEN), DType::F32, &device).unwrap(),
+            b_ih: Tensor::zeros(PRED_HIDDEN * 4, DType::F32, &device).unwrap(),
+            b_hh: Tensor::zeros(PRED_HIDDEN * 4, DType::F32, &device).unwrap(),
+            cuda_views: None,
+        }
+    }
+
+    fn zero_predictor(vocab_plus_blank: usize) -> Predictor {
+        Predictor {
+            embed: Tensor::zeros((vocab_plus_blank, PRED_HIDDEN), DType::F32, &Device::Cpu)
+                .unwrap(),
+            lstm_l0: zero_lstm_cell(),
+            lstm_l1: zero_lstm_cell(),
+            blank_idx: vocab_plus_blank - 1,
+        }
+    }
+
+    fn zero_prompt_kernel() -> PromptKernel {
+        let device = Device::Cpu;
+        PromptKernel {
+            linear0: Linear::new(
+                Tensor::zeros((PROMPT_HIDDEN, ENCODER_DIM + PROMPT_DIM), DType::F32, &device)
+                    .unwrap(),
+                Some(Tensor::zeros(PROMPT_HIDDEN, DType::F32, &device).unwrap()),
+            ),
+            linear2: Linear::new(
+                Tensor::zeros((ENCODER_DIM, PROMPT_HIDDEN), DType::F32, &device).unwrap(),
+                Some(Tensor::zeros(ENCODER_DIM, DType::F32, &device).unwrap()),
+            ),
+            prompt_cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn rnnt_test_network(output_bias: Vec<f32>, max_symbols_per_frame: usize) -> NemotronNetwork {
+        let device = Device::Cpu;
+        let vocab_plus_blank = output_bias.len();
+        NemotronNetwork {
+            preprocessor: test_preprocessor(FeatureNormalize::None),
+            pre_encode: zero_subsampling(),
+            layers: Vec::new(),
+            predictor: zero_predictor(vocab_plus_blank),
+            joint: Joint {
+                pred: Linear::new(
+                    Tensor::zeros((JOINT_HIDDEN, PRED_HIDDEN), DType::F32, &device).unwrap(),
+                    Some(Tensor::zeros(JOINT_HIDDEN, DType::F32, &device).unwrap()),
+                ),
+                enc: Linear::new(
+                    Tensor::zeros((JOINT_HIDDEN, ENCODER_DIM), DType::F32, &device).unwrap(),
+                    Some(Tensor::zeros(JOINT_HIDDEN, DType::F32, &device).unwrap()),
+                ),
+                out: Linear::new(
+                    Tensor::zeros((vocab_plus_blank, JOINT_HIDDEN), DType::F32, &device).unwrap(),
+                    Some(Tensor::from_vec(output_bias, vocab_plus_blank, &device).unwrap()),
+                ),
+            },
+            prompt_kernel: zero_prompt_kernel(),
+            prompt_dictionary: HashMap::from([("auto".to_string(), 0usize)]),
+            left_context_frames: 56,
+            right_context_frames: 0,
+            blank_idx: vocab_plus_blank - 1,
+            max_symbols_per_frame,
+            rel_pos_cache: Mutex::new(HashMap::new()),
+            att_mask_cache: Mutex::new(HashMap::new()),
+            dtype: DType::F32,
+        }
+    }
+
     fn feature_chunk(
         features: &Tensor,
         start_frame: usize,
@@ -2210,6 +2409,60 @@ mod tests {
 
         let err = state.push_pre_encoded(encoded_chunk(1, 1, false)).unwrap_err();
         assert!(err.to_string().contains("expected start frame 0"));
+    }
+
+    #[test]
+    fn rnnt_stream_state_accumulates_blank_stats_across_chunks() {
+        let network = rnnt_test_network(vec![0.0, 0.0, 10.0], DEFAULT_MAX_SYMBOLS_PER_FRAME);
+        let mut state = network.start_rnnt_stream().unwrap();
+        let first = Tensor::zeros((1, 2, ENCODER_DIM), DType::F32, &Device::Cpu).unwrap();
+        let second = Tensor::zeros((1, 1, ENCODER_DIM), DType::F32, &Device::Cpu).unwrap();
+        let mut emitted = Vec::new();
+
+        let step = network
+            .decode_rnnt_streaming_chunk(&mut state, &first, 2, &mut |token| emitted.push(token))
+            .unwrap();
+        assert!(step.new_token_ids.is_empty());
+        assert!(step.token_ids.is_empty());
+        assert_eq!(step.stats.encoded_frames, 2);
+        assert_eq!(step.stats.blank_frames, 2);
+
+        let step = network
+            .decode_rnnt_streaming_chunk(&mut state, &second, 1, &mut |token| emitted.push(token))
+            .unwrap();
+        assert!(emitted.is_empty());
+        assert_eq!(step.stats.encoded_frames, 3);
+        assert_eq!(step.stats.blank_frames, 3);
+        assert!(state.token_ids().is_empty());
+    }
+
+    #[test]
+    fn rnnt_stream_state_keeps_token_history_across_chunks() {
+        let network = rnnt_test_network(vec![10.0, 0.0, 1.0], 2);
+        let mut state = network.start_rnnt_stream().unwrap();
+        let encoded = Tensor::zeros((1, 1, ENCODER_DIM), DType::F32, &Device::Cpu).unwrap();
+        let mut emitted = Vec::new();
+
+        let first = network
+            .decode_rnnt_streaming_chunk(&mut state, &encoded, 1, &mut |token| {
+                emitted.push(token)
+            })
+            .unwrap();
+        assert_eq!(first.new_token_ids, vec![0, 0]);
+        assert_eq!(first.token_ids, vec![0, 0]);
+        assert_eq!(first.stats.guard_exits, 1);
+
+        let second = network
+            .decode_rnnt_streaming_chunk(&mut state, &encoded, 1, &mut |token| {
+                emitted.push(token)
+            })
+            .unwrap();
+        assert_eq!(second.new_token_ids, vec![0, 0]);
+        assert_eq!(second.token_ids, vec![0, 0, 0, 0]);
+        assert_eq!(second.stats.encoded_frames, 2);
+        assert_eq!(second.stats.emitted_tokens, 4);
+        assert_eq!(second.stats.guard_exits, 2);
+        assert_eq!(emitted, vec![0, 0, 0, 0]);
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
@@ -177,19 +177,36 @@ impl NemotronNetwork {
         } else {
             features.to_dtype(self.dtype)?
         };
-        let (mut x, encoded_len) = self.pre_encode.forward(&features, feature_frames)?;
+        let (x, encoded_len) = self.pre_encode.forward(&features, feature_frames)?;
         if encoded_len == 0 {
             return Err(Error::InferenceError(
                 "Nemotron encoder produced zero frames".to_string(),
             ));
         }
 
+        self.encode_preencoded_with_prompt(
+            x,
+            encoded_len,
+            prompt_id,
+            self.left_context_frames,
+            self.right_context_frames,
+        )
+    }
+
+    fn encode_preencoded_with_prompt(
+        &self,
+        mut x: Tensor,
+        encoded_len: usize,
+        prompt_id: usize,
+        left_context_frames: usize,
+        right_context_frames: usize,
+    ) -> Result<(Tensor, usize)> {
         let pos_len = x.dim(1)?;
         let pos_emb = self.rel_positional_embedding(pos_len, x.dtype(), x.device())?;
         let att_mask = self.limited_context_mask(
             pos_len,
-            self.left_context_frames,
-            self.right_context_frames,
+            left_context_frames,
+            right_context_frames,
             x.dtype(),
             x.device(),
         )?;
@@ -199,6 +216,45 @@ impl NemotronNetwork {
 
         let x = self.prompt_kernel.forward(&x, prompt_id)?;
         Ok((x, encoded_len.min(pos_len)))
+    }
+
+    pub(super) fn encode_streaming_chunk(
+        &self,
+        state: &mut NemotronStreamingEncoderState,
+        prompt_id: usize,
+    ) -> Result<Option<NemotronStreamingEncoderChunk>> {
+        let Some(pre_encoded) = state.pre_encoded.as_ref() else {
+            return Ok(None);
+        };
+        let ready_frames = state.ready_frames();
+        if ready_frames <= state.emitted_frames {
+            return Ok(None);
+        }
+
+        let (encoded, encoded_len) = self.encode_preencoded_with_prompt(
+            pre_encoded.clone(),
+            state.encoded_frames,
+            prompt_id,
+            state.left_context_frames,
+            state.right_context_frames,
+        )?;
+        let ready_frames = ready_frames.min(encoded_len);
+        if ready_frames <= state.emitted_frames {
+            return Ok(None);
+        }
+
+        let start_frame = state.emitted_frames;
+        let frames = ready_frames - start_frame;
+        let encoded = encoded.narrow(1, start_frame, frames)?.contiguous()?;
+        state.emitted_frames = ready_frames;
+
+        Ok(Some(NemotronStreamingEncoderChunk {
+            encoded,
+            start_frame,
+            frames,
+            total_ready_frames: ready_frames,
+            is_final: state.input_finished && ready_frames == encoded_len,
+        }))
     }
 
     pub(super) fn decode_rnnt_greedy(
@@ -520,6 +576,23 @@ pub(super) struct NemotronStreamingEncodedChunk {
     pub is_final: bool,
 }
 
+pub(super) struct NemotronStreamingEncoderState {
+    pre_encoded: Option<Tensor>,
+    encoded_frames: usize,
+    emitted_frames: usize,
+    left_context_frames: usize,
+    right_context_frames: usize,
+    input_finished: bool,
+}
+
+pub(super) struct NemotronStreamingEncoderChunk {
+    pub encoded: Tensor,
+    pub start_frame: usize,
+    pub frames: usize,
+    pub total_ready_frames: usize,
+    pub is_final: bool,
+}
+
 impl NemotronStreamingFeatureState {
     pub(super) fn new() -> Self {
         Self {
@@ -614,6 +687,60 @@ impl NemotronStreamingPreEncodeState {
 
     pub(super) fn finish_input(&mut self) {
         self.input_finished = true;
+    }
+}
+
+impl NemotronStreamingEncoderState {
+    pub(super) fn new(left_context_frames: usize, right_context_frames: usize) -> Self {
+        Self {
+            pre_encoded: None,
+            encoded_frames: 0,
+            emitted_frames: 0,
+            left_context_frames,
+            right_context_frames,
+            input_finished: false,
+        }
+    }
+
+    pub(super) fn push_pre_encoded(
+        &mut self,
+        chunk: NemotronStreamingEncodedChunk,
+    ) -> Result<()> {
+        if self.input_finished {
+            return Err(Error::InvalidInput(
+                "Cannot push encoder frames into a finalized Nemotron encoder stream".to_string(),
+            ));
+        }
+        if chunk.start_frame != self.encoded_frames {
+            return Err(Error::InvalidInput(format!(
+                "Nemotron encoder stream expected start frame {}, got {}",
+                self.encoded_frames, chunk.start_frame
+            )));
+        }
+        if chunk.frames == 0 {
+            return Ok(());
+        }
+
+        self.pre_encoded = Some(if let Some(existing) = self.pre_encoded.as_ref() {
+            Tensor::cat(&[existing, &chunk.encoded], 1)?
+        } else {
+            chunk.encoded
+        });
+        self.encoded_frames = self.encoded_frames.saturating_add(chunk.frames);
+        self.input_finished = chunk.is_final;
+        Ok(())
+    }
+
+    pub(super) fn finish_input(&mut self) {
+        self.input_finished = true;
+    }
+
+    fn ready_frames(&self) -> usize {
+        if self.input_finished {
+            self.encoded_frames
+        } else {
+            self.encoded_frames.saturating_sub(self.right_context_frames)
+        }
     }
 }
 
@@ -1784,6 +1911,20 @@ mod tests {
         }
     }
 
+    fn encoded_chunk(
+        start_frame: usize,
+        frames: usize,
+        is_final: bool,
+    ) -> NemotronStreamingEncodedChunk {
+        NemotronStreamingEncodedChunk {
+            encoded: Tensor::zeros((1, frames, ENCODER_DIM), DType::F32, &Device::Cpu).unwrap(),
+            start_frame,
+            frames,
+            total_stable_frames: start_frame + frames,
+            is_final,
+        }
+    }
+
     fn assert_tensor_close(lhs: &Tensor, rhs: &Tensor, tolerance: f32) {
         assert_eq!(lhs.dims(), rhs.dims());
         let lhs = lhs.flatten_all().unwrap().to_vec1::<f32>().unwrap();
@@ -2043,6 +2184,31 @@ mod tests {
         let err = state
             .push_features(feature_chunk(&features, 1, 1, false))
             .unwrap_err();
+        assert!(err.to_string().contains("expected start frame 0"));
+    }
+
+    #[test]
+    fn streaming_encoder_state_delays_until_right_context_is_available() {
+        let mut state = NemotronStreamingEncoderState::new(56, 3);
+
+        state.push_pre_encoded(encoded_chunk(0, 2, false)).unwrap();
+        assert_eq!(state.ready_frames(), 0);
+
+        state.push_pre_encoded(encoded_chunk(2, 2, false)).unwrap();
+        assert_eq!(state.ready_frames(), 1);
+
+        state.push_pre_encoded(encoded_chunk(4, 4, false)).unwrap();
+        assert_eq!(state.ready_frames(), 5);
+
+        state.finish_input();
+        assert_eq!(state.ready_frames(), 8);
+    }
+
+    #[test]
+    fn streaming_encoder_state_rejects_out_of_order_frames() {
+        let mut state = NemotronStreamingEncoderState::new(56, 1);
+
+        let err = state.push_pre_encoded(encoded_chunk(1, 1, false)).unwrap_err();
         assert!(err.to_string().contains("expected start frame 0"));
     }
 

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use candle_core::{DType, Device, IndexOp, Tensor, D};
 use candle_nn::ops;
@@ -7,7 +7,7 @@ use candle_nn::{
     layer_norm, Conv1d, Conv1dConfig, Conv2d, Conv2dConfig, LayerNorm, Linear, Module, VarBuilder,
 };
 use rustfft::num_complex::Complex;
-use rustfft::FftPlanner;
+use rustfft::{Fft, FftPlanner};
 use serde_json::json;
 
 use super::config::NemotronConfigInventory;
@@ -486,7 +486,76 @@ struct NemotronPreprocessor {
     device: Device,
     padded_window: Vec<f32>,
     fb: Vec<f32>,
+    fft: Arc<dyn Fft<f32>>,
     normalize: FeatureNormalize,
+}
+
+pub(super) struct NemotronStreamingFeatureState {
+    preemphasized: Vec<f32>,
+    last_raw_sample: Option<f32>,
+    next_frame: usize,
+    input_finished: bool,
+}
+
+pub(super) struct NemotronStreamingFeatureChunk {
+    pub features: Tensor,
+    pub start_frame: usize,
+    pub frames: usize,
+    pub total_ready_frames: usize,
+    pub is_final: bool,
+}
+
+impl NemotronStreamingFeatureState {
+    pub(super) fn new() -> Self {
+        Self {
+            preemphasized: Vec::new(),
+            last_raw_sample: None,
+            next_frame: 0,
+            input_finished: false,
+        }
+    }
+
+    pub(super) fn push_samples(&mut self, samples: &[f32]) -> Result<()> {
+        if self.input_finished {
+            return Err(Error::InvalidInput(
+                "Cannot push audio into a finalized Nemotron feature stream".to_string(),
+            ));
+        }
+        if samples.is_empty() {
+            return Ok(());
+        }
+
+        self.preemphasized.reserve(samples.len());
+        for &sample in samples {
+            let value = if let Some(prev) = self.last_raw_sample {
+                sample - PREEMPH * prev
+            } else {
+                sample
+            };
+            self.preemphasized.push(value);
+            self.last_raw_sample = Some(sample);
+        }
+        Ok(())
+    }
+
+    pub(super) fn finish_input(&mut self) {
+        self.input_finished = true;
+    }
+
+    fn ready_frames(&self) -> usize {
+        if self.preemphasized.is_empty() {
+            return 0;
+        }
+        if self.input_finished {
+            return ((self.preemphasized.len() + HOP_LENGTH - 1) / HOP_LENGTH).max(1);
+        }
+
+        let center_pad = N_FFT / 2;
+        if self.preemphasized.len() < center_pad {
+            return 0;
+        }
+        ((self.preemphasized.len() - center_pad) / HOP_LENGTH) + 1
+    }
 }
 
 impl NemotronPreprocessor {
@@ -531,10 +600,14 @@ impl NemotronPreprocessor {
         let offset = (N_FFT - WIN_LENGTH) / 2;
         padded_window[offset..offset + WIN_LENGTH].copy_from_slice(&window);
 
+        let mut planner = FftPlanner::<f32>::new();
+        let fft = planner.plan_fft_forward(N_FFT);
+
         Ok(Self {
             device,
             padded_window,
             fb,
+            fft,
             normalize: FeatureNormalize::from_config(inventory.normalize.as_deref()),
         })
     }
@@ -559,8 +632,6 @@ impl NemotronPreprocessor {
             1
         };
 
-        let mut planner = FftPlanner::<f32>::new();
-        let fft = planner.plan_fft_forward(N_FFT);
         let mut spectrum = vec![0f32; frame_count * (N_FFT / 2 + 1)];
         let mut buffer = vec![Complex::<f32>::new(0.0, 0.0); N_FFT];
 
@@ -572,7 +643,7 @@ impl NemotronPreprocessor {
                 buffer[i].im = 0.0;
             }
 
-            fft.process(&mut buffer);
+            self.fft.process(&mut buffer);
 
             for k in 0..(N_FFT / 2 + 1) {
                 let mag = (buffer[k].re * buffer[k].re + buffer[k].im * buffer[k].im).sqrt();
@@ -611,6 +682,100 @@ impl NemotronPreprocessor {
 
         let features = Tensor::from_vec(mel, (1, N_MELS, frame_count), &self.device)?;
         Ok((features, valid_frames))
+    }
+
+    pub(super) fn compute_streaming_features(
+        &self,
+        state: &mut NemotronStreamingFeatureState,
+    ) -> Result<Option<NemotronStreamingFeatureChunk>> {
+        if self.normalize == FeatureNormalize::PerFeature {
+            return Err(Error::InferenceError(
+                "Nemotron streaming frontend does not support per-feature normalization".to_string(),
+            ));
+        }
+
+        let ready_frames = state.ready_frames();
+        if ready_frames <= state.next_frame {
+            return Ok(None);
+        }
+
+        let start_frame = state.next_frame;
+        let frames = ready_frames - start_frame;
+        let mel = self.compute_mel_frames(
+            &state.preemphasized,
+            start_frame,
+            frames,
+            state.input_finished,
+        )?;
+        let features = Tensor::from_vec(mel, (1, N_MELS, frames), &self.device)?;
+        state.next_frame = ready_frames;
+
+        Ok(Some(NemotronStreamingFeatureChunk {
+            features,
+            start_frame,
+            frames,
+            total_ready_frames: ready_frames,
+            is_final: state.input_finished,
+        }))
+    }
+
+    fn compute_mel_frames(
+        &self,
+        preemphasized: &[f32],
+        start_frame: usize,
+        frames: usize,
+        allow_right_padding: bool,
+    ) -> Result<Vec<f32>> {
+        if frames == 0 {
+            return Ok(Vec::new());
+        }
+
+        let n_freqs = N_FFT / 2 + 1;
+        let center_pad = N_FFT / 2;
+        let mut spectrum = vec![0f32; frames * n_freqs];
+        let mut buffer = vec![Complex::<f32>::new(0.0, 0.0); N_FFT];
+
+        for local_frame in 0..frames {
+            let frame_idx = start_frame + local_frame;
+            let center = frame_idx * HOP_LENGTH;
+            for i in 0..N_FFT {
+                let sample = match center.checked_add(i).and_then(|v| v.checked_sub(center_pad)) {
+                    Some(src_idx) if src_idx < preemphasized.len() => preemphasized[src_idx],
+                    Some(_) if allow_right_padding => 0.0,
+                    Some(src_idx) => {
+                        return Err(Error::InferenceError(format!(
+                            "Nemotron streaming frontend frame {frame_idx} requires sample {src_idx}, but only {} samples are available",
+                            preemphasized.len()
+                        )));
+                    }
+                    None => 0.0,
+                };
+                buffer[i].re = sample * self.padded_window[i];
+                buffer[i].im = 0.0;
+            }
+
+            self.fft.process(&mut buffer);
+
+            for k in 0..n_freqs {
+                let mag = (buffer[k].re * buffer[k].re + buffer[k].im * buffer[k].im).sqrt();
+                spectrum[local_frame * n_freqs + k] = mag * mag;
+            }
+        }
+
+        let mut mel = vec![0f32; N_MELS * frames];
+        for m in 0..N_MELS {
+            for t in 0..frames {
+                let mut acc = 0f32;
+                let spec_row = &spectrum[t * n_freqs..(t + 1) * n_freqs];
+                let fb_row = &self.fb[m * n_freqs..(m + 1) * n_freqs];
+                for f in 0..n_freqs {
+                    acc += spec_row[f] * fb_row[f];
+                }
+                mel[m * frames + t] = (acc + LOG_GUARD).ln();
+            }
+        }
+
+        Ok(mel)
     }
 }
 
@@ -1408,6 +1573,38 @@ fn normalize_per_feature(mel: &mut [f32], n_mels: usize, frames: usize, valid_fr
 mod tests {
     use super::*;
 
+    fn test_preprocessor(normalize: FeatureNormalize) -> NemotronPreprocessor {
+        let device = Device::Cpu;
+        let mut planner = FftPlanner::<f32>::new();
+        let fft = planner.plan_fft_forward(N_FFT);
+        let mut fb = vec![0f32; N_MELS * (N_FFT / 2 + 1)];
+        let n_freqs = N_FFT / 2 + 1;
+        for m in 0..N_MELS {
+            fb[m * n_freqs + (m % n_freqs)] = 1.0;
+        }
+
+        NemotronPreprocessor {
+            device,
+            padded_window: vec![1.0; N_FFT],
+            fb,
+            fft,
+            normalize,
+        }
+    }
+
+    fn assert_tensor_close(lhs: &Tensor, rhs: &Tensor, tolerance: f32) {
+        assert_eq!(lhs.dims(), rhs.dims());
+        let lhs = lhs.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let rhs = rhs.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        for (idx, (a, b)) in lhs.iter().zip(rhs.iter()).enumerate() {
+            let diff = (a - b).abs();
+            assert!(
+                diff <= tolerance,
+                "tensor mismatch at {idx}: lhs={a} rhs={b} diff={diff}"
+            );
+        }
+    }
+
     #[test]
     fn resample_linear_downsamples_24khz_to_16khz_length() {
         let audio = vec![0.0f32; 24_000];
@@ -1504,6 +1701,78 @@ mod tests {
         assert_eq!(prompt.dims(), &[1, 1, PROMPT_DIM]);
         assert_eq!(values[3], 1.0);
         assert_eq!(values.iter().filter(|value| **value == 1.0).count(), 1);
+    }
+
+    #[test]
+    fn streaming_feature_state_waits_for_centered_frame_samples() {
+        let preprocessor = test_preprocessor(FeatureNormalize::None);
+        let mut state = NemotronStreamingFeatureState::new();
+
+        state.push_samples(&vec![0.25; (N_FFT / 2) - 1]).unwrap();
+        assert!(preprocessor
+            .compute_streaming_features(&mut state)
+            .unwrap()
+            .is_none());
+
+        state.push_samples(&[0.5]).unwrap();
+        let chunk = preprocessor
+            .compute_streaming_features(&mut state)
+            .unwrap()
+            .expect("first centered frame");
+
+        assert_eq!(chunk.start_frame, 0);
+        assert_eq!(chunk.frames, 1);
+        assert_eq!(chunk.total_ready_frames, 1);
+        assert!(!chunk.is_final);
+    }
+
+    #[test]
+    fn streaming_features_match_full_valid_features_after_chunked_pushes() {
+        let preprocessor = test_preprocessor(FeatureNormalize::None);
+        let audio = (0..4_013)
+            .map(|idx| ((idx as f32) * 0.017).sin() * 0.3)
+            .collect::<Vec<_>>();
+        let (full, valid_frames) = preprocessor.compute_features(&audio).unwrap();
+        let full = full.narrow(2, 0, valid_frames).unwrap();
+
+        let mut state = NemotronStreamingFeatureState::new();
+        let mut chunks = Vec::<Tensor>::new();
+        let mut offset = 0usize;
+        for size in [17usize, 439, 811, 1_003, 571, 1_172] {
+            let end = offset.saturating_add(size).min(audio.len());
+            if end == offset {
+                break;
+            }
+            state.push_samples(&audio[offset..end]).unwrap();
+            if let Some(chunk) = preprocessor.compute_streaming_features(&mut state).unwrap() {
+                chunks.push(chunk.features);
+            }
+            offset = end;
+        }
+        if offset < audio.len() {
+            state.push_samples(&audio[offset..]).unwrap();
+            if let Some(chunk) = preprocessor.compute_streaming_features(&mut state).unwrap() {
+                chunks.push(chunk.features);
+            }
+        }
+        state.finish_input();
+        if let Some(chunk) = preprocessor.compute_streaming_features(&mut state).unwrap() {
+            assert!(chunk.is_final);
+            chunks.push(chunk.features);
+        }
+
+        let refs = chunks.iter().collect::<Vec<_>>();
+        let streamed = Tensor::cat(&refs, 2).unwrap();
+        assert_tensor_close(&streamed, &full, 1e-4);
+    }
+
+    #[test]
+    fn streaming_feature_state_rejects_push_after_finish() {
+        let mut state = NemotronStreamingFeatureState::new();
+        state.finish_input();
+
+        let err = state.push_samples(&[0.0]).unwrap_err();
+        assert!(err.to_string().contains("finalized"));
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
@@ -257,6 +257,20 @@ impl NemotronNetwork {
         }))
     }
 
+    pub(super) fn compute_streaming_features(
+        &self,
+        state: &mut NemotronStreamingFeatureState,
+    ) -> Result<Option<NemotronStreamingFeatureChunk>> {
+        self.preprocessor.compute_streaming_features(state)
+    }
+
+    pub(super) fn pre_encode_streaming_chunk(
+        &self,
+        state: &mut NemotronStreamingPreEncodeState,
+    ) -> Result<Option<NemotronStreamingEncodedChunk>> {
+        self.pre_encode.forward_streaming_chunk(state)
+    }
+
     pub(super) fn decode_rnnt_greedy(
         &self,
         encoded: &Tensor,
@@ -386,9 +400,11 @@ impl NemotronNetwork {
                                     .to_string(),
                             )
                         })?;
-                    self.joint.joint_from_projections(&enc_t, predictor_projection)?
+                    self.joint
+                        .joint_from_projections(&enc_t, predictor_projection)?
                 } else {
-                    self.joint.joint_after_projection(&enc_t, &state.predictor_out)?
+                    self.joint
+                        .joint_after_projection(&enc_t, &state.predictor_out)?
                 }
                 .squeeze(0)?
                 .squeeze(0)?
@@ -778,10 +794,7 @@ impl NemotronStreamingPreEncodeState {
         }
     }
 
-    pub(super) fn push_features(
-        &mut self,
-        chunk: NemotronStreamingFeatureChunk,
-    ) -> Result<()> {
+    pub(super) fn push_features(&mut self, chunk: NemotronStreamingFeatureChunk) -> Result<()> {
         if self.input_finished {
             return Err(Error::InvalidInput(
                 "Cannot push features into a finalized Nemotron pre-encode stream".to_string(),
@@ -824,10 +837,7 @@ impl NemotronStreamingEncoderState {
         }
     }
 
-    pub(super) fn push_pre_encoded(
-        &mut self,
-        chunk: NemotronStreamingEncodedChunk,
-    ) -> Result<()> {
+    pub(super) fn push_pre_encoded(&mut self, chunk: NemotronStreamingEncodedChunk) -> Result<()> {
         if self.input_finished {
             return Err(Error::InvalidInput(
                 "Cannot push encoder frames into a finalized Nemotron encoder stream".to_string(),
@@ -861,7 +871,8 @@ impl NemotronStreamingEncoderState {
         if self.input_finished {
             self.encoded_frames
         } else {
-            self.encoded_frames.saturating_sub(self.right_context_frames)
+            self.encoded_frames
+                .saturating_sub(self.right_context_frames)
         }
     }
 }
@@ -1004,7 +1015,8 @@ impl NemotronPreprocessor {
     ) -> Result<Option<NemotronStreamingFeatureChunk>> {
         if self.normalize == FeatureNormalize::PerFeature {
             return Err(Error::InferenceError(
-                "Nemotron streaming frontend does not support per-feature normalization".to_string(),
+                "Nemotron streaming frontend does not support per-feature normalization"
+                    .to_string(),
             ));
         }
 
@@ -1053,7 +1065,10 @@ impl NemotronPreprocessor {
             let frame_idx = start_frame + local_frame;
             let center = frame_idx * HOP_LENGTH;
             for i in 0..N_FFT {
-                let sample = match center.checked_add(i).and_then(|v| v.checked_sub(center_pad)) {
+                let sample = match center
+                    .checked_add(i)
+                    .and_then(|v| v.checked_sub(center_pad))
+                {
                     Some(src_idx) if src_idx < preemphasized.len() => preemphasized[src_idx],
                     Some(_) if allow_right_padding => 0.0,
                     Some(src_idx) => {
@@ -2049,8 +2064,12 @@ mod tests {
         let device = Device::Cpu;
         PromptKernel {
             linear0: Linear::new(
-                Tensor::zeros((PROMPT_HIDDEN, ENCODER_DIM + PROMPT_DIM), DType::F32, &device)
-                    .unwrap(),
+                Tensor::zeros(
+                    (PROMPT_HIDDEN, ENCODER_DIM + PROMPT_DIM),
+                    DType::F32,
+                    &device,
+                )
+                .unwrap(),
                 Some(Tensor::zeros(PROMPT_HIDDEN, DType::F32, &device).unwrap()),
             ),
             linear2: Linear::new(
@@ -2407,7 +2426,9 @@ mod tests {
     fn streaming_encoder_state_rejects_out_of_order_frames() {
         let mut state = NemotronStreamingEncoderState::new(56, 1);
 
-        let err = state.push_pre_encoded(encoded_chunk(1, 1, false)).unwrap_err();
+        let err = state
+            .push_pre_encoded(encoded_chunk(1, 1, false))
+            .unwrap_err();
         assert!(err.to_string().contains("expected start frame 0"));
     }
 
@@ -2444,18 +2465,14 @@ mod tests {
         let mut emitted = Vec::new();
 
         let first = network
-            .decode_rnnt_streaming_chunk(&mut state, &encoded, 1, &mut |token| {
-                emitted.push(token)
-            })
+            .decode_rnnt_streaming_chunk(&mut state, &encoded, 1, &mut |token| emitted.push(token))
             .unwrap();
         assert_eq!(first.new_token_ids, vec![0, 0]);
         assert_eq!(first.token_ids, vec![0, 0]);
         assert_eq!(first.stats.guard_exits, 1);
 
         let second = network
-            .decode_rnnt_streaming_chunk(&mut state, &encoded, 1, &mut |token| {
-                emitted.push(token)
-            })
+            .decode_rnnt_streaming_chunk(&mut state, &encoded, 1, &mut |token| emitted.push(token))
             .unwrap();
         assert_eq!(second.new_token_ids, vec![0, 0]);
         assert_eq!(second.token_ids, vec![0, 0, 0, 0]);

--- a/crates/izwi-core/src/models/registry.rs
+++ b/crates/izwi-core/src/models/registry.rs
@@ -17,7 +17,7 @@ use crate::models::architectures::lfm25_audio::{
     Lfm25AudioGenerationConfig, Lfm25AudioModel, Lfm25AudioStreamConfig,
 };
 use crate::models::architectures::nemotron::asr::{
-    NemotronAsrModel, NemotronAsrTranscriptionOutput,
+    NemotronAsrDecodeStep, NemotronAsrModel, NemotronAsrTranscriptionOutput, NemotronStreamingState,
 };
 use crate::models::architectures::parakeet::asr::ParakeetAsrModel;
 use crate::models::architectures::qwen3::asr::{
@@ -485,6 +485,7 @@ pub struct NativeAudioChatGeneration {
 
 pub enum NativeAsrDecodeState {
     Qwen3(Qwen3AsrDecodeState),
+    Nemotron(NemotronStreamingState),
 }
 
 pub enum NativeDiarizationModel {
@@ -782,7 +783,7 @@ impl NativeAsrModel {
     }
 
     pub fn supports_incremental_decode(&self) -> bool {
-        matches!(self, Self::Qwen3(_))
+        matches!(self, Self::Qwen3(_) | Self::Nemotron(_))
     }
 
     pub fn max_audio_seconds_hint(&self) -> Option<f32> {
@@ -826,8 +827,14 @@ impl NativeAsrModel {
             Self::Parakeet(_) => Err(Error::InvalidInput(
                 "Incremental decode state is not available for this ASR model".to_string(),
             )),
-            Self::Nemotron(_) => Err(Error::InvalidInput(
-                "Incremental decode state is not available for this ASR model".to_string(),
+            Self::Nemotron(model) => Ok(NativeAsrDecodeState::Nemotron(
+                model.start_decode_with_prompt(
+                    audio,
+                    sample_rate,
+                    language,
+                    prompt,
+                    max_new_tokens,
+                )?,
             )),
             Self::WhisperTurbo(_) => Err(Error::InvalidInput(
                 "Incremental decode state is not available for this ASR model".to_string(),
@@ -842,6 +849,15 @@ impl NativeAsrModel {
         match (self, state) {
             (Self::Qwen3(model), NativeAsrDecodeState::Qwen3(state)) => {
                 let step: Qwen3AsrDecodeStep = model.decode_step(state)?;
+                Ok(NativeAsrDecodeStep {
+                    delta: step.delta,
+                    text: step.text,
+                    tokens_generated: step.tokens_generated,
+                    finished: step.finished,
+                })
+            }
+            (Self::Nemotron(model), NativeAsrDecodeState::Nemotron(state)) => {
+                let step: NemotronAsrDecodeStep = model.decode_step(state)?;
                 Ok(NativeAsrDecodeStep {
                     delta: step.delta,
                     text: step.text,
@@ -1742,9 +1758,8 @@ mod tests {
 
     #[test]
     fn resolves_nemotron_asr_loader_registration() {
-        let registration =
-            resolve_asr_loader_registration(ModelVariant::Nemotron35AsrStreaming06B)
-                .expect("Nemotron ASR loader should be registered");
+        let registration = resolve_asr_loader_registration(ModelVariant::Nemotron35AsrStreaming06B)
+            .expect("Nemotron ASR loader should be registered");
 
         assert_eq!(registration.name, "nemotron_asr");
         assert_eq!(registration.family, ModelFamily::NemotronAsr);

--- a/crates/izwi-core/src/models/registry.rs
+++ b/crates/izwi-core/src/models/registry.rs
@@ -488,6 +488,10 @@ pub enum NativeAsrDecodeState {
     Nemotron(NemotronStreamingState),
 }
 
+pub enum NativeAsrRealtimeState {
+    Nemotron(NemotronStreamingState),
+}
+
 pub enum NativeDiarizationModel {
     Sortformer(SortformerDiarizerModel),
 }
@@ -498,6 +502,14 @@ pub struct NativeAsrDecodeStep {
     pub text: String,
     pub tokens_generated: usize,
     pub finished: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct NativeAsrRealtimeEvent {
+    pub delta: String,
+    pub text: String,
+    pub is_final: bool,
+    pub chunk_index: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -783,7 +795,71 @@ impl NativeAsrModel {
     }
 
     pub fn supports_incremental_decode(&self) -> bool {
-        matches!(self, Self::Qwen3(_) | Self::Nemotron(_))
+        matches!(self, Self::Qwen3(_))
+    }
+
+    pub fn supports_realtime_stream_decode(&self) -> bool {
+        matches!(self, Self::Nemotron(_))
+    }
+
+    pub fn start_realtime_stream_state(
+        &self,
+        language: Option<&str>,
+        prompt: Option<&str>,
+        right_context_frames: Option<usize>,
+    ) -> Result<NativeAsrRealtimeState> {
+        match self {
+            Self::Nemotron(model) => Ok(NativeAsrRealtimeState::Nemotron(
+                model.start_stream_state(language, prompt, right_context_frames)?,
+            )),
+            _ => Err(Error::InvalidInput(
+                "Realtime audio stream state is not available for this ASR model".to_string(),
+            )),
+        }
+    }
+
+    pub fn push_realtime_stream_samples(
+        &self,
+        state: &mut NativeAsrRealtimeState,
+        samples: &[f32],
+        sample_rate: u32,
+    ) -> Result<Vec<NativeAsrRealtimeEvent>> {
+        match (self, state) {
+            (Self::Nemotron(model), NativeAsrRealtimeState::Nemotron(state)) => Ok(model
+                .push_stream_samples(state, samples, sample_rate)?
+                .into_iter()
+                .map(|event| NativeAsrRealtimeEvent {
+                    delta: event.delta,
+                    text: event.text,
+                    is_final: event.is_final,
+                    chunk_index: event.chunk_index,
+                })
+                .collect()),
+            _ => Err(Error::InvalidInput(
+                "ASR realtime stream state does not match loaded ASR model".to_string(),
+            )),
+        }
+    }
+
+    pub fn finish_realtime_stream(
+        &self,
+        state: &mut NativeAsrRealtimeState,
+    ) -> Result<Vec<NativeAsrRealtimeEvent>> {
+        match (self, state) {
+            (Self::Nemotron(model), NativeAsrRealtimeState::Nemotron(state)) => Ok(model
+                .finish_stream(state)?
+                .into_iter()
+                .map(|event| NativeAsrRealtimeEvent {
+                    delta: event.delta,
+                    text: event.text,
+                    is_final: event.is_final,
+                    chunk_index: event.chunk_index,
+                })
+                .collect()),
+            _ => Err(Error::InvalidInput(
+                "ASR realtime stream state does not match loaded ASR model".to_string(),
+            )),
+        }
     }
 
     pub fn max_audio_seconds_hint(&self) -> Option<f32> {

--- a/crates/izwi-core/src/runtime/asr.rs
+++ b/crates/izwi-core/src/runtime/asr.rs
@@ -1,9 +1,12 @@
 //! ASR runtime methods routed through the unified core engine.
 
-use crate::catalog::{parse_model_variant, resolve_asr_model_variant};
+use std::sync::Arc;
+
+use crate::catalog::{parse_model_variant, resolve_asr_model_variant, ModelFamily};
 use crate::engine::EngineCoreRequest;
 use crate::error::{Error, Result};
-use crate::model::ModelVariant;
+use crate::model::{ModelResidencyLease, ModelVariant};
+use crate::models::registry::{NativeAsrModel, NativeAsrRealtimeEvent, NativeAsrRealtimeState};
 use crate::runtime::adapters::CapabilityKind;
 use crate::runtime::audio_io::{base64_decode, decode_audio_bytes};
 use crate::runtime::request::{AlignmentRuntimeRequest, AsrRuntimeRequest};
@@ -15,7 +18,93 @@ enum AsrAudioInput<'a> {
     Bytes(&'a [u8]),
 }
 
+fn resolve_asr_realtime_stream_variant(model_id: Option<&str>) -> Option<ModelVariant> {
+    let variant = resolve_asr_model_variant(model_id);
+    (variant.family() == ModelFamily::NemotronAsr).then_some(variant)
+}
+
+pub struct RuntimeAsrRealtimeStream {
+    variant: ModelVariant,
+    model: Arc<NativeAsrModel>,
+    state: NativeAsrRealtimeState,
+    _lease: ModelResidencyLease,
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeAsrRealtimeEvent {
+    pub delta: String,
+    pub text: String,
+    pub is_final: bool,
+    pub chunk_index: usize,
+}
+
+fn map_native_realtime_events(events: Vec<NativeAsrRealtimeEvent>) -> Vec<RuntimeAsrRealtimeEvent> {
+    events
+        .into_iter()
+        .map(|event| RuntimeAsrRealtimeEvent {
+            delta: event.delta,
+            text: event.text,
+            is_final: event.is_final,
+            chunk_index: event.chunk_index,
+        })
+        .collect()
+}
+
 impl RuntimeService {
+    pub async fn try_start_asr_realtime_stream(
+        &self,
+        model_id: Option<&str>,
+        language: Option<&str>,
+        prompt: Option<&str>,
+    ) -> Result<Option<RuntimeAsrRealtimeStream>> {
+        let Some(variant) = resolve_asr_realtime_stream_variant(model_id) else {
+            return Ok(None);
+        };
+
+        self.load_model(variant).await?;
+        let lease = self.acquire_model_residency_lease(variant);
+        let model =
+            self.model_registry.get_asr(variant).await.ok_or_else(|| {
+                Error::ModelNotFound(format!("ASR model {variant} is not loaded"))
+            })?;
+        if !model.supports_realtime_stream_decode() {
+            return Ok(None);
+        }
+        let state = model.start_realtime_stream_state(language, prompt, None)?;
+
+        Ok(Some(RuntimeAsrRealtimeStream {
+            variant,
+            model,
+            state,
+            _lease: lease,
+        }))
+    }
+
+    pub fn push_asr_realtime_samples(
+        &self,
+        stream: &mut RuntimeAsrRealtimeStream,
+        samples: &[f32],
+        sample_rate: u32,
+    ) -> Result<Vec<RuntimeAsrRealtimeEvent>> {
+        let events =
+            stream
+                .model
+                .push_realtime_stream_samples(&mut stream.state, samples, sample_rate)?;
+        Ok(map_native_realtime_events(events))
+    }
+
+    pub fn finish_asr_realtime_stream(
+        &self,
+        stream: &mut RuntimeAsrRealtimeStream,
+    ) -> Result<Vec<RuntimeAsrRealtimeEvent>> {
+        let events = stream.model.finish_realtime_stream(&mut stream.state)?;
+        Ok(map_native_realtime_events(events))
+    }
+
+    pub fn asr_realtime_stream_variant(&self, stream: &RuntimeAsrRealtimeStream) -> ModelVariant {
+        stream.variant
+    }
+
     async fn asr_transcribe_audio_chat_samples<F>(
         &self,
         variant: ModelVariant,
@@ -901,6 +990,36 @@ mod tests {
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn realtime_stream_variant_resolves_only_nemotron_asr() {
+        assert_eq!(
+            resolve_asr_realtime_stream_variant(Some("nvidia/nemotron-3.5-asr-streaming-0.6b",)),
+            Some(ModelVariant::Nemotron35AsrStreaming06B)
+        );
+        assert_eq!(
+            resolve_asr_realtime_stream_variant(Some("Nemotron 3.5 ASR Streaming 0.6B")),
+            Some(ModelVariant::Nemotron35AsrStreaming06B)
+        );
+
+        assert_eq!(resolve_asr_realtime_stream_variant(None), None);
+        assert_eq!(
+            resolve_asr_realtime_stream_variant(Some("Qwen3-ASR-1.7B")),
+            None
+        );
+        assert_eq!(
+            resolve_asr_realtime_stream_variant(Some("Whisper-Large-v3-Turbo")),
+            None
+        );
+        assert_eq!(
+            resolve_asr_realtime_stream_variant(Some("Parakeet-TDT-0.6B-v3")),
+            None
+        );
+        assert_eq!(
+            resolve_asr_realtime_stream_variant(Some("not-a-real-model")),
+            None
+        );
     }
 
     #[tokio::test]

--- a/crates/izwi-core/src/runtime/mod.rs
+++ b/crates/izwi-core/src/runtime/mod.rs
@@ -24,6 +24,7 @@ mod types;
 mod voice_metrics;
 mod voice_session;
 
+pub use asr::{RuntimeAsrRealtimeEvent, RuntimeAsrRealtimeStream};
 pub use conformance::{
     capability_conformance_cases, required_conformance_capabilities,
     CapabilityConformanceCase, ConformanceCapability, ConformanceExecutionClass,

--- a/crates/izwi-server/src/app/transcription_realtime.rs
+++ b/crates/izwi-server/src/app/transcription_realtime.rs
@@ -6,8 +6,8 @@ use std::time::{Duration, Instant};
 use axum::extract::ws::{Message, WebSocket};
 use futures::{SinkExt, StreamExt};
 use izwi_core::{
-    RuntimeService,
     audio::{AudioEncoder, AudioFormat},
+    RuntimeAsrRealtimeEvent, RuntimeAsrRealtimeStream, RuntimeService,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -153,6 +153,8 @@ struct RealtimeSessionState {
     last_emitted_sequence: u64,
     committed_text: String,
     trailing_text: String,
+    native_stream_checked: bool,
+    native_asr_stream: Option<RuntimeAsrRealtimeStream>,
 }
 
 impl Default for RealtimeSessionState {
@@ -171,6 +173,8 @@ impl Default for RealtimeSessionState {
             last_emitted_sequence: 0,
             committed_text: String::new(),
             trailing_text: String::new(),
+            native_stream_checked: false,
+            native_asr_stream: None,
         }
     }
 }
@@ -470,6 +474,8 @@ async fn handle_worker_command(
             session.last_emitted_sequence = 0;
             session.committed_text.clear();
             session.trailing_text.clear();
+            session.native_stream_checked = false;
+            session.native_asr_stream = None;
 
             send_json(out_tx, json!({ "type": "session_started" }));
             false
@@ -479,17 +485,40 @@ async fn handle_worker_command(
             sample_rate,
             payload,
         } => {
-            if let Err(err) = ingest_audio_frame(session, frame_seq, sample_rate, &payload) {
-                send_json(out_tx, json!({ "type": "error", "message": err }));
-                return false;
-            }
+            let frame_samples = match ingest_audio_frame(session, frame_seq, sample_rate, &payload)
+            {
+                Ok(samples) => samples,
+                Err(err) => {
+                    send_json(out_tx, json!({ "type": "error", "message": err }));
+                    return false;
+                }
+            };
 
-            if let Err(err) = maybe_schedule_inference(state, correlation_id, session, false) {
-                send_json(out_tx, json!({ "type": "error", "message": err }));
+            match maybe_process_native_stream_frame(
+                state,
+                out_tx,
+                session,
+                &frame_samples,
+                sample_rate,
+            )
+            .await
+            {
+                Ok(true) => {}
+                Ok(false) => {
+                    if let Err(err) =
+                        maybe_schedule_inference(state, correlation_id, session, false)
+                    {
+                        send_json(out_tx, json!({ "type": "error", "message": err }));
+                    }
+                }
+                Err(err) => send_json(out_tx, json!({ "type": "error", "message": err })),
             }
             false
         }
         WorkerCommand::SessionStop => {
+            if let Err(err) = finish_native_stream_if_needed(state, out_tx, session).await {
+                send_json(out_tx, json!({ "type": "error", "message": err }));
+            }
             send_json(out_tx, json!({ "type": "session_done" }));
             true
         }
@@ -502,12 +531,12 @@ fn ingest_audio_frame(
     frame_seq: u32,
     sample_rate: u32,
     payload: &[u8],
-) -> Result<(), String> {
+) -> Result<Vec<i16>, String> {
     if !session.started {
         return Err("session_start is required before streaming audio".to_string());
     }
     if payload.is_empty() {
-        return Ok(());
+        return Ok(Vec::new());
     }
     if payload.len() > MAX_FRAME_BYTES {
         return Err(format!(
@@ -529,7 +558,7 @@ fn ingest_audio_frame(
                 "transcription realtime stale frame ignored: frame_seq={} last_frame_seq={}",
                 frame_seq, last
             );
-            return Ok(());
+            return Ok(Vec::new());
         }
     }
     session.last_frame_seq = Some(frame_seq);
@@ -546,7 +575,7 @@ fn ingest_audio_frame(
 
     let samples = pcm16_bytes_to_i16(payload);
     if samples.is_empty() {
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     session.samples_i16.extend_from_slice(&samples);
@@ -558,7 +587,109 @@ fn ingest_audio_frame(
         session.samples_i16.drain(0..drain);
     }
 
+    Ok(samples)
+}
+
+async fn maybe_process_native_stream_frame(
+    state: &AppState,
+    out_tx: &OutboundTx,
+    session: &mut RealtimeSessionState,
+    frame_samples: &[i16],
+    sample_rate: u32,
+) -> Result<bool, String> {
+    if frame_samples.is_empty() {
+        return Ok(session.native_asr_stream.is_some());
+    }
+
+    if !session.native_stream_checked {
+        session.native_stream_checked = true;
+        let _permit = state.acquire_permit().await;
+        session.native_asr_stream = state
+            .runtime
+            .try_start_asr_realtime_stream(
+                session.model_id.as_deref(),
+                session.language.as_deref(),
+                None,
+            )
+            .await
+            .map_err(|err| err.to_string())?;
+    }
+
+    let Some(stream) = session.native_asr_stream.as_mut() else {
+        return Ok(false);
+    };
+
+    let samples = pcm16_i16_to_f32(frame_samples);
+    let started = Instant::now();
+    let _permit = state.acquire_permit().await;
+    let events = state
+        .runtime
+        .push_asr_realtime_samples(stream, &samples, sample_rate)
+        .map_err(|err| err.to_string())?;
+    let processing_time_ms = started.elapsed().as_secs_f64() * 1000.0;
+    emit_native_stream_events(out_tx, session, events, sample_rate, processing_time_ms);
+    session.pending_recompute = false;
+    Ok(true)
+}
+
+async fn finish_native_stream_if_needed(
+    state: &AppState,
+    out_tx: &OutboundTx,
+    session: &mut RealtimeSessionState,
+) -> Result<(), String> {
+    let Some(mut stream) = session.native_asr_stream.take() else {
+        return Ok(());
+    };
+
+    let sample_rate = session.sample_rate.unwrap_or(16_000);
+    let started = Instant::now();
+    let _permit = state.acquire_permit().await;
+    let events = state
+        .runtime
+        .finish_asr_realtime_stream(&mut stream)
+        .map_err(|err| err.to_string())?;
+    let processing_time_ms = started.elapsed().as_secs_f64() * 1000.0;
+    emit_native_stream_events(out_tx, session, events, sample_rate, processing_time_ms);
     Ok(())
+}
+
+fn emit_native_stream_events(
+    out_tx: &OutboundTx,
+    session: &mut RealtimeSessionState,
+    events: Vec<RuntimeAsrRealtimeEvent>,
+    sample_rate: u32,
+    processing_time_ms: f64,
+) {
+    let audio_duration_secs = if sample_rate > 0 {
+        session.samples_i16.len() as f32 / sample_rate as f32
+    } else {
+        0.0
+    };
+    let rtf = (audio_duration_secs > 0.0)
+        .then_some((processing_time_ms / 1000.0) / audio_duration_secs as f64);
+
+    for event in events {
+        if event.delta.is_empty() && !event.is_final {
+            continue;
+        }
+        session.committed_text = event.text.clone();
+        session.trailing_text.clear();
+        session.last_emitted_sequence = event.chunk_index as u64;
+        send_json(
+            out_tx,
+            json!({
+                "type": "transcript_partial",
+                "sequence": event.chunk_index,
+                "text": event.text,
+                "language": session.language.clone(),
+                "audio_duration_secs": audio_duration_secs,
+                "processing_time_ms": processing_time_ms,
+                "rtf": rtf,
+                "native_stream": true,
+                "is_final": event.is_final,
+            }),
+        );
+    }
 }
 
 fn maybe_schedule_inference(
@@ -567,6 +698,9 @@ fn maybe_schedule_inference(
     session: &mut RealtimeSessionState,
     force_interval_check: bool,
 ) -> Result<(), String> {
+    if session.native_asr_stream.is_some() {
+        return Ok(());
+    }
     if !session.started || session.in_flight.is_some() || !session.pending_recompute {
         return Ok(());
     }
@@ -1170,11 +1304,18 @@ fn pcm16_bytes_to_i16(bytes: &[u8]) -> Vec<i16> {
     out
 }
 
+fn pcm16_i16_to_f32(samples_i16: &[i16]) -> Vec<f32> {
+    samples_i16
+        .iter()
+        .map(|sample| *sample as f32 / 32768.0)
+        .collect()
+}
+
 fn wav_bytes_from_pcm16_mono(samples_i16: &[i16], sample_rate: u32) -> Result<Vec<u8>, String> {
     if sample_rate == 0 {
         return Err("Invalid sample rate 0".to_string());
     }
-    let samples_f32: Vec<f32> = samples_i16.iter().map(|s| *s as f32 / 32768.0).collect();
+    let samples_f32 = pcm16_i16_to_f32(samples_i16);
     AudioEncoder::new(sample_rate, 1)
         .encode(&samples_f32, AudioFormat::Wav)
         .map_err(|err| format!("Failed to encode streamed WAV: {err}"))
@@ -1204,8 +1345,9 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::{
-        OutboundTx, RealtimeInferenceDiagnostics, collapse_unstable_repetition,
-        merge_online_transcript, strip_suffix_prefix_overlap_with_lookahead_by_words,
+        collapse_unstable_repetition, ingest_audio_frame, merge_online_transcript,
+        pcm16_i16_to_f32, strip_suffix_prefix_overlap_with_lookahead_by_words, OutboundTx,
+        RealtimeInferenceDiagnostics, RealtimeSessionState,
     };
 
     #[tokio::test]
@@ -1258,6 +1400,40 @@ mod tests {
         assert_eq!(value["output_text_chars"], 13);
         assert!(value.get("text").is_none());
         assert!(value.get("transcript").is_none());
+    }
+
+    #[test]
+    fn pcm16_i16_to_f32_uses_standard_pcm16_scale() {
+        let converted = pcm16_i16_to_f32(&[-32768, -16384, 0, 16384, 32767]);
+
+        assert_eq!(converted[0], -1.0);
+        assert_eq!(converted[1], -0.5);
+        assert_eq!(converted[2], 0.0);
+        assert_eq!(converted[3], 0.5);
+        assert!((converted[4] - 0.9999695).abs() < 1e-7);
+    }
+
+    #[test]
+    fn ingest_audio_frame_returns_only_fresh_samples_for_native_streaming() {
+        let mut session = RealtimeSessionState {
+            started: true,
+            ..RealtimeSessionState::default()
+        };
+        let payload = [0x00, 0x00, 0x00, 0x80, 0xff, 0x7f];
+
+        let samples = ingest_audio_frame(&mut session, 1, 16_000, &payload).expect("fresh frame");
+
+        assert_eq!(samples, vec![0, -32768, 32767]);
+        assert_eq!(session.samples_i16, samples);
+        assert_eq!(session.sample_rate, Some(16_000));
+        assert_eq!(session.last_frame_seq, Some(1));
+        assert!(session.pending_recompute);
+
+        let stale_samples =
+            ingest_audio_frame(&mut session, 1, 16_000, &payload).expect("stale frame ignored");
+
+        assert!(stale_samples.is_empty());
+        assert_eq!(session.samples_i16, samples);
     }
 
     #[test]


### PR DESCRIPTION
Adds CUDA-focused Nemotron ASR caching plus model-card-aligned native streaming state and websocket push-stream integration, with CPU/Metal dtype behavior preserved.