### PR TITLE
Optimize Nemotron ASR on Metal with native depthwise kernels

### DIFF
--- a/crates/izwi-cli/src/commands/bench.rs
+++ b/crates/izwi-cli/src/commands/bench.rs
@@ -2,10 +2,10 @@ use crate::error::{CliError, Result};
 use crate::http;
 use crate::style::Theme;
 use crate::{BenchCommands, OutputFormat};
-use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
 use chrono::{DateTime, Utc};
-use futures::{StreamExt, stream};
+use futures::{stream, StreamExt};
 use indicatif::{ProgressBar, ProgressStyle};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
@@ -148,7 +148,15 @@ struct AsrBenchSample {
 struct AsrStageTimings {
     audio_decode: Option<f64>,
     mel_prepare: Option<f64>,
+    feature_extract: Option<f64>,
+    feature_upload: Option<f64>,
+    subsample: Option<f64>,
     encoder_forward: Option<f64>,
+    encoder_ffn: Option<f64>,
+    encoder_attention: Option<f64>,
+    encoder_conv: Option<f64>,
+    encoder_norm: Option<f64>,
+    prompt_kernel: Option<f64>,
     language_detect: Option<f64>,
     resample: Option<f64>,
     mel: Option<f64>,
@@ -160,6 +168,9 @@ struct AsrStageTimings {
     audio_tokens: Option<u64>,
     generated_tokens: Option<u64>,
     max_new_tokens: Option<u64>,
+    rnnt_joint_steps: Option<u64>,
+    host_argmax_reads: Option<u64>,
+    device_argmax_reads: Option<u64>,
     execution: Option<AsrExecutionDiagnostics>,
 }
 
@@ -995,7 +1006,11 @@ fn summary_metric(summary: &serde_json::Value, path: &[&str]) -> Option<f64> {
 
 fn percent_change(current: f64, baseline: f64) -> f64 {
     if baseline == 0.0 {
-        if current == 0.0 { 0.0 } else { f64::INFINITY }
+        if current == 0.0 {
+            0.0
+        } else {
+            f64::INFINITY
+        }
     } else {
         (current - baseline) * 100.0 / baseline
     }
@@ -1867,9 +1882,8 @@ async fn bench_asr(
                 saw_whisper_diagnostics = true;
             }
             stage_samples.extend(collect_asr_stage_timings_from_diagnostics(diagnostics));
-            decode_profile_samples.extend(collect_asr_decode_profiles_from_diagnostics(
-                diagnostics,
-            ));
+            decode_profile_samples
+                .extend(collect_asr_decode_profiles_from_diagnostics(diagnostics));
         }
     }
 
@@ -2568,8 +2582,24 @@ fn asr_stage_timings_from_diagnostics(diagnostics: &serde_json::Value) -> Option
     Some(AsrStageTimings {
         audio_decode: timings.get("audio_decode").and_then(|value| value.as_f64()),
         mel_prepare: timings.get("mel_prepare").and_then(|value| value.as_f64()),
+        feature_extract: timings
+            .get("feature_extract")
+            .and_then(|value| value.as_f64()),
+        feature_upload: timings
+            .get("feature_upload")
+            .and_then(|value| value.as_f64()),
+        subsample: timings.get("subsample").and_then(|value| value.as_f64()),
         encoder_forward: timings
             .get("encoder_forward")
+            .and_then(|value| value.as_f64()),
+        encoder_ffn: timings.get("encoder_ffn").and_then(|value| value.as_f64()),
+        encoder_attention: timings
+            .get("encoder_attention")
+            .and_then(|value| value.as_f64()),
+        encoder_conv: timings.get("encoder_conv").and_then(|value| value.as_f64()),
+        encoder_norm: timings.get("encoder_norm").and_then(|value| value.as_f64()),
+        prompt_kernel: timings
+            .get("prompt_kernel")
             .and_then(|value| value.as_f64()),
         language_detect: timings
             .get("language_detect")
@@ -2596,6 +2626,9 @@ fn asr_stage_timings_from_diagnostics(diagnostics: &serde_json::Value) -> Option
                     .or_else(|| value.get("max_steps"))
             })
             .and_then(|value| value.as_u64()),
+        rnnt_joint_steps: diagnostic_u64(decode, &["joint_steps", "rnnt_joint_steps"]),
+        host_argmax_reads: diagnostic_u64(decode, &["host_argmax_reads"]),
+        device_argmax_reads: diagnostic_u64(decode, &["device_argmax_reads"]),
         execution,
     })
 }
@@ -2743,13 +2776,19 @@ fn asr_decode_profile_from_diagnostics(
                 &["forward_totals_ms", "token_embedding"],
             ),
             forward_rope_build_ms: summary_metric(profile, &["forward_totals_ms", "rope_build"]),
-            forward_layers_total_ms: summary_metric(profile, &["forward_totals_ms", "layers_total"]),
+            forward_layers_total_ms: summary_metric(
+                profile,
+                &["forward_totals_ms", "layers_total"],
+            ),
             forward_final_norm_ms: summary_metric(profile, &["forward_totals_ms", "final_norm"]),
             forward_lm_head_ms: summary_metric(profile, &["forward_totals_ms", "lm_head"]),
             decoder_total_ms: summary_metric(profile, &["decoder_totals_ms", "total"]),
             attention_qkv_ms: summary_metric(profile, &["decoder_totals_ms", "attention", "qkv"]),
             attention_rope_ms: summary_metric(profile, &["decoder_totals_ms", "attention", "rope"]),
-            attention_cache_ms: summary_metric(profile, &["decoder_totals_ms", "attention", "cache"]),
+            attention_cache_ms: summary_metric(
+                profile,
+                &["decoder_totals_ms", "attention", "cache"],
+            ),
             attention_kernel_ms: summary_metric(
                 profile,
                 &["decoder_totals_ms", "attention", "kernel"],
@@ -2773,7 +2812,9 @@ fn asr_decode_profile_from_diagnostics(
 
     Some(AsrDecodeProfileTimings {
         steps: diagnostic_u64(Some(decode), &["generated_tokens", "generated_token_count"]),
-        step_total_avg_ms: profile.get("step_total_ms").and_then(|value| value.as_f64()),
+        step_total_avg_ms: profile
+            .get("step_total_ms")
+            .and_then(|value| value.as_f64()),
         step_total_p95_ms: None,
         loop_argmax_ms: None,
         loop_scalar_read_ms: profile.get("sampling_ms").and_then(|value| value.as_f64()),
@@ -2786,8 +2827,12 @@ fn asr_decode_profile_from_diagnostics(
         forward_rope_build_ms: None,
         forward_layers_total_ms: None,
         forward_final_norm_ms: None,
-        forward_lm_head_ms: profile.get("final_linear_ms").and_then(|value| value.as_f64()),
-        decoder_total_ms: profile.get("step_total_ms").and_then(|value| value.as_f64()),
+        forward_lm_head_ms: profile
+            .get("final_linear_ms")
+            .and_then(|value| value.as_f64()),
+        decoder_total_ms: profile
+            .get("step_total_ms")
+            .and_then(|value| value.as_f64()),
         attention_qkv_ms: None,
         attention_rope_ms: None,
         attention_cache_ms: None,
@@ -2796,7 +2841,9 @@ fn asr_decode_profile_from_diagnostics(
         mlp_gate_up_ms: None,
         mlp_activation_ms: None,
         mlp_down_ms: None,
-        residual_ms: profile.get("unattributed_ms").and_then(|value| value.as_f64()),
+        residual_ms: profile
+            .get("unattributed_ms")
+            .and_then(|value| value.as_f64()),
     })
 }
 
@@ -2873,7 +2920,15 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
 
     let mut audio_decode = Vec::new();
     let mut mel_prepare = Vec::new();
+    let mut feature_extract = Vec::new();
+    let mut feature_upload = Vec::new();
+    let mut subsample = Vec::new();
     let mut encoder_forward = Vec::new();
+    let mut encoder_ffn = Vec::new();
+    let mut encoder_attention = Vec::new();
+    let mut encoder_conv = Vec::new();
+    let mut encoder_norm = Vec::new();
+    let mut prompt_kernel = Vec::new();
     let mut language_detect = Vec::new();
     let mut resample = Vec::new();
     let mut mel = Vec::new();
@@ -2885,6 +2940,9 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
     let mut audio_tokens = Vec::new();
     let mut generated_tokens = Vec::new();
     let mut max_new_tokens = Vec::new();
+    let mut rnnt_joint_steps = Vec::new();
+    let mut host_argmax_reads = Vec::new();
+    let mut device_argmax_reads = Vec::new();
     let mut cuda_dense_decode_cache = Vec::new();
     let mut dense_head_decode_enabled = Vec::new();
     let mut dense_decode_max_tokens = Vec::new();
@@ -2904,8 +2962,32 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
         if let Some(value) = sample.mel_prepare {
             mel_prepare.push(value);
         }
+        if let Some(value) = sample.feature_extract {
+            feature_extract.push(value);
+        }
+        if let Some(value) = sample.feature_upload {
+            feature_upload.push(value);
+        }
+        if let Some(value) = sample.subsample {
+            subsample.push(value);
+        }
         if let Some(value) = sample.encoder_forward {
             encoder_forward.push(value);
+        }
+        if let Some(value) = sample.encoder_ffn {
+            encoder_ffn.push(value);
+        }
+        if let Some(value) = sample.encoder_attention {
+            encoder_attention.push(value);
+        }
+        if let Some(value) = sample.encoder_conv {
+            encoder_conv.push(value);
+        }
+        if let Some(value) = sample.encoder_norm {
+            encoder_norm.push(value);
+        }
+        if let Some(value) = sample.prompt_kernel {
+            prompt_kernel.push(value);
         }
         if let Some(value) = sample.language_detect {
             language_detect.push(value);
@@ -2939,6 +3021,15 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
         }
         if let Some(value) = sample.max_new_tokens {
             max_new_tokens.push(value);
+        }
+        if let Some(value) = sample.rnnt_joint_steps {
+            rnnt_joint_steps.push(value);
+        }
+        if let Some(value) = sample.host_argmax_reads {
+            host_argmax_reads.push(value);
+        }
+        if let Some(value) = sample.device_argmax_reads {
+            device_argmax_reads.push(value);
         }
         if let Some(execution) = sample.execution {
             if let Some(value) = execution.cuda_dense_decode_cache {
@@ -2979,7 +3070,15 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
 
     if audio_decode.is_empty()
         && mel_prepare.is_empty()
+        && feature_extract.is_empty()
+        && feature_upload.is_empty()
+        && subsample.is_empty()
         && encoder_forward.is_empty()
+        && encoder_ffn.is_empty()
+        && encoder_attention.is_empty()
+        && encoder_conv.is_empty()
+        && encoder_norm.is_empty()
+        && prompt_kernel.is_empty()
         && language_detect.is_empty()
         && resample.is_empty()
         && mel.is_empty()
@@ -2991,6 +3090,9 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
         && audio_tokens.is_empty()
         && generated_tokens.is_empty()
         && max_new_tokens.is_empty()
+        && rnnt_joint_steps.is_empty()
+        && host_argmax_reads.is_empty()
+        && device_argmax_reads.is_empty()
         && cuda_dense_decode_cache.is_empty()
         && dense_head_decode_enabled.is_empty()
         && dense_decode_max_tokens.is_empty()
@@ -3014,7 +3116,15 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
     );
     summarize_stage("audio_decode", &audio_decode);
     summarize_stage("mel_prepare", &mel_prepare);
+    summarize_stage("feature_ext", &feature_extract);
+    summarize_stage("feature_up", &feature_upload);
+    summarize_stage("subsample", &subsample);
     summarize_stage("encoder_fwd", &encoder_forward);
+    summarize_stage("encoder_ffn", &encoder_ffn);
+    summarize_stage("encoder_attn", &encoder_attention);
+    summarize_stage("encoder_conv", &encoder_conv);
+    summarize_stage("encoder_norm", &encoder_norm);
+    summarize_stage("prompt", &prompt_kernel);
     summarize_stage("lang_detect", &language_detect);
     summarize_stage("resample", &resample);
     summarize_stage("mel", &mel);
@@ -3026,6 +3136,9 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
     summarize_count("audio_tokens", &audio_tokens);
     summarize_count("gen_tokens", &generated_tokens);
     summarize_count("max_new_tokens", &max_new_tokens);
+    summarize_count("rnnt_steps", &rnnt_joint_steps);
+    summarize_count("host_argmax", &host_argmax_reads);
+    summarize_count("dev_argmax", &device_argmax_reads);
     summarize_bool_count("cuda_dense", &cuda_dense_decode_cache);
     summarize_bool_count("dense_head", &dense_head_decode_enabled);
     summarize_count("dense_max", &dense_decode_max_tokens);
@@ -3745,10 +3858,9 @@ mod tests {
         .await
         .expect_err("saved and direct references should conflict");
 
-        assert!(
-            err.to_string()
-                .contains("Use either --saved-voice-id or --reference-audio/--reference-text")
-        );
+        assert!(err
+            .to_string()
+            .contains("Use either --saved-voice-id or --reference-audio/--reference-text"));
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/metal_kernels.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/metal_kernels.rs
@@ -1,0 +1,693 @@
+#[cfg(feature = "metal")]
+use std::collections::HashMap;
+#[cfg(feature = "metal")]
+use std::sync::{Mutex, OnceLock};
+
+#[cfg(feature = "metal")]
+use candle_core::{
+    backend::BackendStorage, bail, CpuStorage, CustomOp2, CustomOp3, DType, Layout, MetalStorage,
+    Result as CandleResult, Shape, Tensor,
+};
+
+#[cfg(feature = "metal")]
+use candle_metal_kernels::metal::{ComputePipeline, Device as MetalDevice};
+
+#[cfg(feature = "metal")]
+const NEMOTRON_METAL_SOURCE: &str = r#"
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void nemotron_depthwise_conv1d_f32(
+    device const float* input [[buffer(0)]],
+    device const float* weight [[buffer(1)]],
+    device float* output [[buffer(2)]],
+    constant uint& batch [[buffer(3)]],
+    constant uint& channels [[buffer(4)]],
+    constant uint& input_width [[buffer(5)]],
+    constant uint& output_width [[buffer(6)]],
+    constant uint& kernel_width [[buffer(7)]],
+    constant uint& padding [[buffer(8)]],
+    constant uint& stride [[buffer(9)]],
+    constant uint& dilation [[buffer(10)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    uint total = batch * channels * output_width;
+    if (gid >= total) {
+        return;
+    }
+
+    uint out_t = gid % output_width;
+    uint channel = (gid / output_width) % channels;
+    uint batch_idx = gid / (output_width * channels);
+
+    float acc = 0.0f;
+    int base_t = int(out_t * stride) - int(padding);
+    uint input_batch_base = batch_idx * channels * input_width;
+    uint input_channel_base = input_batch_base + channel * input_width;
+    uint weight_channel_base = channel * kernel_width;
+
+    for (uint k = 0; k < kernel_width; ++k) {
+        int input_t = base_t + int(k * dilation);
+        if (input_t >= 0 && input_t < int(input_width)) {
+            acc += input[input_channel_base + uint(input_t)] * weight[weight_channel_base + k];
+        }
+    }
+
+    output[gid] = acc;
+}
+
+kernel void nemotron_depthwise_conv2d_bias_f32(
+    device const float* input [[buffer(0)]],
+    device const float* weight [[buffer(1)]],
+    device const float* bias [[buffer(2)]],
+    device float* output [[buffer(3)]],
+    constant uint& batch [[buffer(4)]],
+    constant uint& channels [[buffer(5)]],
+    constant uint& input_height [[buffer(6)]],
+    constant uint& input_width [[buffer(7)]],
+    constant uint& output_height [[buffer(8)]],
+    constant uint& output_width [[buffer(9)]],
+    constant uint& kernel_height [[buffer(10)]],
+    constant uint& kernel_width [[buffer(11)]],
+    constant uint& padding [[buffer(12)]],
+    constant uint& stride [[buffer(13)]],
+    constant uint& dilation [[buffer(14)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    uint total = batch * channels * output_height * output_width;
+    if (gid >= total) {
+        return;
+    }
+
+    uint out_w = gid % output_width;
+    uint out_h = (gid / output_width) % output_height;
+    uint channel = (gid / (output_width * output_height)) % channels;
+    uint batch_idx = gid / (output_width * output_height * channels);
+
+    int base_h = int(out_h * stride) - int(padding);
+    int base_w = int(out_w * stride) - int(padding);
+    uint input_batch_base = batch_idx * channels * input_height * input_width;
+    uint input_channel_base = input_batch_base + channel * input_height * input_width;
+    uint weight_channel_base = channel * kernel_height * kernel_width;
+
+    float acc = bias[channel];
+    for (uint kh = 0; kh < kernel_height; ++kh) {
+        int input_h = base_h + int(kh * dilation);
+        if (input_h < 0 || input_h >= int(input_height)) {
+            continue;
+        }
+        for (uint kw = 0; kw < kernel_width; ++kw) {
+            int input_w = base_w + int(kw * dilation);
+            if (input_w >= 0 && input_w < int(input_width)) {
+                uint input_idx = input_channel_base + uint(input_h) * input_width + uint(input_w);
+                uint weight_idx = weight_channel_base + kh * kernel_width + kw;
+                acc += input[input_idx] * weight[weight_idx];
+            }
+        }
+    }
+
+    output[gid] = acc;
+}
+"#;
+
+#[cfg(feature = "metal")]
+#[derive(Debug, Clone, Copy)]
+struct DepthwiseConv1dOp {
+    padding: usize,
+    stride: usize,
+    dilation: usize,
+}
+
+#[cfg(feature = "metal")]
+#[derive(Debug, Clone, Copy)]
+struct DepthwiseConv2dBiasOp {
+    padding: usize,
+    stride: usize,
+    dilation: usize,
+}
+
+#[cfg(feature = "metal")]
+impl CustomOp2 for DepthwiseConv1dOp {
+    fn name(&self) -> &'static str {
+        "nemotron-depthwise-conv1d-metal"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _s1: &CpuStorage,
+        _l1: &Layout,
+        _s2: &CpuStorage,
+        _l2: &Layout,
+    ) -> CandleResult<(CpuStorage, Shape)> {
+        bail!("nemotron-depthwise-conv1d-metal requires a Metal tensor")
+    }
+
+    fn metal_fwd(
+        &self,
+        input_storage: &MetalStorage,
+        input_layout: &Layout,
+        weight_storage: &MetalStorage,
+        weight_layout: &Layout,
+    ) -> CandleResult<(MetalStorage, Shape)> {
+        if input_storage.dtype() != DType::F32 || weight_storage.dtype() != DType::F32 {
+            bail!("nemotron-depthwise-conv1d-metal only supports F32 tensors")
+        }
+        if !input_layout.is_contiguous() || !weight_layout.is_contiguous() {
+            bail!("nemotron-depthwise-conv1d-metal requires contiguous inputs")
+        }
+
+        let input_dims = input_layout.dims();
+        let weight_dims = weight_layout.dims();
+        if input_dims.len() != 3 || weight_dims.len() != 3 {
+            bail!("nemotron-depthwise-conv1d-metal expects rank-3 tensors")
+        }
+
+        let batch = input_dims[0];
+        let channels = input_dims[1];
+        let input_width = input_dims[2];
+        let out_channels = weight_dims[0];
+        let in_per_group = weight_dims[1];
+        let kernel_width = weight_dims[2];
+        if out_channels != channels || in_per_group != 1 {
+            bail!("nemotron-depthwise-conv1d-metal expects depthwise weights shaped [C,1,K]")
+        }
+        if self.stride == 0 || self.dilation == 0 {
+            bail!("nemotron-depthwise-conv1d-metal received invalid stride/dilation")
+        }
+        if input_width + 2 * self.padding < self.dilation * (kernel_width - 1) + 1 {
+            bail!("nemotron-depthwise-conv1d-metal output width would underflow")
+        }
+
+        let output_width =
+            (input_width + 2 * self.padding - self.dilation * (kernel_width - 1) - 1) / self.stride
+                + 1;
+        let elem_count = batch * channels * output_width;
+
+        let device = input_storage.device().clone();
+        let output = device.new_buffer(elem_count, DType::F32, "nemotron-depthwise-conv1d")?;
+        let encoder = device.command_encoder()?;
+        encoder.set_label("nemotron-depthwise-conv1d");
+        let pipeline = depthwise_conv1d_pipeline(device.metal_device())?;
+        encoder.set_compute_pipeline_state(&pipeline);
+
+        encoder.set_buffer(
+            0,
+            Some(input_storage.buffer()),
+            input_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_buffer(
+            1,
+            Some(weight_storage.buffer()),
+            weight_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_buffer(2, Some(&output), 0);
+        encoder.set_bytes(3, &(batch as u32));
+        encoder.set_bytes(4, &(channels as u32));
+        encoder.set_bytes(5, &(input_width as u32));
+        encoder.set_bytes(6, &(output_width as u32));
+        encoder.set_bytes(7, &(kernel_width as u32));
+        encoder.set_bytes(8, &(self.padding as u32));
+        encoder.set_bytes(9, &(self.stride as u32));
+        encoder.set_bytes(10, &(self.dilation as u32));
+
+        let threads_per_threadgroup = pipeline.max_total_threads_per_threadgroup().min(256).max(1);
+        encoder.dispatch_threads(
+            objc2_metal::MTLSize {
+                width: elem_count,
+                height: 1,
+                depth: 1,
+            },
+            objc2_metal::MTLSize {
+                width: threads_per_threadgroup,
+                height: 1,
+                depth: 1,
+            },
+        );
+
+        Ok((
+            MetalStorage::new(output, device, elem_count, DType::F32),
+            Shape::from_dims(&[batch, channels, output_width]),
+        ))
+    }
+}
+
+#[cfg(feature = "metal")]
+impl CustomOp3 for DepthwiseConv2dBiasOp {
+    fn name(&self) -> &'static str {
+        "nemotron-depthwise-conv2d-bias-metal"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _s1: &CpuStorage,
+        _l1: &Layout,
+        _s2: &CpuStorage,
+        _l2: &Layout,
+        _s3: &CpuStorage,
+        _l3: &Layout,
+    ) -> CandleResult<(CpuStorage, Shape)> {
+        bail!("nemotron-depthwise-conv2d-bias-metal requires a Metal tensor")
+    }
+
+    fn metal_fwd(
+        &self,
+        input_storage: &MetalStorage,
+        input_layout: &Layout,
+        weight_storage: &MetalStorage,
+        weight_layout: &Layout,
+        bias_storage: &MetalStorage,
+        bias_layout: &Layout,
+    ) -> CandleResult<(MetalStorage, Shape)> {
+        if input_storage.dtype() != DType::F32
+            || weight_storage.dtype() != DType::F32
+            || bias_storage.dtype() != DType::F32
+        {
+            bail!("nemotron-depthwise-conv2d-bias-metal only supports F32 tensors")
+        }
+        if !input_layout.is_contiguous()
+            || !weight_layout.is_contiguous()
+            || !bias_layout.is_contiguous()
+        {
+            bail!("nemotron-depthwise-conv2d-bias-metal requires contiguous inputs")
+        }
+
+        let input_dims = input_layout.dims();
+        let weight_dims = weight_layout.dims();
+        let bias_dims = bias_layout.dims();
+        if input_dims.len() != 4 || weight_dims.len() != 4 || bias_dims.len() != 1 {
+            bail!("nemotron-depthwise-conv2d-bias-metal expects ranks [4,4,1]")
+        }
+
+        let batch = input_dims[0];
+        let channels = input_dims[1];
+        let input_height = input_dims[2];
+        let input_width = input_dims[3];
+        let out_channels = weight_dims[0];
+        let in_per_group = weight_dims[1];
+        let kernel_height = weight_dims[2];
+        let kernel_width = weight_dims[3];
+        if out_channels != channels || in_per_group != 1 || bias_dims[0] != channels {
+            bail!("nemotron-depthwise-conv2d-bias-metal expects [B,C,H,W], [C,1,Kh,Kw], [C]")
+        }
+        if self.stride == 0 || self.dilation == 0 {
+            bail!("nemotron-depthwise-conv2d-bias-metal received invalid stride/dilation")
+        }
+        if input_height + 2 * self.padding < self.dilation * (kernel_height - 1) + 1
+            || input_width + 2 * self.padding < self.dilation * (kernel_width - 1) + 1
+        {
+            bail!("nemotron-depthwise-conv2d-bias-metal output shape would underflow")
+        }
+
+        let output_height =
+            (input_height + 2 * self.padding - self.dilation * (kernel_height - 1) - 1)
+                / self.stride
+                + 1;
+        let output_width =
+            (input_width + 2 * self.padding - self.dilation * (kernel_width - 1) - 1) / self.stride
+                + 1;
+        let elem_count = batch * channels * output_height * output_width;
+
+        let device = input_storage.device().clone();
+        let output = device.new_buffer(elem_count, DType::F32, "nemotron-depthwise-conv2d-bias")?;
+        let encoder = device.command_encoder()?;
+        encoder.set_label("nemotron-depthwise-conv2d-bias");
+        let pipeline = depthwise_conv2d_bias_pipeline(device.metal_device())?;
+        encoder.set_compute_pipeline_state(&pipeline);
+
+        encoder.set_buffer(
+            0,
+            Some(input_storage.buffer()),
+            input_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_buffer(
+            1,
+            Some(weight_storage.buffer()),
+            weight_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_buffer(
+            2,
+            Some(bias_storage.buffer()),
+            bias_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_buffer(3, Some(&output), 0);
+        encoder.set_bytes(4, &(batch as u32));
+        encoder.set_bytes(5, &(channels as u32));
+        encoder.set_bytes(6, &(input_height as u32));
+        encoder.set_bytes(7, &(input_width as u32));
+        encoder.set_bytes(8, &(output_height as u32));
+        encoder.set_bytes(9, &(output_width as u32));
+        encoder.set_bytes(10, &(kernel_height as u32));
+        encoder.set_bytes(11, &(kernel_width as u32));
+        encoder.set_bytes(12, &(self.padding as u32));
+        encoder.set_bytes(13, &(self.stride as u32));
+        encoder.set_bytes(14, &(self.dilation as u32));
+
+        let threads_per_threadgroup = pipeline.max_total_threads_per_threadgroup().min(256).max(1);
+        encoder.dispatch_threads(
+            objc2_metal::MTLSize {
+                width: elem_count,
+                height: 1,
+                depth: 1,
+            },
+            objc2_metal::MTLSize {
+                width: threads_per_threadgroup,
+                height: 1,
+                depth: 1,
+            },
+        );
+
+        Ok((
+            MetalStorage::new(output, device, elem_count, DType::F32),
+            Shape::from_dims(&[batch, channels, output_height, output_width]),
+        ))
+    }
+}
+
+#[cfg(feature = "metal")]
+fn depthwise_conv1d_pipeline(device: &MetalDevice) -> CandleResult<ComputePipeline> {
+    static PIPELINES: OnceLock<Mutex<HashMap<u64, ComputePipeline>>> = OnceLock::new();
+    let registry_id = device.registry_id();
+    let pipelines = PIPELINES.get_or_init(|| Mutex::new(HashMap::new()));
+
+    if let Some(pipeline) = pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .get(&registry_id)
+        .cloned()
+    {
+        return Ok(pipeline);
+    }
+
+    let library = device
+        .new_library_with_source(NEMOTRON_METAL_SOURCE, None)
+        .map_err(candle_core::Error::wrap)?;
+    let function = library
+        .get_function("nemotron_depthwise_conv1d_f32", None)
+        .map_err(candle_core::Error::wrap)?;
+    let pipeline = device
+        .new_compute_pipeline_state_with_function(&function)
+        .map_err(candle_core::Error::wrap)?;
+
+    pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .insert(registry_id, pipeline.clone());
+
+    Ok(pipeline)
+}
+
+#[cfg(feature = "metal")]
+fn depthwise_conv2d_bias_pipeline(device: &MetalDevice) -> CandleResult<ComputePipeline> {
+    static PIPELINES: OnceLock<Mutex<HashMap<u64, ComputePipeline>>> = OnceLock::new();
+    let registry_id = device.registry_id();
+    let pipelines = PIPELINES.get_or_init(|| Mutex::new(HashMap::new()));
+
+    if let Some(pipeline) = pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .get(&registry_id)
+        .cloned()
+    {
+        return Ok(pipeline);
+    }
+
+    let library = device
+        .new_library_with_source(NEMOTRON_METAL_SOURCE, None)
+        .map_err(candle_core::Error::wrap)?;
+    let function = library
+        .get_function("nemotron_depthwise_conv2d_bias_f32", None)
+        .map_err(candle_core::Error::wrap)?;
+    let pipeline = device
+        .new_compute_pipeline_state_with_function(&function)
+        .map_err(candle_core::Error::wrap)?;
+
+    pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .insert(registry_id, pipeline.clone());
+
+    Ok(pipeline)
+}
+
+#[cfg(feature = "metal")]
+pub fn depthwise_conv1d_enabled_for_device(device: &candle_core::Device) -> bool {
+    device.is_metal()
+        && std::env::var("IZWI_NEMOTRON_METAL_DEPTHWISE_CONV1D")
+            .ok()
+            .map(|value| {
+                matches!(
+                    value.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                )
+            })
+            .unwrap_or(true)
+}
+
+#[cfg(feature = "metal")]
+pub fn depthwise_conv2d_enabled_for_device(device: &candle_core::Device) -> bool {
+    device.is_metal()
+        && std::env::var("IZWI_NEMOTRON_METAL_DEPTHWISE_CONV2D")
+            .ok()
+            .map(|value| {
+                matches!(
+                    value.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                )
+            })
+            .unwrap_or(true)
+}
+
+#[cfg(feature = "metal")]
+pub fn try_depthwise_conv1d(
+    input: &Tensor,
+    weight: &Tensor,
+    padding: usize,
+    stride: usize,
+    dilation: usize,
+) -> Option<Tensor> {
+    if input.dtype() != DType::F32 || weight.dtype() != DType::F32 {
+        return None;
+    }
+    if !depthwise_conv1d_enabled_for_device(input.device()) || !weight.device().is_metal() {
+        return None;
+    }
+    let (batch, channels, input_width) = input.dims3().ok()?;
+    let (out_channels, in_per_group, kernel_width) = weight.dims3().ok()?;
+    if batch == 0
+        || channels == 0
+        || input_width == 0
+        || out_channels != channels
+        || in_per_group != 1
+        || kernel_width == 0
+        || stride == 0
+        || dilation == 0
+    {
+        return None;
+    }
+
+    let input = if input.is_contiguous() {
+        input.clone()
+    } else {
+        input.contiguous().ok()?
+    };
+    let weight = if weight.is_contiguous() {
+        weight.clone()
+    } else {
+        weight.contiguous().ok()?
+    };
+
+    input
+        .apply_op2_no_bwd(
+            &weight,
+            &DepthwiseConv1dOp {
+                padding,
+                stride,
+                dilation,
+            },
+        )
+        .ok()
+}
+
+#[cfg(feature = "metal")]
+pub fn try_depthwise_conv2d_bias(
+    input: &Tensor,
+    weight: &Tensor,
+    bias: &Tensor,
+    padding: usize,
+    stride: usize,
+    dilation: usize,
+) -> Option<Tensor> {
+    if input.dtype() != DType::F32 || weight.dtype() != DType::F32 || bias.dtype() != DType::F32 {
+        return None;
+    }
+    if !depthwise_conv2d_enabled_for_device(input.device())
+        || !weight.device().is_metal()
+        || !bias.device().is_metal()
+    {
+        return None;
+    }
+    let (batch, channels, input_height, input_width) = input.dims4().ok()?;
+    let (out_channels, in_per_group, kernel_height, kernel_width) = weight.dims4().ok()?;
+    let bias_channels = bias.dims1().ok()?;
+    if batch == 0
+        || channels == 0
+        || input_height == 0
+        || input_width == 0
+        || out_channels != channels
+        || in_per_group != 1
+        || bias_channels != channels
+        || kernel_height == 0
+        || kernel_width == 0
+        || stride == 0
+        || dilation == 0
+    {
+        return None;
+    }
+
+    let input = if input.is_contiguous() {
+        input.clone()
+    } else {
+        input.contiguous().ok()?
+    };
+    let weight = if weight.is_contiguous() {
+        weight.clone()
+    } else {
+        weight.contiguous().ok()?
+    };
+    let bias = if bias.is_contiguous() {
+        bias.clone()
+    } else {
+        bias.contiguous().ok()?
+    };
+
+    input
+        .apply_op3_no_bwd(
+            &weight,
+            &bias,
+            &DepthwiseConv2dBiasOp {
+                padding,
+                stride,
+                dilation,
+            },
+        )
+        .ok()
+}
+
+#[cfg(not(feature = "metal"))]
+pub fn try_depthwise_conv1d(
+    _input: &candle_core::Tensor,
+    _weight: &candle_core::Tensor,
+    _padding: usize,
+    _stride: usize,
+    _dilation: usize,
+) -> Option<candle_core::Tensor> {
+    None
+}
+
+#[cfg(not(feature = "metal"))]
+pub fn try_depthwise_conv2d_bias(
+    _input: &candle_core::Tensor,
+    _weight: &candle_core::Tensor,
+    _bias: &candle_core::Tensor,
+    _padding: usize,
+    _stride: usize,
+    _dilation: usize,
+) -> Option<candle_core::Tensor> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::{Device, Tensor};
+
+    #[test]
+    fn depthwise_conv1d_falls_back_on_cpu() {
+        let device = Device::Cpu;
+        let input = Tensor::from_vec(vec![1.0f32, 2.0, 3.0, 4.0], (1, 1, 4), &device).unwrap();
+        let weight = Tensor::from_vec(vec![0.25f32, 0.5, 0.25], (1, 1, 3), &device).unwrap();
+
+        assert!(try_depthwise_conv1d(&input, &weight, 1, 1, 1).is_none());
+    }
+
+    #[test]
+    fn depthwise_conv2d_bias_falls_back_on_cpu() {
+        let device = Device::Cpu;
+        let input = Tensor::from_vec(
+            (0..16).map(|idx| idx as f32).collect(),
+            (1, 1, 4, 4),
+            &device,
+        )
+        .unwrap();
+        let weight = Tensor::from_vec(vec![0.0f32, 1.0, 0.0, 1.0], (1, 1, 2, 2), &device).unwrap();
+        let bias = Tensor::from_vec(vec![0.125f32], 1, &device).unwrap();
+
+        assert!(try_depthwise_conv2d_bias(&input, &weight, &bias, 0, 1, 1).is_none());
+    }
+
+    #[cfg(feature = "metal")]
+    #[test]
+    fn depthwise_conv1d_metal_matches_candle_reference() -> candle_core::Result<()> {
+        let device = match std::panic::catch_unwind(|| Device::new_metal(0)) {
+            Ok(Ok(device)) => device,
+            _ => return Ok(()),
+        };
+
+        let input_values: Vec<f32> = (0..40).map(|idx| (idx as f32 - 11.0) * 0.125).collect();
+        let weight_values: Vec<f32> = (0..15).map(|idx| (idx as f32 - 4.0) * 0.0625).collect();
+        let input = Tensor::from_vec(input_values, (2, 2, 10), &device)?;
+        let weight = Tensor::from_vec(weight_values, (2, 1, 5), &device)?;
+
+        let reference = input.conv1d(&weight, 2, 1, 1, 2)?;
+        let actual = try_depthwise_conv1d(&input, &weight, 2, 1, 1)
+            .expect("metal depthwise conv1d should run");
+
+        let reference = reference.to_vec3::<f32>()?;
+        let actual = actual.to_vec3::<f32>()?;
+        for (reference_b, actual_b) in reference.iter().zip(actual.iter()) {
+            for (reference_c, actual_c) in reference_b.iter().zip(actual_b.iter()) {
+                for (reference, actual) in reference_c.iter().zip(actual_c.iter()) {
+                    assert!(
+                        (reference - actual).abs() < 1e-4,
+                        "reference={reference} actual={actual}"
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "metal")]
+    #[test]
+    fn depthwise_conv2d_bias_metal_matches_candle_reference() -> candle_core::Result<()> {
+        let device = match std::panic::catch_unwind(|| Device::new_metal(0)) {
+            Ok(Ok(device)) => device,
+            _ => return Ok(()),
+        };
+
+        let input_values: Vec<f32> = (0..150).map(|idx| (idx as f32 - 21.0) * 0.03125).collect();
+        let weight_values: Vec<f32> = (0..27).map(|idx| (idx as f32 - 9.0) * 0.015625).collect();
+        let bias_values: Vec<f32> = vec![-0.25, 0.125, 0.5];
+        let input = Tensor::from_vec(input_values, (2, 3, 5, 5), &device)?;
+        let weight = Tensor::from_vec(weight_values, (3, 1, 3, 3), &device)?;
+        let bias = Tensor::from_vec(bias_values, 3, &device)?;
+
+        let reference = input
+            .conv2d(&weight, 1, 2, 1, 3)?
+            .broadcast_add(&bias.reshape((1, 3, 1, 1))?)?;
+        let actual = try_depthwise_conv2d_bias(&input, &weight, &bias, 1, 2, 1)
+            .expect("metal depthwise conv2d bias should run");
+
+        let reference = reference.flatten_all()?.to_vec1::<f32>()?;
+        let actual = actual.flatten_all()?.to_vec1::<f32>()?;
+        for (reference, actual) in reference.iter().zip(actual.iter()) {
+            assert!(
+                (reference - actual).abs() < 1e-4,
+                "reference={reference} actual={actual}"
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/mod.rs
@@ -1,6 +1,7 @@
 //! Nemotron 3.5 ASR artifact and native inference support.
 
 pub mod config;
+mod metal_kernels;
 pub mod nemo;
 mod network;
 
@@ -22,8 +23,8 @@ use crate::tokenizer::Tokenizer;
 pub use config::NemotronConfigInventory;
 pub use nemo::{ensure_nemotron_artifacts, NemotronArtifacts, NEMOTRON_NEMO_FILENAME};
 use network::{
-    resample_linear, NemotronNetwork, NemotronRnntStreamState, NemotronStreamingEncoderState,
-    NemotronStreamingFeatureState, NemotronStreamingPreEncodeState,
+    resample_linear, NemotronEncodeProfile, NemotronNetwork, NemotronRnntStreamState,
+    NemotronStreamingEncoderState, NemotronStreamingFeatureState, NemotronStreamingPreEncodeState,
 };
 
 const SAMPLE_RATE: u32 = 16_000;
@@ -609,13 +610,53 @@ struct NemotronDecodeRequest {
 struct NemotronStageTimings {
     resample: Duration,
     encode: Duration,
+    encode_profile: Option<NemotronEncodeProfile>,
     rnnt_decode: Duration,
     text_assembly: Duration,
 }
 
 impl NemotronStageTimings {
     fn diagnostics(&self) -> serde_json::Value {
+        let profile = self.encode_profile.as_ref();
+        let profile_timing =
+            |f: fn(&network::NemotronEncodeProfile) -> Duration| profile.map(f).map(duration_ms);
+        let feature_extract = profile_timing(|profile| profile.timings.feature_extract);
+        let feature_upload = profile_timing(|profile| profile.timings.feature_upload);
+        let dtype_cast = profile_timing(|profile| profile.timings.dtype_cast);
+        let subsample = profile_timing(|profile| profile.timings.subsample);
+        let pos_emb = profile_timing(|profile| profile.timings.pos_emb);
+        let att_mask = profile_timing(|profile| profile.timings.att_mask);
+        let encoder_ffn = profile_timing(|profile| profile.timings.encoder_ffn);
+        let encoder_attention = profile_timing(|profile| profile.timings.encoder_attention);
+        let encoder_conv = profile_timing(|profile| profile.timings.encoder_conv);
+        let encoder_norm = profile_timing(|profile| profile.timings.encoder_norm);
+        let prompt_kernel = profile_timing(|profile| profile.timings.prompt_kernel);
+        let encoder_forward = profile_timing(|profile| profile.timings.encoder_layers_total());
+        let mel_prepare = profile.map(|profile| {
+            duration_ms(profile.timings.feature_extract + profile.timings.feature_upload)
+        });
+        let model_total = self.resample + self.encode + self.rnnt_decode + self.text_assembly;
+
         json!({
+            "resample": duration_ms(self.resample),
+            "feature_extract": feature_extract,
+            "feature_upload": feature_upload,
+            "mel_prepare": mel_prepare,
+            "mel": feature_extract,
+            "dtype_cast": dtype_cast,
+            "subsample": subsample,
+            "pos_emb": pos_emb,
+            "att_mask": att_mask,
+            "encoder_forward": encoder_forward,
+            "encoder_ffn": encoder_ffn,
+            "encoder_attention": encoder_attention,
+            "encoder_conv": encoder_conv,
+            "encoder_norm": encoder_norm,
+            "prompt_kernel": prompt_kernel,
+            "audio_encode": duration_ms(self.encode),
+            "prefill": duration_ms(model_total),
+            "decode": duration_ms(self.rnnt_decode),
+            "model_total": duration_ms(model_total),
             "resample_ms": duration_ms(self.resample),
             "encode_ms": duration_ms(self.encode),
             "rnnt_decode_ms": duration_ms(self.rnnt_decode),
@@ -1037,8 +1078,11 @@ impl NemotronAsrModel {
         timings.resample = resample_start.elapsed();
         let prompt_id = self.network.prompt_id(&request.prompt.target_lang)?;
         let encode_start = Instant::now();
-        let (encoded, encoded_len) = self.network.encode_with_prompt(&audio_16khz, prompt_id)?;
+        let (encoded, encoded_len, encode_profile) = self
+            .network
+            .encode_with_prompt_profile(&audio_16khz, prompt_id)?;
         timings.encode = encode_start.elapsed();
+        timings.encode_profile = Some(encode_profile);
 
         let mut token_ids = Vec::<usize>::new();
         let mut assembled = String::new();
@@ -1094,8 +1138,11 @@ impl NemotronAsrModel {
 
         let prompt_id = self.network.prompt_id(&request.prompt.target_lang)?;
         let encode_start = Instant::now();
-        let (encoded, encoded_len) = self.network.encode_with_prompt(&audio_16khz, prompt_id)?;
+        let (encoded, encoded_len, encode_profile) = self
+            .network
+            .encode_with_prompt_profile(&audio_16khz, prompt_id)?;
         timings.encode = encode_start.elapsed();
+        timings.encode_profile = Some(encode_profile);
 
         let mut no_op = |_token_id: usize| {};
         let decode_start = Instant::now();
@@ -1129,6 +1176,14 @@ impl NemotronAsrModel {
         timings: NemotronStageTimings,
         decode_mode: &'static str,
     ) -> NemotronAsrTranscriptionOutput {
+        let encode_diagnostics = timings
+            .encode_profile
+            .as_ref()
+            .map(|profile| profile.stats.diagnostics());
+        let feature_frames = timings
+            .encode_profile
+            .as_ref()
+            .map(|profile| profile.stats.feature_frames);
         NemotronAsrTranscriptionOutput {
             text,
             language: Some(request.prompt.target_lang.clone()),
@@ -1138,7 +1193,9 @@ impl NemotronAsrModel {
                     "target_sample_rate": request.target_sample_rate,
                     "input_samples": request.samples,
                     "resampled_samples": resampled_samples,
+                    "acoustic_frames": feature_frames,
                 },
+                "encode": encode_diagnostics,
                 "prompt": request.prompt.diagnostics(),
                 "prompt_id": prompt_id,
                 "blank_id": self.network.blank_idx(),
@@ -1567,9 +1624,14 @@ mod tests {
             encode: Duration::from_millis(2),
             rnnt_decode: Duration::from_micros(3_250),
             text_assembly: Duration::from_millis(4),
+            ..Default::default()
         };
         let diagnostics = timings.diagnostics();
 
+        assert_eq!(diagnostics["resample"], 1.5);
+        assert_eq!(diagnostics["audio_encode"], 2.0);
+        assert_eq!(diagnostics["decode"], 3.25);
+        assert_eq!(diagnostics["model_total"], 10.75);
         assert_eq!(diagnostics["resample_ms"], 1.5);
         assert_eq!(diagnostics["encode_ms"], 2.0);
         assert_eq!(diagnostics["rnnt_decode_ms"], 3.25);
@@ -1705,7 +1767,10 @@ mod tests {
         assert_eq!(state.samples, vec![0.1, 0.2, 0.3, 0.4]);
         assert_eq!(state.text(), "");
         assert_eq!(state.emitted_tokens(), 0);
-        assert_eq!(state.diagnostics()["supports_realtime_stream_decode"], false);
+        assert_eq!(
+            state.diagnostics()["supports_realtime_stream_decode"],
+            false
+        );
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
+++ b/crates/izwi-core/src/models/architectures/nemotron/asr/network.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use candle_core::{DType, Device, IndexOp, Tensor, D};
 use candle_nn::ops;
@@ -36,12 +37,15 @@ const LOG_GUARD: f32 = 5.960_464_5e-8;
 const NORMALIZE_EPS: f32 = 1e-5;
 const DEFAULT_MAX_SYMBOLS_PER_FRAME: usize = 10;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub(super) struct NemotronDecodeStats {
     pub encoded_frames: usize,
     pub emitted_tokens: usize,
     pub blank_frames: usize,
     pub guard_exits: usize,
+    pub joint_steps: usize,
+    pub host_argmax_reads: usize,
+    pub device_argmax_reads: usize,
     pub max_symbols_per_frame: usize,
 }
 
@@ -50,8 +54,12 @@ impl NemotronDecodeStats {
         json!({
             "encoded_frames": self.encoded_frames,
             "emitted_tokens": self.emitted_tokens,
+            "generated_tokens": self.emitted_tokens,
             "blank_frames": self.blank_frames,
             "guard_exits": self.guard_exits,
+            "joint_steps": self.joint_steps,
+            "host_argmax_reads": self.host_argmax_reads,
+            "device_argmax_reads": self.device_argmax_reads,
             "max_symbols_per_frame": self.max_symbols_per_frame,
         })
     }
@@ -61,6 +69,61 @@ impl NemotronDecodeStats {
 pub(super) struct NemotronDecodedTokens {
     pub token_ids: Vec<usize>,
     pub stats: NemotronDecodeStats,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct NemotronEncodeTimings {
+    pub feature_extract: Duration,
+    pub feature_upload: Duration,
+    pub dtype_cast: Duration,
+    pub subsample: Duration,
+    pub pos_emb: Duration,
+    pub att_mask: Duration,
+    pub encoder_ffn: Duration,
+    pub encoder_attention: Duration,
+    pub encoder_conv: Duration,
+    pub encoder_norm: Duration,
+    pub prompt_kernel: Duration,
+}
+
+impl NemotronEncodeTimings {
+    pub(super) fn encoder_layers_total(&self) -> Duration {
+        self.encoder_ffn + self.encoder_attention + self.encoder_conv + self.encoder_norm
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct NemotronEncodeStats {
+    pub feature_frames: usize,
+    pub encoded_frames: usize,
+    pub encoder_layers: usize,
+}
+
+impl NemotronEncodeStats {
+    pub(super) fn diagnostics(&self) -> serde_json::Value {
+        json!({
+            "feature_frames": self.feature_frames,
+            "encoded_frames": self.encoded_frames,
+            "encoder_layers": self.encoder_layers,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct NemotronEncodeProfile {
+    pub timings: NemotronEncodeTimings,
+    pub stats: NemotronEncodeStats,
+}
+
+struct NemotronFeatureTimings {
+    feature_extract: Duration,
+    feature_upload: Duration,
+}
+
+struct NemotronFeatureOutput {
+    features: Tensor,
+    valid_frames: usize,
+    timings: NemotronFeatureTimings,
 }
 
 pub(super) struct NemotronNetwork {
@@ -193,38 +256,88 @@ impl NemotronNetwork {
         audio_16khz: &[f32],
         prompt_id: usize,
     ) -> Result<(Tensor, usize)> {
-        let (features, feature_frames) = self.preprocessor.compute_features(audio_16khz)?;
+        let (encoded, encoded_len, _profile) =
+            self.encode_with_prompt_profile(audio_16khz, prompt_id)?;
+        Ok((encoded, encoded_len))
+    }
+
+    pub(super) fn encode_with_prompt_profile(
+        &self,
+        audio_16khz: &[f32],
+        prompt_id: usize,
+    ) -> Result<(Tensor, usize, NemotronEncodeProfile)> {
+        let mut profile = NemotronEncodeProfile::default();
+        let feature_output = self.preprocessor.compute_features_profile(audio_16khz)?;
+        profile.timings.feature_extract = feature_output.timings.feature_extract;
+        profile.timings.feature_upload = feature_output.timings.feature_upload;
+        profile.stats.feature_frames = feature_output.valid_frames;
+
+        let dtype_start = Instant::now();
+        let features = feature_output.features;
         let features = if features.dtype() == self.dtype {
             features
         } else {
             features.to_dtype(self.dtype)?
         };
-        let (x, encoded_len) = self.pre_encode.forward(&features, feature_frames)?;
+        profile.timings.dtype_cast = dtype_start.elapsed();
+
+        let subsample_start = Instant::now();
+        let (x, encoded_len) = self
+            .pre_encode
+            .forward(&features, feature_output.valid_frames)?;
+        profile.timings.subsample = subsample_start.elapsed();
+        profile.stats.encoded_frames = encoded_len;
         if encoded_len == 0 {
             return Err(Error::InferenceError(
                 "Nemotron encoder produced zero frames".to_string(),
             ));
         }
 
-        self.encode_preencoded_with_prompt(
+        let (encoded, encoded_len) = self.encode_preencoded_with_prompt_profile(
             x,
             encoded_len,
             prompt_id,
             self.left_context_frames,
             self.right_context_frames,
-        )
+            &mut profile,
+        )?;
+        profile.stats.encoded_frames = encoded_len;
+        Ok((encoded, encoded_len, profile))
     }
 
     fn encode_preencoded_with_prompt(
+        &self,
+        x: Tensor,
+        encoded_len: usize,
+        prompt_id: usize,
+        left_context_frames: usize,
+        right_context_frames: usize,
+    ) -> Result<(Tensor, usize)> {
+        let mut profile = NemotronEncodeProfile::default();
+        self.encode_preencoded_with_prompt_profile(
+            x,
+            encoded_len,
+            prompt_id,
+            left_context_frames,
+            right_context_frames,
+            &mut profile,
+        )
+    }
+
+    fn encode_preencoded_with_prompt_profile(
         &self,
         mut x: Tensor,
         encoded_len: usize,
         prompt_id: usize,
         left_context_frames: usize,
         right_context_frames: usize,
+        profile: &mut NemotronEncodeProfile,
     ) -> Result<(Tensor, usize)> {
         let pos_len = x.dim(1)?;
+        let pos_start = Instant::now();
         let pos_emb = self.rel_positional_embedding(pos_len, x.dtype(), x.device())?;
+        profile.timings.pos_emb += pos_start.elapsed();
+        let mask_start = Instant::now();
         let att_mask = self.limited_context_mask(
             pos_len,
             left_context_frames,
@@ -232,11 +345,15 @@ impl NemotronNetwork {
             x.dtype(),
             x.device(),
         )?;
+        profile.timings.att_mask += mask_start.elapsed();
         for layer in &self.layers {
-            x = layer.forward(&x, &pos_emb, &att_mask)?;
+            x = layer.forward_profile(&x, &pos_emb, &att_mask, profile)?;
+            profile.stats.encoder_layers = profile.stats.encoder_layers.saturating_add(1);
         }
 
+        let prompt_start = Instant::now();
         let x = self.prompt_kernel.forward(&x, prompt_id)?;
+        profile.timings.prompt_kernel += prompt_start.elapsed();
         Ok((x, encoded_len.min(pos_len)))
     }
 
@@ -309,7 +426,7 @@ impl NemotronNetwork {
         encoded_len: usize,
         on_token: &mut dyn FnMut(usize),
     ) -> Result<NemotronDecodedTokens> {
-        if encoded.device().is_cuda() {
+        if use_rnnt_cached_projection(encoded.device()) {
             return self.decode_rnnt_greedy_cuda_cached(encoded, encoded_len, on_token);
         }
 
@@ -322,6 +439,9 @@ impl NemotronNetwork {
         let mut token_ids = Vec::new();
         let mut blank_frames = 0usize;
         let mut guard_exits = 0usize;
+        let mut joint_steps = 0usize;
+        let mut host_argmax_reads = 0usize;
+        let mut device_argmax_reads = 0usize;
 
         for t in 0..encoded_len {
             let enc_t = encoded.i((t, ..))?.unsqueeze(0)?.unsqueeze(0)?; // [1, 1, D]
@@ -334,6 +454,12 @@ impl NemotronNetwork {
                     .squeeze(0)?
                     .squeeze(0)?
                     .squeeze(0)?; // [V + blank]
+                joint_steps = joint_steps.saturating_add(1);
+                if argmax_uses_device(&logits) {
+                    device_argmax_reads = device_argmax_reads.saturating_add(1);
+                } else {
+                    host_argmax_reads = host_argmax_reads.saturating_add(1);
+                }
                 let label = argmax_1d(&logits)?;
 
                 if label == self.blank_idx {
@@ -367,6 +493,9 @@ impl NemotronNetwork {
                 emitted_tokens: token_ids.len(),
                 blank_frames,
                 guard_exits,
+                joint_steps,
+                host_argmax_reads,
+                device_argmax_reads,
                 max_symbols_per_frame: self.max_symbols_per_frame,
             },
             token_ids,
@@ -379,7 +508,7 @@ impl NemotronNetwork {
         let predictor_out = self
             .predictor
             .step(self.blank_idx, &mut predictor_state, device)?;
-        let predictor_projection = if device.is_cuda() {
+        let predictor_projection = if use_rnnt_cached_projection(device) {
             Some(self.joint.project_predictor(&predictor_out)?)
         } else {
             None
@@ -395,6 +524,9 @@ impl NemotronNetwork {
                 emitted_tokens: 0,
                 blank_frames: 0,
                 guard_exits: 0,
+                joint_steps: 0,
+                host_argmax_reads: 0,
+                device_argmax_reads: 0,
                 max_symbols_per_frame: self.max_symbols_per_frame,
             },
         })
@@ -408,7 +540,7 @@ impl NemotronNetwork {
         on_token: &mut dyn FnMut(usize),
     ) -> Result<NemotronRnntStreamStep> {
         let encoded = encoded.i((0, ..encoded_len, ..))?;
-        let encoded_projection = if encoded.device().is_cuda() {
+        let encoded_projection = if use_rnnt_cached_projection(encoded.device()) {
             Some(self.joint.project_encoder(&encoded)?)
         } else {
             None
@@ -428,7 +560,7 @@ impl NemotronNetwork {
                     let predictor_projection =
                         state.predictor_projection.as_ref().ok_or_else(|| {
                             Error::InferenceError(
-                                "Nemotron CUDA RNNT stream is missing predictor projection"
+                                "Nemotron accelerated RNNT stream is missing predictor projection"
                                     .to_string(),
                             )
                         })?;
@@ -441,6 +573,13 @@ impl NemotronNetwork {
                 .squeeze(0)?
                 .squeeze(0)?
                 .squeeze(0)?;
+                state.stats.joint_steps = state.stats.joint_steps.saturating_add(1);
+                if argmax_uses_device(&logits) {
+                    state.stats.device_argmax_reads =
+                        state.stats.device_argmax_reads.saturating_add(1);
+                } else {
+                    state.stats.host_argmax_reads = state.stats.host_argmax_reads.saturating_add(1);
+                }
                 let label = argmax_1d(&logits)?;
 
                 if label == self.blank_idx {
@@ -500,6 +639,9 @@ impl NemotronNetwork {
         let mut token_ids = Vec::new();
         let mut blank_frames = 0usize;
         let mut guard_exits = 0usize;
+        let mut joint_steps = 0usize;
+        let mut host_argmax_reads = 0usize;
+        let mut device_argmax_reads = 0usize;
 
         for t in 0..encoded_len {
             let enc_t = encoded_projection.i((t, ..))?.unsqueeze(0)?.unsqueeze(0)?;
@@ -512,6 +654,12 @@ impl NemotronNetwork {
                     .squeeze(0)?
                     .squeeze(0)?
                     .squeeze(0)?;
+                joint_steps = joint_steps.saturating_add(1);
+                if argmax_uses_device(&logits) {
+                    device_argmax_reads = device_argmax_reads.saturating_add(1);
+                } else {
+                    host_argmax_reads = host_argmax_reads.saturating_add(1);
+                }
                 let label = argmax_1d(&logits)?;
 
                 if label == self.blank_idx {
@@ -546,6 +694,9 @@ impl NemotronNetwork {
                 emitted_tokens: token_ids.len(),
                 blank_frames,
                 guard_exits,
+                joint_steps,
+                host_argmax_reads,
+                device_argmax_reads,
                 max_symbols_per_frame: self.max_symbols_per_frame,
             },
             token_ids,
@@ -643,7 +794,9 @@ impl NemotronNetwork {
         if let Some(cached) = self
             .stream_rel_pos_cache
             .lock()
-            .map_err(|_| Error::InferenceError("Nemotron stream rel-pos cache lock poisoned".into()))?
+            .map_err(|_| {
+                Error::InferenceError("Nemotron stream rel-pos cache lock poisoned".into())
+            })?
             .get(&key)
             .cloned()
         {
@@ -660,7 +813,9 @@ impl NemotronNetwork {
         )?;
         self.stream_rel_pos_cache
             .lock()
-            .map_err(|_| Error::InferenceError("Nemotron stream rel-pos cache lock poisoned".into()))?
+            .map_err(|_| {
+                Error::InferenceError("Nemotron stream rel-pos cache lock poisoned".into())
+            })?
             .insert(key, tensor.clone());
         Ok(tensor)
     }
@@ -986,11 +1141,12 @@ impl NemotronStreamingEncoderState {
         if self.pending_pre_encoded.is_none() {
             self.pending_start_frame = chunk.start_frame;
         }
-        self.pending_pre_encoded = Some(if let Some(existing) = self.pending_pre_encoded.as_ref() {
-            Tensor::cat(&[existing, &chunk.encoded], 1)?
-        } else {
-            chunk.encoded
-        });
+        self.pending_pre_encoded =
+            Some(if let Some(existing) = self.pending_pre_encoded.as_ref() {
+                Tensor::cat(&[existing, &chunk.encoded], 1)?
+            } else {
+                chunk.encoded
+            });
         self.received_frames = self.received_frames.saturating_add(chunk.frames);
         self.input_finished = chunk.is_final;
         Ok(())
@@ -1034,10 +1190,9 @@ impl NemotronStreamingEncoderState {
         }
 
         let frames = pending_frames.min(self.chunk_frames);
-        let pending = self
-            .pending_pre_encoded
-            .take()
-            .ok_or_else(|| Error::InferenceError("Nemotron encoder stream lost pending frames".into()))?;
+        let pending = self.pending_pre_encoded.take().ok_or_else(|| {
+            Error::InferenceError("Nemotron encoder stream lost pending frames".into())
+        })?;
         let chunk = pending.narrow(1, 0, frames)?.contiguous()?;
         let remaining = pending_frames - frames;
         self.last_chunk_start_frame = self.pending_start_frame;
@@ -1122,6 +1277,12 @@ impl NemotronPreprocessor {
     }
 
     fn compute_features(&self, audio: &[f32]) -> Result<(Tensor, usize)> {
+        let output = self.compute_features_profile(audio)?;
+        Ok((output.features, output.valid_frames))
+    }
+
+    fn compute_features_profile(&self, audio: &[f32]) -> Result<NemotronFeatureOutput> {
+        let feature_start = Instant::now();
         if audio.is_empty() {
             return Err(Error::InvalidInput("Empty audio input".to_string()));
         }
@@ -1189,8 +1350,18 @@ impl NemotronPreprocessor {
             }
         }
 
+        let feature_extract = feature_start.elapsed();
+        let upload_start = Instant::now();
         let features = Tensor::from_vec(mel, (1, N_MELS, frame_count), &self.device)?;
-        Ok((features, valid_frames))
+        let feature_upload = upload_start.elapsed();
+        Ok(NemotronFeatureOutput {
+            features,
+            valid_frames,
+            timings: NemotronFeatureTimings {
+                feature_extract,
+                feature_upload,
+            },
+        })
     }
 
     pub(super) fn compute_streaming_features(
@@ -1352,9 +1523,9 @@ impl ConvSubsamplingDw {
         let mut x = features.transpose(1, 2)?.unsqueeze(1)?;
 
         x = self.conv0.forward(&x)?.relu()?;
-        x = self.conv2.forward(&x)?;
+        x = self.depthwise_conv2d_forward(&self.conv2, &x)?;
         x = self.conv3.forward(&x)?.relu()?;
-        x = self.conv5.forward(&x)?;
+        x = self.depthwise_conv2d_forward(&self.conv5, &x)?;
         x = self.conv6.forward(&x)?.relu()?;
 
         let (b, c, t, mut f) = x.dims4()?;
@@ -1417,6 +1588,25 @@ impl ConvSubsamplingDw {
             is_final: state.input_finished && stable_frames == encoded_len,
         }))
     }
+
+    fn depthwise_conv2d_forward(&self, conv: &Conv2d, x: &Tensor) -> Result<Tensor> {
+        let cfg = conv.config();
+        if let Some(bias) = conv.bias() {
+            if let Some(y) = super::metal_kernels::try_depthwise_conv2d_bias(
+                x,
+                conv.weight(),
+                bias,
+                cfg.padding,
+                cfg.stride,
+                cfg.dilation,
+            ) {
+                return Ok(y);
+            }
+        }
+
+        conv.forward(x)
+            .map_err(|e| Error::InferenceError(e.to_string()))
+    }
 }
 
 fn load_subsampling_out_projection(vb: VarBuilder) -> Result<(Linear, usize)> {
@@ -1477,25 +1667,48 @@ impl ConformerLayer {
     }
 
     fn forward(&self, x: &Tensor, pos_emb: &Tensor, att_mask: &Tensor) -> Result<Tensor> {
+        let mut profile = NemotronEncodeProfile::default();
+        self.forward_profile(x, pos_emb, att_mask, &mut profile)
+    }
+
+    fn forward_profile(
+        &self,
+        x: &Tensor,
+        pos_emb: &Tensor,
+        att_mask: &Tensor,
+        profile: &mut NemotronEncodeProfile,
+    ) -> Result<Tensor> {
         let mut residual = x.clone();
 
+        let ff1_start = Instant::now();
         let ff1 = self.ff1.forward(&self.norm_ff1.forward(&residual)?)?;
         residual = residual.broadcast_add(&ff1.affine(0.5, 0.0)?)?;
+        profile.timings.encoder_ffn += ff1_start.elapsed();
 
+        let attn_start = Instant::now();
         let attn =
             self.self_attn
                 .forward(&self.norm_self_att.forward(&residual)?, pos_emb, att_mask)?;
         residual = residual.broadcast_add(&attn)?;
+        profile.timings.encoder_attention += attn_start.elapsed();
 
+        let conv_start = Instant::now();
         let conv = self.conv.forward(&self.norm_conv.forward(&residual)?)?;
         residual = residual.broadcast_add(&conv)?;
+        profile.timings.encoder_conv += conv_start.elapsed();
 
+        let ff2_start = Instant::now();
         let ff2 = self.ff2.forward(&self.norm_ff2.forward(&residual)?)?;
         residual = residual.broadcast_add(&ff2.affine(0.5, 0.0)?)?;
+        profile.timings.encoder_ffn += ff2_start.elapsed();
 
-        self.norm_out
+        let norm_start = Instant::now();
+        let out = self
+            .norm_out
             .forward(&residual)
-            .map_err(|e| Error::InferenceError(e.to_string()))
+            .map_err(|e| Error::InferenceError(e.to_string()))?;
+        profile.timings.encoder_norm += norm_start.elapsed();
+        Ok(out)
     }
 
     fn forward_streaming(
@@ -1518,16 +1731,13 @@ impl ConformerLayer {
             pos_pair,
             att_mask,
         )?;
-        state.attn_cache = update_time_cache_dim1(
-            state.attn_cache.take(),
-            &att_input,
-            left_context_frames,
-        )?;
+        state.attn_cache =
+            update_time_cache_dim1(state.attn_cache.take(), &att_input, left_context_frames)?;
         residual = residual.broadcast_add(&attn)?;
 
-        let conv =
-            self.conv
-                .forward_streaming(&self.norm_conv.forward(&residual)?, &mut state.conv_cache)?;
+        let conv = self
+            .conv
+            .forward_streaming(&self.norm_conv.forward(&residual)?, &mut state.conv_cache)?;
         residual = residual.broadcast_add(&conv)?;
 
         let ff2 = self.ff2.forward(&self.norm_ff2.forward(&residual)?)?;
@@ -1612,7 +1822,7 @@ impl ConformerConv {
         x = x_a.broadcast_mul(&ops::sigmoid(&x_b)?)?;
 
         x = x.pad_with_zeros(2, CONV_KERNEL_1D - 1, 0)?;
-        x = self.depthwise_conv.forward(&x)?;
+        x = self.depthwise_conv_forward(&x)?;
         x = self
             .conv_norm
             .forward(&x.transpose(1, 2)?)?
@@ -1630,7 +1840,10 @@ impl ConformerConv {
         let x_b = x.i((.., ENCODER_DIM.., ..))?;
         let x = x_a.broadcast_mul(&ops::sigmoid(&x_b)?)?;
 
-        let cache_len = cache.as_ref().and_then(|cache| cache.dim(2).ok()).unwrap_or(0);
+        let cache_len = cache
+            .as_ref()
+            .and_then(|cache| cache.dim(2).ok())
+            .unwrap_or(0);
         let cached_and_current = if let Some(existing) = cache.as_ref() {
             Tensor::cat(&[existing, &x], 2)?
         } else {
@@ -1643,7 +1856,7 @@ impl ConformerConv {
         };
         *cache = update_time_cache_dim2(None, &cached_and_current, CONV_KERNEL_1D - 1)?;
 
-        let mut x = self.depthwise_conv.forward(&conv_input)?;
+        let mut x = self.depthwise_conv_forward(&conv_input)?;
         x = self
             .conv_norm
             .forward(&x.transpose(1, 2)?)?
@@ -1652,6 +1865,23 @@ impl ConformerConv {
         x = self.pointwise_conv2.forward(&x)?;
 
         x.transpose(1, 2).map_err(Error::from)
+    }
+
+    fn depthwise_conv_forward(&self, x: &Tensor) -> Result<Tensor> {
+        let cfg = self.depthwise_conv.config();
+        if let Some(y) = super::metal_kernels::try_depthwise_conv1d(
+            x,
+            self.depthwise_conv.weight(),
+            cfg.padding,
+            cfg.stride,
+            cfg.dilation,
+        ) {
+            return Ok(y);
+        }
+
+        self.depthwise_conv
+            .forward(x)
+            .map_err(|e| Error::InferenceError(e.to_string()))
     }
 }
 
@@ -2354,11 +2584,19 @@ fn argmax_1d(x: &Tensor) -> Result<usize> {
             x.shape().dims()
         )));
     }
-    if x.device().is_cuda() {
+    if argmax_uses_device(x) {
         return argmax_1d_device(x);
     }
 
     argmax_1d_host(x)
+}
+
+fn argmax_uses_device(x: &Tensor) -> bool {
+    x.device().is_cuda()
+}
+
+fn use_rnnt_cached_projection(device: &Device) -> bool {
+    device.is_cuda() || device.is_metal()
 }
 
 fn argmax_1d_device(x: &Tensor) -> Result<usize> {
@@ -2707,8 +2945,7 @@ mod tests {
 
     #[test]
     fn streaming_limited_context_mask_uses_bounded_key_window() {
-        let mask =
-            build_streaming_limited_context_mask(2, 5, 3, 2, 1, &Device::Cpu).unwrap();
+        let mask = build_streaming_limited_context_mask(2, 5, 3, 2, 1, &Device::Cpu).unwrap();
         let values = mask
             .squeeze(0)
             .unwrap()
@@ -2718,7 +2955,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(mask.dims(), &[1, 1, 2, 5]);
-        assert!(values[0][0] < -1.0e8, "query 3 cannot attend before left context");
+        assert!(
+            values[0][0] < -1.0e8,
+            "query 3 cannot attend before left context"
+        );
         assert_eq!(values[0][1], 0.0);
         assert_eq!(values[0][4], 0.0, "query 3 can attend one frame right");
         assert_eq!(values[1][2], 0.0);
@@ -2726,9 +2966,15 @@ mod tests {
 
     #[test]
     fn streaming_rel_positional_embedding_is_pairwise_bounded() {
-        let pos =
-            build_streaming_rel_positional_embedding_for_dtype(2, 5, 3, 8, &Device::Cpu, DType::F32)
-                .unwrap();
+        let pos = build_streaming_rel_positional_embedding_for_dtype(
+            2,
+            5,
+            3,
+            8,
+            &Device::Cpu,
+            DType::F32,
+        )
+        .unwrap();
 
         assert_eq!(pos.dtype(), DType::F32);
         assert_eq!(pos.dims(), &[1, 10, 8]);


### PR DESCRIPTION
Adds Nemotron ASR diagnostics, native Metal depthwise Conv1d/Conv2d paths, and Metal RNNT cached projections, reducing the benchmark to ~896ms avg / ~915ms p95.