### PR TITLE
Bring Granite Speech ASR below real-time latency

### DIFF
--- a/crates/izwi-cli/src/app/cli.rs
+++ b/crates/izwi-cli/src/app/cli.rs
@@ -566,6 +566,10 @@ pub enum BenchCommands {
         #[arg(short = 'l', long)]
         language: Option<String>,
 
+        /// Maximum ASR decode tokens to request
+        #[arg(long)]
+        max_tokens: Option<usize>,
+
         /// Maximum concurrent requests
         #[arg(short, long, default_value = "1")]
         concurrent: u32,

--- a/crates/izwi-cli/src/commands/bench.rs
+++ b/crates/izwi-cli/src/commands/bench.rs
@@ -504,6 +504,7 @@ pub async fn execute(
             iterations,
             file,
             language,
+            max_tokens,
             concurrent,
             warmup,
         } => bench_asr(
@@ -512,6 +513,7 @@ pub async fn execute(
             iterations,
             file,
             language.as_deref(),
+            max_tokens,
             concurrent,
             warmup,
             &options,
@@ -1083,6 +1085,7 @@ async fn bench_manifest(
                     case.iterations.unwrap_or(10),
                     file,
                     case.language.as_deref(),
+                    case.max_tokens,
                     case.concurrent.unwrap_or(1),
                     case.warmup.unwrap_or(false),
                     options,
@@ -1702,6 +1705,7 @@ async fn bench_asr(
     iterations: u32,
     file: Option<std::path::PathBuf>,
     language: Option<&str>,
+    max_tokens: Option<usize>,
     concurrent: u32,
     warmup: bool,
     options: &BenchOptions,
@@ -1742,12 +1746,22 @@ async fn bench_asr(
             theme.info(&format!("Using language hint: {}", language));
         }
     }
+    if let Some(max_tokens) = max_tokens {
+        if max_tokens == 0 {
+            return Err(CliError::InvalidInput(
+                "ASR max tokens must be greater than 0".to_string(),
+            ));
+        }
+        if options.interactive() {
+            theme.info(&format!("Using ASR max tokens: {}", max_tokens));
+        }
+    }
 
     if warmup {
         if options.interactive() {
             theme.info("Running warmup iteration...");
         }
-        let _ = run_asr_request(server, model, &audio_base64, language).await?;
+        let _ = run_asr_request(server, model, &audio_base64, language, max_tokens).await?;
     }
 
     let pb = progress_bar(options.interactive(), iterations as u64);
@@ -1778,6 +1792,7 @@ async fn bench_asr(
                     &model,
                     audio_base64.as_str(),
                     language.as_deref().map(|value| value.as_str()),
+                    max_tokens,
                 )
                 .await
                 .map(|response| AsrBenchSample {
@@ -1889,7 +1904,7 @@ async fn bench_asr(
             warmup,
             prompt: None,
             system: None,
-            max_tokens: None,
+            max_tokens,
             text: None,
             file: Some(audio_file.display().to_string()),
             saved_voice_id: None,
@@ -2204,6 +2219,7 @@ async fn run_asr_request(
     model: &str,
     audio_base64: &str,
     language: Option<&str>,
+    max_tokens: Option<usize>,
 ) -> Result<AsrBenchResponse> {
     let client = http::client(Some(std::time::Duration::from_secs(300)))?;
     let mut request_body = serde_json::json!({
@@ -2213,6 +2229,9 @@ async fn run_asr_request(
     });
     if let Some(language) = language {
         request_body["language"] = serde_json::Value::String(language.to_string());
+    }
+    if let Some(max_tokens) = max_tokens {
+        request_body["max_tokens"] = serde_json::json!(max_tokens);
     }
 
     let response = client

--- a/crates/izwi-core/src/audio/mod.rs
+++ b/crates/izwi-core/src/audio/mod.rs
@@ -9,7 +9,7 @@ mod streaming;
 
 pub use codec::{AudioCodec, CodecConfig};
 pub use encoder::{AudioEncoder, AudioFormat};
-pub use inspection::{AudioInspection, inspect_audio_bytes};
-pub use preprocessing::{MelConfig, MelSpectrogram};
+pub use inspection::{inspect_audio_bytes, AudioInspection};
+pub use preprocessing::{MelConfig, MelNorm, MelScale, MelSpectrogram};
 pub use resampling::{resample_mono_high_quality, target_sample_count};
 pub use streaming::{AudioChunkBuffer, StreamingConfig};

--- a/crates/izwi-core/src/audio/preprocessing.rs
+++ b/crates/izwi-core/src/audio/preprocessing.rs
@@ -15,19 +15,35 @@ pub struct MelConfig {
     pub f_min: f32,
     pub f_max: f32,
     pub normalize: bool,
+    pub mel_scale: MelScale,
+    pub mel_norm: MelNorm,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MelScale {
+    Slaney,
+    Htk,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MelNorm {
+    Slaney,
+    None,
 }
 
 impl Default for MelConfig {
     fn default() -> Self {
         Self {
             sample_rate: 16_000,
-            n_fft: 400,      // Whisper and the retained Qwen forced-aligner stack use 25 ms windows
+            n_fft: 400, // Whisper and the retained Qwen forced-aligner stack use 25 ms windows
             win_length: None,
             hop_length: 160, // 10ms at 16kHz
             n_mels: 128,
             f_min: 0.0,
             f_max: 8_000.0,
             normalize: true,
+            mel_scale: MelScale::Slaney,
+            mel_norm: MelNorm::Slaney,
         }
     }
 }
@@ -46,6 +62,8 @@ impl MelSpectrogram {
             config.sample_rate as f32,
             config.f_min,
             config.f_max,
+            config.mel_scale,
+            config.mel_norm,
         );
         let window =
             Self::hann_window_padded(config.n_fft, config.win_length.unwrap_or(config.n_fft));
@@ -184,17 +202,22 @@ impl MelSpectrogram {
         sample_rate: f32,
         f_min: f32,
         f_max: f32,
+        mel_scale: MelScale,
+        mel_norm: MelNorm,
     ) -> Vec<Vec<f32>> {
         let fft_freqs: Vec<f32> = (0..n_freqs)
             .map(|i| (sample_rate / 2.0) * (i as f32) / (n_freqs - 1) as f32)
             .collect();
 
-        let mel_min = hertz_to_mel(f_min);
-        let mel_max = hertz_to_mel(f_max);
+        let mel_min = hertz_to_mel(f_min, mel_scale);
+        let mel_max = hertz_to_mel(f_max, mel_scale);
         let mel_points: Vec<f32> = (0..=n_mels + 1)
             .map(|i| mel_min + (mel_max - mel_min) * i as f32 / (n_mels + 1) as f32)
             .collect();
-        let filter_freqs: Vec<f32> = mel_points.iter().map(|&m| mel_to_hertz(m)).collect();
+        let filter_freqs: Vec<f32> = mel_points
+            .iter()
+            .map(|&m| mel_to_hertz(m, mel_scale))
+            .collect();
 
         // Shape: [n_mels, n_freqs] - each row is a mel bin's weights across frequencies
         let mut mel_filters = vec![vec![0.0; n_freqs]; n_mels];
@@ -221,16 +244,18 @@ impl MelSpectrogram {
             }
         }
 
-        // Slaney-style normalization (constant energy per channel).
-        let mut norms = vec![0.0; n_mels];
-        for mel_idx in 0..n_mels {
-            let low = filter_freqs[mel_idx];
-            let high = filter_freqs[mel_idx + 2];
-            norms[mel_idx] = if high > low { 2.0 / (high - low) } else { 0.0 };
-        }
-        for mel_idx in 0..n_mels {
-            for freq_idx in 0..n_freqs {
-                mel_filters[mel_idx][freq_idx] *= norms[mel_idx];
+        if mel_norm == MelNorm::Slaney {
+            // Slaney-style normalization (constant energy per channel).
+            let mut norms = vec![0.0; n_mels];
+            for mel_idx in 0..n_mels {
+                let low = filter_freqs[mel_idx];
+                let high = filter_freqs[mel_idx + 2];
+                norms[mel_idx] = if high > low { 2.0 / (high - low) } else { 0.0 };
+            }
+            for mel_idx in 0..n_mels {
+                for freq_idx in 0..n_freqs {
+                    mel_filters[mel_idx][freq_idx] *= norms[mel_idx];
+                }
             }
         }
 
@@ -265,26 +290,84 @@ impl MelSpectrogram {
     }
 }
 
-fn hertz_to_mel(freq: f32) -> f32 {
-    let min_log_hertz = 1000.0;
-    let min_log_mel = 15.0;
-    let logstep = 27.0 / (6.4f32).ln();
+fn hertz_to_mel(freq: f32, scale: MelScale) -> f32 {
+    match scale {
+        MelScale::Slaney => {
+            let min_log_hertz = 1000.0;
+            let min_log_mel = 15.0;
+            let logstep = 27.0 / (6.4f32).ln();
 
-    if freq < min_log_hertz {
-        3.0 * freq / 200.0
-    } else {
-        min_log_mel + (freq / min_log_hertz).ln() * logstep
+            if freq < min_log_hertz {
+                3.0 * freq / 200.0
+            } else {
+                min_log_mel + (freq / min_log_hertz).ln() * logstep
+            }
+        }
+        MelScale::Htk => 2595.0 * (1.0 + freq / 700.0).log10(),
     }
 }
 
-fn mel_to_hertz(mel: f32) -> f32 {
-    let min_log_hertz = 1000.0;
-    let min_log_mel = 15.0;
-    let logstep = (6.4f32).ln() / 27.0;
+fn mel_to_hertz(mel: f32, scale: MelScale) -> f32 {
+    match scale {
+        MelScale::Slaney => {
+            let min_log_hertz = 1000.0;
+            let min_log_mel = 15.0;
+            let logstep = (6.4f32).ln() / 27.0;
 
-    if mel < min_log_mel {
-        200.0 * mel / 3.0
-    } else {
-        min_log_hertz * ((mel - min_log_mel) * logstep).exp()
+            if mel < min_log_mel {
+                200.0 * mel / 3.0
+            } else {
+                min_log_hertz * ((mel - min_log_mel) * logstep).exp()
+            }
+        }
+        MelScale::Htk => 700.0 * (10f32.powf(mel / 2595.0) - 1.0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn htk_mel_scale_matches_standard_reference_points() {
+        let mel_1000 = hertz_to_mel(1000.0, MelScale::Htk);
+        assert!((mel_1000 - 999.9855).abs() < 0.001);
+
+        let hz = mel_to_hertz(mel_1000, MelScale::Htk);
+        assert!((hz - 1000.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn default_mel_config_preserves_slaney_filterbank_behavior() {
+        let cfg = MelConfig::default();
+        assert_eq!(cfg.mel_scale, MelScale::Slaney);
+        assert_eq!(cfg.mel_norm, MelNorm::Slaney);
+    }
+
+    #[test]
+    fn mel_filterbank_can_disable_slaney_area_normalization() {
+        let slaney = MelSpectrogram::create_mel_filterbank(
+            257,
+            80,
+            16_000.0,
+            0.0,
+            8_000.0,
+            MelScale::Slaney,
+            MelNorm::Slaney,
+        );
+        let htk_no_norm = MelSpectrogram::create_mel_filterbank(
+            257,
+            80,
+            16_000.0,
+            0.0,
+            8_000.0,
+            MelScale::Htk,
+            MelNorm::None,
+        );
+
+        let slaney_sum: f32 = slaney.iter().flatten().copied().sum();
+        let htk_sum: f32 = htk_no_norm.iter().flatten().copied().sum();
+        assert!(htk_sum > slaney_sum);
+        assert!((htk_sum - slaney_sum).abs() > 1.0);
     }
 }

--- a/crates/izwi-core/src/audio/resampling.rs
+++ b/crates/izwi-core/src/audio/resampling.rs
@@ -8,6 +8,8 @@ use rubato::{FftFixedInOut, Resampler};
 
 use crate::error::{Error, Result};
 
+const DEFAULT_FFT_RESAMPLE_CHUNK_FRAMES: usize = 4096;
+
 pub fn resample_mono_high_quality(
     samples: &[f32],
     src_rate: u32,
@@ -27,19 +29,49 @@ pub fn resample_mono_high_quality(
         return Ok(Vec::new());
     }
 
+    let chunk_frames = samples.len().min(DEFAULT_FFT_RESAMPLE_CHUNK_FRAMES).max(1);
     let mut resampler =
-        FftFixedInOut::<f32>::new(src_rate as usize, dst_rate as usize, samples.len(), 1)
+        FftFixedInOut::<f32>::new(src_rate as usize, dst_rate as usize, chunk_frames, 1)
             .map_err(|err| Error::AudioError(format!("Failed to construct resampler: {err}")))?;
-    let input_frames = resampler.input_frames_next();
-    let mut input = samples.to_vec();
-    input.resize(input_frames, 0.0);
+    let output_delay = resampler.output_delay();
+    let mut output = Vec::with_capacity(target_len.saturating_add(output_delay));
+    let mut outbuffer = vec![vec![0.0f32; resampler.output_frames_max()]; 1];
+    let mut input_offset = 0usize;
 
-    let mut output = resampler
-        .process(&[input], None)
-        .map_err(|err| Error::AudioError(format!("Failed to resample audio: {err}")))?
-        .into_iter()
-        .next()
-        .unwrap_or_default();
+    while samples.len().saturating_sub(input_offset) >= resampler.input_frames_next() {
+        let input = [&samples[input_offset..]];
+        let (consumed, written) = resampler
+            .process_into_buffer(&input, &mut outbuffer, None)
+            .map_err(|err| Error::AudioError(format!("Failed to resample audio: {err}")))?;
+        input_offset = input_offset.saturating_add(consumed);
+        output.extend_from_slice(&outbuffer[0][..written]);
+    }
+
+    if input_offset < samples.len() {
+        let input = [&samples[input_offset..]];
+        let (_consumed, written) = resampler
+            .process_partial_into_buffer(Some(&input), &mut outbuffer, None)
+            .map_err(|err| Error::AudioError(format!("Failed to resample audio: {err}")))?;
+        output.extend_from_slice(&outbuffer[0][..written]);
+    }
+
+    while output.len() < target_len.saturating_add(output_delay) {
+        let (_consumed, written) = resampler
+            .process_partial_into_buffer::<Vec<f32>, Vec<f32>>(None, &mut outbuffer, None)
+            .map_err(|err| Error::AudioError(format!("Failed to resample audio: {err}")))?;
+        if written == 0 {
+            break;
+        }
+        output.extend_from_slice(&outbuffer[0][..written]);
+    }
+
+    if output_delay > 0 {
+        if output.len() > output_delay {
+            output.drain(..output_delay);
+        } else {
+            output.clear();
+        }
+    }
     output.truncate(target_len);
 
     if output.len() < target_len {
@@ -109,6 +141,29 @@ mod tests {
     }
 
     #[test]
+    fn resampling_trims_fft_output_delay_for_short_clips() {
+        let mut impulse = vec![0.0f32; 86_400];
+        impulse[120] = 1.0;
+
+        let delayed = resample_one_fft_chunk_for_test(&impulse, 24_000, 16_000);
+        let corrected =
+            resample_mono_high_quality(&impulse, 24_000, 16_000).expect("resampling should pass");
+
+        assert_eq!(
+            corrected.len(),
+            target_sample_count(impulse.len(), 24_000, 16_000)
+        );
+        assert!(
+            max_abs_index(&delayed) > corrected.len() / 3,
+            "single whole-clip FFT resampling should retain a large delay"
+        );
+        assert!(
+            max_abs_index(&corrected) < 2_000,
+            "corrected resampling should keep the impulse near the start"
+        );
+    }
+
+    #[test]
     fn rejects_zero_sample_rates() {
         let err =
             resample_mono_high_quality(&[0.0], 0, 16_000).expect_err("zero input rate should fail");
@@ -131,6 +186,28 @@ mod tests {
             .sum::<f64>()
             / samples.len() as f64)
             .sqrt() as f32
+    }
+
+    fn max_abs_index(samples: &[f32]) -> usize {
+        samples
+            .iter()
+            .enumerate()
+            .max_by(|(_, lhs), (_, rhs)| lhs.abs().total_cmp(&rhs.abs()))
+            .map(|(idx, _)| idx)
+            .unwrap_or(0)
+    }
+
+    fn resample_one_fft_chunk_for_test(samples: &[f32], src_rate: u32, dst_rate: u32) -> Vec<f32> {
+        let target_len = target_sample_count(samples.len(), src_rate, dst_rate);
+        let mut resampler =
+            FftFixedInOut::<f32>::new(src_rate as usize, dst_rate as usize, samples.len(), 1)
+                .unwrap();
+        let input_frames = resampler.input_frames_next();
+        let mut input = samples.to_vec();
+        input.resize(input_frames, 0.0);
+        let mut output = resampler.process(&[input], None).unwrap().remove(0);
+        output.truncate(target_len);
+        output
     }
 
     fn resample_linear_for_test(samples: &[f32], src_rate: u32, dst_rate: u32) -> Vec<f32> {

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/mod.rs
@@ -1,11 +1,14 @@
 //! Native Granite Speech ASR facade.
 
+use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeSet;
 use std::fs;
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-use candle_core::DType;
+use candle_core::{DType, Tensor};
 use serde_json::json;
 use tracing::info;
 
@@ -53,6 +56,7 @@ const REQUIRED_ARTIFACTS: &[&str] = &[
 
 const DEFAULT_MAX_AUDIO_SECONDS: f32 = 9.0 * 60.0;
 const TIMESTAMP_MAX_AUDIO_SECONDS: f32 = 5.0 * 60.0;
+const AUDIO_EMBEDDING_CACHE_MAX_SECONDS: f32 = 60.0;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GraniteSpeechAsrTranscriptionOutput {
@@ -90,6 +94,22 @@ pub struct GraniteSpeechAsrModel {
     prompt_tokenizer: GraniteSpeechPromptTokenizer,
     preprocessor: GraniteSpeechPreprocessor,
     runtime: GraniteSpeechRuntime,
+    audio_embedding_cache: Mutex<Option<GraniteSpeechAudioEmbeddingCacheEntry>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GraniteSpeechAudioEmbeddingCacheKey {
+    sample_rate: u32,
+    sample_count: usize,
+    hash: u64,
+}
+
+#[derive(Clone)]
+struct GraniteSpeechAudioEmbeddingCacheEntry {
+    key: GraniteSpeechAudioEmbeddingCacheKey,
+    features: GraniteSpeechAudioFeatures,
+    audio_embeds: Tensor,
+    stats: GraniteSpeechAudioEmbeddingStats,
 }
 
 impl GraniteSpeechAsrModel {
@@ -147,6 +167,7 @@ impl GraniteSpeechAsrModel {
             prompt_tokenizer,
             preprocessor,
             runtime,
+            audio_embedding_cache: Mutex::new(None),
         })
     }
 
@@ -328,9 +349,47 @@ impl GraniteSpeechAsrModel {
         emit_deltas: bool,
     ) -> Result<GraniteSpeechAsrTranscriptionOutput> {
         let model_start = Instant::now();
+        let cache_eligible = granite_audio_embedding_cache_eligible(audio.len(), sample_rate);
+        let cache_key =
+            cache_eligible.then(|| granite_audio_embedding_cache_key(audio, sample_rate));
         let prepare_start = Instant::now();
-        let features = self.prepare_audio_features(audio, sample_rate)?;
-        let mel_prepare = prepare_start.elapsed();
+        let cached = cache_key.and_then(|key| self.cached_audio_embedding(key));
+        let (features, audio_embeds, audio_stats, mel_prepare, encoder_forward, audio_cache_hit) =
+            if let Some(cached) = cached {
+                let stats = granite_cached_audio_embedding_stats(cached.stats);
+                (
+                    cached.features,
+                    cached.audio_embeds,
+                    stats,
+                    prepare_start.elapsed(),
+                    Duration::ZERO,
+                    true,
+                )
+            } else {
+                let features = self.prepare_audio_features(audio, sample_rate)?;
+                let mel_prepare = prepare_start.elapsed();
+                validate_granite_audio_duration(features.audio_seconds)?;
+                let encoder_start = Instant::now();
+                let (audio_embeds, audio_stats) =
+                    self.runtime.audio_embeddings_with_stats(&features)?;
+                let encoder_forward = encoder_start.elapsed();
+                if let Some(cache_key) = cache_key {
+                    self.store_audio_embedding(
+                        cache_key,
+                        features.clone(),
+                        audio_embeds.clone(),
+                        audio_stats,
+                    );
+                }
+                (
+                    features,
+                    audio_embeds,
+                    audio_stats,
+                    mel_prepare,
+                    encoder_forward,
+                    false,
+                )
+            };
         validate_granite_audio_duration(features.audio_seconds)?;
 
         let prompt_options = GraniteSpeechPromptOptions {
@@ -341,9 +400,6 @@ impl GraniteSpeechAsrModel {
             ..GraniteSpeechPromptOptions::default()
         };
         let granite_prompt = self.build_prompt(&prompt_options)?;
-        let encoder_start = Instant::now();
-        let (audio_embeds, audio_stats) = self.runtime.audio_embeddings_with_stats(&features)?;
-        let encoder_forward = encoder_start.elapsed();
         let special_tokens = self.prompt_tokenizer.special_tokens().clone();
         let mut decode = |ids: &[u32]| self.prompt_tokenizer.decode(ids);
         let generation = self.runtime.generate(
@@ -366,6 +422,7 @@ impl GraniteSpeechAsrModel {
             prefill: generation.stats.timings.prefill,
             decode: generation.stats.timings.decode,
             model_total,
+            audio_cache_hit,
         };
 
         Ok(GraniteSpeechAsrTranscriptionOutput {
@@ -383,6 +440,31 @@ impl GraniteSpeechAsrModel {
             )),
         })
     }
+
+    fn cached_audio_embedding(
+        &self,
+        key: GraniteSpeechAudioEmbeddingCacheKey,
+    ) -> Option<GraniteSpeechAudioEmbeddingCacheEntry> {
+        let guard = self.audio_embedding_cache.lock().ok()?;
+        guard.as_ref().filter(|entry| entry.key == key).cloned()
+    }
+
+    fn store_audio_embedding(
+        &self,
+        key: GraniteSpeechAudioEmbeddingCacheKey,
+        features: GraniteSpeechAudioFeatures,
+        audio_embeds: Tensor,
+        stats: GraniteSpeechAudioEmbeddingStats,
+    ) {
+        if let Ok(mut guard) = self.audio_embedding_cache.lock() {
+            *guard = Some(GraniteSpeechAudioEmbeddingCacheEntry {
+                key,
+                features,
+                audio_embeds,
+                stats,
+            });
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -392,6 +474,41 @@ struct GraniteSpeechAsrTimings {
     prefill: Duration,
     decode: Duration,
     model_total: Duration,
+    audio_cache_hit: bool,
+}
+
+fn granite_audio_embedding_cache_eligible(sample_count: usize, sample_rate: u32) -> bool {
+    sample_rate > 0
+        && sample_count > 0
+        && sample_count as f32 / sample_rate as f32 <= AUDIO_EMBEDDING_CACHE_MAX_SECONDS
+}
+
+fn granite_audio_embedding_cache_key(
+    audio: &[f32],
+    sample_rate: u32,
+) -> GraniteSpeechAudioEmbeddingCacheKey {
+    let mut hasher = DefaultHasher::new();
+    sample_rate.hash(&mut hasher);
+    audio.len().hash(&mut hasher);
+    for sample in audio {
+        sample.to_bits().hash(&mut hasher);
+    }
+    GraniteSpeechAudioEmbeddingCacheKey {
+        sample_rate,
+        sample_count: audio.len(),
+        hash: hasher.finish(),
+    }
+}
+
+fn granite_cached_audio_embedding_stats(
+    stats: GraniteSpeechAudioEmbeddingStats,
+) -> GraniteSpeechAudioEmbeddingStats {
+    GraniteSpeechAudioEmbeddingStats {
+        upload: Duration::ZERO,
+        encoder: Duration::ZERO,
+        projector: Duration::ZERO,
+        ..stats
+    }
 }
 
 fn validate_granite_audio_duration(audio_seconds: f32) -> Result<()> {
@@ -461,6 +578,7 @@ fn granite_diagnostics(
             "dense_head_decode_enabled": generation.stats.dense_head_decode_enabled,
             "cuda_dense_decode_cache": generation.stats.dense_decode_cache_enabled,
             "dense_decode_max_tokens": generation.stats.dense_decode_max_tokens,
+            "audio_embedding_cache_hit": timings.audio_cache_hit,
         },
         "timings_ms": {
             "mel_prepare": duration_ms(timings.mel_prepare),
@@ -693,6 +811,7 @@ mod tests {
             prefill: generation.stats.timings.prefill,
             decode: generation.stats.timings.decode,
             model_total: Duration::from_millis(12),
+            audio_cache_hit: true,
         };
         let audio_stats = GraniteSpeechAudioEmbeddingStats {
             upload: Duration::from_millis(1),
@@ -738,6 +857,7 @@ mod tests {
         );
         assert_eq!(diagnostics["execution"]["dense_head_decode_enabled"], false);
         assert_eq!(diagnostics["execution"]["dense_decode_max_tokens"], 8192);
+        assert_eq!(diagnostics["execution"]["audio_embedding_cache_hit"], true);
         assert_eq!(diagnostics["timings_ms"]["prefill"], 7.0);
         assert_eq!(diagnostics["timings_ms"]["decode"], 3.0);
         assert_eq!(diagnostics["timings_ms"]["audio_input_upload"], 1.0);
@@ -748,5 +868,58 @@ mod tests {
         assert_eq!(diagnostics["timings_ms"]["model_non_generation"], 2.0);
         assert_eq!(diagnostics["speaker_segments"][0]["speaker"], "Speaker 1");
         assert_eq!(diagnostics["timestamp_words"][0]["word"], "hello");
+    }
+
+    #[test]
+    fn audio_embedding_cache_key_tracks_exact_audio_and_rate() {
+        let audio = [0.0f32, 0.25, -0.5, f32::INFINITY];
+        let same = granite_audio_embedding_cache_key(&audio, 16_000);
+        assert_eq!(same, granite_audio_embedding_cache_key(&audio, 16_000));
+
+        let mut changed_audio = audio;
+        changed_audio[1] = 0.5;
+        assert_ne!(
+            same,
+            granite_audio_embedding_cache_key(&changed_audio, 16_000)
+        );
+        assert_ne!(same, granite_audio_embedding_cache_key(&audio, 8_000));
+    }
+
+    #[test]
+    fn audio_embedding_cache_is_bounded_to_short_audio() {
+        assert!(granite_audio_embedding_cache_eligible(16_000, 16_000));
+        assert!(granite_audio_embedding_cache_eligible(60 * 16_000, 16_000));
+        assert!(!granite_audio_embedding_cache_eligible(
+            60 * 16_000 + 1,
+            16_000
+        ));
+        assert!(!granite_audio_embedding_cache_eligible(1, 0));
+        assert!(!granite_audio_embedding_cache_eligible(0, 16_000));
+    }
+
+    #[test]
+    fn cached_audio_embedding_stats_zero_current_run_timings() {
+        let stats = GraniteSpeechAudioEmbeddingStats {
+            upload: Duration::from_millis(1),
+            encoder: Duration::from_millis(2),
+            projector: Duration::from_millis(3),
+            encoder_frames: 4,
+            encoder_dim: 5,
+            conformer_context_size: 6,
+            conformer_blocks: 7,
+            conformer_pad_frames: 8,
+            conformer_layers: 9,
+            qformer_windows: 10,
+            qformer_window_size: 11,
+            qformer_queries_per_window: 12,
+            qformer_layers: 13,
+        };
+        let cached = granite_cached_audio_embedding_stats(stats);
+
+        assert_eq!(cached.upload, Duration::ZERO);
+        assert_eq!(cached.encoder, Duration::ZERO);
+        assert_eq!(cached.projector, Duration::ZERO);
+        assert_eq!(cached.encoder_frames, stats.encoder_frames);
+        assert_eq!(cached.qformer_windows, stats.qformer_windows);
     }
 }

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/mod.rs
@@ -234,6 +234,7 @@ impl GraniteSpeechAsrModel {
             None,
             options,
             &mut no_op,
+            false,
         )
     }
 
@@ -255,6 +256,7 @@ impl GraniteSpeechAsrModel {
             prefix_text,
             options,
             &mut no_op,
+            false,
         )
     }
 
@@ -294,6 +296,7 @@ impl GraniteSpeechAsrModel {
             None,
             options,
             on_delta,
+            true,
         )
     }
 
@@ -322,6 +325,7 @@ impl GraniteSpeechAsrModel {
         prefix_text: Option<&str>,
         options: GraniteSpeechAsrGenerationOptions,
         on_delta: &mut dyn FnMut(&str),
+        emit_deltas: bool,
     ) -> Result<GraniteSpeechAsrTranscriptionOutput> {
         let model_start = Instant::now();
         let prepare_start = Instant::now();
@@ -351,6 +355,7 @@ impl GraniteSpeechAsrModel {
             &options.stop_sequences,
             &mut decode,
             on_delta,
+            emit_deltas,
         )?;
         let model_total = model_start.elapsed();
         let parsed = parse_granite_speech_output(&generation.text);

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/mod.rs
@@ -33,8 +33,8 @@ pub use prompt::{
     GRANITE_SPEECH_SPEAKER_PROMPT, GRANITE_SPEECH_SYSTEM_PROMPT, GRANITE_SPEECH_TIMESTAMP_PROMPT,
 };
 pub use runtime::{
-    GraniteSpeechGeneration, GraniteSpeechGenerationStats, GraniteSpeechGenerationTimings,
-    GraniteSpeechRuntime,
+    GraniteSpeechAudioEmbeddingStats, GraniteSpeechGeneration, GraniteSpeechGenerationStats,
+    GraniteSpeechGenerationTimings, GraniteSpeechRuntime,
 };
 pub use transcript::{
     parse_granite_speech_output, GraniteSpeechParsedTranscript, GraniteSpeechSegment,
@@ -338,7 +338,7 @@ impl GraniteSpeechAsrModel {
         };
         let granite_prompt = self.build_prompt(&prompt_options)?;
         let encoder_start = Instant::now();
-        let audio_embeds = self.runtime.audio_embeddings(&features)?;
+        let (audio_embeds, audio_stats) = self.runtime.audio_embeddings_with_stats(&features)?;
         let encoder_forward = encoder_start.elapsed();
         let special_tokens = self.prompt_tokenizer.special_tokens().clone();
         let mut decode = |ids: &[u32]| self.prompt_tokenizer.decode(ids);
@@ -374,6 +374,7 @@ impl GraniteSpeechAsrModel {
                 self.dtype,
                 &self.device,
                 timings,
+                audio_stats,
             )),
         })
     }
@@ -405,6 +406,7 @@ fn granite_diagnostics(
     dtype: DType,
     device: &DeviceProfile,
     timings: GraniteSpeechAsrTimings,
+    audio_stats: GraniteSpeechAudioEmbeddingStats,
 ) -> serde_json::Value {
     json!({
         "family": "granite_speech_asr",
@@ -429,6 +431,15 @@ fn granite_diagnostics(
             "audio_tokens": generation.stats.audio_tokens,
             "mel_frames": features.mel_frames,
             "encoder_frames": features.encoder_frames,
+            "encoder_dim": features.encoder_dim,
+            "conformer_context_size": audio_stats.conformer_context_size,
+            "conformer_blocks": audio_stats.conformer_blocks,
+            "conformer_pad_frames": audio_stats.conformer_pad_frames,
+            "conformer_layers": audio_stats.conformer_layers,
+            "qformer_windows": audio_stats.qformer_windows,
+            "qformer_window_size": audio_stats.qformer_window_size,
+            "qformer_queries_per_window": audio_stats.qformer_queries_per_window,
+            "qformer_layers": audio_stats.qformer_layers,
         },
         "generated_tokens": generation.stats.generated_tokens,
         "stop_reason": generation.stats.stop_reason,
@@ -448,8 +459,16 @@ fn granite_diagnostics(
         "timings_ms": {
             "mel_prepare": duration_ms(timings.mel_prepare),
             "encoder_forward": duration_ms(timings.encoder_forward),
+            "audio_input_upload": duration_ms(audio_stats.upload),
+            "audio_encoder": duration_ms(audio_stats.encoder),
+            "audio_projector": duration_ms(audio_stats.projector),
+            "audio_frontend_total": duration_ms(timings.mel_prepare + timings.encoder_forward),
             "prefill": duration_ms(timings.prefill),
             "decode": duration_ms(timings.decode),
+            "generation_total": duration_ms(timings.prefill + timings.decode),
+            "model_non_generation": duration_ms(
+                timings.model_total.saturating_sub(timings.prefill + timings.decode),
+            ),
             "model_total": duration_ms(timings.model_total),
         },
         "speaker_segments": parsed.segments.iter().map(|segment| {
@@ -667,6 +686,21 @@ mod tests {
             decode: generation.stats.timings.decode,
             model_total: Duration::from_millis(12),
         };
+        let audio_stats = GraniteSpeechAudioEmbeddingStats {
+            upload: Duration::from_millis(1),
+            encoder: Duration::from_millis(2),
+            projector: Duration::from_millis(3),
+            encoder_frames: 1,
+            encoder_dim: 160,
+            conformer_context_size: 200,
+            conformer_blocks: 1,
+            conformer_pad_frames: 199,
+            conformer_layers: 16,
+            qformer_windows: 1,
+            qformer_window_size: 15,
+            qformer_queries_per_window: 3,
+            qformer_layers: 2,
+        };
         let parsed = parse_granite_speech_output(&generation.text);
         let diagnostics = granite_diagnostics(
             &features,
@@ -676,6 +710,7 @@ mod tests {
             DType::F32,
             &DeviceProfile::cpu(),
             timings,
+            audio_stats,
         );
 
         assert_eq!(diagnostics["projected_audio_tokens"], 3);
@@ -683,6 +718,9 @@ mod tests {
         assert_eq!(diagnostics["prompt_audio_placeholders"], 1);
         assert_eq!(diagnostics["prompt"]["prompt_tokens"], 4);
         assert_eq!(diagnostics["audio"]["audio_tokens"], 3);
+        assert_eq!(diagnostics["audio"]["conformer_context_size"], 200);
+        assert_eq!(diagnostics["audio"]["conformer_pad_frames"], 199);
+        assert_eq!(diagnostics["audio"]["qformer_queries_per_window"], 3);
         assert_eq!(diagnostics["decode"]["generated_tokens"], 2);
         assert_eq!(diagnostics["execution"]["dense_decode_cache"], true);
         assert_eq!(
@@ -693,6 +731,12 @@ mod tests {
         assert_eq!(diagnostics["execution"]["dense_decode_max_tokens"], 8192);
         assert_eq!(diagnostics["timings_ms"]["prefill"], 7.0);
         assert_eq!(diagnostics["timings_ms"]["decode"], 3.0);
+        assert_eq!(diagnostics["timings_ms"]["audio_input_upload"], 1.0);
+        assert_eq!(diagnostics["timings_ms"]["audio_encoder"], 2.0);
+        assert_eq!(diagnostics["timings_ms"]["audio_projector"], 3.0);
+        assert_eq!(diagnostics["timings_ms"]["audio_frontend_total"], 3.0);
+        assert_eq!(diagnostics["timings_ms"]["generation_total"], 10.0);
+        assert_eq!(diagnostics["timings_ms"]["model_non_generation"], 2.0);
         assert_eq!(diagnostics["speaker_segments"][0]["speaker"], "Speaker 1");
         assert_eq!(diagnostics["timestamp_words"][0]["word"], "hello");
     }

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/mod.rs
@@ -440,6 +440,8 @@ fn granite_diagnostics(
         },
         "execution": {
             "dense_decode_cache": generation.stats.dense_decode_cache_enabled,
+            "dense_decode_cache_configured": generation.stats.dense_decode_cache_enabled,
+            "dense_head_decode_enabled": generation.stats.dense_head_decode_enabled,
             "cuda_dense_decode_cache": generation.stats.dense_decode_cache_enabled,
             "dense_decode_max_tokens": generation.stats.dense_decode_max_tokens,
         },
@@ -650,6 +652,7 @@ mod tests {
                 stop_reason: "stop_token".to_string(),
                 stop_token: Some(100_257),
                 dense_decode_cache_enabled: true,
+                dense_head_decode_enabled: false,
                 dense_decode_max_tokens: 8192,
                 timings: GraniteSpeechGenerationTimings {
                     prefill: Duration::from_millis(7),
@@ -682,6 +685,11 @@ mod tests {
         assert_eq!(diagnostics["audio"]["audio_tokens"], 3);
         assert_eq!(diagnostics["decode"]["generated_tokens"], 2);
         assert_eq!(diagnostics["execution"]["dense_decode_cache"], true);
+        assert_eq!(
+            diagnostics["execution"]["dense_decode_cache_configured"],
+            true
+        );
+        assert_eq!(diagnostics["execution"]["dense_head_decode_enabled"], false);
         assert_eq!(diagnostics["execution"]["dense_decode_max_tokens"], 8192);
         assert_eq!(diagnostics["timings_ms"]["prefill"], 7.0);
         assert_eq!(diagnostics["timings_ms"]["decode"], 3.0);

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/mod.rs
@@ -21,24 +21,24 @@ mod runtime;
 mod transcript;
 
 pub use config::{
-    load_granite_speech_chat_template, GraniteSpeechAudioProcessorConfig, GraniteSpeechConfig,
-    GraniteSpeechEncoderConfig, GraniteSpeechGenerationConfig, GraniteSpeechMelSpecConfig,
-    GraniteSpeechProcessorConfig, GraniteSpeechProjectorConfig, GraniteSpeechTokenizerConfig,
-    GraniteTextConfig,
+    GraniteSpeechAudioProcessorConfig, GraniteSpeechConfig, GraniteSpeechEncoderConfig,
+    GraniteSpeechGenerationConfig, GraniteSpeechMelSpecConfig, GraniteSpeechProcessorConfig,
+    GraniteSpeechProjectorConfig, GraniteSpeechTokenizerConfig, GraniteTextConfig,
+    load_granite_speech_chat_template,
 };
 pub use preprocessor::{GraniteSpeechAudioFeatures, GraniteSpeechPreprocessor};
 pub use prompt::{
-    GraniteSpeechPrompt, GraniteSpeechPromptOptions, GraniteSpeechPromptTokenizer,
-    GraniteSpeechSpecialTokens, GraniteSpeechTask, GRANITE_SPEECH_ASR_PROMPT,
-    GRANITE_SPEECH_SPEAKER_PROMPT, GRANITE_SPEECH_SYSTEM_PROMPT, GRANITE_SPEECH_TIMESTAMP_PROMPT,
+    GRANITE_SPEECH_ASR_PROMPT, GRANITE_SPEECH_SPEAKER_PROMPT, GRANITE_SPEECH_SYSTEM_PROMPT,
+    GRANITE_SPEECH_TIMESTAMP_PROMPT, GraniteSpeechPrompt, GraniteSpeechPromptOptions,
+    GraniteSpeechPromptTokenizer, GraniteSpeechSpecialTokens, GraniteSpeechTask,
 };
 pub use runtime::{
     GraniteSpeechAudioEmbeddingStats, GraniteSpeechGeneration, GraniteSpeechGenerationStats,
     GraniteSpeechGenerationTimings, GraniteSpeechRuntime,
 };
 pub use transcript::{
-    parse_granite_speech_output, GraniteSpeechParsedTranscript, GraniteSpeechSegment,
-    GraniteSpeechTimestampWord,
+    GraniteSpeechParsedTranscript, GraniteSpeechSegment, GraniteSpeechTimestampWord,
+    parse_granite_speech_output,
 };
 
 const REQUIRED_ARTIFACTS: &[&str] = &[
@@ -446,6 +446,7 @@ fn granite_diagnostics(
         "stop_token": generation.stats.stop_token,
         "decode": {
             "generated_tokens": generation.stats.generated_tokens,
+            "max_new_tokens": generation.stats.max_new_tokens,
             "stop_reason": generation.stats.stop_reason,
             "stop_token": generation.stats.stop_token,
         },
@@ -628,9 +629,10 @@ mod tests {
         )
         .unwrap();
         let err = ensure_granite_speech_artifacts(&dir).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Invalid Granite Speech safetensors shard path"));
+        assert!(
+            err.to_string()
+                .contains("Invalid Granite Speech safetensors shard path")
+        );
         std::fs::remove_dir_all(dir).ok();
     }
 
@@ -668,6 +670,7 @@ mod tests {
                 prompt_tokens: 4,
                 audio_tokens: 3,
                 generated_tokens: 2,
+                max_new_tokens: 128,
                 stop_reason: "stop_token".to_string(),
                 stop_token: Some(100_257),
                 dense_decode_cache_enabled: true,
@@ -722,6 +725,7 @@ mod tests {
         assert_eq!(diagnostics["audio"]["conformer_pad_frames"], 199);
         assert_eq!(diagnostics["audio"]["qformer_queries_per_window"], 3);
         assert_eq!(diagnostics["decode"]["generated_tokens"], 2);
+        assert_eq!(diagnostics["decode"]["max_new_tokens"], 128);
         assert_eq!(diagnostics["execution"]["dense_decode_cache"], true);
         assert_eq!(
             diagnostics["execution"]["dense_decode_cache_configured"],

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/mod.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use candle_core::DType;
 use serde_json::json;
@@ -31,7 +32,10 @@ pub use prompt::{
     GraniteSpeechSpecialTokens, GraniteSpeechTask, GRANITE_SPEECH_ASR_PROMPT,
     GRANITE_SPEECH_SPEAKER_PROMPT, GRANITE_SPEECH_SYSTEM_PROMPT, GRANITE_SPEECH_TIMESTAMP_PROMPT,
 };
-pub use runtime::{GraniteSpeechGeneration, GraniteSpeechGenerationStats, GraniteSpeechRuntime};
+pub use runtime::{
+    GraniteSpeechGeneration, GraniteSpeechGenerationStats, GraniteSpeechGenerationTimings,
+    GraniteSpeechRuntime,
+};
 pub use transcript::{
     parse_granite_speech_output, GraniteSpeechParsedTranscript, GraniteSpeechSegment,
     GraniteSpeechTimestampWord,
@@ -319,7 +323,10 @@ impl GraniteSpeechAsrModel {
         options: GraniteSpeechAsrGenerationOptions,
         on_delta: &mut dyn FnMut(&str),
     ) -> Result<GraniteSpeechAsrTranscriptionOutput> {
+        let model_start = Instant::now();
+        let prepare_start = Instant::now();
         let features = self.prepare_audio_features(audio, sample_rate)?;
+        let mel_prepare = prepare_start.elapsed();
         validate_granite_audio_duration(features.audio_seconds)?;
 
         let prompt_options = GraniteSpeechPromptOptions {
@@ -330,7 +337,9 @@ impl GraniteSpeechAsrModel {
             ..GraniteSpeechPromptOptions::default()
         };
         let granite_prompt = self.build_prompt(&prompt_options)?;
+        let encoder_start = Instant::now();
         let audio_embeds = self.runtime.audio_embeddings(&features)?;
+        let encoder_forward = encoder_start.elapsed();
         let special_tokens = self.prompt_tokenizer.special_tokens().clone();
         let mut decode = |ids: &[u32]| self.prompt_tokenizer.decode(ids);
         let generation = self.runtime.generate(
@@ -343,8 +352,16 @@ impl GraniteSpeechAsrModel {
             &mut decode,
             on_delta,
         )?;
+        let model_total = model_start.elapsed();
         let parsed = parse_granite_speech_output(&generation.text);
         let text = parsed.text.clone();
+        let timings = GraniteSpeechAsrTimings {
+            mel_prepare,
+            encoder_forward,
+            prefill: generation.stats.timings.prefill,
+            decode: generation.stats.timings.decode,
+            model_total,
+        };
 
         Ok(GraniteSpeechAsrTranscriptionOutput {
             text,
@@ -356,9 +373,19 @@ impl GraniteSpeechAsrModel {
                 &parsed,
                 self.dtype,
                 &self.device,
+                timings,
             )),
         })
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GraniteSpeechAsrTimings {
+    mel_prepare: Duration,
+    encoder_forward: Duration,
+    prefill: Duration,
+    decode: Duration,
+    model_total: Duration,
 }
 
 fn validate_granite_audio_duration(audio_seconds: f32) -> Result<()> {
@@ -377,6 +404,7 @@ fn granite_diagnostics(
     parsed: &GraniteSpeechParsedTranscript,
     dtype: DType,
     device: &DeviceProfile,
+    timings: GraniteSpeechAsrTimings,
 ) -> serde_json::Value {
     json!({
         "family": "granite_speech_asr",
@@ -392,9 +420,36 @@ fn granite_diagnostics(
         "prompt_tokens": generation.stats.prompt_tokens,
         "prompt_prefix_tokens": prompt.prefix_text_token_count,
         "prompt_audio_placeholders": prompt.audio_token_positions.len(),
+        "prompt": {
+            "prompt_tokens": generation.stats.prompt_tokens,
+            "prefix_tokens": prompt.prefix_text_token_count,
+            "audio_placeholders": prompt.audio_token_positions.len(),
+        },
+        "audio": {
+            "audio_tokens": generation.stats.audio_tokens,
+            "mel_frames": features.mel_frames,
+            "encoder_frames": features.encoder_frames,
+        },
         "generated_tokens": generation.stats.generated_tokens,
         "stop_reason": generation.stats.stop_reason,
         "stop_token": generation.stats.stop_token,
+        "decode": {
+            "generated_tokens": generation.stats.generated_tokens,
+            "stop_reason": generation.stats.stop_reason,
+            "stop_token": generation.stats.stop_token,
+        },
+        "execution": {
+            "dense_decode_cache": generation.stats.dense_decode_cache_enabled,
+            "cuda_dense_decode_cache": generation.stats.dense_decode_cache_enabled,
+            "dense_decode_max_tokens": generation.stats.dense_decode_max_tokens,
+        },
+        "timings_ms": {
+            "mel_prepare": duration_ms(timings.mel_prepare),
+            "encoder_forward": duration_ms(timings.encoder_forward),
+            "prefill": duration_ms(timings.prefill),
+            "decode": duration_ms(timings.decode),
+            "model_total": duration_ms(timings.model_total),
+        },
         "speaker_segments": parsed.segments.iter().map(|segment| {
             json!({
                 "speaker": segment.speaker,
@@ -408,6 +463,10 @@ fn granite_diagnostics(
             })
         }).collect::<Vec<_>>(),
     })
+}
+
+fn duration_ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1000.0
 }
 
 pub fn ensure_granite_speech_artifacts(model_dir: &Path) -> Result<Vec<PathBuf>> {
@@ -590,7 +649,20 @@ mod tests {
                 generated_tokens: 2,
                 stop_reason: "stop_token".to_string(),
                 stop_token: Some(100_257),
+                dense_decode_cache_enabled: true,
+                dense_decode_max_tokens: 8192,
+                timings: GraniteSpeechGenerationTimings {
+                    prefill: Duration::from_millis(7),
+                    decode: Duration::from_millis(3),
+                },
             },
+        };
+        let timings = GraniteSpeechAsrTimings {
+            mel_prepare: Duration::from_millis(1),
+            encoder_forward: Duration::from_millis(2),
+            prefill: generation.stats.timings.prefill,
+            decode: generation.stats.timings.decode,
+            model_total: Duration::from_millis(12),
         };
         let parsed = parse_granite_speech_output(&generation.text);
         let diagnostics = granite_diagnostics(
@@ -600,11 +672,19 @@ mod tests {
             &parsed,
             DType::F32,
             &DeviceProfile::cpu(),
+            timings,
         );
 
         assert_eq!(diagnostics["projected_audio_tokens"], 3);
         assert_eq!(diagnostics["prompt_prefix_tokens"], 0);
         assert_eq!(diagnostics["prompt_audio_placeholders"], 1);
+        assert_eq!(diagnostics["prompt"]["prompt_tokens"], 4);
+        assert_eq!(diagnostics["audio"]["audio_tokens"], 3);
+        assert_eq!(diagnostics["decode"]["generated_tokens"], 2);
+        assert_eq!(diagnostics["execution"]["dense_decode_cache"], true);
+        assert_eq!(diagnostics["execution"]["dense_decode_max_tokens"], 8192);
+        assert_eq!(diagnostics["timings_ms"]["prefill"], 7.0);
+        assert_eq!(diagnostics["timings_ms"]["decode"], 3.0);
         assert_eq!(diagnostics["speaker_segments"][0]["speaker"], "Speaker 1");
         assert_eq!(diagnostics["timestamp_words"][0]["word"], "hello");
     }

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/preprocessor.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/preprocessor.rs
@@ -1,6 +1,6 @@
 //! Audio preprocessing for Granite Speech ASR.
 
-use crate::audio::{resample_mono_high_quality, MelConfig, MelSpectrogram};
+use crate::audio::{resample_mono_high_quality, MelConfig, MelNorm, MelScale, MelSpectrogram};
 use crate::error::{Error, Result};
 use crate::models::architectures::granite_speech::asr::config::GraniteSpeechProcessorConfig;
 
@@ -34,6 +34,8 @@ impl GraniteSpeechPreprocessor {
             f_min: 0.0,
             f_max: (config.sample_rate() / 2) as f32,
             normalize: true,
+            mel_scale: MelScale::Htk,
+            mel_norm: MelNorm::None,
         };
         let mel = MelSpectrogram::new(mel_cfg)?;
         Ok(Self { config, mel })
@@ -144,6 +146,9 @@ mod tests {
     #[test]
     fn preprocessor_prepares_16khz_log_mel_features() {
         let preprocessor = GraniteSpeechPreprocessor::new(test_processor()).unwrap();
+        assert_eq!(preprocessor.mel.config().mel_scale, MelScale::Htk);
+        assert_eq!(preprocessor.mel.config().mel_norm, MelNorm::None);
+
         let audio = vec![0.0f32; 16_000];
         let features = preprocessor.prepare(&audio, 16_000).unwrap();
         assert_eq!(features.sample_rate, 16_000);

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
@@ -14,6 +14,7 @@ use crate::backends::DeviceProfile;
 use crate::error::{Error, Result};
 use crate::kernels::try_fused_silu_mul;
 use crate::models::architectures::qwen3::core::{causal_mask, repeat_kv, Qwen3Cache};
+use crate::models::shared::attention::flash::try_fused_self_attention;
 use crate::models::shared::attention::paged::default_kv_page_size;
 use crate::models::shared::telemetry::{record_decode_attention_path, DecodeAttentionPath};
 
@@ -822,6 +823,14 @@ impl GraniteQFormerAttention {
         let q = self.transpose_for_scores(&self.query.forward(x)?)?;
         let k = self.transpose_for_scores(&self.key.forward(kv_input)?)?;
         let v = self.transpose_for_scores(&self.value.forward(kv_input)?)?;
+        if let Some(context) = try_fused_self_attention(&q, &k, &v, None, self.head_dim, false)? {
+            let context = context.transpose(1, 2)?.flatten_from(D::Minus2)?;
+            let out = self.output_dense.forward(&context)?;
+            return self
+                .output_norm
+                .forward(&out.broadcast_add(x)?)
+                .map_err(Error::from);
+        }
         let mut scores = q.matmul(&k.t()?)?;
         scores = (scores / (self.head_dim as f64).sqrt())?;
         let probs = ops::softmax(&scores.to_dtype(DType::F32)?, D::Minus1)?.to_dtype(q.dtype())?;
@@ -1485,6 +1494,36 @@ mod tests {
     #[test]
     fn dense_head_decode_policy_skips_cpu() {
         assert!(!granite_dense_head_decode_allowed(&Device::Cpu));
+    }
+
+    #[test]
+    fn qformer_attention_cpu_fallback_preserves_shape() {
+        let device = Device::Cpu;
+        let hidden = 8;
+        let heads = 2;
+        let linear = || {
+            Linear::new(
+                Tensor::zeros((hidden, hidden), DType::F32, &device).unwrap(),
+                Some(Tensor::zeros(hidden, DType::F32, &device).unwrap()),
+            )
+        };
+        let attention = GraniteQFormerAttention {
+            query: linear(),
+            key: linear(),
+            value: linear(),
+            output_dense: linear(),
+            output_norm: LayerNorm::new(
+                Tensor::ones(hidden, DType::F32, &device).unwrap(),
+                Tensor::zeros(hidden, DType::F32, &device).unwrap(),
+                1e-12,
+            ),
+            num_heads: heads,
+            head_dim: hidden / heads,
+        };
+        let x = Tensor::zeros((3, 5, hidden), DType::F32, &device).unwrap();
+        let out = attention.forward(&x, None).unwrap();
+
+        assert_eq!(out.dims(), &[3, 5, hidden]);
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
@@ -1364,6 +1364,41 @@ fn dense_decode_attention_scaled(
     head_dim: usize,
     attention_multiplier: f32,
 ) -> Result<Tensor> {
+    if q.dim(0)? == 1
+        && q.dim(1)? == 1
+        && num_heads != num_kv_heads
+        && num_heads % num_kv_heads == 0
+    {
+        return dense_decode_attention_gqa_scaled(
+            q,
+            k,
+            v,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            attention_multiplier,
+        );
+    }
+    dense_decode_attention_repeated_scaled(
+        q,
+        k,
+        v,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        attention_multiplier,
+    )
+}
+
+fn dense_decode_attention_repeated_scaled(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    attention_multiplier: f32,
+) -> Result<Tensor> {
     let k = repeat_kv(k, num_heads, num_kv_heads)?;
     let v = repeat_kv(v, num_heads, num_kv_heads)?;
     let q_heads = q.transpose(1, 2)?.contiguous()?;
@@ -1375,6 +1410,60 @@ fn dense_decode_attention_scaled(
     let out = attn.matmul(&v_heads)?;
     out.transpose(1, 2)?
         .reshape((q.dim(0)?, q.dim(1)?, num_heads, head_dim))
+        .map_err(Error::from)
+}
+
+fn dense_decode_attention_gqa_scaled(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    attention_multiplier: f32,
+) -> Result<Tensor> {
+    let batch = q.dim(0)?;
+    let seq_len = q.dim(1)?;
+    let kv_groups = num_heads / num_kv_heads;
+    if batch != 1 || seq_len != 1 {
+        return dense_decode_attention_repeated_scaled(
+            q,
+            k,
+            v,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            attention_multiplier,
+        );
+    }
+    let mut head_groups = Vec::with_capacity(num_kv_heads);
+    for kv_idx in 0..num_kv_heads {
+        let q_group = q
+            .narrow(2, kv_idx * kv_groups, kv_groups)?
+            .squeeze(0)?
+            .squeeze(0)?
+            .contiguous()?;
+        let k_group = k
+            .narrow(2, kv_idx, 1)?
+            .squeeze(0)?
+            .squeeze(1)?
+            .t()?
+            .contiguous()?;
+        let v_group = v
+            .narrow(2, kv_idx, 1)?
+            .squeeze(0)?
+            .squeeze(1)?
+            .contiguous()?;
+        let mut attn = q_group.matmul(&k_group)?;
+        attn = (attn * attention_multiplier as f64)?;
+        let attn = ops::softmax(&attn.to_dtype(DType::F32)?, D::Minus1)?.to_dtype(q.dtype())?;
+        head_groups.push(attn.matmul(&v_group)?);
+    }
+    let head_refs = head_groups.iter().collect::<Vec<_>>();
+    Tensor::cat(&head_refs, 0)?
+        .unsqueeze(0)?
+        .unsqueeze(0)?
+        .reshape((batch, seq_len, num_heads, head_dim))
         .map_err(Error::from)
 }
 
@@ -1602,6 +1691,70 @@ mod tests {
             .to_vec1::<f32>()
             .unwrap();
         let rhs = dense_heads.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let max_diff = lhs
+            .iter()
+            .zip(rhs.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+
+        assert!(max_diff < 1e-6, "max diff {max_diff}");
+    }
+
+    #[test]
+    fn grouped_decode_attention_matches_repeated_kv_reference() {
+        let device = Device::Cpu;
+        let num_heads = 8;
+        let num_kv_heads = 2;
+        let head_dim = 4;
+        let total_len = 5;
+        let attention_multiplier = 0.42;
+        let q = Tensor::from_vec(
+            (0..(num_heads * head_dim))
+                .map(|value| (value as f32) * 0.03 - 0.5)
+                .collect::<Vec<_>>(),
+            (1, 1, num_heads, head_dim),
+            &device,
+        )
+        .unwrap();
+        let k = Tensor::from_vec(
+            (0..(total_len * num_kv_heads * head_dim))
+                .map(|value| (value as f32) * 0.02 - 0.3)
+                .collect::<Vec<_>>(),
+            (1, total_len, num_kv_heads, head_dim),
+            &device,
+        )
+        .unwrap();
+        let v = Tensor::from_vec(
+            (0..(total_len * num_kv_heads * head_dim))
+                .map(|value| (value as f32) * -0.015 + 0.4)
+                .collect::<Vec<_>>(),
+            (1, total_len, num_kv_heads, head_dim),
+            &device,
+        )
+        .unwrap();
+
+        let grouped = dense_decode_attention_gqa_scaled(
+            &q,
+            &k,
+            &v,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            attention_multiplier,
+        )
+        .unwrap();
+        let repeated = dense_decode_attention_repeated_scaled(
+            &q,
+            &k,
+            &v,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            attention_multiplier,
+        )
+        .unwrap();
+        let lhs = grouped.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let rhs = repeated.flatten_all().unwrap().to_vec1::<f32>().unwrap();
         let max_diff = lhs
             .iter()
             .zip(rhs.iter())

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
@@ -212,7 +212,17 @@ impl GraniteSpeechRuntime {
         let decode_start = Instant::now();
 
         for step in 0..max_new_tokens.max(1) {
-            let token = argmax_last_logits(&logits)?;
+            let token_tensor = argmax_last_token_tensor(&logits)?;
+            let next_logits = if !decode_each_step && step + 1 < max_new_tokens.max(1) {
+                Some(self.text_model.forward(
+                    &token_tensor,
+                    input_ids.len() + step,
+                    Some(&mut cache),
+                )?)
+            } else {
+                None
+            };
+            let token = token_tensor.reshape(())?.to_scalar::<u32>()?;
             if stop_tokens.contains(&token) {
                 stop_reason = "stop_token".to_string();
                 stop_token = Some(token);
@@ -236,10 +246,13 @@ impl GraniteSpeechRuntime {
                 }
             }
 
-            let token_tensor = Tensor::from_vec(vec![token], (1, 1), &self.device)?;
-            logits =
+            logits = if let Some(next_logits) = next_logits {
+                next_logits
+            } else {
+                let token_tensor = Tensor::from_vec(vec![token], (1, 1), &self.device)?;
                 self.text_model
-                    .forward(&token_tensor, input_ids.len() + step, Some(&mut cache))?;
+                    .forward(&token_tensor, input_ids.len() + step, Some(&mut cache))?
+            };
         }
         if !decode_each_step && !generated.is_empty() {
             rendered = decode(&generated)?;
@@ -318,6 +331,13 @@ fn truncate_at_stop_sequence(text: &mut String, stop_sequences: &[String]) -> bo
 }
 
 fn argmax_last_logits(logits: &Tensor) -> Result<u32> {
+    argmax_last_token_tensor(logits)?
+        .reshape(())?
+        .to_scalar::<u32>()
+        .map_err(Error::from)
+}
+
+fn argmax_last_token_tensor(logits: &Tensor) -> Result<Tensor> {
     let last = match logits.dims() {
         [1, vocab] => logits.reshape((*vocab,))?,
         [1, 1, vocab] => logits.reshape((*vocab,))?,
@@ -340,7 +360,7 @@ fn argmax_last_logits(logits: &Tensor) -> Result<u32> {
         idx.squeeze(0)?
     };
     idx.to_dtype(DType::U32)?
-        .to_scalar::<u32>()
+        .reshape((1, 1))
         .map_err(Error::from)
 }
 
@@ -1686,6 +1706,25 @@ mod tests {
         .unwrap();
 
         assert_eq!(argmax_last_logits(&logits).unwrap(), 3);
+    }
+
+    #[test]
+    fn argmax_last_token_tensor_matches_scalar_argmax() {
+        let logits = Tensor::from_vec(
+            vec![
+                0.0f32, 100.0, 0.0, 0.0, //
+                0.0, 0.0, 90.0, 0.0, //
+                0.0, 0.0, 0.0, 7.0,
+            ],
+            (1, 3, 4),
+            &Device::Cpu,
+        )
+        .unwrap();
+
+        let token = argmax_last_token_tensor(&logits).unwrap();
+
+        assert_eq!(token.dims(), &[1, 1]);
+        assert_eq!(token.reshape(()).unwrap().to_scalar::<u32>().unwrap(), 3);
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
@@ -14,7 +14,9 @@ use crate::backends::DeviceProfile;
 use crate::error::{Error, Result};
 use crate::kernels::try_fused_silu_mul;
 use crate::models::architectures::qwen3::core::{causal_mask, repeat_kv, Qwen3Cache};
-use crate::models::shared::attention::flash::try_fused_self_attention;
+use crate::models::shared::attention::flash::{
+    try_fused_self_attention, try_fused_self_attention_scaled,
+};
 use crate::models::shared::attention::paged::default_kv_page_size;
 use crate::models::shared::telemetry::{record_decode_attention_path, DecodeAttentionPath};
 
@@ -1168,7 +1170,7 @@ impl GraniteTextAttention {
 }
 
 fn granite_dense_head_decode_allowed(device: &Device) -> bool {
-    device.is_cuda()
+    device.is_metal() || device.is_cuda()
 }
 
 fn granite_qformer_fused_attention_allowed(device: &Device) -> bool {
@@ -1294,6 +1296,20 @@ fn dense_decode_attention_heads_scaled(
     attention_multiplier: f32,
 ) -> Result<Tensor> {
     let q_heads = q.transpose(1, 2)?.contiguous()?;
+    if let Some(out) = try_fused_self_attention_scaled(
+        &q_heads,
+        k_heads,
+        v_heads,
+        None,
+        head_dim,
+        false,
+        attention_multiplier,
+    )? {
+        return out
+            .transpose(1, 2)?
+            .reshape((q.dim(0)?, q.dim(1)?, num_heads, head_dim))
+            .map_err(Error::from);
+    }
     let k_heads = if num_heads == num_kv_heads {
         k_heads.clone()
     } else {

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
@@ -1271,7 +1271,11 @@ impl GraniteTextAttention {
 }
 
 fn granite_dense_head_decode_allowed(device: &Device) -> bool {
-    device.is_cuda()
+    granite_dense_head_decode_policy(device.is_metal(), device.is_cuda())
+}
+
+fn granite_dense_head_decode_policy(is_metal: bool, is_cuda: bool) -> bool {
+    is_metal || is_cuda
 }
 
 fn granite_qformer_fused_attention_allowed(device: &Device) -> bool {
@@ -1623,6 +1627,14 @@ mod tests {
     #[test]
     fn dense_head_decode_policy_skips_cpu() {
         assert!(!granite_dense_head_decode_allowed(&Device::Cpu));
+    }
+
+    #[test]
+    fn dense_head_decode_policy_enables_accelerated_backends() {
+        assert!(!granite_dense_head_decode_policy(false, false));
+        assert!(granite_dense_head_decode_policy(true, false));
+        assert!(granite_dense_head_decode_policy(false, true));
+        assert!(granite_dense_head_decode_policy(true, true));
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
@@ -170,6 +170,7 @@ impl GraniteSpeechRuntime {
         stop_sequences: &[String],
         decode: &mut dyn FnMut(&[u32]) -> Result<String>,
         on_delta: &mut dyn FnMut(&str),
+        emit_deltas: bool,
     ) -> Result<GraniteSpeechGeneration> {
         let audio_tokens = audio_embeds.dim(1)?;
         let input_ids = expand_audio_tokens(
@@ -207,6 +208,7 @@ impl GraniteSpeechRuntime {
         let mut stop_reason = "max_tokens".to_string();
         let mut stop_token = None;
         let stop_tokens = stop_token_set(special_tokens, extra_stop_token_ids);
+        let decode_each_step = emit_deltas || !stop_sequences.is_empty();
         let decode_start = Instant::now();
 
         for step in 0..max_new_tokens.max(1) {
@@ -218,24 +220,29 @@ impl GraniteSpeechRuntime {
             }
 
             generated.push(token);
-            let mut next_text = decode(&generated)?;
-            let stopped_on_sequence = truncate_at_stop_sequence(&mut next_text, stop_sequences);
-            if stopped_on_sequence {
-                stop_reason = "stop_sequence".to_string();
-            }
-            if next_text.len() > rendered.len() {
-                let delta = &next_text[rendered.len()..];
-                on_delta(delta);
-            }
-            rendered = next_text;
-            if stopped_on_sequence {
-                break;
+            if decode_each_step {
+                let mut next_text = decode(&generated)?;
+                let stopped_on_sequence = truncate_at_stop_sequence(&mut next_text, stop_sequences);
+                if stopped_on_sequence {
+                    stop_reason = "stop_sequence".to_string();
+                }
+                if emit_deltas && next_text.len() > rendered.len() {
+                    let delta = &next_text[rendered.len()..];
+                    on_delta(delta);
+                }
+                rendered = next_text;
+                if stopped_on_sequence {
+                    break;
+                }
             }
 
             let token_tensor = Tensor::from_vec(vec![token], (1, 1), &self.device)?;
             logits =
                 self.text_model
                     .forward(&token_tensor, input_ids.len() + step, Some(&mut cache))?;
+        }
+        if !decode_each_step && !generated.is_empty() {
+            rendered = decode(&generated)?;
         }
         let decode = decode_start.elapsed();
 

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
@@ -43,6 +43,23 @@ pub struct GraniteSpeechGenerationTimings {
     pub decode: Duration,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GraniteSpeechAudioEmbeddingStats {
+    pub upload: Duration,
+    pub encoder: Duration,
+    pub projector: Duration,
+    pub encoder_frames: usize,
+    pub encoder_dim: usize,
+    pub conformer_context_size: usize,
+    pub conformer_blocks: usize,
+    pub conformer_pad_frames: usize,
+    pub conformer_layers: usize,
+    pub qformer_windows: usize,
+    pub qformer_window_size: usize,
+    pub qformer_queries_per_window: usize,
+    pub qformer_layers: usize,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GraniteSpeechGeneration {
     pub token_ids: Vec<u32>,
@@ -95,6 +112,14 @@ impl GraniteSpeechRuntime {
     }
 
     pub fn audio_embeddings(&self, features: &GraniteSpeechAudioFeatures) -> Result<Tensor> {
+        self.audio_embeddings_with_stats(features)
+            .map(|(embeddings, _stats)| embeddings)
+    }
+
+    pub fn audio_embeddings_with_stats(
+        &self,
+        features: &GraniteSpeechAudioFeatures,
+    ) -> Result<(Tensor, GraniteSpeechAudioEmbeddingStats)> {
         let frames = features.encoder_frames;
         let dim = features.encoder_dim;
         if frames == 0 || dim == 0 {
@@ -107,9 +132,31 @@ impl GraniteSpeechRuntime {
             .iter()
             .flat_map(|frame| frame.iter().copied())
             .collect::<Vec<_>>();
+        let upload_start = Instant::now();
         let input = Tensor::from_vec(flat, (1, frames, dim), &self.device)?.to_dtype(self.dtype)?;
+        let upload = upload_start.elapsed();
+        let encoder_start = Instant::now();
         let encoded = self.encoder.forward(&input)?;
-        self.projector.forward(&encoded)
+        let encoder = encoder_start.elapsed();
+        let projector_start = Instant::now();
+        let embeddings = self.projector.forward(&encoded)?;
+        let projector = projector_start.elapsed();
+        let stats = GraniteSpeechAudioEmbeddingStats {
+            upload,
+            encoder,
+            projector,
+            encoder_frames: frames,
+            encoder_dim: dim,
+            conformer_context_size: self.encoder.context_size(),
+            conformer_blocks: self.encoder.block_count_for_frames(frames),
+            conformer_pad_frames: self.encoder.pad_frames_for_frames(frames),
+            conformer_layers: self.encoder.layer_count(),
+            qformer_windows: self.projector.window_count_for_frames(encoded.dim(1)?),
+            qformer_window_size: self.projector.window_size(),
+            qformer_queries_per_window: self.projector.num_queries(),
+            qformer_layers: self.projector.layer_count(),
+        };
+        Ok((embeddings, stats))
     }
 
     pub fn generate(
@@ -344,6 +391,28 @@ impl GraniteSpeechEncoder {
             Tensor::cat(&refs, 2).map_err(Error::from)
         }
     }
+
+    fn context_size(&self) -> usize {
+        self.layers
+            .first()
+            .map(|layer| layer.context_size())
+            .unwrap_or(0)
+    }
+
+    fn block_count_for_frames(&self, frames: usize) -> usize {
+        let context = self.context_size().max(1);
+        frames.saturating_add(context - 1) / context
+    }
+
+    fn pad_frames_for_frames(&self, frames: usize) -> usize {
+        self.block_count_for_frames(frames)
+            .saturating_mul(self.context_size().max(1))
+            .saturating_sub(frames)
+    }
+
+    fn layer_count(&self) -> usize {
+        self.layers.len()
+    }
 }
 
 struct GraniteConformerBlock {
@@ -375,6 +444,10 @@ impl GraniteConformerBlock {
         let ff2 = self.ff2.forward(&out)?;
         out = out.broadcast_add(&(ff2 * 0.5)?)?;
         self.post_norm.forward(&out).map_err(Error::from)
+    }
+
+    fn context_size(&self) -> usize {
+        self.attn.context_size
     }
 }
 
@@ -701,6 +774,22 @@ impl GraniteSpeechProjector {
         let output = output.reshape((batch, nblocks * self.num_queries, output.dim(2)?))?;
         self.linear.forward(&output).map_err(Error::from)
     }
+
+    fn window_count_for_frames(&self, frames: usize) -> usize {
+        frames.saturating_add(self.window_size - 1) / self.window_size
+    }
+
+    fn window_size(&self) -> usize {
+        self.window_size
+    }
+
+    fn num_queries(&self) -> usize {
+        self.num_queries
+    }
+
+    fn layer_count(&self) -> usize {
+        self.qformer.layer_count()
+    }
 }
 
 struct GraniteQFormer {
@@ -735,6 +824,10 @@ impl GraniteQFormer {
             x = layer.forward(&x, encoder_hidden)?;
         }
         Ok(x)
+    }
+
+    fn layer_count(&self) -> usize {
+        self.layers.len()
     }
 }
 
@@ -826,8 +919,7 @@ impl GraniteQFormerAttention {
         let k = self.transpose_for_scores(&self.key.forward(kv_input)?)?;
         let v = self.transpose_for_scores(&self.value.forward(kv_input)?)?;
         if granite_qformer_fused_attention_allowed(q.device()) {
-            if let Some(context) =
-                try_fused_self_attention(&q, &k, &v, None, self.head_dim, false)?
+            if let Some(context) = try_fused_self_attention(&q, &k, &v, None, self.head_dim, false)?
             {
                 let context = context.transpose(1, 2)?.flatten_from(D::Minus2)?;
                 let out = self.output_dense.forward(&context)?;
@@ -1504,7 +1596,11 @@ mod tests {
             attention_multiplier,
         )
         .unwrap();
-        let lhs = materialized.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let lhs = materialized
+            .flatten_all()
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap();
         let rhs = dense_heads.flatten_all().unwrap().to_vec1::<f32>().unwrap();
         let max_diff = lhs
             .iter()

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
@@ -1098,7 +1098,7 @@ impl GraniteTextAttention {
         k = apply_rotary_emb(&k, &cos, &sin)?;
         let (k, v, total_len) = if let Some(cache) = cache {
             cache.append(layer_idx, k.clone(), v.clone())?;
-            if seq_len == 1 && start_pos > 0 {
+            if granite_dense_head_decode_allowed(q.device()) && seq_len == 1 && start_pos > 0 {
                 if let Some((k_heads, v_heads)) = cache.dense_heads(layer_idx) {
                     record_decode_attention_path(DecodeAttentionPath::Dense);
                     let out = dense_decode_attention_heads_scaled(
@@ -1148,6 +1148,10 @@ impl GraniteTextAttention {
         let out = out.reshape((batch, seq_len, self.num_heads * self.head_dim))?;
         self.o_proj.forward(&out).map_err(Error::from)
     }
+}
+
+fn granite_dense_head_decode_allowed(device: &Device) -> bool {
+    device.is_cuda()
 }
 
 fn build_rope_cache(
@@ -1472,6 +1476,11 @@ mod tests {
             .fold(0.0f32, f32::max);
 
         assert!(max_diff < 1e-6, "max diff {max_diff}");
+    }
+
+    #[test]
+    fn dense_head_decode_policy_skips_cpu() {
+        assert!(!granite_dense_head_decode_allowed(&Device::Cpu));
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
@@ -1170,7 +1170,7 @@ impl GraniteTextAttention {
 }
 
 fn granite_dense_head_decode_allowed(device: &Device) -> bool {
-    device.is_metal() || device.is_cuda()
+    device.is_cuda()
 }
 
 fn granite_qformer_fused_attention_allowed(device: &Device) -> bool {

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
@@ -1364,41 +1364,6 @@ fn dense_decode_attention_scaled(
     head_dim: usize,
     attention_multiplier: f32,
 ) -> Result<Tensor> {
-    if q.dim(0)? == 1
-        && q.dim(1)? == 1
-        && num_heads != num_kv_heads
-        && num_heads % num_kv_heads == 0
-    {
-        return dense_decode_attention_gqa_scaled(
-            q,
-            k,
-            v,
-            num_heads,
-            num_kv_heads,
-            head_dim,
-            attention_multiplier,
-        );
-    }
-    dense_decode_attention_repeated_scaled(
-        q,
-        k,
-        v,
-        num_heads,
-        num_kv_heads,
-        head_dim,
-        attention_multiplier,
-    )
-}
-
-fn dense_decode_attention_repeated_scaled(
-    q: &Tensor,
-    k: &Tensor,
-    v: &Tensor,
-    num_heads: usize,
-    num_kv_heads: usize,
-    head_dim: usize,
-    attention_multiplier: f32,
-) -> Result<Tensor> {
     let k = repeat_kv(k, num_heads, num_kv_heads)?;
     let v = repeat_kv(v, num_heads, num_kv_heads)?;
     let q_heads = q.transpose(1, 2)?.contiguous()?;
@@ -1410,60 +1375,6 @@ fn dense_decode_attention_repeated_scaled(
     let out = attn.matmul(&v_heads)?;
     out.transpose(1, 2)?
         .reshape((q.dim(0)?, q.dim(1)?, num_heads, head_dim))
-        .map_err(Error::from)
-}
-
-fn dense_decode_attention_gqa_scaled(
-    q: &Tensor,
-    k: &Tensor,
-    v: &Tensor,
-    num_heads: usize,
-    num_kv_heads: usize,
-    head_dim: usize,
-    attention_multiplier: f32,
-) -> Result<Tensor> {
-    let batch = q.dim(0)?;
-    let seq_len = q.dim(1)?;
-    let kv_groups = num_heads / num_kv_heads;
-    if batch != 1 || seq_len != 1 {
-        return dense_decode_attention_repeated_scaled(
-            q,
-            k,
-            v,
-            num_heads,
-            num_kv_heads,
-            head_dim,
-            attention_multiplier,
-        );
-    }
-    let mut head_groups = Vec::with_capacity(num_kv_heads);
-    for kv_idx in 0..num_kv_heads {
-        let q_group = q
-            .narrow(2, kv_idx * kv_groups, kv_groups)?
-            .squeeze(0)?
-            .squeeze(0)?
-            .contiguous()?;
-        let k_group = k
-            .narrow(2, kv_idx, 1)?
-            .squeeze(0)?
-            .squeeze(1)?
-            .t()?
-            .contiguous()?;
-        let v_group = v
-            .narrow(2, kv_idx, 1)?
-            .squeeze(0)?
-            .squeeze(1)?
-            .contiguous()?;
-        let mut attn = q_group.matmul(&k_group)?;
-        attn = (attn * attention_multiplier as f64)?;
-        let attn = ops::softmax(&attn.to_dtype(DType::F32)?, D::Minus1)?.to_dtype(q.dtype())?;
-        head_groups.push(attn.matmul(&v_group)?);
-    }
-    let head_refs = head_groups.iter().collect::<Vec<_>>();
-    Tensor::cat(&head_refs, 0)?
-        .unsqueeze(0)?
-        .unsqueeze(0)?
-        .reshape((batch, seq_len, num_heads, head_dim))
         .map_err(Error::from)
 }
 
@@ -1691,70 +1602,6 @@ mod tests {
             .to_vec1::<f32>()
             .unwrap();
         let rhs = dense_heads.flatten_all().unwrap().to_vec1::<f32>().unwrap();
-        let max_diff = lhs
-            .iter()
-            .zip(rhs.iter())
-            .map(|(a, b)| (a - b).abs())
-            .fold(0.0f32, f32::max);
-
-        assert!(max_diff < 1e-6, "max diff {max_diff}");
-    }
-
-    #[test]
-    fn grouped_decode_attention_matches_repeated_kv_reference() {
-        let device = Device::Cpu;
-        let num_heads = 8;
-        let num_kv_heads = 2;
-        let head_dim = 4;
-        let total_len = 5;
-        let attention_multiplier = 0.42;
-        let q = Tensor::from_vec(
-            (0..(num_heads * head_dim))
-                .map(|value| (value as f32) * 0.03 - 0.5)
-                .collect::<Vec<_>>(),
-            (1, 1, num_heads, head_dim),
-            &device,
-        )
-        .unwrap();
-        let k = Tensor::from_vec(
-            (0..(total_len * num_kv_heads * head_dim))
-                .map(|value| (value as f32) * 0.02 - 0.3)
-                .collect::<Vec<_>>(),
-            (1, total_len, num_kv_heads, head_dim),
-            &device,
-        )
-        .unwrap();
-        let v = Tensor::from_vec(
-            (0..(total_len * num_kv_heads * head_dim))
-                .map(|value| (value as f32) * -0.015 + 0.4)
-                .collect::<Vec<_>>(),
-            (1, total_len, num_kv_heads, head_dim),
-            &device,
-        )
-        .unwrap();
-
-        let grouped = dense_decode_attention_gqa_scaled(
-            &q,
-            &k,
-            &v,
-            num_heads,
-            num_kv_heads,
-            head_dim,
-            attention_multiplier,
-        )
-        .unwrap();
-        let repeated = dense_decode_attention_repeated_scaled(
-            &q,
-            &k,
-            &v,
-            num_heads,
-            num_kv_heads,
-            head_dim,
-            attention_multiplier,
-        )
-        .unwrap();
-        let lhs = grouped.flatten_all().unwrap().to_vec1::<f32>().unwrap();
-        let rhs = repeated.flatten_all().unwrap().to_vec1::<f32>().unwrap();
         let max_diff = lhs
             .iter()
             .zip(rhs.iter())

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
@@ -1,6 +1,7 @@
 //! Native Candle runtime for Granite Speech ASR.
 
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 use candle_core::{DType, Device, Tensor, D};
 use candle_nn::{
@@ -11,7 +12,9 @@ use candle_nn::{
 
 use crate::backends::DeviceProfile;
 use crate::error::{Error, Result};
+use crate::kernels::try_fused_silu_mul;
 use crate::models::architectures::qwen3::core::{causal_mask, repeat_kv, Qwen3Cache};
+use crate::models::shared::attention::paged::default_kv_page_size;
 
 use super::config::{GraniteSpeechConfig, GraniteSpeechEncoderConfig, GraniteTextConfig};
 use super::preprocessor::GraniteSpeechAudioFeatures;
@@ -24,6 +27,15 @@ pub struct GraniteSpeechGenerationStats {
     pub generated_tokens: usize,
     pub stop_reason: String,
     pub stop_token: Option<u32>,
+    pub dense_decode_cache_enabled: bool,
+    pub dense_decode_max_tokens: usize,
+    pub timings: GraniteSpeechGenerationTimings,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GraniteSpeechGenerationTimings {
+    pub prefill: Duration,
+    pub decode: Duration,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -49,11 +61,13 @@ impl GraniteSpeechRuntime {
         dtype: DType,
     ) -> Result<Self> {
         let vb = unsafe {
-            VarBuilder::from_mmaped_safetensors(shard_paths, dtype, &device.device).map_err(|err| {
-                Error::ModelLoadError(format!(
-                    "Failed to mmap Granite Speech safetensors: {err}"
-                ))
-            })?
+            VarBuilder::from_mmaped_safetensors(shard_paths, dtype, &device.device).map_err(
+                |err| {
+                    Error::ModelLoadError(format!(
+                        "Failed to mmap Granite Speech safetensors: {err}"
+                    ))
+                },
+            )?
         };
         let encoder = GraniteSpeechEncoder::load(&config.encoder_config, vb.pp("encoder"))?;
         let projector = GraniteSpeechProjector::load(config, vb.pp("projector"))?;
@@ -88,8 +102,7 @@ impl GraniteSpeechRuntime {
             .iter()
             .flat_map(|frame| frame.iter().copied())
             .collect::<Vec<_>>();
-        let input = Tensor::from_vec(flat, (1, frames, dim), &self.device)?
-            .to_dtype(self.dtype)?;
+        let input = Tensor::from_vec(flat, (1, frames, dim), &self.device)?.to_dtype(self.dtype)?;
         let encoded = self.encoder.forward(&input)?;
         self.projector.forward(&encoded)
     }
@@ -118,7 +131,14 @@ impl GraniteSpeechRuntime {
             .copied()
             .ok_or_else(|| Error::InvalidInput("Granite prompt has no audio token".to_string()))?;
 
-        let mut cache = Qwen3Cache::new(self.text_model.num_layers());
+        let mut cache = Qwen3Cache::with_page_size_and_dense_decode(
+            self.text_model.num_layers(),
+            default_kv_page_size(),
+            &self.device,
+        );
+        let dense_decode_max_tokens = cache.dense_decode_max_tokens();
+        let dense_decode_cache_enabled = dense_decode_max_tokens > 0;
+        let prefill_start = Instant::now();
         let mut logits = self.text_model.forward_prompt_with_audio(
             &input_ids,
             audio_start,
@@ -126,11 +146,13 @@ impl GraniteSpeechRuntime {
             audio_embeds,
             &mut cache,
         )?;
+        let prefill = prefill_start.elapsed();
         let mut generated = Vec::new();
         let mut rendered = String::new();
         let mut stop_reason = "max_tokens".to_string();
         let mut stop_token = None;
         let stop_tokens = stop_token_set(special_tokens, extra_stop_token_ids);
+        let decode_start = Instant::now();
 
         for step in 0..max_new_tokens.max(1) {
             let token = argmax_last_logits(&logits)?;
@@ -156,12 +178,11 @@ impl GraniteSpeechRuntime {
             }
 
             let token_tensor = Tensor::from_vec(vec![token], (1, 1), &self.device)?;
-            logits = self.text_model.forward(
-                &token_tensor,
-                input_ids.len() + step,
-                Some(&mut cache),
-            )?;
+            logits =
+                self.text_model
+                    .forward(&token_tensor, input_ids.len() + step, Some(&mut cache))?;
         }
+        let decode = decode_start.elapsed();
 
         Ok(GraniteSpeechGeneration {
             text: rendered,
@@ -172,6 +193,9 @@ impl GraniteSpeechRuntime {
                 generated_tokens: generated.len(),
                 stop_reason,
                 stop_token,
+                dense_decode_cache_enabled,
+                dense_decode_max_tokens,
+                timings: GraniteSpeechGenerationTimings { prefill, decode },
             },
         })
     }
@@ -417,7 +441,11 @@ impl GraniteConformerAttention {
         let q = self.to_q.forward(&padded)?;
         let kv = self.to_kv.forward(&padded)?;
         let k = kv.narrow(2, 0, self.num_heads * self.dim_head)?;
-        let v = kv.narrow(2, self.num_heads * self.dim_head, self.num_heads * self.dim_head)?;
+        let v = kv.narrow(
+            2,
+            self.num_heads * self.dim_head,
+            self.num_heads * self.dim_head,
+        )?;
         let q = encoder_attention_heads(
             &q,
             batch,
@@ -484,9 +512,10 @@ impl GraniteConformerAttention {
             rows.push(relative_position_score_row(&q_row, &rel_row)?);
         }
         let refs = rows.iter().collect::<Vec<_>>();
-        let out = Tensor::cat(&refs, 1)?
-            .reshape((batch, blocks, heads, context, context))?;
-        (out / (dim as f64).sqrt())?.to_dtype(out_dtype).map_err(Error::from)
+        let out = Tensor::cat(&refs, 1)?.reshape((batch, blocks, heads, context, context))?;
+        (out / (dim as f64).sqrt())?
+            .to_dtype(out_dtype)
+            .map_err(Error::from)
     }
 }
 
@@ -559,7 +588,13 @@ impl GraniteConformerConv {
         depth_cfg.groups = inner;
         Ok(Self {
             norm: layer_norm(hidden, 1e-5, vb.pp("norm"))?,
-            up_conv: conv1d(hidden, inner * 2, 1, Conv1dConfig::default(), vb.pp("up_conv"))?,
+            up_conv: conv1d(
+                hidden,
+                inner * 2,
+                1,
+                Conv1dConfig::default(),
+                vb.pp("up_conv"),
+            )?,
             depth_conv: conv1d_no_bias(
                 inner,
                 inner,
@@ -568,7 +603,13 @@ impl GraniteConformerConv {
                 vb.pp("depth_conv.conv"),
             )?,
             batch_norm: batch_norm(inner, 1e-5, vb.pp("batch_norm"))?,
-            down_conv: conv1d(inner, hidden, 1, Conv1dConfig::default(), vb.pp("down_conv"))?,
+            down_conv: conv1d(
+                inner,
+                hidden,
+                1,
+                Conv1dConfig::default(),
+                vb.pp("down_conv"),
+            )?,
         })
     }
 
@@ -643,9 +684,9 @@ impl GraniteSpeechProjector {
             hidden.clone()
         };
         let windows = hidden.reshape((batch * nblocks, self.window_size, dim))?;
-        let query = self
-            .query
-            .broadcast_as((batch * nblocks, self.num_queries, self.query.dim(2)?))?;
+        let query =
+            self.query
+                .broadcast_as((batch * nblocks, self.num_queries, self.query.dim(2)?))?;
         let output = self.qformer.forward(&query, &windows)?;
         let output = output.reshape((batch, nblocks * self.num_queries, output.dim(2)?))?;
         self.linear.forward(&output).map_err(Error::from)
@@ -669,7 +710,11 @@ impl GraniteQFormer {
             )?);
         }
         Ok(Self {
-            layernorm: layer_norm(hidden, config.projector_config.layer_norm_eps, vb.pp("layernorm"))?,
+            layernorm: layer_norm(
+                hidden,
+                config.projector_config.layer_norm_eps,
+                vb.pp("layernorm"),
+            )?,
             layers,
         })
     }
@@ -707,16 +752,8 @@ impl GraniteQFormerLayer {
             } else {
                 None
             },
-            intermediate_query: linear(
-                hidden,
-                intermediate,
-                vb.pp("intermediate_query.dense"),
-            )?,
-            output_query_dense: linear(
-                intermediate,
-                hidden,
-                vb.pp("output_query.dense"),
-            )?,
+            intermediate_query: linear(hidden, intermediate, vb.pp("intermediate_query.dense"))?,
+            output_query_dense: linear(intermediate, hidden, vb.pp("output_query.dense"))?,
             output_query_norm: layer_norm(
                 hidden,
                 config.projector_config.layer_norm_eps,
@@ -781,10 +818,7 @@ impl GraniteQFormerAttention {
         let mut scores = q.matmul(&k.t()?)?;
         scores = (scores / (self.head_dim as f64).sqrt())?;
         let probs = ops::softmax(&scores.to_dtype(DType::F32)?, D::Minus1)?.to_dtype(q.dtype())?;
-        let context = probs
-            .matmul(&v)?
-            .transpose(1, 2)?
-            .flatten_from(D::Minus2)?;
+        let context = probs.matmul(&v)?.transpose(1, 2)?.flatten_from(D::Minus2)?;
         let out = self.output_dense.forward(&context)?;
         self.output_norm
             .forward(&out.broadcast_add(x)?)
@@ -827,11 +861,8 @@ impl GraniteLanguageModel {
                 vb.pp(format!("model.layers.{idx}")),
             )?);
         }
-        let norm = candle_nn::rms_norm(
-            config.hidden_size,
-            config.rms_norm_eps,
-            vb.pp("model.norm"),
-        )?;
+        let norm =
+            candle_nn::rms_norm(config.hidden_size, config.rms_norm_eps, vb.pp("model.norm"))?;
         let lm_head = if config.tie_word_embeddings {
             Linear::new(embed_tokens.embeddings().clone(), None)
         } else {
@@ -907,11 +938,26 @@ impl GraniteLanguageModel {
         mut cache: Option<&mut Qwen3Cache>,
     ) -> Result<Tensor> {
         let mut x = (embeds * self.cfg.embedding_multiplier as f64)?;
+        let rope = self
+            .layers
+            .first()
+            .map(|layer| {
+                build_rope_cache(
+                    x.dim(1)?,
+                    layer.self_attn.head_dim,
+                    start_pos,
+                    layer.self_attn.rope_theta,
+                    x.device(),
+                    x.dtype(),
+                )
+            })
+            .transpose()?;
         for (idx, layer) in self.layers.iter().enumerate() {
             let cache_ref = cache.as_deref_mut();
-            x = layer.forward(&x, start_pos, cache_ref, idx)?;
+            x = layer.forward(&x, start_pos, cache_ref, idx, rope.as_ref())?;
         }
         let hidden = self.norm.forward(&x)?;
+        let hidden = last_hidden_for_logits(&hidden)?;
         let logits = self.lm_head.forward(&hidden)?;
         (logits / self.cfg.logits_scaling as f64)
             .and_then(|tensor| tensor.to_dtype(DType::F32))
@@ -952,10 +998,13 @@ impl GraniteDecoderLayer {
         start_pos: usize,
         cache: Option<&mut Qwen3Cache>,
         layer_idx: usize,
+        rope: Option<&(Tensor, Tensor)>,
     ) -> Result<Tensor> {
         let residual = x;
         let normed = self.input_layernorm.forward(x)?;
-        let attn = self.self_attn.forward(&normed, start_pos, cache, layer_idx)?;
+        let attn = self
+            .self_attn
+            .forward(&normed, start_pos, cache, layer_idx, rope)?;
         let x = residual.broadcast_add(&(attn * self.residual_multiplier as f64)?)?;
         let residual = &x;
         let normed = self.post_attention_layernorm.forward(&x)?;
@@ -1016,28 +1065,32 @@ impl GraniteTextAttention {
         start_pos: usize,
         cache: Option<&mut Qwen3Cache>,
         layer_idx: usize,
+        rope: Option<&(Tensor, Tensor)>,
     ) -> Result<Tensor> {
         let (batch, seq_len, _) = x.dims3()?;
-        let mut q = self
-            .q_proj
-            .forward(x)?
-            .reshape((batch, seq_len, self.num_heads, self.head_dim))?;
-        let mut k = self
-            .k_proj
-            .forward(x)?
-            .reshape((batch, seq_len, self.num_kv_heads, self.head_dim))?;
-        let v = self
-            .v_proj
-            .forward(x)?
-            .reshape((batch, seq_len, self.num_kv_heads, self.head_dim))?;
-        let (cos, sin) = build_rope_cache(
-            seq_len,
-            self.head_dim,
-            start_pos,
-            self.rope_theta,
-            x.device(),
-            q.dtype(),
-        )?;
+        let mut q =
+            self.q_proj
+                .forward(x)?
+                .reshape((batch, seq_len, self.num_heads, self.head_dim))?;
+        let mut k =
+            self.k_proj
+                .forward(x)?
+                .reshape((batch, seq_len, self.num_kv_heads, self.head_dim))?;
+        let v =
+            self.v_proj
+                .forward(x)?
+                .reshape((batch, seq_len, self.num_kv_heads, self.head_dim))?;
+        let (cos, sin) = match rope {
+            Some((cos, sin)) => (cos.clone(), sin.clone()),
+            None => build_rope_cache(
+                seq_len,
+                self.head_dim,
+                start_pos,
+                self.rope_theta,
+                x.device(),
+                q.dtype(),
+            )?,
+        };
         q = apply_rotary_emb(&q, &cos, &sin)?;
         k = apply_rotary_emb(&k, &cos, &sin)?;
         let (k, v, total_len) = if let Some(cache) = cache {
@@ -1119,6 +1172,21 @@ fn apply_rotary_emb(x: &Tensor, cos_half: &Tensor, sin_half: &Tensor) -> Result<
     Tensor::cat(&[first, second], 3).map_err(Error::from)
 }
 
+fn last_hidden_for_logits(hidden: &Tensor) -> Result<Tensor> {
+    match hidden.dims() {
+        [batch, seq, dim] if *seq > 0 => hidden
+            .narrow(1, seq - 1, 1)?
+            .reshape((*batch, 1, *dim))
+            .map_err(Error::from),
+        [_, 0, _] => Err(Error::InferenceError(
+            "Granite Speech hidden sequence is empty".to_string(),
+        )),
+        dims => Err(Error::InferenceError(format!(
+            "Granite Speech hidden states expected [batch,seq,dim], got {dims:?}"
+        ))),
+    }
+}
+
 fn text_attention(
     q: &Tensor,
     k: &Tensor,
@@ -1143,7 +1211,10 @@ fn text_attention(
     attn.matmul(&v_heads)?
         .transpose(1, 2)
         .map_err(Error::from)
-        .and_then(|out| out.reshape((q.dim(0)?, q.dim(1)?, num_heads, head_dim)).map_err(Error::from))
+        .and_then(|out| {
+            out.reshape((q.dim(0)?, q.dim(1)?, num_heads, head_dim))
+                .map_err(Error::from)
+        })
 }
 
 fn dense_decode_attention_scaled(
@@ -1178,18 +1249,34 @@ struct GraniteTextMlp {
 impl GraniteTextMlp {
     fn load(config: &GraniteTextConfig, vb: VarBuilder) -> Result<Self> {
         Ok(Self {
-            gate_proj: linear_no_bias(config.hidden_size, config.intermediate_size, vb.pp("gate_proj"))?,
-            up_proj: linear_no_bias(config.hidden_size, config.intermediate_size, vb.pp("up_proj"))?,
-            down_proj: linear_no_bias(config.intermediate_size, config.hidden_size, vb.pp("down_proj"))?,
+            gate_proj: linear_no_bias(
+                config.hidden_size,
+                config.intermediate_size,
+                vb.pp("gate_proj"),
+            )?,
+            up_proj: linear_no_bias(
+                config.hidden_size,
+                config.intermediate_size,
+                vb.pp("up_proj"),
+            )?,
+            down_proj: linear_no_bias(
+                config.intermediate_size,
+                config.hidden_size,
+                vb.pp("down_proj"),
+            )?,
         })
     }
 
     fn forward(&self, x: &Tensor) -> Result<Tensor> {
-        let gate = self.gate_proj.forward(x)?.silu()?;
+        let gate = self.gate_proj.forward(x)?;
         let up = self.up_proj.forward(x)?;
-        self.down_proj
-            .forward(&gate.broadcast_mul(&up)?)
-            .map_err(Error::from)
+        let hidden = if let Some(fused) = try_fused_silu_mul(&gate, &up) {
+            fused
+        } else {
+            let gate = gate.silu()?;
+            gate.broadcast_mul(&up)?
+        };
+        self.down_proj.forward(&hidden).map_err(Error::from)
     }
 }
 
@@ -1241,7 +1328,10 @@ mod tests {
         assert_eq!(heads.dims(), &[1, 1, 8, 200, 128]);
         assert!(heads.is_contiguous());
         assert_eq!(heads.stride(), &[204800, 204800, 25600, 128, 1]);
-        assert_eq!(heads.t().unwrap().stride(), &[204800, 204800, 25600, 1, 128]);
+        assert_eq!(
+            heads.t().unwrap().stride(),
+            &[204800, 204800, 25600, 1, 128]
+        );
     }
 
     #[test]
@@ -1304,7 +1394,10 @@ mod tests {
     #[test]
     fn stop_sequence_truncates_generated_text() {
         let mut text = "hello<stop>ignored".to_string();
-        assert!(truncate_at_stop_sequence(&mut text, &["<stop>".to_string()]));
+        assert!(truncate_at_stop_sequence(
+            &mut text,
+            &["<stop>".to_string()]
+        ));
         assert_eq!(text, "hello");
     }
 }

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
@@ -823,13 +823,17 @@ impl GraniteQFormerAttention {
         let q = self.transpose_for_scores(&self.query.forward(x)?)?;
         let k = self.transpose_for_scores(&self.key.forward(kv_input)?)?;
         let v = self.transpose_for_scores(&self.value.forward(kv_input)?)?;
-        if let Some(context) = try_fused_self_attention(&q, &k, &v, None, self.head_dim, false)? {
-            let context = context.transpose(1, 2)?.flatten_from(D::Minus2)?;
-            let out = self.output_dense.forward(&context)?;
-            return self
-                .output_norm
-                .forward(&out.broadcast_add(x)?)
-                .map_err(Error::from);
+        if granite_qformer_fused_attention_allowed(q.device()) {
+            if let Some(context) =
+                try_fused_self_attention(&q, &k, &v, None, self.head_dim, false)?
+            {
+                let context = context.transpose(1, 2)?.flatten_from(D::Minus2)?;
+                let out = self.output_dense.forward(&context)?;
+                return self
+                    .output_norm
+                    .forward(&out.broadcast_add(x)?)
+                    .map_err(Error::from);
+            }
         }
         let mut scores = q.matmul(&k.t()?)?;
         scores = (scores / (self.head_dim as f64).sqrt())?;
@@ -1167,6 +1171,10 @@ fn granite_dense_head_decode_allowed(device: &Device) -> bool {
     device.is_cuda()
 }
 
+fn granite_qformer_fused_attention_allowed(device: &Device) -> bool {
+    device.is_cuda()
+}
+
 fn build_rope_cache(
     seq_len: usize,
     head_dim: usize,
@@ -1494,6 +1502,11 @@ mod tests {
     #[test]
     fn dense_head_decode_policy_skips_cpu() {
         assert!(!granite_dense_head_decode_allowed(&Device::Cpu));
+    }
+
+    #[test]
+    fn qformer_fused_attention_policy_skips_cpu() {
+        assert!(!granite_qformer_fused_attention_allowed(&Device::Cpu));
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
@@ -161,8 +161,7 @@ impl GraniteSpeechRuntime {
         let stop_tokens = stop_token_set(special_tokens, extra_stop_token_ids);
         let decode_start = Instant::now();
 
-        let max_steps = max_new_tokens.max(1);
-        for step in 0..max_steps {
+        for step in 0..max_new_tokens.max(1) {
             let token = argmax_last_logits(&logits)?;
             if stop_tokens.contains(&token) {
                 stop_reason = "stop_token".to_string();
@@ -182,9 +181,6 @@ impl GraniteSpeechRuntime {
             }
             rendered = next_text;
             if stopped_on_sequence {
-                break;
-            }
-            if step + 1 == max_steps {
                 break;
             }
 

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
@@ -29,6 +29,7 @@ pub struct GraniteSpeechGenerationStats {
     pub stop_reason: String,
     pub stop_token: Option<u32>,
     pub dense_decode_cache_enabled: bool,
+    pub dense_head_decode_enabled: bool,
     pub dense_decode_max_tokens: usize,
     pub timings: GraniteSpeechGenerationTimings,
 }
@@ -139,6 +140,8 @@ impl GraniteSpeechRuntime {
         );
         let dense_decode_max_tokens = cache.dense_decode_max_tokens();
         let dense_decode_cache_enabled = dense_decode_max_tokens > 0;
+        let dense_head_decode_enabled =
+            dense_decode_cache_enabled && granite_dense_head_decode_allowed(&self.device);
         let prefill_start = Instant::now();
         let mut logits = self.text_model.forward_prompt_with_audio(
             &input_ids,
@@ -195,6 +198,7 @@ impl GraniteSpeechRuntime {
                 stop_reason,
                 stop_token,
                 dense_decode_cache_enabled,
+                dense_head_decode_enabled,
                 dense_decode_max_tokens,
                 timings: GraniteSpeechGenerationTimings { prefill, decode },
             },

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
@@ -161,7 +161,8 @@ impl GraniteSpeechRuntime {
         let stop_tokens = stop_token_set(special_tokens, extra_stop_token_ids);
         let decode_start = Instant::now();
 
-        for step in 0..max_new_tokens.max(1) {
+        let max_steps = max_new_tokens.max(1);
+        for step in 0..max_steps {
             let token = argmax_last_logits(&logits)?;
             if stop_tokens.contains(&token) {
                 stop_reason = "stop_token".to_string();
@@ -181,6 +182,9 @@ impl GraniteSpeechRuntime {
             }
             rendered = next_text;
             if stopped_on_sequence {
+                break;
+            }
+            if step + 1 == max_steps {
                 break;
             }
 

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
@@ -15,6 +15,7 @@ use crate::error::{Error, Result};
 use crate::kernels::try_fused_silu_mul;
 use crate::models::architectures::qwen3::core::{causal_mask, repeat_kv, Qwen3Cache};
 use crate::models::shared::attention::paged::default_kv_page_size;
+use crate::models::shared::telemetry::{record_decode_attention_path, DecodeAttentionPath};
 
 use super::config::{GraniteSpeechConfig, GraniteSpeechEncoderConfig, GraniteTextConfig};
 use super::preprocessor::GraniteSpeechAudioFeatures;
@@ -269,13 +270,15 @@ fn argmax_last_logits(logits: &Tensor) -> Result<u32> {
             )));
         }
     };
-    let values = last.to_dtype(DType::F32)?.to_vec1::<f32>()?;
-    let (idx, _) = values
-        .iter()
-        .enumerate()
-        .max_by(|(_, a), (_, b)| a.total_cmp(b))
-        .ok_or_else(|| Error::InferenceError("Granite Speech empty logits".to_string()))?;
-    Ok(idx as u32)
+    let idx = last.argmax(D::Minus1)?;
+    let idx = if idx.rank() == 0 {
+        idx
+    } else {
+        idx.squeeze(0)?
+    };
+    idx.to_dtype(DType::U32)?
+        .to_scalar::<u32>()
+        .map_err(Error::from)
 }
 
 struct GraniteSpeechEncoder {
@@ -1095,6 +1098,22 @@ impl GraniteTextAttention {
         k = apply_rotary_emb(&k, &cos, &sin)?;
         let (k, v, total_len) = if let Some(cache) = cache {
             cache.append(layer_idx, k.clone(), v.clone())?;
+            if seq_len == 1 && start_pos > 0 {
+                if let Some((k_heads, v_heads)) = cache.dense_heads(layer_idx) {
+                    record_decode_attention_path(DecodeAttentionPath::Dense);
+                    let out = dense_decode_attention_heads_scaled(
+                        &q,
+                        k_heads,
+                        v_heads,
+                        self.num_heads,
+                        self.num_kv_heads,
+                        self.head_dim,
+                        self.attention_multiplier,
+                    )?;
+                    let out = out.reshape((batch, seq_len, self.num_heads * self.head_dim))?;
+                    return self.o_proj.forward(&out).map_err(Error::from);
+                }
+            }
             let (cached_k, cached_v) = cache.materialize(layer_idx)?;
             let total_len = cached_k.dim(1)?;
             (cached_k, cached_v, total_len)
@@ -1240,6 +1259,41 @@ fn dense_decode_attention_scaled(
         .map_err(Error::from)
 }
 
+fn dense_decode_attention_heads_scaled(
+    q: &Tensor,
+    k_heads: &Tensor,
+    v_heads: &Tensor,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    attention_multiplier: f32,
+) -> Result<Tensor> {
+    let q_heads = q.transpose(1, 2)?.contiguous()?;
+    let k_heads = if num_heads == num_kv_heads {
+        k_heads.clone()
+    } else {
+        let k = k_heads.transpose(1, 2)?.contiguous()?;
+        repeat_kv(&k, num_heads, num_kv_heads)?
+            .transpose(1, 2)?
+            .contiguous()?
+    };
+    let v_heads = if num_heads == num_kv_heads {
+        v_heads.clone()
+    } else {
+        let v = v_heads.transpose(1, 2)?.contiguous()?;
+        repeat_kv(&v, num_heads, num_kv_heads)?
+            .transpose(1, 2)?
+            .contiguous()?
+    };
+    let mut attn = q_heads.matmul(&k_heads.t()?)?;
+    attn = (attn * attention_multiplier as f64)?;
+    let attn = ops::softmax(&attn.to_dtype(DType::F32)?, D::Minus1)?.to_dtype(q.dtype())?;
+    let out = attn.matmul(&v_heads)?;
+    out.transpose(1, 2)?
+        .reshape((q.dim(0)?, q.dim(1)?, num_heads, head_dim))
+        .map_err(Error::from)
+}
+
 struct GraniteTextMlp {
     gate_proj: Linear,
     up_proj: Linear,
@@ -1353,6 +1407,71 @@ mod tests {
         assert!(heads.is_contiguous());
         assert_eq!(heads.stride(), &[15360, 960, 64, 1]);
         assert_eq!(heads.t().unwrap().stride(), &[15360, 960, 1, 64]);
+    }
+
+    #[test]
+    fn dense_head_decode_matches_materialized_scaled_attention() {
+        let device = Device::Cpu;
+        let num_heads = 4;
+        let num_kv_heads = 2;
+        let head_dim = 2;
+        let attention_multiplier = 0.37;
+        let q = Tensor::from_vec(
+            vec![0.2f32, -0.4, 0.1, 0.8, -0.3, 0.7, 0.5, -0.6],
+            (1, 1, num_heads, head_dim),
+            &device,
+        )
+        .unwrap();
+        let k = Tensor::from_vec(
+            vec![
+                0.1f32, 0.2, -0.3, 0.4, 0.5, -0.2, //
+                -0.6, 0.7, 0.2, -0.1, 0.3, 0.9,
+            ],
+            (1, 3, num_kv_heads, head_dim),
+            &device,
+        )
+        .unwrap();
+        let v = Tensor::from_vec(
+            vec![
+                -0.2f32, 0.4, 0.6, -0.1, 0.8, 0.3, //
+                0.5, -0.7, -0.4, 0.2, 0.1, 0.9,
+            ],
+            (1, 3, num_kv_heads, head_dim),
+            &device,
+        )
+        .unwrap();
+        let k_heads = k.transpose(1, 2).unwrap().contiguous().unwrap();
+        let v_heads = v.transpose(1, 2).unwrap().contiguous().unwrap();
+
+        let materialized = dense_decode_attention_scaled(
+            &q,
+            &k,
+            &v,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            attention_multiplier,
+        )
+        .unwrap();
+        let dense_heads = dense_decode_attention_heads_scaled(
+            &q,
+            &k_heads,
+            &v_heads,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            attention_multiplier,
+        )
+        .unwrap();
+        let lhs = materialized.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let rhs = dense_heads.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let max_diff = lhs
+            .iter()
+            .zip(rhs.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+
+        assert!(max_diff < 1e-6, "max diff {max_diff}");
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
+++ b/crates/izwi-core/src/models/architectures/granite_speech/asr/runtime.rs
@@ -3,22 +3,22 @@
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-use candle_core::{DType, Device, Tensor, D};
+use candle_core::{D, DType, Device, Tensor};
 use candle_nn::{
-    batch_norm, conv1d, conv1d_no_bias, embedding, layer_norm, linear, linear_no_bias, ops,
     BatchNorm, Conv1d, Conv1dConfig, Embedding, LayerNorm, Linear, Module, ModuleT, RmsNorm,
-    VarBuilder,
+    VarBuilder, batch_norm, conv1d, conv1d_no_bias, embedding, layer_norm, linear, linear_no_bias,
+    ops,
 };
 
 use crate::backends::DeviceProfile;
 use crate::error::{Error, Result};
 use crate::kernels::try_fused_silu_mul;
-use crate::models::architectures::qwen3::core::{causal_mask, repeat_kv, Qwen3Cache};
+use crate::models::architectures::qwen3::core::{Qwen3Cache, causal_mask, repeat_kv};
 use crate::models::shared::attention::flash::{
     try_fused_self_attention, try_fused_self_attention_scaled,
 };
 use crate::models::shared::attention::paged::default_kv_page_size;
-use crate::models::shared::telemetry::{record_decode_attention_path, DecodeAttentionPath};
+use crate::models::shared::telemetry::{DecodeAttentionPath, record_decode_attention_path};
 
 use super::config::{GraniteSpeechConfig, GraniteSpeechEncoderConfig, GraniteTextConfig};
 use super::preprocessor::GraniteSpeechAudioFeatures;
@@ -29,6 +29,7 @@ pub struct GraniteSpeechGenerationStats {
     pub prompt_tokens: usize,
     pub audio_tokens: usize,
     pub generated_tokens: usize,
+    pub max_new_tokens: usize,
     pub stop_reason: String,
     pub stop_token: Option<u32>,
     pub dense_decode_cache_enabled: bool,
@@ -245,6 +246,7 @@ impl GraniteSpeechRuntime {
                 prompt_tokens: input_ids.len(),
                 audio_tokens,
                 generated_tokens: generated.len(),
+                max_new_tokens,
                 stop_reason,
                 stop_token,
                 dense_decode_cache_enabled,

--- a/crates/izwi-core/src/models/architectures/qwen3/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/qwen3/asr/mod.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 use serde_json::json;
 use tracing::{debug, info, warn};
 
-use crate::audio::{MelConfig, MelSpectrogram};
+use crate::audio::{MelConfig, MelNorm, MelScale, MelSpectrogram};
 use crate::backends::{backend_kind_for_device, DTypeSelectionRequest, DeviceKind, DeviceProfile};
 use crate::catalog::ModelFamily;
 use crate::error::{Error, Result};
@@ -335,6 +335,8 @@ impl Qwen3AsrModel {
             f_min: 0.0,
             f_max: 8_000.0,
             normalize: true,
+            mel_scale: MelScale::Slaney,
+            mel_norm: MelNorm::Slaney,
         };
         let mel = MelSpectrogram::new(mel_cfg)?;
 

--- a/crates/izwi-core/src/models/architectures/voxtral/realtime/model.rs
+++ b/crates/izwi-core/src/models/architectures/voxtral/realtime/model.rs
@@ -7,7 +7,7 @@ use candle_core::{DType, IndexOp, Tensor};
 use candle_nn::{Module, VarBuilder};
 use tracing::info;
 
-use crate::audio::{MelConfig, MelSpectrogram};
+use crate::audio::{MelConfig, MelNorm, MelScale, MelSpectrogram};
 use crate::backends::{DeviceKind, DeviceProfile};
 use crate::catalog::ModelFamily;
 use crate::error::{Error, Result};
@@ -107,6 +107,8 @@ impl VoxtralRealtimeModel {
             f_min: 0.0,
             f_max: 8000.0,
             normalize: audio_cfg.global_log_mel_max.is_none(),
+            mel_scale: MelScale::Slaney,
+            mel_norm: MelNorm::Slaney,
         };
         let mel = MelSpectrogram::new(mel_cfg)?;
 

--- a/crates/izwi-core/src/models/architectures/whisper/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/whisper/asr/mod.rs
@@ -23,7 +23,7 @@ use serde::Deserialize;
 use serde_json::json;
 use tracing::{debug, info};
 
-use crate::audio::{MelConfig, MelSpectrogram};
+use crate::audio::{MelConfig, MelNorm, MelScale, MelSpectrogram};
 use crate::backends::{DeviceKind, DeviceProfile};
 use crate::catalog::ModelFamily;
 use crate::error::{Error, Result};
@@ -428,6 +428,8 @@ impl WhisperTurboAsrModel {
             f_min: 0.0,
             f_max: (whisper::SAMPLE_RATE / 2) as f32,
             normalize: true,
+            mel_scale: MelScale::Slaney,
+            mel_norm: MelNorm::Slaney,
         })?;
 
         info!(

--- a/crates/izwi-core/src/models/shared/attention/flash.rs
+++ b/crates/izwi-core/src/models/shared/attention/flash.rs
@@ -153,13 +153,30 @@ pub fn try_fused_self_attention(
     head_dim: usize,
     causal: bool,
 ) -> Result<Option<Tensor>> {
-    try_fused_self_attention_with_options(
+    let scale = 1.0f32 / (head_dim as f32).sqrt();
+    try_fused_self_attention_scaled(q, k, v, mask, head_dim, causal, scale)
+}
+
+/// Try a fused self-attention kernel with an explicit attention score scale.
+///
+/// Input/output layout: `[batch, heads, seq, head_dim]`.
+pub fn try_fused_self_attention_scaled(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    mask: Option<&Tensor>,
+    head_dim: usize,
+    causal: bool,
+    scale: f32,
+) -> Result<Option<Tensor>> {
+    try_fused_self_attention_with_options_and_scale(
         q,
         k,
         v,
         mask,
         head_dim,
         causal,
+        scale,
         CudaFlashAttentionOptions::default(),
     )
 }
@@ -179,6 +196,28 @@ pub fn try_fused_self_attention_with_options(
     cuda_options: CudaFlashAttentionOptions<'_>,
 ) -> Result<Option<Tensor>> {
     let scale = 1.0f32 / (head_dim as f32).sqrt();
+    try_fused_self_attention_with_options_and_scale(
+        q,
+        k,
+        v,
+        mask,
+        head_dim,
+        causal,
+        scale,
+        cuda_options,
+    )
+}
+
+fn try_fused_self_attention_with_options_and_scale(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    mask: Option<&Tensor>,
+    head_dim: usize,
+    causal: bool,
+    scale: f32,
+    cuda_options: CudaFlashAttentionOptions<'_>,
+) -> Result<Option<Tensor>> {
     let masked = mask.is_some();
     record_fused_attention_attempt();
     if masked {

--- a/crates/izwi-core/src/runtime/asr.rs
+++ b/crates/izwi-core/src/runtime/asr.rs
@@ -19,10 +19,10 @@ enum AsrAudioInput<'a> {
     Bytes(&'a [u8]),
 }
 
-const GRANITE_ASR_AUTO_MIN_TOKENS: usize = 96;
+const GRANITE_ASR_AUTO_MIN_TOKENS: usize = 76;
 const GRANITE_ASR_AUTO_MAX_TOKENS: usize = 2048;
+const GRANITE_ASR_AUTO_BASE_SECONDS: f32 = 28.0;
 const GRANITE_ASR_AUTO_TOKENS_PER_SECOND: f32 = 4.0;
-const GRANITE_ASR_AUTO_TOKEN_MARGIN: usize = 16;
 
 fn resolve_asr_realtime_stream_variant(model_id: Option<&str>) -> Option<ModelVariant> {
     let variant = resolve_asr_model_variant(model_id);
@@ -30,13 +30,15 @@ fn resolve_asr_realtime_stream_variant(model_id: Option<&str>) -> Option<ModelVa
 }
 
 fn granite_auto_asr_max_tokens_for_duration(audio_seconds: f32) -> usize {
-    let duration_budget = if audio_seconds.is_finite() && audio_seconds > 0.0 {
-        (audio_seconds * GRANITE_ASR_AUTO_TOKENS_PER_SECOND).ceil() as usize
-    } else {
-        0
-    };
-    duration_budget
-        .saturating_add(GRANITE_ASR_AUTO_TOKEN_MARGIN)
+    let duration_budget =
+        if audio_seconds.is_finite() && audio_seconds > GRANITE_ASR_AUTO_BASE_SECONDS {
+            ((audio_seconds - GRANITE_ASR_AUTO_BASE_SECONDS) * GRANITE_ASR_AUTO_TOKENS_PER_SECOND)
+                .ceil() as usize
+        } else {
+            0
+        };
+    GRANITE_ASR_AUTO_MIN_TOKENS
+        .saturating_add(duration_budget)
         .clamp(GRANITE_ASR_AUTO_MIN_TOKENS, GRANITE_ASR_AUTO_MAX_TOKENS)
 }
 
@@ -1065,11 +1067,13 @@ mod tests {
 
     #[test]
     fn granite_auto_asr_budget_scales_with_audio_duration() {
-        assert_eq!(granite_auto_asr_max_tokens_for_duration(0.0), 96);
-        assert_eq!(granite_auto_asr_max_tokens_for_duration(3.6), 96);
-        assert_eq!(granite_auto_asr_max_tokens_for_duration(27.303175), 126);
-        assert_eq!(granite_auto_asr_max_tokens_for_duration(60.0), 256);
+        assert_eq!(granite_auto_asr_max_tokens_for_duration(0.0), 76);
+        assert_eq!(granite_auto_asr_max_tokens_for_duration(3.6), 76);
+        assert_eq!(granite_auto_asr_max_tokens_for_duration(27.303175), 76);
+        assert_eq!(granite_auto_asr_max_tokens_for_duration(28.0), 76);
+        assert_eq!(granite_auto_asr_max_tokens_for_duration(60.0), 204);
         assert_eq!(granite_auto_asr_max_tokens_for_duration(600.0), 2048);
+        assert_eq!(granite_auto_asr_max_tokens_for_duration(1200.0), 2048);
     }
 
     #[tokio::test]

--- a/crates/izwi-core/src/runtime/asr.rs
+++ b/crates/izwi-core/src/runtime/asr.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use crate::catalog::{parse_model_variant, resolve_asr_model_variant, ModelFamily};
+use crate::catalog::{ModelFamily, parse_model_variant, resolve_asr_model_variant};
 use crate::engine::EngineCoreRequest;
 use crate::error::{Error, Result};
 use crate::model::{ModelResidencyLease, ModelVariant};
@@ -13,14 +13,53 @@ use crate::runtime::request::{AlignmentRuntimeRequest, AsrRuntimeRequest};
 use crate::runtime::service::RuntimeService;
 use crate::runtime::types::AsrTranscription;
 
+#[derive(Clone, Copy)]
 enum AsrAudioInput<'a> {
     Base64(&'a str),
     Bytes(&'a [u8]),
 }
 
+const GRANITE_ASR_AUTO_MIN_TOKENS: usize = 96;
+const GRANITE_ASR_AUTO_MAX_TOKENS: usize = 2048;
+const GRANITE_ASR_AUTO_TOKENS_PER_SECOND: f32 = 4.0;
+const GRANITE_ASR_AUTO_TOKEN_MARGIN: usize = 16;
+
 fn resolve_asr_realtime_stream_variant(model_id: Option<&str>) -> Option<ModelVariant> {
     let variant = resolve_asr_model_variant(model_id);
     (variant.family() == ModelFamily::NemotronAsr).then_some(variant)
+}
+
+fn granite_auto_asr_max_tokens_for_duration(audio_seconds: f32) -> usize {
+    let duration_budget = if audio_seconds.is_finite() && audio_seconds > 0.0 {
+        (audio_seconds * GRANITE_ASR_AUTO_TOKENS_PER_SECOND).ceil() as usize
+    } else {
+        0
+    };
+    duration_budget
+        .saturating_add(GRANITE_ASR_AUTO_TOKEN_MARGIN)
+        .clamp(GRANITE_ASR_AUTO_MIN_TOKENS, GRANITE_ASR_AUTO_MAX_TOKENS)
+}
+
+fn granite_auto_asr_max_tokens(
+    variant: ModelVariant,
+    audio_input: AsrAudioInput<'_>,
+) -> Result<Option<usize>> {
+    if variant.family() != ModelFamily::GraniteSpeechAsr {
+        return Ok(None);
+    }
+    let audio_bytes = match audio_input {
+        AsrAudioInput::Base64(audio_base64) => base64_decode(audio_base64)?,
+        AsrAudioInput::Bytes(audio_bytes) => audio_bytes.to_vec(),
+    };
+    let (samples, sample_rate) = decode_audio_bytes(&audio_bytes)?;
+    let audio_seconds = if sample_rate > 0 {
+        samples.len() as f32 / sample_rate as f32
+    } else {
+        0.0
+    };
+    Ok(Some(granite_auto_asr_max_tokens_for_duration(
+        audio_seconds,
+    )))
 }
 
 pub struct RuntimeAsrRealtimeStream {
@@ -202,6 +241,8 @@ impl RuntimeService {
         let mut request = runtime_request.into_engine_request();
         if let Some(max_tokens) = max_tokens {
             request.params.max_tokens = max_tokens;
+        } else if let Some(auto_max_tokens) = granite_auto_asr_max_tokens(variant, audio_input)? {
+            request.params.max_tokens = auto_max_tokens;
         }
         Ok(request)
     }
@@ -1020,6 +1061,15 @@ mod tests {
             resolve_asr_realtime_stream_variant(Some("not-a-real-model")),
             None
         );
+    }
+
+    #[test]
+    fn granite_auto_asr_budget_scales_with_audio_duration() {
+        assert_eq!(granite_auto_asr_max_tokens_for_duration(0.0), 96);
+        assert_eq!(granite_auto_asr_max_tokens_for_duration(3.6), 96);
+        assert_eq!(granite_auto_asr_max_tokens_for_duration(27.303175), 126);
+        assert_eq!(granite_auto_asr_max_tokens_for_duration(60.0), 256);
+        assert_eq!(granite_auto_asr_max_tokens_for_duration(600.0), 2048);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fix Granite transcription truncation and add diagnostics, benchmark controls, dense/fused decode paths, adaptive decode limits, pipelined decoding, Metal support, and short-audio embedding caching to reduce diarization ASR below RTF 1 while preserving dtype behavior.