### PR TITLE
Improve Metal performance for Sortformer and Qwen ForcedAligner

### DIFF
--- a/crates/izwi-cli/src/app/cli.rs
+++ b/crates/izwi-cli/src/app/cli.rs
@@ -579,6 +579,72 @@ pub enum BenchCommands {
         warmup: bool,
     },
 
+    /// Benchmark diarization inference
+    Diarize {
+        /// Diarization model to benchmark
+        #[arg(short, long, default_value = "sortformer-4spk")]
+        model: String,
+
+        /// Number of iterations
+        #[arg(short, long, default_value = "10")]
+        iterations: u32,
+
+        /// Audio file to use
+        #[arg(short, long)]
+        file: Option<PathBuf>,
+
+        /// Expected number of speakers (optional, auto-detect if not specified)
+        #[arg(short = 'n', long)]
+        num_speakers: Option<u32>,
+
+        /// ASR model used for transcript generation
+        #[arg(long, default_value = "parakeet-tdt-0.6b-v3")]
+        asr_model: String,
+
+        /// Maximum concurrent requests
+        #[arg(short, long, default_value = "1")]
+        concurrent: u32,
+
+        /// Enable warmup iteration
+        #[arg(long)]
+        warmup: bool,
+    },
+
+    /// Benchmark forced alignment inference
+    Align {
+        /// Forced aligner model to benchmark
+        #[arg(short, long, default_value = "Qwen3-ForcedAligner-0.6B")]
+        model: String,
+
+        /// Number of iterations
+        #[arg(short, long, default_value = "10")]
+        iterations: u32,
+
+        /// Audio file to use
+        #[arg(short, long)]
+        file: Option<PathBuf>,
+
+        /// Reference text to align
+        #[arg(short, long)]
+        text: Option<String>,
+
+        /// File containing the reference text to align
+        #[arg(long, value_name = "PATH")]
+        text_file: Option<PathBuf>,
+
+        /// Optional language hint (for example: en, es)
+        #[arg(short = 'l', long)]
+        language: Option<String>,
+
+        /// Maximum concurrent requests
+        #[arg(short, long, default_value = "1")]
+        concurrent: u32,
+
+        /// Enable warmup iteration
+        #[arg(long)]
+        warmup: bool,
+    },
+
     /// Benchmark system throughput
     Throughput {
         /// Duration in seconds

--- a/crates/izwi-cli/src/commands/bench.rs
+++ b/crates/izwi-cli/src/commands/bench.rs
@@ -205,6 +205,8 @@ struct AsrStageTimings {
     transformer_forward: Option<f64>,
     head: Option<f64>,
     host_read: Option<f64>,
+    device_sync: Option<f64>,
+    host_copy: Option<f64>,
     prompt_kernel: Option<f64>,
     language_detect: Option<f64>,
     resample: Option<f64>,
@@ -3557,6 +3559,8 @@ fn asr_stage_timings_from_diagnostics(diagnostics: &serde_json::Value) -> Option
             .and_then(|value| value.as_f64()),
         head: timings.get("head").and_then(|value| value.as_f64()),
         host_read: timings.get("host_read").and_then(|value| value.as_f64()),
+        device_sync: timings.get("device_sync").and_then(|value| value.as_f64()),
+        host_copy: timings.get("host_copy").and_then(|value| value.as_f64()),
         prompt_kernel: timings
             .get("prompt_kernel")
             .and_then(|value| value.as_f64()),
@@ -3902,6 +3906,8 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
     let mut transformer_forward = Vec::new();
     let mut head = Vec::new();
     let mut host_read = Vec::new();
+    let mut device_sync = Vec::new();
+    let mut host_copy = Vec::new();
     let mut prompt_kernel = Vec::new();
     let mut language_detect = Vec::new();
     let mut resample = Vec::new();
@@ -3973,6 +3979,12 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
         }
         if let Some(value) = sample.host_read {
             host_read.push(value);
+        }
+        if let Some(value) = sample.device_sync {
+            device_sync.push(value);
+        }
+        if let Some(value) = sample.host_copy {
+            host_copy.push(value);
         }
         if let Some(value) = sample.prompt_kernel {
             prompt_kernel.push(value);
@@ -4084,6 +4096,8 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
         && transformer_forward.is_empty()
         && head.is_empty()
         && host_read.is_empty()
+        && device_sync.is_empty()
+        && host_copy.is_empty()
         && prompt_kernel.is_empty()
         && language_detect.is_empty()
         && resample.is_empty()
@@ -4138,6 +4152,8 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
     summarize_stage("transformer", &transformer_forward);
     summarize_stage("head", &head);
     summarize_stage("host_read", &host_read);
+    summarize_stage("device_sync", &device_sync);
+    summarize_stage("host_copy", &host_copy);
     summarize_stage("prompt", &prompt_kernel);
     summarize_stage("lang_detect", &language_detect);
     summarize_stage("resample", &resample);

--- a/crates/izwi-cli/src/commands/bench.rs
+++ b/crates/izwi-cli/src/commands/bench.rs
@@ -214,6 +214,15 @@ struct AsrStageTimings {
     audio_encode: Option<f64>,
     prompt_build: Option<f64>,
     prefill: Option<f64>,
+    prefill_input_norm: Option<f64>,
+    prefill_attention: Option<f64>,
+    prefill_attention_residual: Option<f64>,
+    prefill_post_attention_norm: Option<f64>,
+    prefill_mlp: Option<f64>,
+    prefill_mlp_residual: Option<f64>,
+    prefill_layers_total: Option<f64>,
+    prefill_final_norm: Option<f64>,
+    prefill_lm_head: Option<f64>,
     timestamp_argmax: Option<f64>,
     timestamp_fixup: Option<f64>,
     postprocess: Option<f64>,
@@ -3526,6 +3535,7 @@ fn asr_stage_timings_from_diagnostics(diagnostics: &serde_json::Value) -> Option
     let prompt = diagnostics.get("prompt");
     let audio = diagnostics.get("audio");
     let decode = diagnostics.get("decode");
+    let prefill_profile = diagnostics.get("prefill_profile_ms");
     let execution = asr_execution_from_single_diagnostics(diagnostics);
     Some(AsrStageTimings {
         audio_decode: timings.get("audio_decode").and_then(|value| value.as_f64()),
@@ -3572,6 +3582,15 @@ fn asr_stage_timings_from_diagnostics(diagnostics: &serde_json::Value) -> Option
         audio_encode: timings.get("audio_encode").and_then(|value| value.as_f64()),
         prompt_build: timings.get("prompt_build").and_then(|value| value.as_f64()),
         prefill: timings.get("prefill").and_then(|value| value.as_f64()),
+        prefill_input_norm: diagnostic_f64(prefill_profile, &["input_norm"]),
+        prefill_attention: diagnostic_f64(prefill_profile, &["attention"]),
+        prefill_attention_residual: diagnostic_f64(prefill_profile, &["attention_residual"]),
+        prefill_post_attention_norm: diagnostic_f64(prefill_profile, &["post_attention_norm"]),
+        prefill_mlp: diagnostic_f64(prefill_profile, &["mlp"]),
+        prefill_mlp_residual: diagnostic_f64(prefill_profile, &["mlp_residual"]),
+        prefill_layers_total: diagnostic_f64(prefill_profile, &["layers_total"]),
+        prefill_final_norm: diagnostic_f64(prefill_profile, &["final_norm"]),
+        prefill_lm_head: diagnostic_f64(prefill_profile, &["lm_head"]),
         timestamp_argmax: timings
             .get("timestamp_argmax")
             .and_then(|value| value.as_f64()),
@@ -3608,6 +3627,12 @@ fn diagnostic_u64(value: Option<&serde_json::Value>, keys: &[&str]) -> Option<u6
     let value = value?;
     keys.iter()
         .find_map(|key| value.get(*key).and_then(|value| value.as_u64()))
+}
+
+fn diagnostic_f64(value: Option<&serde_json::Value>, keys: &[&str]) -> Option<f64> {
+    let value = value?;
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(|value| value.as_f64()))
 }
 
 fn asr_execution_from_diagnostics(
@@ -3915,6 +3940,15 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
     let mut audio_encode = Vec::new();
     let mut prompt_build = Vec::new();
     let mut prefill = Vec::new();
+    let mut prefill_input_norm = Vec::new();
+    let mut prefill_attention = Vec::new();
+    let mut prefill_attention_residual = Vec::new();
+    let mut prefill_post_attention_norm = Vec::new();
+    let mut prefill_mlp = Vec::new();
+    let mut prefill_mlp_residual = Vec::new();
+    let mut prefill_layers_total = Vec::new();
+    let mut prefill_final_norm = Vec::new();
+    let mut prefill_lm_head = Vec::new();
     let mut timestamp_argmax = Vec::new();
     let mut timestamp_fixup = Vec::new();
     let mut postprocess = Vec::new();
@@ -4006,6 +4040,33 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
         }
         if let Some(value) = sample.prefill {
             prefill.push(value);
+        }
+        if let Some(value) = sample.prefill_input_norm {
+            prefill_input_norm.push(value);
+        }
+        if let Some(value) = sample.prefill_attention {
+            prefill_attention.push(value);
+        }
+        if let Some(value) = sample.prefill_attention_residual {
+            prefill_attention_residual.push(value);
+        }
+        if let Some(value) = sample.prefill_post_attention_norm {
+            prefill_post_attention_norm.push(value);
+        }
+        if let Some(value) = sample.prefill_mlp {
+            prefill_mlp.push(value);
+        }
+        if let Some(value) = sample.prefill_mlp_residual {
+            prefill_mlp_residual.push(value);
+        }
+        if let Some(value) = sample.prefill_layers_total {
+            prefill_layers_total.push(value);
+        }
+        if let Some(value) = sample.prefill_final_norm {
+            prefill_final_norm.push(value);
+        }
+        if let Some(value) = sample.prefill_lm_head {
+            prefill_lm_head.push(value);
         }
         if let Some(value) = sample.timestamp_argmax {
             timestamp_argmax.push(value);
@@ -4105,6 +4166,15 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
         && audio_encode.is_empty()
         && prompt_build.is_empty()
         && prefill.is_empty()
+        && prefill_input_norm.is_empty()
+        && prefill_attention.is_empty()
+        && prefill_attention_residual.is_empty()
+        && prefill_post_attention_norm.is_empty()
+        && prefill_mlp.is_empty()
+        && prefill_mlp_residual.is_empty()
+        && prefill_layers_total.is_empty()
+        && prefill_final_norm.is_empty()
+        && prefill_lm_head.is_empty()
         && timestamp_argmax.is_empty()
         && timestamp_fixup.is_empty()
         && postprocess.is_empty()
@@ -4161,6 +4231,15 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
     summarize_stage("audio_encode", &audio_encode);
     summarize_stage("prompt_build", &prompt_build);
     summarize_stage("prefill", &prefill);
+    summarize_stage("pf_in_norm", &prefill_input_norm);
+    summarize_stage("pf_attn", &prefill_attention);
+    summarize_stage("pf_attn_res", &prefill_attention_residual);
+    summarize_stage("pf_postnorm", &prefill_post_attention_norm);
+    summarize_stage("pf_mlp", &prefill_mlp);
+    summarize_stage("pf_mlp_res", &prefill_mlp_residual);
+    summarize_stage("pf_layers", &prefill_layers_total);
+    summarize_stage("pf_norm", &prefill_final_norm);
+    summarize_stage("pf_lm_head", &prefill_lm_head);
     summarize_stage("ts_argmax", &timestamp_argmax);
     summarize_stage("ts_fixup", &timestamp_fixup);
     summarize_stage("postprocess", &postprocess);

--- a/crates/izwi-cli/src/commands/bench.rs
+++ b/crates/izwi-cli/src/commands/bench.rs
@@ -216,6 +216,12 @@ struct AsrStageTimings {
     prefill: Option<f64>,
     prefill_input_norm: Option<f64>,
     prefill_attention: Option<f64>,
+    prefill_attention_qkv_proj: Option<f64>,
+    prefill_attention_qk_norm: Option<f64>,
+    prefill_attention_rope: Option<f64>,
+    prefill_attention_cache: Option<f64>,
+    prefill_attention_core: Option<f64>,
+    prefill_attention_o_proj: Option<f64>,
     prefill_attention_residual: Option<f64>,
     prefill_post_attention_norm: Option<f64>,
     prefill_mlp: Option<f64>,
@@ -3584,6 +3590,12 @@ fn asr_stage_timings_from_diagnostics(diagnostics: &serde_json::Value) -> Option
         prefill: timings.get("prefill").and_then(|value| value.as_f64()),
         prefill_input_norm: diagnostic_f64(prefill_profile, &["input_norm"]),
         prefill_attention: diagnostic_f64(prefill_profile, &["attention"]),
+        prefill_attention_qkv_proj: diagnostic_f64(prefill_profile, &["attention_qkv_proj"]),
+        prefill_attention_qk_norm: diagnostic_f64(prefill_profile, &["attention_qk_norm"]),
+        prefill_attention_rope: diagnostic_f64(prefill_profile, &["attention_rope"]),
+        prefill_attention_cache: diagnostic_f64(prefill_profile, &["attention_cache"]),
+        prefill_attention_core: diagnostic_f64(prefill_profile, &["attention_core"]),
+        prefill_attention_o_proj: diagnostic_f64(prefill_profile, &["attention_o_proj"]),
         prefill_attention_residual: diagnostic_f64(prefill_profile, &["attention_residual"]),
         prefill_post_attention_norm: diagnostic_f64(prefill_profile, &["post_attention_norm"]),
         prefill_mlp: diagnostic_f64(prefill_profile, &["mlp"]),
@@ -3942,6 +3954,12 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
     let mut prefill = Vec::new();
     let mut prefill_input_norm = Vec::new();
     let mut prefill_attention = Vec::new();
+    let mut prefill_attention_qkv_proj = Vec::new();
+    let mut prefill_attention_qk_norm = Vec::new();
+    let mut prefill_attention_rope = Vec::new();
+    let mut prefill_attention_cache = Vec::new();
+    let mut prefill_attention_core = Vec::new();
+    let mut prefill_attention_o_proj = Vec::new();
     let mut prefill_attention_residual = Vec::new();
     let mut prefill_post_attention_norm = Vec::new();
     let mut prefill_mlp = Vec::new();
@@ -4046,6 +4064,24 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
         }
         if let Some(value) = sample.prefill_attention {
             prefill_attention.push(value);
+        }
+        if let Some(value) = sample.prefill_attention_qkv_proj {
+            prefill_attention_qkv_proj.push(value);
+        }
+        if let Some(value) = sample.prefill_attention_qk_norm {
+            prefill_attention_qk_norm.push(value);
+        }
+        if let Some(value) = sample.prefill_attention_rope {
+            prefill_attention_rope.push(value);
+        }
+        if let Some(value) = sample.prefill_attention_cache {
+            prefill_attention_cache.push(value);
+        }
+        if let Some(value) = sample.prefill_attention_core {
+            prefill_attention_core.push(value);
+        }
+        if let Some(value) = sample.prefill_attention_o_proj {
+            prefill_attention_o_proj.push(value);
         }
         if let Some(value) = sample.prefill_attention_residual {
             prefill_attention_residual.push(value);
@@ -4168,6 +4204,12 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
         && prefill.is_empty()
         && prefill_input_norm.is_empty()
         && prefill_attention.is_empty()
+        && prefill_attention_qkv_proj.is_empty()
+        && prefill_attention_qk_norm.is_empty()
+        && prefill_attention_rope.is_empty()
+        && prefill_attention_cache.is_empty()
+        && prefill_attention_core.is_empty()
+        && prefill_attention_o_proj.is_empty()
         && prefill_attention_residual.is_empty()
         && prefill_post_attention_norm.is_empty()
         && prefill_mlp.is_empty()
@@ -4233,6 +4275,12 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
     summarize_stage("prefill", &prefill);
     summarize_stage("pf_in_norm", &prefill_input_norm);
     summarize_stage("pf_attn", &prefill_attention);
+    summarize_stage("pf_qkv", &prefill_attention_qkv_proj);
+    summarize_stage("pf_qk_norm", &prefill_attention_qk_norm);
+    summarize_stage("pf_rope", &prefill_attention_rope);
+    summarize_stage("pf_cache", &prefill_attention_cache);
+    summarize_stage("pf_core", &prefill_attention_core);
+    summarize_stage("pf_o_proj", &prefill_attention_o_proj);
     summarize_stage("pf_attn_res", &prefill_attention_residual);
     summarize_stage("pf_postnorm", &prefill_post_attention_norm);
     summarize_stage("pf_mlp", &prefill_mlp);

--- a/crates/izwi-cli/src/commands/bench.rs
+++ b/crates/izwi-cli/src/commands/bench.rs
@@ -144,6 +144,52 @@ struct AsrBenchSample {
     response: AsrBenchResponse,
 }
 
+#[derive(Debug, Clone, Deserialize, Default)]
+struct DiarizeBenchResponse {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    duration_secs: Option<f64>,
+    #[serde(default)]
+    processing_time_ms: f64,
+    #[serde(default)]
+    rtf: Option<f64>,
+    #[serde(default)]
+    speaker_count: usize,
+    #[serde(default)]
+    processing_status: String,
+    #[serde(default)]
+    processing_error: Option<String>,
+    #[serde(default)]
+    izwi_diarization_diagnostics: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone)]
+struct DiarizeBenchSample {
+    total_ms: f64,
+    response: DiarizeBenchResponse,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct AlignBenchResponse {
+    #[serde(default)]
+    duration: Option<f64>,
+    #[serde(default)]
+    processing_time_ms: Option<f64>,
+    #[serde(default)]
+    word_count: Option<usize>,
+    #[serde(default)]
+    izwi_asr_diagnostics: Option<serde_json::Value>,
+    #[serde(default)]
+    izwi_alignment_diagnostics: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone)]
+struct AlignBenchSample {
+    total_ms: f64,
+    response: AlignBenchResponse,
+}
+
 #[derive(Debug, Clone, Copy)]
 struct AsrStageTimings {
     audio_decode: Option<f64>,
@@ -156,12 +202,19 @@ struct AsrStageTimings {
     encoder_attention: Option<f64>,
     encoder_conv: Option<f64>,
     encoder_norm: Option<f64>,
+    transformer_forward: Option<f64>,
+    head: Option<f64>,
+    host_read: Option<f64>,
     prompt_kernel: Option<f64>,
     language_detect: Option<f64>,
     resample: Option<f64>,
     mel: Option<f64>,
     audio_encode: Option<f64>,
+    prompt_build: Option<f64>,
     prefill: Option<f64>,
+    timestamp_argmax: Option<f64>,
+    timestamp_fixup: Option<f64>,
+    postprocess: Option<f64>,
     decode: Option<f64>,
     model_total: Option<f64>,
     prompt_tokens: Option<u64>,
@@ -201,6 +254,7 @@ struct AsrDecodeProfileTimings {
 
 #[derive(Debug, Clone, Copy, Serialize)]
 struct AsrExecutionDiagnostics {
+    kv_cache_enabled: Option<bool>,
     cuda_dense_decode_cache: Option<bool>,
     dense_head_decode_enabled: Option<bool>,
     dense_decode_max_tokens: Option<u64>,
@@ -270,6 +324,7 @@ struct BenchmarkReport {
 #[derive(Debug, Serialize)]
 struct BenchmarkRunConfig {
     model: Option<String>,
+    asr_model: Option<String>,
     iterations: Option<u32>,
     concurrent: Option<u32>,
     warmup: bool,
@@ -277,7 +332,9 @@ struct BenchmarkRunConfig {
     system: Option<String>,
     max_tokens: Option<usize>,
     text: Option<String>,
+    text_file: Option<String>,
     file: Option<String>,
+    num_speakers: Option<u32>,
     saved_voice_id: Option<String>,
     reference_audio: Option<String>,
     reference_text: Option<String>,
@@ -352,6 +409,7 @@ struct BenchmarkManifestCase {
     name: Option<String>,
     command: String,
     model: Option<String>,
+    asr_model: Option<String>,
     iterations: Option<u32>,
     concurrent: Option<u32>,
     warmup: Option<bool>,
@@ -359,7 +417,9 @@ struct BenchmarkManifestCase {
     system: Option<String>,
     max_tokens: Option<usize>,
     text: Option<String>,
+    text_file: Option<String>,
     file: Option<String>,
+    num_speakers: Option<u32>,
     saved_voice_id: Option<String>,
     reference_audio: Option<String>,
     reference_text: Option<String>,
@@ -372,6 +432,7 @@ struct BenchmarkManifestCase {
 #[derive(Debug, Clone, Deserialize, Default)]
 struct BenchmarkManifestMatrix {
     model: Option<Vec<String>>,
+    asr_model: Option<Vec<String>>,
     iterations: Option<Vec<u32>>,
     concurrent: Option<Vec<u32>>,
     warmup: Option<Vec<bool>>,
@@ -379,7 +440,9 @@ struct BenchmarkManifestMatrix {
     system: Option<Vec<String>>,
     max_tokens: Option<Vec<usize>>,
     text: Option<Vec<String>>,
+    text_file: Option<Vec<String>>,
     file: Option<Vec<String>>,
+    num_speakers: Option<Vec<u32>>,
     saved_voice_id: Option<Vec<String>>,
     reference_audio: Option<Vec<String>>,
     reference_text: Option<Vec<String>>,
@@ -397,6 +460,7 @@ struct MatrixDimension {
 #[derive(Debug, Clone)]
 enum MatrixValue {
     Model(String),
+    AsrModel(String),
     Iterations(u32),
     Concurrent(u32),
     Warmup(bool),
@@ -404,7 +468,9 @@ enum MatrixValue {
     System(String),
     MaxTokens(usize),
     Text(String),
+    TextFile(String),
     File(String),
+    NumSpeakers(u32),
     SavedVoiceId(String),
     ReferenceAudio(String),
     ReferenceText(String),
@@ -565,6 +631,52 @@ pub async fn execute(
         )
         .await
         .and_then(|report| emit_report(&options, &report)),
+        BenchCommands::Diarize {
+            model,
+            iterations,
+            file,
+            num_speakers,
+            asr_model,
+            concurrent,
+            warmup,
+        } => bench_diarize(
+            server,
+            &model,
+            iterations,
+            file,
+            num_speakers,
+            &asr_model,
+            concurrent,
+            warmup,
+            &options,
+            theme,
+        )
+        .await
+        .and_then(|report| emit_report(&options, &report)),
+        BenchCommands::Align {
+            model,
+            iterations,
+            file,
+            text,
+            text_file,
+            language,
+            concurrent,
+            warmup,
+        } => bench_align(
+            server,
+            &model,
+            iterations,
+            file,
+            text.as_deref(),
+            text_file.as_deref(),
+            language.as_deref(),
+            concurrent,
+            warmup,
+            &options,
+            theme,
+        )
+        .await
+        .and_then(|report| emit_report(&options, &report)),
         BenchCommands::Throughput {
             duration,
             concurrent,
@@ -689,6 +801,7 @@ impl MatrixValue {
     fn apply(&self, case: &mut BenchmarkManifestCase) {
         match self {
             MatrixValue::Model(value) => case.model = Some(value.clone()),
+            MatrixValue::AsrModel(value) => case.asr_model = Some(value.clone()),
             MatrixValue::Iterations(value) => case.iterations = Some(*value),
             MatrixValue::Concurrent(value) => case.concurrent = Some(*value),
             MatrixValue::Warmup(value) => case.warmup = Some(*value),
@@ -696,7 +809,9 @@ impl MatrixValue {
             MatrixValue::System(value) => case.system = Some(value.clone()),
             MatrixValue::MaxTokens(value) => case.max_tokens = Some(*value),
             MatrixValue::Text(value) => case.text = Some(value.clone()),
+            MatrixValue::TextFile(value) => case.text_file = Some(value.clone()),
             MatrixValue::File(value) => case.file = Some(value.clone()),
+            MatrixValue::NumSpeakers(value) => case.num_speakers = Some(*value),
             MatrixValue::SavedVoiceId(value) => case.saved_voice_id = Some(value.clone()),
             MatrixValue::ReferenceAudio(value) => case.reference_audio = Some(value.clone()),
             MatrixValue::ReferenceText(value) => case.reference_text = Some(value.clone()),
@@ -709,9 +824,11 @@ impl MatrixValue {
     fn label_value(&self) -> String {
         match self {
             MatrixValue::Model(value)
+            | MatrixValue::AsrModel(value)
             | MatrixValue::Prompt(value)
             | MatrixValue::System(value)
             | MatrixValue::Text(value)
+            | MatrixValue::TextFile(value)
             | MatrixValue::File(value)
             | MatrixValue::SavedVoiceId(value)
             | MatrixValue::ReferenceAudio(value)
@@ -721,6 +838,7 @@ impl MatrixValue {
             MatrixValue::Iterations(value) => value.to_string(),
             MatrixValue::Concurrent(value) => value.to_string(),
             MatrixValue::MaxTokens(value) => value.to_string(),
+            MatrixValue::NumSpeakers(value) => value.to_string(),
             MatrixValue::DurationSecs(value) => value.to_string(),
             MatrixValue::Warmup(value) => value.to_string(),
         }
@@ -731,6 +849,12 @@ impl BenchmarkManifestMatrix {
     fn dimensions(&self) -> Result<Vec<MatrixDimension>> {
         let mut dimensions = Vec::new();
         add_matrix_dimension(&mut dimensions, "model", &self.model, MatrixValue::Model)?;
+        add_matrix_dimension(
+            &mut dimensions,
+            "asr_model",
+            &self.asr_model,
+            MatrixValue::AsrModel,
+        )?;
         add_matrix_dimension(
             &mut dimensions,
             "iterations",
@@ -753,7 +877,19 @@ impl BenchmarkManifestMatrix {
             MatrixValue::MaxTokens,
         )?;
         add_matrix_dimension(&mut dimensions, "text", &self.text, MatrixValue::Text)?;
+        add_matrix_dimension(
+            &mut dimensions,
+            "text_file",
+            &self.text_file,
+            MatrixValue::TextFile,
+        )?;
         add_matrix_dimension(&mut dimensions, "file", &self.file, MatrixValue::File)?;
+        add_matrix_dimension(
+            &mut dimensions,
+            "num_speakers",
+            &self.num_speakers,
+            MatrixValue::NumSpeakers,
+        )?;
         add_matrix_dimension(
             &mut dimensions,
             "saved_voice_id",
@@ -1141,6 +1277,68 @@ async fn bench_manifest(
                 )
                 .await?
             }
+            "diarize" | "diarization" => {
+                let file = case.file.as_ref().map(|file| {
+                    let path = Path::new(file);
+                    if path.is_absolute() {
+                        path.to_path_buf()
+                    } else {
+                        manifest_dir.join(path)
+                    }
+                });
+                let model = case.model.as_deref().unwrap_or("sortformer-4spk");
+                let asr_model = case.asr_model.as_deref().unwrap_or("parakeet-tdt-0.6b-v3");
+                bench_diarize(
+                    &suite_server,
+                    model,
+                    case.iterations.unwrap_or(10),
+                    file,
+                    case.num_speakers,
+                    asr_model,
+                    case.concurrent.unwrap_or(1),
+                    case.warmup.unwrap_or(false),
+                    options,
+                    theme,
+                )
+                .await?
+            }
+            "align" | "alignment" => {
+                let file = case.file.as_ref().map(|file| {
+                    let path = Path::new(file);
+                    if path.is_absolute() {
+                        path.to_path_buf()
+                    } else {
+                        manifest_dir.join(path)
+                    }
+                });
+                let text_file = case
+                    .text_file
+                    .as_ref()
+                    .or(case.reference_text_file.as_ref())
+                    .map(|file| {
+                        let path = Path::new(file);
+                        if path.is_absolute() {
+                            path.to_path_buf()
+                        } else {
+                            manifest_dir.join(path)
+                        }
+                    });
+                let model = case.model.as_deref().unwrap_or("Qwen3-ForcedAligner-0.6B");
+                bench_align(
+                    &suite_server,
+                    model,
+                    case.iterations.unwrap_or(10),
+                    file,
+                    case.text.as_deref(),
+                    text_file.as_deref(),
+                    case.language.as_deref(),
+                    case.concurrent.unwrap_or(1),
+                    case.warmup.unwrap_or(false),
+                    options,
+                    theme,
+                )
+                .await?
+            }
             "throughput" => {
                 bench_throughput(
                     &suite_server,
@@ -1442,6 +1640,7 @@ async fn bench_chat(
         duration_ms: run_start.elapsed().as_secs_f64() * 1000.0,
         config: BenchmarkRunConfig {
             model: Some(model.to_string()),
+            asr_model: None,
             iterations: Some(iterations),
             concurrent: Some(concurrent),
             warmup,
@@ -1449,7 +1648,9 @@ async fn bench_chat(
             system: system.as_deref().map(|value| value.to_string()),
             max_tokens: Some(max_tokens),
             text: None,
+            text_file: None,
             file: None,
+            num_speakers: None,
             saved_voice_id: None,
             reference_audio: None,
             reference_text: None,
@@ -1685,6 +1886,7 @@ async fn bench_tts(
         duration_ms: run_start.elapsed().as_secs_f64() * 1000.0,
         config: BenchmarkRunConfig {
             model: Some(model.to_string()),
+            asr_model: None,
             iterations: Some(iterations),
             concurrent: Some(concurrent),
             warmup,
@@ -1692,7 +1894,9 @@ async fn bench_tts(
             system: None,
             max_tokens: None,
             text: Some(text.as_ref().clone()),
+            text_file: None,
             file: None,
+            num_speakers: None,
             saved_voice_id: reference.saved_voice_id.clone(),
             reference_audio: reference.reference_audio_path.clone(),
             reference_text: reference.reference_text.clone(),
@@ -1951,6 +2155,7 @@ async fn bench_asr(
         duration_ms: run_start.elapsed().as_secs_f64() * 1000.0,
         config: BenchmarkRunConfig {
             model: Some(model.to_string()),
+            asr_model: None,
             iterations: Some(iterations),
             concurrent: Some(concurrent),
             warmup,
@@ -1958,7 +2163,9 @@ async fn bench_asr(
             system: None,
             max_tokens,
             text: None,
+            text_file: None,
             file: Some(audio_file.display().to_string()),
+            num_speakers: None,
             saved_voice_id: None,
             reference_audio: None,
             reference_text: None,
@@ -2003,6 +2210,518 @@ async fn bench_asr(
                     .response
                     .izwi_asr_diagnostics
                     .as_ref()
+                    .and_then(asr_execution_from_diagnostics),
+            })
+            .collect(),
+        telemetry: RuntimeTelemetryReport {
+            delta_available: metrics_before.is_some() && metrics_after.is_some(),
+            before: metrics_before,
+            after: metrics_after,
+        },
+    })
+}
+
+async fn bench_diarize(
+    server: &str,
+    model: &str,
+    iterations: u32,
+    file: Option<PathBuf>,
+    num_speakers: Option<u32>,
+    asr_model: &str,
+    concurrent: u32,
+    warmup: bool,
+    options: &BenchOptions,
+    theme: &Theme,
+) -> Result<BenchmarkReport> {
+    if iterations == 0 {
+        return Err(CliError::InvalidInput(
+            "Iterations must be greater than 0".to_string(),
+        ));
+    }
+    if concurrent == 0 {
+        return Err(CliError::InvalidInput(
+            "Concurrent requests must be greater than 0".to_string(),
+        ));
+    }
+
+    if options.interactive() {
+        theme.step(1, 3, &format!("Benchmarking diarization with '{}'", model));
+    }
+    let started_at = Utc::now();
+    let run_start = Instant::now();
+    let metrics_before = fetch_runtime_metrics(server).await;
+
+    let audio_file = file.unwrap_or_else(|| PathBuf::from("data/diarization.wav"));
+    if !audio_file.exists() {
+        return Err(CliError::InvalidInput(format!(
+            "Audio file not found: {}",
+            audio_file.display()
+        )));
+    }
+    let audio_data = tokio::fs::read(&audio_file).await.map_err(CliError::Io)?;
+    let audio_base64 = STANDARD.encode(&audio_data);
+
+    if let Some(num_speakers) = num_speakers {
+        if num_speakers == 0 {
+            return Err(CliError::InvalidInput(
+                "Speaker count must be greater than 0".to_string(),
+            ));
+        }
+        if options.interactive() {
+            theme.info(&format!("Using fixed speaker count: {}", num_speakers));
+        }
+    }
+
+    if warmup {
+        if options.interactive() {
+            theme.info("Running warmup iteration...");
+        }
+        let _ = run_diarize_request(
+            server,
+            model,
+            asr_model,
+            &audio_file,
+            &audio_base64,
+            num_speakers,
+        )
+        .await?;
+    }
+
+    let pb = progress_bar(options.interactive(), iterations as u64);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template(
+                "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} iterations",
+            )
+            .unwrap()
+            .progress_chars("#>-"),
+    );
+
+    let progress = Arc::new(pb);
+    let audio_base64 = Arc::new(audio_base64);
+    let audio_file = Arc::new(audio_file);
+    let wall_start = Instant::now();
+    let samples: Vec<DiarizeBenchSample> = stream::iter(0..iterations)
+        .map(|_| {
+            let progress = Arc::clone(&progress);
+            let audio_base64 = Arc::clone(&audio_base64);
+            let audio_file = Arc::clone(&audio_file);
+            let model = model.to_string();
+            let asr_model = asr_model.to_string();
+            let server = server.to_string();
+            async move {
+                let start = Instant::now();
+                let result = run_diarize_request(
+                    &server,
+                    &model,
+                    &asr_model,
+                    audio_file.as_ref(),
+                    audio_base64.as_str(),
+                    num_speakers,
+                )
+                .await
+                .map(|response| DiarizeBenchSample {
+                    total_ms: start.elapsed().as_secs_f64() * 1000.0,
+                    response,
+                });
+                progress.inc(1);
+                result
+            }
+        })
+        .buffer_unordered(concurrent as usize)
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?;
+    let wall_elapsed = wall_start.elapsed();
+    progress.finish_with_message("Benchmark complete");
+
+    let times: Vec<f64> = samples.iter().map(|sample| sample.total_ms).collect();
+    let processing_ms: Vec<f64> = samples
+        .iter()
+        .map(|sample| sample.response.processing_time_ms)
+        .collect();
+    let audio_duration_secs: Vec<f64> = samples
+        .iter()
+        .filter_map(|sample| sample.response.duration_secs)
+        .collect();
+    let rtf: Vec<f64> = samples
+        .iter()
+        .filter_map(|sample| sample.response.rtf)
+        .collect();
+    let stage_samples: Vec<AsrStageTimings> = samples
+        .iter()
+        .filter_map(|sample| sample.response.izwi_diarization_diagnostics.as_ref())
+        .flat_map(collect_asr_stage_timings_from_diagnostics)
+        .collect();
+
+    let avg = times.iter().sum::<f64>() / times.len() as f64;
+    let min = times.iter().copied().fold(f64::INFINITY, f64::min);
+    let max = times.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    let p50 = percentile(&times, 0.5);
+    let p95 = percentile(&times, 0.95);
+    let p99 = percentile(&times, 0.99);
+    if options.human_output() {
+        println!("\n{}", console::style("Results:").bold().underlined());
+        println!("  Iterations: {}", iterations);
+        println!("  Concurrent: {}", concurrent);
+        println!("  Average:    {:.2} ms", avg);
+        println!("  Min:        {:.2} ms", min);
+        println!("  Max:        {:.2} ms", max);
+        println!("  P50:        {:.2} ms", p50);
+        println!("  P95:        {:.2} ms", p95);
+        println!("  P99:        {:.2} ms", p99);
+        println!(
+            "  Throughput: {:.2} req/s",
+            iterations as f64 / wall_elapsed.as_secs_f64()
+        );
+        if !audio_duration_secs.is_empty() {
+            println!(
+                "  Audio duration (avg/p50/p95): {:.2} / {:.2} / {:.2} s",
+                audio_duration_secs.iter().sum::<f64>() / audio_duration_secs.len() as f64,
+                percentile(&audio_duration_secs, 0.5),
+                percentile(&audio_duration_secs, 0.95)
+            );
+        }
+        if !rtf.is_empty() {
+            println!(
+                "  RTF (avg/p50/p95):            {:.3} / {:.3} / {:.3}",
+                rtf.iter().sum::<f64>() / rtf.len() as f64,
+                percentile(&rtf, 0.5),
+                percentile(&rtf, 0.95)
+            );
+        }
+        print_asr_stage_timing_summary(&stage_samples);
+    }
+
+    let metrics_after = fetch_runtime_metrics(server).await;
+    if options.human_output() {
+        print_runtime_delta(
+            metrics_before.clone(),
+            metrics_after.clone(),
+            RuntimeTelemetryContext::Default,
+        );
+    }
+    let ended_at = Utc::now();
+    Ok(BenchmarkReport {
+        schema_version: 1,
+        command: "diarize",
+        server: server.to_string(),
+        started_at,
+        ended_at,
+        duration_ms: run_start.elapsed().as_secs_f64() * 1000.0,
+        config: BenchmarkRunConfig {
+            model: Some(model.to_string()),
+            asr_model: Some(asr_model.to_string()),
+            iterations: Some(iterations),
+            concurrent: Some(concurrent),
+            warmup,
+            prompt: None,
+            system: None,
+            max_tokens: None,
+            text: None,
+            text_file: None,
+            file: Some(audio_file.display().to_string()),
+            num_speakers,
+            saved_voice_id: None,
+            reference_audio: None,
+            reference_text: None,
+            language: None,
+            duration_secs: None,
+        },
+        summary: BenchmarkSummary {
+            latency_ms: stats(&times),
+            ttft_ms: None,
+            end_to_end_ms: stats(&times),
+            completion_tps: None,
+            tokens_per_second: None,
+            server_generation_ms: None,
+            server_processing_ms: stats(&processing_ms),
+            audio_duration_secs: stats(&audio_duration_secs),
+            rtf: stats(&rtf),
+            prompt_tokens_avg: None,
+            completion_tokens_avg: None,
+            throughput_rps: Some(iterations as f64 / wall_elapsed.as_secs_f64()),
+            successful: Some(iterations as u64),
+            failed: Some(0),
+            total: Some(iterations as u64),
+        },
+        samples: samples
+            .iter()
+            .enumerate()
+            .map(|(index, sample)| BenchmarkSample {
+                index: index + 1,
+                latency_ms: Some(sample.total_ms),
+                ttft_ms: None,
+                end_to_end_ms: Some(sample.total_ms),
+                completion_tps: None,
+                tokens_per_second: None,
+                prompt_tokens: None,
+                completion_tokens: None,
+                server_generation_ms: None,
+                server_processing_ms: Some(sample.response.processing_time_ms),
+                audio_duration_secs: sample.response.duration_secs,
+                rtf: sample.response.rtf,
+                tokens_generated: None,
+                asr_execution: None,
+            })
+            .collect(),
+        telemetry: RuntimeTelemetryReport {
+            delta_available: metrics_before.is_some() && metrics_after.is_some(),
+            before: metrics_before,
+            after: metrics_after,
+        },
+    })
+}
+
+async fn bench_align(
+    server: &str,
+    model: &str,
+    iterations: u32,
+    file: Option<PathBuf>,
+    text: Option<&str>,
+    text_file: Option<&Path>,
+    language: Option<&str>,
+    concurrent: u32,
+    warmup: bool,
+    options: &BenchOptions,
+    theme: &Theme,
+) -> Result<BenchmarkReport> {
+    if iterations == 0 {
+        return Err(CliError::InvalidInput(
+            "Iterations must be greater than 0".to_string(),
+        ));
+    }
+    if concurrent == 0 {
+        return Err(CliError::InvalidInput(
+            "Concurrent requests must be greater than 0".to_string(),
+        ));
+    }
+
+    if options.interactive() {
+        theme.step(
+            1,
+            3,
+            &format!("Benchmarking forced alignment with '{}'", model),
+        );
+    }
+    let started_at = Utc::now();
+    let run_start = Instant::now();
+    let metrics_before = fetch_runtime_metrics(server).await;
+
+    let audio_file = file.unwrap_or_else(|| PathBuf::from("data/fox.wav"));
+    if !audio_file.exists() {
+        return Err(CliError::InvalidInput(format!(
+            "Audio file not found: {}",
+            audio_file.display()
+        )));
+    }
+    let reference_text = resolve_align_bench_text(text, text_file).await?;
+    let audio_data = tokio::fs::read(&audio_file).await.map_err(CliError::Io)?;
+    let audio_base64 = STANDARD.encode(&audio_data);
+
+    if let Some(language) = language {
+        if options.interactive() {
+            theme.info(&format!("Using language hint: {}", language));
+        }
+    }
+
+    if warmup {
+        if options.interactive() {
+            theme.info("Running warmup iteration...");
+        }
+        let _ = run_align_request(server, model, &audio_base64, &reference_text, language).await?;
+    }
+
+    let pb = progress_bar(options.interactive(), iterations as u64);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template(
+                "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} iterations",
+            )
+            .unwrap()
+            .progress_chars("#>-"),
+    );
+
+    let progress = Arc::new(pb);
+    let audio_base64 = Arc::new(audio_base64);
+    let reference_text = Arc::new(reference_text);
+    let language = language.map(|value| Arc::new(value.to_string()));
+    let wall_start = Instant::now();
+    let samples: Vec<AlignBenchSample> = stream::iter(0..iterations)
+        .map(|_| {
+            let progress = Arc::clone(&progress);
+            let audio_base64 = Arc::clone(&audio_base64);
+            let reference_text = Arc::clone(&reference_text);
+            let language = language.clone();
+            let model = model.to_string();
+            let server = server.to_string();
+            async move {
+                let start = Instant::now();
+                let result = run_align_request(
+                    &server,
+                    &model,
+                    audio_base64.as_str(),
+                    reference_text.as_str(),
+                    language.as_deref().map(|value| value.as_str()),
+                )
+                .await
+                .map(|response| AlignBenchSample {
+                    total_ms: start.elapsed().as_secs_f64() * 1000.0,
+                    response,
+                });
+                progress.inc(1);
+                result
+            }
+        })
+        .buffer_unordered(concurrent as usize)
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?;
+    let wall_elapsed = wall_start.elapsed();
+    progress.finish_with_message("Benchmark complete");
+
+    let times: Vec<f64> = samples.iter().map(|sample| sample.total_ms).collect();
+    let processing_ms: Vec<f64> = samples
+        .iter()
+        .filter_map(|sample| sample.response.processing_time_ms)
+        .collect();
+    let audio_duration_secs: Vec<f64> = samples
+        .iter()
+        .filter_map(|sample| sample.response.duration)
+        .collect();
+    let rtf: Vec<f64> = samples
+        .iter()
+        .filter_map(|sample| align_sample_rtf(&sample.response))
+        .collect();
+    let word_counts: Vec<f64> = samples
+        .iter()
+        .filter_map(|sample| sample.response.word_count.map(|value| value as f64))
+        .collect();
+    let stage_samples: Vec<AsrStageTimings> = samples
+        .iter()
+        .filter_map(|sample| align_response_diagnostics(&sample.response))
+        .flat_map(collect_asr_stage_timings_from_diagnostics)
+        .collect();
+
+    let avg = times.iter().sum::<f64>() / times.len() as f64;
+    let min = times.iter().copied().fold(f64::INFINITY, f64::min);
+    let max = times.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    let p50 = percentile(&times, 0.5);
+    let p95 = percentile(&times, 0.95);
+    let p99 = percentile(&times, 0.99);
+    if options.human_output() {
+        println!("\n{}", console::style("Results:").bold().underlined());
+        println!("  Iterations: {}", iterations);
+        println!("  Concurrent: {}", concurrent);
+        println!("  Average:    {:.2} ms", avg);
+        println!("  Min:        {:.2} ms", min);
+        println!("  Max:        {:.2} ms", max);
+        println!("  P50:        {:.2} ms", p50);
+        println!("  P95:        {:.2} ms", p95);
+        println!("  P99:        {:.2} ms", p99);
+        println!(
+            "  Throughput: {:.2} req/s",
+            iterations as f64 / wall_elapsed.as_secs_f64()
+        );
+        if !word_counts.is_empty() {
+            println!(
+                "  Words (avg/p50/p95):          {:.1} / {:.1} / {:.1}",
+                word_counts.iter().sum::<f64>() / word_counts.len() as f64,
+                percentile(&word_counts, 0.5),
+                percentile(&word_counts, 0.95)
+            );
+        }
+        if !audio_duration_secs.is_empty() {
+            println!(
+                "  Alignment duration (avg/p50/p95): {:.2} / {:.2} / {:.2} s",
+                audio_duration_secs.iter().sum::<f64>() / audio_duration_secs.len() as f64,
+                percentile(&audio_duration_secs, 0.5),
+                percentile(&audio_duration_secs, 0.95)
+            );
+        }
+        if !rtf.is_empty() {
+            println!(
+                "  RTF (avg/p50/p95):            {:.3} / {:.3} / {:.3}",
+                rtf.iter().sum::<f64>() / rtf.len() as f64,
+                percentile(&rtf, 0.5),
+                percentile(&rtf, 0.95)
+            );
+        }
+        print_asr_stage_timing_summary(&stage_samples);
+    }
+
+    let metrics_after = fetch_runtime_metrics(server).await;
+    if options.human_output() {
+        print_runtime_delta(
+            metrics_before.clone(),
+            metrics_after.clone(),
+            RuntimeTelemetryContext::Default,
+        );
+    }
+    let ended_at = Utc::now();
+    Ok(BenchmarkReport {
+        schema_version: 1,
+        command: "align",
+        server: server.to_string(),
+        started_at,
+        ended_at,
+        duration_ms: run_start.elapsed().as_secs_f64() * 1000.0,
+        config: BenchmarkRunConfig {
+            model: Some(model.to_string()),
+            asr_model: None,
+            iterations: Some(iterations),
+            concurrent: Some(concurrent),
+            warmup,
+            prompt: None,
+            system: None,
+            max_tokens: None,
+            text: Some(reference_text.as_ref().clone()),
+            text_file: text_file.map(|path| path.display().to_string()),
+            file: Some(audio_file.display().to_string()),
+            num_speakers: None,
+            saved_voice_id: None,
+            reference_audio: None,
+            reference_text: None,
+            language: language.as_deref().map(|value| value.to_string()),
+            duration_secs: None,
+        },
+        summary: BenchmarkSummary {
+            latency_ms: stats(&times),
+            ttft_ms: None,
+            end_to_end_ms: stats(&times),
+            completion_tps: None,
+            tokens_per_second: None,
+            server_generation_ms: None,
+            server_processing_ms: stats(&processing_ms),
+            audio_duration_secs: stats(&audio_duration_secs),
+            rtf: stats(&rtf),
+            prompt_tokens_avg: None,
+            completion_tokens_avg: None,
+            throughput_rps: Some(iterations as f64 / wall_elapsed.as_secs_f64()),
+            successful: Some(iterations as u64),
+            failed: Some(0),
+            total: Some(iterations as u64),
+        },
+        samples: samples
+            .iter()
+            .enumerate()
+            .map(|(index, sample)| BenchmarkSample {
+                index: index + 1,
+                latency_ms: Some(sample.total_ms),
+                ttft_ms: None,
+                end_to_end_ms: Some(sample.total_ms),
+                completion_tps: None,
+                tokens_per_second: None,
+                prompt_tokens: None,
+                completion_tokens: None,
+                server_generation_ms: None,
+                server_processing_ms: sample.response.processing_time_ms,
+                audio_duration_secs: sample.response.duration,
+                rtf: align_sample_rtf(&sample.response),
+                tokens_generated: sample.response.word_count.map(|value| value as u64),
+                asr_execution: align_response_diagnostics(&sample.response)
                     .and_then(asr_execution_from_diagnostics),
             })
             .collect(),
@@ -2094,6 +2813,7 @@ async fn bench_throughput(
         duration_ms: measured_elapsed.as_secs_f64() * 1000.0,
         config: BenchmarkRunConfig {
             model: None,
+            asr_model: None,
             iterations: None,
             concurrent: Some(concurrent),
             warmup: false,
@@ -2101,7 +2821,9 @@ async fn bench_throughput(
             system: None,
             max_tokens: None,
             text: None,
+            text_file: None,
             file: None,
+            num_speakers: None,
             saved_voice_id: None,
             reference_audio: None,
             reference_text: None,
@@ -2306,6 +3028,230 @@ async fn run_asr_request(
         .json::<AsrBenchResponse>()
         .await
         .map_err(|e| CliError::Other(format!("Failed to parse ASR benchmark response: {e}")))
+}
+
+async fn run_diarize_request(
+    server: &str,
+    model: &str,
+    asr_model: &str,
+    audio_file: &Path,
+    audio_base64: &str,
+    num_speakers: Option<u32>,
+) -> Result<DiarizeBenchResponse> {
+    let client = http::client(Some(std::time::Duration::from_secs(600)))?;
+    let mut request_body = serde_json::json!({
+        "model": model,
+        "audio_base64": audio_base64,
+        "asr_model": asr_model,
+        "include_transcript": false,
+    });
+    if let Some(filename) = audio_filename_from_path(audio_file) {
+        request_body["audio_filename"] = serde_json::Value::String(filename);
+    }
+    if let Some(mime_type) = audio_mime_type_from_path(audio_file) {
+        request_body["audio_mime_type"] = serde_json::Value::String(mime_type.to_string());
+    }
+    if let Some(num_speakers) = num_speakers {
+        request_body["min_speakers"] = serde_json::json!(num_speakers);
+        request_body["max_speakers"] = serde_json::json!(num_speakers);
+    }
+
+    let response = client
+        .post(create_diarization_job_url(server))
+        .json(&request_body)
+        .send()
+        .await
+        .map_err(|e| CliError::ConnectionError(e.to_string()))?;
+
+    if !response.status().is_success() {
+        let status = response.status().as_u16();
+        let text = response.text().await.unwrap_or_default();
+        return Err(CliError::ApiError {
+            status,
+            message: text,
+        });
+    }
+
+    let created = response
+        .json::<DiarizeBenchResponse>()
+        .await
+        .map_err(|e| CliError::Other(format!("Failed to parse diarization job response: {e}")))?;
+    wait_for_diarization_bench_job(&client, server, created).await
+}
+
+async fn wait_for_diarization_bench_job(
+    client: &reqwest::Client,
+    server: &str,
+    mut record: DiarizeBenchResponse,
+) -> Result<DiarizeBenchResponse> {
+    let started = Instant::now();
+    let timeout = Duration::from_secs(600);
+    let poll_interval = Duration::from_millis(500);
+    let job_id = record.id.clone();
+    if job_id.trim().is_empty() {
+        return Err(CliError::Other(
+            "Diarization job response missing id".to_string(),
+        ));
+    }
+
+    loop {
+        match record.processing_status.as_str() {
+            "ready" => return Ok(record),
+            "failed" => {
+                return Err(CliError::ApiError {
+                    status: 500,
+                    message: record
+                        .processing_error
+                        .unwrap_or_else(|| "Diarization failed".to_string()),
+                });
+            }
+            "pending" | "processing" | "" => {}
+            other => {
+                return Err(CliError::Other(format!(
+                    "Unexpected diarization status: {other}"
+                )));
+            }
+        }
+
+        if started.elapsed() >= timeout {
+            return Err(CliError::Other(
+                "Timed out waiting for diarization benchmark job".to_string(),
+            ));
+        }
+
+        tokio::time::sleep(poll_interval).await;
+        let response = client
+            .get(diarization_job_url(server, &job_id))
+            .send()
+            .await
+            .map_err(|e| CliError::ConnectionError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let text = response.text().await.unwrap_or_default();
+            return Err(CliError::ApiError {
+                status,
+                message: text,
+            });
+        }
+
+        record = response.json::<DiarizeBenchResponse>().await.map_err(|e| {
+            CliError::Other(format!("Failed to parse diarization poll response: {e}"))
+        })?;
+    }
+}
+
+async fn run_align_request(
+    server: &str,
+    model: &str,
+    audio_base64: &str,
+    reference_text: &str,
+    language: Option<&str>,
+) -> Result<AlignBenchResponse> {
+    let client = http::client(Some(std::time::Duration::from_secs(300)))?;
+    let mut request_body = serde_json::json!({
+        "model": model,
+        "audio_base64": audio_base64,
+        "text": reference_text,
+        "response_format": "verbose_json",
+    });
+    if let Some(language) = language {
+        request_body["language"] = serde_json::Value::String(language.to_string());
+    }
+
+    let response = client
+        .post(format!("{}/v1/audio/align", server))
+        .json(&request_body)
+        .send()
+        .await
+        .map_err(|e| CliError::ConnectionError(e.to_string()))?;
+
+    if !response.status().is_success() {
+        let status = response.status().as_u16();
+        let text = response.text().await.unwrap_or_default();
+        return Err(CliError::ApiError {
+            status,
+            message: text,
+        });
+    }
+
+    response
+        .json::<AlignBenchResponse>()
+        .await
+        .map_err(|e| CliError::Other(format!("Failed to parse align benchmark response: {e}")))
+}
+
+async fn resolve_align_bench_text(text: Option<&str>, text_file: Option<&Path>) -> Result<String> {
+    if text.is_some() && text_file.is_some() {
+        return Err(CliError::InvalidInput(
+            "Use either --text or --text-file, not both.".to_string(),
+        ));
+    }
+    let resolved = match (text, text_file) {
+        (Some(text), None) => text.to_string(),
+        (None, Some(path)) => tokio::fs::read_to_string(path)
+            .await
+            .map_err(CliError::Io)?,
+        (None, None) => tokio::fs::read_to_string("data/fox.md")
+            .await
+            .unwrap_or_else(|_| "The quick brown fox jumps over the lazy dog".to_string()),
+        (Some(_), Some(_)) => unreachable!("checked above"),
+    };
+    let trimmed = resolved.trim();
+    if trimmed.is_empty() {
+        return Err(CliError::InvalidInput(
+            "Reference text cannot be empty".to_string(),
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn align_sample_rtf(response: &AlignBenchResponse) -> Option<f64> {
+    let processing_time_ms = response.processing_time_ms?;
+    let duration_secs = response.duration?;
+    (duration_secs > 0.0).then_some((processing_time_ms / 1000.0) / duration_secs)
+}
+
+fn align_response_diagnostics(response: &AlignBenchResponse) -> Option<&serde_json::Value> {
+    response
+        .izwi_asr_diagnostics
+        .as_ref()
+        .or(response.izwi_alignment_diagnostics.as_ref())
+}
+
+fn create_diarization_job_url(server: &str) -> String {
+    format!("{}/v1/speech-to-text/jobs?job_kind=diarization", server)
+}
+
+fn diarization_job_url(server: &str, job_id: &str) -> String {
+    format!(
+        "{}/v1/speech-to-text/jobs/{}?job_kind=diarization",
+        server, job_id
+    )
+}
+
+fn audio_filename_from_path(path: &Path) -> Option<String> {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn audio_mime_type_from_path(path: &Path) -> Option<&'static str> {
+    match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("wav") => Some("audio/wav"),
+        Some("mp3") => Some("audio/mpeg"),
+        Some("flac") => Some("audio/flac"),
+        Some("ogg") => Some("audio/ogg"),
+        Some("m4a") => Some("audio/mp4"),
+        Some("aac") => Some("audio/aac"),
+        _ => None,
+    }
 }
 
 async fn run_chat_request(
@@ -2588,16 +3534,29 @@ fn asr_stage_timings_from_diagnostics(diagnostics: &serde_json::Value) -> Option
         feature_upload: timings
             .get("feature_upload")
             .and_then(|value| value.as_f64()),
-        subsample: timings.get("subsample").and_then(|value| value.as_f64()),
+        subsample: timings
+            .get("subsample")
+            .or_else(|| timings.get("pre_encode"))
+            .and_then(|value| value.as_f64()),
         encoder_forward: timings
             .get("encoder_forward")
+            .or_else(|| timings.get("conformer_forward"))
             .and_then(|value| value.as_f64()),
         encoder_ffn: timings.get("encoder_ffn").and_then(|value| value.as_f64()),
         encoder_attention: timings
             .get("encoder_attention")
+            .or_else(|| timings.get("conformer_attention"))
             .and_then(|value| value.as_f64()),
-        encoder_conv: timings.get("encoder_conv").and_then(|value| value.as_f64()),
+        encoder_conv: timings
+            .get("encoder_conv")
+            .or_else(|| timings.get("conformer_conv"))
+            .and_then(|value| value.as_f64()),
         encoder_norm: timings.get("encoder_norm").and_then(|value| value.as_f64()),
+        transformer_forward: timings
+            .get("transformer_forward")
+            .and_then(|value| value.as_f64()),
+        head: timings.get("head").and_then(|value| value.as_f64()),
+        host_read: timings.get("host_read").and_then(|value| value.as_f64()),
         prompt_kernel: timings
             .get("prompt_kernel")
             .and_then(|value| value.as_f64()),
@@ -2607,7 +3566,15 @@ fn asr_stage_timings_from_diagnostics(diagnostics: &serde_json::Value) -> Option
         resample: timings.get("resample").and_then(|value| value.as_f64()),
         mel: timings.get("mel").and_then(|value| value.as_f64()),
         audio_encode: timings.get("audio_encode").and_then(|value| value.as_f64()),
+        prompt_build: timings.get("prompt_build").and_then(|value| value.as_f64()),
         prefill: timings.get("prefill").and_then(|value| value.as_f64()),
+        timestamp_argmax: timings
+            .get("timestamp_argmax")
+            .and_then(|value| value.as_f64()),
+        timestamp_fixup: timings
+            .get("timestamp_fixup")
+            .and_then(|value| value.as_f64()),
+        postprocess: timings.get("postprocess").and_then(|value| value.as_f64()),
         decode: timings.get("decode").and_then(|value| value.as_f64()),
         model_total: timings.get("model_total").and_then(|value| value.as_f64()),
         prompt_tokens: diagnostic_u64(prompt, &["prompt_tokens", "tokens"]),
@@ -2652,6 +3619,9 @@ fn asr_execution_from_single_diagnostics(
 ) -> Option<AsrExecutionDiagnostics> {
     let execution = diagnostics.get("execution")?;
     let sample = AsrExecutionDiagnostics {
+        kv_cache_enabled: execution
+            .get("kv_cache_enabled")
+            .and_then(|value| value.as_bool()),
         cuda_dense_decode_cache: execution
             .get("cuda_dense_decode_cache")
             .and_then(|value| value.as_bool()),
@@ -2686,7 +3656,8 @@ fn asr_execution_from_single_diagnostics(
             .get("stop_check_interval")
             .and_then(|value| value.as_u64()),
     };
-    (sample.cuda_dense_decode_cache.is_some()
+    (sample.kv_cache_enabled.is_some()
+        || sample.cuda_dense_decode_cache.is_some()
         || sample.dense_head_decode_enabled.is_some()
         || sample.dense_decode_max_tokens.is_some()
         || sample.audio_embedding_cache_hit.is_some()
@@ -2928,12 +3899,19 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
     let mut encoder_attention = Vec::new();
     let mut encoder_conv = Vec::new();
     let mut encoder_norm = Vec::new();
+    let mut transformer_forward = Vec::new();
+    let mut head = Vec::new();
+    let mut host_read = Vec::new();
     let mut prompt_kernel = Vec::new();
     let mut language_detect = Vec::new();
     let mut resample = Vec::new();
     let mut mel = Vec::new();
     let mut audio_encode = Vec::new();
+    let mut prompt_build = Vec::new();
     let mut prefill = Vec::new();
+    let mut timestamp_argmax = Vec::new();
+    let mut timestamp_fixup = Vec::new();
+    let mut postprocess = Vec::new();
     let mut decode = Vec::new();
     let mut model_total = Vec::new();
     let mut prompt_tokens = Vec::new();
@@ -2944,6 +3922,7 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
     let mut host_argmax_reads = Vec::new();
     let mut device_argmax_reads = Vec::new();
     let mut cuda_dense_decode_cache = Vec::new();
+    let mut kv_cache_enabled = Vec::new();
     let mut dense_head_decode_enabled = Vec::new();
     let mut dense_decode_max_tokens = Vec::new();
     let mut audio_embedding_cache_hit = Vec::new();
@@ -2986,6 +3965,15 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
         if let Some(value) = sample.encoder_norm {
             encoder_norm.push(value);
         }
+        if let Some(value) = sample.transformer_forward {
+            transformer_forward.push(value);
+        }
+        if let Some(value) = sample.head {
+            head.push(value);
+        }
+        if let Some(value) = sample.host_read {
+            host_read.push(value);
+        }
         if let Some(value) = sample.prompt_kernel {
             prompt_kernel.push(value);
         }
@@ -3001,8 +3989,20 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
         if let Some(value) = sample.audio_encode {
             audio_encode.push(value);
         }
+        if let Some(value) = sample.prompt_build {
+            prompt_build.push(value);
+        }
         if let Some(value) = sample.prefill {
             prefill.push(value);
+        }
+        if let Some(value) = sample.timestamp_argmax {
+            timestamp_argmax.push(value);
+        }
+        if let Some(value) = sample.timestamp_fixup {
+            timestamp_fixup.push(value);
+        }
+        if let Some(value) = sample.postprocess {
+            postprocess.push(value);
         }
         if let Some(value) = sample.decode {
             decode.push(value);
@@ -3032,6 +4032,9 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
             device_argmax_reads.push(value);
         }
         if let Some(execution) = sample.execution {
+            if let Some(value) = execution.kv_cache_enabled {
+                kv_cache_enabled.push(value);
+            }
             if let Some(value) = execution.cuda_dense_decode_cache {
                 cuda_dense_decode_cache.push(value);
             }
@@ -3078,12 +4081,19 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
         && encoder_attention.is_empty()
         && encoder_conv.is_empty()
         && encoder_norm.is_empty()
+        && transformer_forward.is_empty()
+        && head.is_empty()
+        && host_read.is_empty()
         && prompt_kernel.is_empty()
         && language_detect.is_empty()
         && resample.is_empty()
         && mel.is_empty()
         && audio_encode.is_empty()
+        && prompt_build.is_empty()
         && prefill.is_empty()
+        && timestamp_argmax.is_empty()
+        && timestamp_fixup.is_empty()
+        && postprocess.is_empty()
         && decode.is_empty()
         && model_total.is_empty()
         && prompt_tokens.is_empty()
@@ -3093,6 +4103,7 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
         && rnnt_joint_steps.is_empty()
         && host_argmax_reads.is_empty()
         && device_argmax_reads.is_empty()
+        && kv_cache_enabled.is_empty()
         && cuda_dense_decode_cache.is_empty()
         && dense_head_decode_enabled.is_empty()
         && dense_decode_max_tokens.is_empty()
@@ -3110,7 +4121,7 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
 
     println!(
         "\n{}",
-        console::style("ASR Stage Timings (run-local):")
+        console::style("Model Stage Timings (run-local):")
             .bold()
             .underlined()
     );
@@ -3124,12 +4135,19 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
     summarize_stage("encoder_attn", &encoder_attention);
     summarize_stage("encoder_conv", &encoder_conv);
     summarize_stage("encoder_norm", &encoder_norm);
+    summarize_stage("transformer", &transformer_forward);
+    summarize_stage("head", &head);
+    summarize_stage("host_read", &host_read);
     summarize_stage("prompt", &prompt_kernel);
     summarize_stage("lang_detect", &language_detect);
     summarize_stage("resample", &resample);
     summarize_stage("mel", &mel);
     summarize_stage("audio_encode", &audio_encode);
+    summarize_stage("prompt_build", &prompt_build);
     summarize_stage("prefill", &prefill);
+    summarize_stage("ts_argmax", &timestamp_argmax);
+    summarize_stage("ts_fixup", &timestamp_fixup);
+    summarize_stage("postprocess", &postprocess);
     summarize_stage("decode", &decode);
     summarize_stage("model_total", &model_total);
     summarize_count("prompt_tokens", &prompt_tokens);
@@ -3139,6 +4157,7 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
     summarize_count("rnnt_steps", &rnnt_joint_steps);
     summarize_count("host_argmax", &host_argmax_reads);
     summarize_count("dev_argmax", &device_argmax_reads);
+    summarize_bool_count("kv_cache", &kv_cache_enabled);
     summarize_bool_count("cuda_dense", &cuda_dense_decode_cache);
     summarize_bool_count("dense_head", &dense_head_decode_enabled);
     summarize_count("dense_max", &dense_decode_max_tokens);

--- a/crates/izwi-core/src/lib.rs
+++ b/crates/izwi-core/src/lib.rs
@@ -43,11 +43,11 @@ pub mod tokenizer;
 
 // Re-export main types from the new engine module
 pub use engine::{
-    AsrEngineInput, AudioChatEngineInput, CacheResidency, ChatEngineInput, Engine, EngineAudioInput,
-    EngineCore, EngineCoreConfig, EngineCoreRequest, EngineMetrics, EngineOutput, EngineTask,
-    GenerationParams, KVCacheManager, ModelExecutor, OutputProcessor, PinnedBlockHandle,
-    RequestProcessor, RequestStatus, Scheduler, SchedulerConfig, SchedulingPolicy,
-    StreamingOutput, TtsEngineInput,
+    AsrEngineInput, AudioChatEngineInput, CacheResidency, ChatEngineInput, Engine,
+    EngineAudioInput, EngineCore, EngineCoreConfig, EngineCoreRequest, EngineMetrics, EngineOutput,
+    EngineTask, GenerationParams, KVCacheManager, ModelExecutor, OutputProcessor,
+    PinnedBlockHandle, RequestProcessor, RequestStatus, Scheduler, SchedulerConfig,
+    SchedulingPolicy, StreamingOutput, TtsEngineInput,
 };
 
 // Legacy re-exports for backward compatibility
@@ -67,21 +67,20 @@ pub use runtime::{
     VOICE_TTS_FIRST_AUDIO_MS, VOICE_VAD_SPEECH_START_MS,
 };
 pub use runtime::{
-    AsrTranscription, ChatGeneration, ChunkStats, DiarizationConfig, DiarizationResult,
-    DiarizationSegment, DiarizationTranscriptResult, DiarizationUtterance, DiarizationWord,
-    GenerationRequest, GenerationResult,
-};
-pub use runtime::{
-    AudioChunk, EngineRuntimeTelemetrySnapshot, GenerationConfig,
-    InferenceBrokerRuntimeTelemetrySnapshot, InferenceOptions, PipelineRuntimeTelemetrySnapshot,
-    ReplayRedaction, RuntimeAsrRealtimeEvent, RuntimeAsrRealtimeStream, RuntimeReplayRecord,
-    RuntimeService, RuntimeTelemetrySnapshot, RuntimeTraceContract, RuntimeTracePhase,
-    SpeechToSpeechGeneration,
+    runtime_trace_contracts, sanitized_replay_record, trace_contract_for_phase, AudioChunk,
+    EngineRuntimeTelemetrySnapshot, GenerationConfig, InferenceBrokerRuntimeTelemetrySnapshot,
+    InferenceOptions, PipelineRuntimeTelemetrySnapshot, ReplayRedaction, RuntimeAsrRealtimeEvent,
+    RuntimeAsrRealtimeStream, RuntimeReplayRecord, RuntimeService, RuntimeTelemetrySnapshot,
+    RuntimeTraceContract, RuntimeTracePhase, SpeechToSpeechGeneration,
     VoiceRuntimeTelemetrySnapshot, VoiceSession, VoiceSessionPhase, RUNTIME_REPLAY_REDACTION,
     RUNTIME_TRACE_CONTRACTS, TRACE_CAPABILITY, TRACE_CORRELATION_ID, TRACE_ERROR_KIND,
     TRACE_EXECUTION_TARGET, TRACE_MODEL_VARIANT, TRACE_PIPELINE_KIND, TRACE_PIPELINE_STAGE,
-    TRACE_REQUEST_ID, TRACE_STREAMING_MODE, runtime_trace_contracts, sanitized_replay_record,
-    trace_contract_for_phase,
+    TRACE_REQUEST_ID, TRACE_STREAMING_MODE,
+};
+pub use runtime::{
+    AsrTranscription, ChatGeneration, ChunkStats, DiarizationConfig, DiarizationResult,
+    DiarizationSegment, DiarizationTranscriptResult, DiarizationUtterance, DiarizationWord,
+    ForcedAlignmentResult, GenerationRequest, GenerationResult,
 };
 pub use serve_runtime::{ServeRuntimeConfig, ServeRuntimeConfigOverrides};
 

--- a/crates/izwi-core/src/models/architectures/parakeet/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/parakeet/asr/mod.rs
@@ -1,5 +1,5 @@
 mod decode;
-mod metal_kernels;
+pub(crate) mod metal_kernels;
 mod nemo;
 mod preprocessor;
 

--- a/crates/izwi-core/src/models/architectures/qwen3/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/qwen3/asr/mod.rs
@@ -1649,7 +1649,9 @@ impl Qwen3AsrModel {
             data.extend_from_slice(&positions);
         }
 
-        Tensor::from_vec(data, (3, seq_len), &self.device.device).map_err(Error::from)
+        // Position IDs are only read back to build M-RoPE tables. Keeping them
+        // on CPU avoids forcing a Metal queue sync before the table upload.
+        Tensor::from_vec(data, (3, seq_len), &candle_core::Device::Cpu).map_err(Error::from)
     }
 }
 

--- a/crates/izwi-core/src/models/architectures/qwen3/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/qwen3/asr/mod.rs
@@ -243,6 +243,7 @@ struct Qwen3ForcedAlignDiagnostics {
     prompt_tokens: usize,
     word_count: usize,
     timestamp_positions: usize,
+    single_timestamp_per_word: bool,
     timestamp_segment_time_ms: u32,
     execution: Qwen3AsrExecutionDiagnostics,
     prefill_profile: Qwen3ForwardDiagnostics,
@@ -272,6 +273,7 @@ impl Qwen3ForcedAlignDiagnostics {
             "alignment": {
                 "word_count": self.word_count,
                 "timestamp_positions": self.timestamp_positions,
+                "single_timestamp_per_word": self.single_timestamp_per_word,
                 "timestamp_segment_time_ms": self.timestamp_segment_time_ms,
             },
             "decode": {
@@ -1224,7 +1226,10 @@ impl Qwen3AsrModel {
             ));
         }
 
-        let prompt = self.build_forced_aligner_prompt(audio_len, &words)?;
+        let single_timestamp_per_word =
+            qwen3_forced_aligner_single_timestamp_enabled(self.device.kind);
+        let prompt =
+            self.build_forced_aligner_prompt(audio_len, &words, single_timestamp_per_word)?;
         let timestamp_positions: Vec<usize> = prompt
             .ids
             .iter()
@@ -1251,47 +1256,35 @@ impl Qwen3AsrModel {
             .map(|cache| self.execution_diagnostics(cache))
             .unwrap_or_else(|| self.execution_diagnostics_without_cache(prompt.ids.len()));
         let prefill_started = Instant::now();
-        let (logits, prefill_profile) = self.forward_with_audio_profiled(
+        let (logits, prefill_profile) = self.forward_timestamp_logits_with_audio_profiled(
             &input_ids,
             &audio_embeds,
             prompt.audio_pad_start,
             prompt.audio_pad_len,
+            &timestamp_positions,
             cache.as_mut(),
         )?;
         let prefill_ms = elapsed_ms(prefill_started);
 
         let segment_time_ms = self.timestamp_segment_time_ms.unwrap_or(20).max(1);
         let timestamp_argmax_started = Instant::now();
-        let timestamp_ms = batched_timestamp_argmax(&logits, &timestamp_positions)?
+        let timestamp_ms = timestamp_argmax_from_selected_logits(&logits)?
             .into_iter()
             .map(|cls_idx| cls_idx.saturating_mul(segment_time_ms))
             .collect::<Vec<_>>();
         let timestamp_argmax_ms = elapsed_ms(timestamp_argmax_started);
 
         let timestamp_fixup_started = Instant::now();
-        let mut fixed = fix_timestamp_sequence(&timestamp_ms);
-        let required = words.len().saturating_mul(2);
-        if fixed.len() < required {
-            let fill = fixed.last().copied().unwrap_or(0);
-            fixed.resize(required, fill);
-        }
+        let fixed = fix_timestamp_sequence(&timestamp_ms);
         let timestamp_fixup_ms = elapsed_ms(timestamp_fixup_started);
 
         let postprocess_started = Instant::now();
-        let mut alignments = Vec::with_capacity(words.len());
-        for (idx, word) in words.iter().enumerate() {
-            let start = fixed.get(idx * 2).copied().unwrap_or(0);
-            let mut end = fixed
-                .get(idx * 2 + 1)
-                .copied()
-                .unwrap_or_else(|| start.saturating_add(segment_time_ms));
-            if end <= start {
-                end = start.saturating_add(1);
-            }
-            alignments.push((word.clone(), start, end));
-        }
-
         let audio_duration_ms = ((audio.len() as f32 / 16_000.0) * 1000.0).round() as u32;
+        let mut alignments = if single_timestamp_per_word {
+            align_words_from_single_timestamps(&words, &fixed, segment_time_ms, audio_duration_ms)
+        } else {
+            align_words_from_paired_timestamps(&words, &fixed, segment_time_ms)
+        };
         normalize_alignment_bounds(&mut alignments, audio_duration_ms);
         if alignment_distribution_is_degenerate(&alignments, audio_duration_ms) {
             warn!(
@@ -1314,6 +1307,7 @@ impl Qwen3AsrModel {
             prompt_tokens: prompt.ids.len(),
             word_count: words.len(),
             timestamp_positions: timestamp_positions.len(),
+            single_timestamp_per_word,
             timestamp_segment_time_ms: segment_time_ms,
             execution,
             prefill_profile,
@@ -1340,6 +1334,7 @@ impl Qwen3AsrModel {
         &self,
         audio_len: usize,
         words: &[String],
+        single_timestamp_per_word: bool,
     ) -> Result<ForcedAlignerPrompt> {
         let timestamp_token_id = self
             .specials
@@ -1360,7 +1355,9 @@ impl Qwen3AsrModel {
         for word in words {
             ids.extend(self.tokenizer.encode_text(word)?);
             ids.push(timestamp_token_id);
-            ids.push(timestamp_token_id);
+            if !single_timestamp_per_word {
+                ids.push(timestamp_token_id);
+            }
         }
 
         Ok(ForcedAlignerPrompt {
@@ -1407,6 +1404,31 @@ impl Qwen3AsrModel {
             self.audio_conditioned_embeds(input_ids, audio_embeds, audio_pad_start, audio_pad_len)?;
         self.text_model
             .forward_with_embeds_profiled(&embeds, 0, cache, position_ids.as_ref())
+    }
+
+    fn forward_timestamp_logits_with_audio_profiled(
+        &self,
+        input_ids: &Tensor,
+        audio_embeds: &Tensor,
+        audio_pad_start: usize,
+        audio_pad_len: usize,
+        timestamp_positions: &[usize],
+        cache: Option<&mut Qwen3Cache>,
+    ) -> Result<(Tensor, Qwen3ForwardDiagnostics)> {
+        let (embeds, position_ids) =
+            self.audio_conditioned_embeds(input_ids, audio_embeds, audio_pad_start, audio_pad_len)?;
+        let (hidden, mut diagnostics) = self.text_model.forward_hidden_with_embeds_profiled(
+            &embeds,
+            0,
+            cache,
+            position_ids.as_ref(),
+        )?;
+        let timestamp_hidden = select_sequence_positions(&hidden, timestamp_positions)?;
+
+        let lm_head_started = Instant::now();
+        let logits = self.text_model.logits_from_hidden(&timestamp_hidden)?;
+        diagnostics.lm_head_ms += elapsed_ms(lm_head_started);
+        Ok((logits, diagnostics))
     }
 
     fn audio_conditioned_embeds(
@@ -2314,6 +2336,68 @@ fn fix_timestamp_sequence(data: &[u32]) -> Vec<u32> {
         .collect()
 }
 
+fn align_words_from_paired_timestamps(
+    words: &[String],
+    timestamps_ms: &[u32],
+    segment_time_ms: u32,
+) -> Vec<(String, u32, u32)> {
+    let mut fixed = timestamps_ms.to_vec();
+    let required = words.len().saturating_mul(2);
+    if fixed.len() < required {
+        let fill = fixed.last().copied().unwrap_or(0);
+        fixed.resize(required, fill);
+    }
+
+    let mut alignments = Vec::with_capacity(words.len());
+    for (idx, word) in words.iter().enumerate() {
+        let start = fixed.get(idx * 2).copied().unwrap_or(0);
+        let mut end = fixed
+            .get(idx * 2 + 1)
+            .copied()
+            .unwrap_or_else(|| start.saturating_add(segment_time_ms));
+        if end <= start {
+            end = start.saturating_add(1);
+        }
+        alignments.push((word.clone(), start, end));
+    }
+    alignments
+}
+
+fn align_words_from_single_timestamps(
+    words: &[String],
+    timestamps_ms: &[u32],
+    segment_time_ms: u32,
+    audio_duration_ms: u32,
+) -> Vec<(String, u32, u32)> {
+    if words.is_empty() {
+        return Vec::new();
+    }
+
+    let mut fixed = timestamps_ms.to_vec();
+    if fixed.len() < words.len() {
+        let fill = fixed
+            .last()
+            .copied()
+            .unwrap_or(audio_duration_ms.max(segment_time_ms));
+        fixed.resize(words.len(), fill);
+    }
+
+    let mut alignments = Vec::with_capacity(words.len());
+    let mut start = 0u32;
+    for (idx, word) in words.iter().enumerate() {
+        let mut end = fixed
+            .get(idx)
+            .copied()
+            .unwrap_or_else(|| start.saturating_add(segment_time_ms));
+        if end <= start {
+            end = start.saturating_add(1);
+        }
+        alignments.push((word.clone(), start, end));
+        start = end;
+    }
+    alignments
+}
+
 fn validate_quantization_config(config: &Qwen3AsrConfig) -> Result<()> {
     let quant = config
         .quantization_config
@@ -2693,6 +2777,10 @@ fn qwen3_forced_aligner_fast_resample_enabled(kind: DeviceKind) -> bool {
     kind.is_metal() && env_bool("IZWI_QWEN3_FORCED_ALIGNER_FAST_RESAMPLE").unwrap_or(true)
 }
 
+fn qwen3_forced_aligner_single_timestamp_enabled(kind: DeviceKind) -> bool {
+    kind.is_metal() && env_bool("IZWI_QWEN3_FORCED_ALIGNER_SINGLE_TIMESTAMP").unwrap_or(true)
+}
+
 fn env_bool(name: &str) -> Option<bool> {
     std::env::var(name).ok().and_then(|raw| {
         let normalized = raw.trim().to_ascii_lowercase();
@@ -2911,6 +2999,52 @@ fn batched_timestamp_argmax(logits: &Tensor, positions: &[usize]) -> Result<Vec<
     let positions = Tensor::from_vec(position_ids, (positions.len(),), logits.device())?;
     let token_logits = logits.i(0)?.index_select(&positions, 0)?;
     let indices = token_logits.argmax(D::Minus1)?.to_dtype(DType::U32)?;
+    indices.to_vec1::<u32>().map_err(Error::from)
+}
+
+fn select_sequence_positions(tensor: &Tensor, positions: &[usize]) -> Result<Tensor> {
+    let dims = tensor.dims();
+    if dims.len() != 3 || dims[0] != 1 {
+        return Err(Error::InferenceError(format!(
+            "Sequence position selection expects tensor shape [1, seq, hidden], got {dims:?}"
+        )));
+    }
+    let seq_len = dims[1];
+    let hidden_dim = dims[2];
+    if positions.is_empty() {
+        return Tensor::zeros((1, 0, hidden_dim), tensor.dtype(), tensor.device())
+            .map_err(Error::from);
+    }
+    let mut position_ids = Vec::with_capacity(positions.len());
+    for &position in positions {
+        if position >= seq_len {
+            return Err(Error::InferenceError(format!(
+                "Sequence selection position {position} is out of range for sequence length {seq_len}"
+            )));
+        }
+        position_ids.push(position as i64);
+    }
+
+    let positions = Tensor::from_vec(position_ids, (positions.len(),), tensor.device())?;
+    tensor
+        .i(0)?
+        .index_select(&positions, 0)?
+        .unsqueeze(0)
+        .map_err(Error::from)
+}
+
+fn timestamp_argmax_from_selected_logits(logits: &Tensor) -> Result<Vec<u32>> {
+    let dims = logits.dims();
+    if dims.len() != 3 || dims[0] != 1 {
+        return Err(Error::InferenceError(format!(
+            "Forced aligner selected timestamp logits expect shape [1, positions, classes], got {dims:?}"
+        )));
+    }
+    if dims[1] == 0 {
+        return Ok(Vec::new());
+    }
+
+    let indices = logits.i(0)?.argmax(D::Minus1)?.to_dtype(DType::U32)?;
     indices.to_vec1::<u32>().map_err(Error::from)
 }
 
@@ -3323,6 +3457,25 @@ mod tests {
     }
 
     #[test]
+    fn single_timestamp_alignment_uses_previous_end_as_next_start() {
+        let words = vec![
+            "hello".to_string(),
+            "world".to_string(),
+            "again".to_string(),
+        ];
+        let alignments = align_words_from_single_timestamps(&words, &[100, 240, 240], 20, 500);
+
+        assert_eq!(
+            alignments,
+            vec![
+                ("hello".to_string(), 0, 100),
+                ("world".to_string(), 100, 240),
+                ("again".to_string(), 240, 241),
+            ]
+        );
+    }
+
+    #[test]
     fn qwen_asr_gguf_filename_matches_new_variants() {
         assert_eq!(
             qwen_asr_gguf_filename(ModelVariant::Qwen3Asr06BGguf),
@@ -3427,6 +3580,25 @@ mod tests {
             .expect_err("timestamp position should be out of range");
 
         assert!(format!("{err}").contains("out of range"));
+    }
+
+    #[test]
+    fn selected_timestamp_argmax_reads_position_rows_directly() {
+        let device = candle_core::Device::Cpu;
+        let logits = Tensor::from_vec(
+            vec![
+                0.1f32, 0.9, 0.2, 0.3, //
+                1.2, 0.1, 0.0, 0.4, //
+                -0.1, -0.2, 0.5, 0.4,
+            ],
+            (1, 3, 4),
+            &device,
+        )
+        .expect("logits");
+
+        let indices = timestamp_argmax_from_selected_logits(&logits).expect("argmax");
+
+        assert_eq!(indices, vec![1, 0, 2]);
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/qwen3/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/qwen3/asr/mod.rs
@@ -97,6 +97,12 @@ pub struct AsrTranscriptionOutput {
     pub diagnostics: Option<serde_json::Value>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AsrAlignmentOutput {
+    pub alignments: Vec<(String, u32, u32)>,
+    pub diagnostics: Option<serde_json::Value>,
+}
+
 #[derive(Debug, Clone, Default)]
 struct Qwen3AsrTimingDiagnostics {
     resample_ms: f64,
@@ -115,6 +121,7 @@ struct Qwen3AsrExecutionDiagnostics {
     checkpoint_format: String,
     flash_attention_requested: bool,
     flash_attention_compiled: bool,
+    kv_cache_enabled: bool,
     kv_page_size: usize,
     dense_decode_enabled: bool,
     dense_decode_max_tokens: usize,
@@ -187,6 +194,7 @@ impl Qwen3AsrDiagnostics {
                 "checkpoint_format": &self.execution.checkpoint_format,
                 "flash_attention_requested": self.execution.flash_attention_requested,
                 "flash_attention_compiled": self.execution.flash_attention_compiled,
+                "kv_cache_enabled": self.execution.kv_cache_enabled,
                 "kv_page_size": self.execution.kv_page_size,
                 "dense_decode_enabled": self.execution.dense_decode_enabled,
                 "dense_decode_max_tokens": self.execution.dense_decode_max_tokens,
@@ -203,6 +211,100 @@ impl Qwen3AsrDiagnostics {
                 "audio_encode": self.timings.audio_encode_ms,
                 "prefill": self.timings.prefill_ms,
                 "decode": self.timings.decode_ms,
+                "model_total": self.timings.total_ms,
+            }
+        })
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct Qwen3ForcedAlignTimingDiagnostics {
+    resample_ms: f64,
+    mel_ms: f64,
+    audio_encode_ms: f64,
+    prompt_build_ms: f64,
+    prefill_ms: f64,
+    timestamp_argmax_ms: f64,
+    timestamp_fixup_ms: f64,
+    postprocess_ms: f64,
+    total_ms: f64,
+}
+
+#[derive(Debug, Clone)]
+struct Qwen3ForcedAlignDiagnostics {
+    input_sample_rate: u32,
+    input_samples: usize,
+    resampled_sample_rate: u32,
+    resampled_samples: usize,
+    mel_frames: usize,
+    mel_frames_before_truncate: usize,
+    mel_frames_truncated: bool,
+    audio_tokens: usize,
+    prompt_tokens: usize,
+    word_count: usize,
+    timestamp_positions: usize,
+    timestamp_segment_time_ms: u32,
+    execution: Qwen3AsrExecutionDiagnostics,
+    timings: Qwen3ForcedAlignTimingDiagnostics,
+}
+
+impl Qwen3ForcedAlignDiagnostics {
+    fn to_json(&self) -> serde_json::Value {
+        let decode_ms = self.timings.timestamp_argmax_ms
+            + self.timings.timestamp_fixup_ms
+            + self.timings.postprocess_ms;
+        json!({
+            "model_family": "qwen3_forced_aligner",
+            "audio": {
+                "input_sample_rate": self.input_sample_rate,
+                "input_samples": self.input_samples,
+                "resampled_sample_rate": self.resampled_sample_rate,
+                "resampled_samples": self.resampled_samples,
+                "mel_frames": self.mel_frames,
+                "mel_frames_before_truncate": self.mel_frames_before_truncate,
+                "mel_frames_truncated": self.mel_frames_truncated,
+                "audio_tokens": self.audio_tokens,
+            },
+            "prompt": {
+                "prompt_tokens": self.prompt_tokens,
+            },
+            "alignment": {
+                "word_count": self.word_count,
+                "timestamp_positions": self.timestamp_positions,
+                "timestamp_segment_time_ms": self.timestamp_segment_time_ms,
+            },
+            "decode": {
+                "generated_tokens": self.timestamp_positions,
+                "host_argmax_reads": 1,
+            },
+            "execution": {
+                "device_kind": &self.execution.device_kind,
+                "audio_dtype": &self.execution.audio_dtype,
+                "text_dtype": &self.execution.text_dtype,
+                "checkpoint_format": &self.execution.checkpoint_format,
+                "flash_attention_requested": self.execution.flash_attention_requested,
+                "flash_attention_compiled": self.execution.flash_attention_compiled,
+                "kv_cache_enabled": self.execution.kv_cache_enabled,
+                "kv_page_size": self.execution.kv_page_size,
+                "dense_decode_enabled": self.execution.dense_decode_enabled,
+                "dense_decode_max_tokens": self.execution.dense_decode_max_tokens,
+                "gguf_qmatmul_text_enabled": self.execution.gguf_qmatmul_text_enabled,
+                "text_projection_backend": &self.execution.text_projection_backend,
+                "text_projection_quantized": self.execution.text_projection_quantized,
+                "qmatmul_projection_count": self.execution.qmatmul_projection_count,
+                "dense_projection_count": self.execution.dense_projection_count,
+                "dense_bias_projection_count": self.execution.dense_bias_projection_count,
+            },
+            "timings_ms": {
+                "resample": self.timings.resample_ms,
+                "mel": self.timings.mel_ms,
+                "audio_encode": self.timings.audio_encode_ms,
+                "prompt_build": self.timings.prompt_build_ms,
+                "prefill": self.timings.prefill_ms,
+                "timestamp_argmax": self.timings.timestamp_argmax_ms,
+                "timestamp_fixup": self.timings.timestamp_fixup_ms,
+                "postprocess": self.timings.postprocess_ms,
+                "decode": decode_ms,
                 "model_total": self.timings.total_ms,
             }
         })
@@ -516,9 +618,42 @@ impl Qwen3AsrModel {
             checkpoint_format: self.checkpoint_format.to_string(),
             flash_attention_requested: flash_attention_requested(),
             flash_attention_compiled: flash_attention_compiled(),
+            kv_cache_enabled: true,
             kv_page_size: cache.page_size(),
             dense_decode_enabled: cache.dense_decode_max_tokens() > 0,
             dense_decode_max_tokens: cache.dense_decode_max_tokens(),
+            gguf_qmatmul_text_enabled: self.gguf_qmatmul_text_enabled,
+            text_projection_backend: text_projection_backend.to_string(),
+            text_projection_quantized,
+            qmatmul_projection_count: projection_diagnostics.quantized_projection_count,
+            dense_projection_count: projection_diagnostics.dense_projection_count,
+            dense_bias_projection_count: projection_diagnostics.dense_bias_projection_count,
+        }
+    }
+
+    fn execution_diagnostics_without_cache(
+        &self,
+        prompt_tokens: usize,
+    ) -> Qwen3AsrExecutionDiagnostics {
+        let projection_diagnostics = self.text_model.projection_diagnostics();
+        let text_projection_quantized = projection_diagnostics.quantized_projection_count > 0;
+        let text_projection_backend = if text_projection_quantized {
+            "qmatmul"
+        } else {
+            "dense_linear"
+        };
+
+        Qwen3AsrExecutionDiagnostics {
+            device_kind: format!("{:?}", self.device.kind),
+            audio_dtype: format!("{:?}", self.audio_dtype),
+            text_dtype: format!("{:?}", self.text_dtype),
+            checkpoint_format: self.checkpoint_format.to_string(),
+            flash_attention_requested: flash_attention_requested(),
+            flash_attention_compiled: flash_attention_compiled(),
+            kv_cache_enabled: false,
+            kv_page_size: qwen3_asr_kv_page_size(&self.device.device, prompt_tokens),
+            dense_decode_enabled: false,
+            dense_decode_max_tokens: 0,
             gguf_qmatmul_text_enabled: self.gguf_qmatmul_text_enabled,
             text_projection_backend: text_projection_backend.to_string(),
             text_projection_quantized,
@@ -740,7 +875,7 @@ impl Qwen3AsrModel {
             &audio_embeds,
             prompt.audio_pad_start,
             prompt.audio_pad_len,
-            &mut cache,
+            Some(&mut cache),
         )?;
         let prefill_ms = elapsed_ms(prefill_started);
         let pos = embeds.dim(1)?;
@@ -911,14 +1046,29 @@ impl Qwen3AsrModel {
         audio: &[f32],
         sample_rate: u32,
         reference_text: &str,
-        _language: Option<&str>,
+        language: Option<&str>,
     ) -> Result<Vec<(String, u32, u32)>> {
+        self.force_align_with_details(audio, sample_rate, reference_text, language)
+            .map(|output| output.alignments)
+    }
+
+    pub fn force_align_with_details(
+        &self,
+        audio: &[f32],
+        sample_rate: u32,
+        reference_text: &str,
+        _language: Option<&str>,
+    ) -> Result<AsrAlignmentOutput> {
         if self.is_forced_aligner {
-            return self.force_align_with_nar_head(audio, sample_rate, reference_text);
+            return self.force_align_with_nar_head_with_details(audio, sample_rate, reference_text);
         }
 
         let audio = if sample_rate != 16_000 {
-            resample(audio, sample_rate, 16_000)?
+            if qwen3_forced_aligner_fast_resample_enabled(self.device.kind) {
+                resample_linear(audio, sample_rate, 16_000)?
+            } else {
+                resample(audio, sample_rate, 16_000)?
+            }
         } else {
             audio.to_vec()
         };
@@ -967,7 +1117,7 @@ impl Qwen3AsrModel {
             &audio_embeds,
             prompt.audio_pad_start,
             prompt.audio_pad_len,
-            &mut cache,
+            Some(&mut cache),
         )?;
 
         let mut pos = embeds.dim(1)?;
@@ -990,25 +1140,43 @@ impl Qwen3AsrModel {
             pos += 1;
         }
 
-        self.parse_alignment(&generated, reference_text, audio.len() as u32 / 16)
+        Ok(AsrAlignmentOutput {
+            alignments: self.parse_alignment(
+                &generated,
+                reference_text,
+                audio.len() as u32 / 16,
+            )?,
+            diagnostics: None,
+        })
     }
 
-    fn force_align_with_nar_head(
+    fn force_align_with_nar_head_with_details(
         &self,
         audio: &[f32],
         sample_rate: u32,
         reference_text: &str,
-    ) -> Result<Vec<(String, u32, u32)>> {
+    ) -> Result<AsrAlignmentOutput> {
+        let input_samples = audio.len();
+        let total_started = Instant::now();
+        let resample_started = Instant::now();
         let audio = if sample_rate != 16_000 {
-            resample(audio, sample_rate, 16_000)?
+            if qwen3_forced_aligner_fast_resample_enabled(self.device.kind) {
+                resample_linear(audio, sample_rate, 16_000)?
+            } else {
+                resample(audio, sample_rate, 16_000)?
+            }
         } else {
             audio.to_vec()
         };
+        let resample_ms = elapsed_ms(resample_started);
 
+        let mel_started = Instant::now();
         let mut mel_spec = self.mel.compute(&audio)?;
+        let mel_frames_before_truncate = mel_spec.len();
         if self.preprocessor.nb_max_frames > 0 && mel_spec.len() > self.preprocessor.nb_max_frames {
             mel_spec.truncate(self.preprocessor.nb_max_frames);
         }
+        let mel_ms = elapsed_ms(mel_started);
 
         let n_mels = self.mel.config().n_mels;
         if mel_spec.is_empty() {
@@ -1028,12 +1196,15 @@ impl Qwen3AsrModel {
             .to_dtype(self.audio_dtype)?;
 
         let feature_lens = vec![frames];
+        let audio_started = Instant::now();
         let mut audio_embeds = self.audio_tower.forward(&mel, Some(&feature_lens))?;
         if audio_embeds.dtype() != self.text_dtype {
             audio_embeds = audio_embeds.to_dtype(self.text_dtype)?;
         }
+        let audio_encode_ms = elapsed_ms(audio_started);
         let audio_len = audio_embeds.dim(1)?;
 
+        let prompt_started = Instant::now();
         let words = extract_alignment_words(reference_text);
         if words.is_empty() {
             return Err(Error::InvalidInput(
@@ -1059,29 +1230,42 @@ impl Qwen3AsrModel {
             (1, prompt.ids.len()),
             &self.device.device,
         )?;
+        let prompt_build_ms = elapsed_ms(prompt_started);
 
-        let mut cache = self.build_decode_cache(prompt.ids.len(), 1);
+        let use_no_cache = qwen3_forced_aligner_nar_no_cache_enabled(self.device.kind);
+        let mut cache = (!use_no_cache).then(|| self.build_decode_cache(prompt.ids.len(), 1));
+        let execution = cache
+            .as_ref()
+            .map(|cache| self.execution_diagnostics(cache))
+            .unwrap_or_else(|| self.execution_diagnostics_without_cache(prompt.ids.len()));
+        let prefill_started = Instant::now();
         let logits = self.forward_with_audio(
             &input_ids,
             &audio_embeds,
             prompt.audio_pad_start,
             prompt.audio_pad_len,
-            &mut cache,
+            cache.as_mut(),
         )?;
+        let prefill_ms = elapsed_ms(prefill_started);
 
         let segment_time_ms = self.timestamp_segment_time_ms.unwrap_or(20).max(1);
+        let timestamp_argmax_started = Instant::now();
         let timestamp_ms = batched_timestamp_argmax(&logits, &timestamp_positions)?
             .into_iter()
             .map(|cls_idx| cls_idx.saturating_mul(segment_time_ms))
             .collect::<Vec<_>>();
+        let timestamp_argmax_ms = elapsed_ms(timestamp_argmax_started);
 
+        let timestamp_fixup_started = Instant::now();
         let mut fixed = fix_timestamp_sequence(&timestamp_ms);
         let required = words.len().saturating_mul(2);
         if fixed.len() < required {
             let fill = fixed.last().copied().unwrap_or(0);
             fixed.resize(required, fill);
         }
+        let timestamp_fixup_ms = elapsed_ms(timestamp_fixup_started);
 
+        let postprocess_started = Instant::now();
         let mut alignments = Vec::with_capacity(words.len());
         for (idx, word) in words.iter().enumerate() {
             let start = fixed.get(idx * 2).copied().unwrap_or(0);
@@ -1104,7 +1288,39 @@ impl Qwen3AsrModel {
             alignments = distribute_words_over_interval(&words, 0, audio_duration_ms.max(1));
             normalize_alignment_bounds(&mut alignments, audio_duration_ms);
         }
-        Ok(alignments)
+        let postprocess_ms = elapsed_ms(postprocess_started);
+
+        let diagnostics = Qwen3ForcedAlignDiagnostics {
+            input_sample_rate: sample_rate,
+            input_samples,
+            resampled_sample_rate: 16_000,
+            resampled_samples: audio.len(),
+            mel_frames: frames,
+            mel_frames_before_truncate,
+            mel_frames_truncated: mel_frames_before_truncate > frames,
+            audio_tokens: audio_len,
+            prompt_tokens: prompt.ids.len(),
+            word_count: words.len(),
+            timestamp_positions: timestamp_positions.len(),
+            timestamp_segment_time_ms: segment_time_ms,
+            execution,
+            timings: Qwen3ForcedAlignTimingDiagnostics {
+                resample_ms,
+                mel_ms,
+                audio_encode_ms,
+                prompt_build_ms,
+                prefill_ms,
+                timestamp_argmax_ms,
+                timestamp_fixup_ms,
+                postprocess_ms,
+                total_ms: elapsed_ms(total_started),
+            },
+        };
+
+        Ok(AsrAlignmentOutput {
+            alignments,
+            diagnostics: Some(diagnostics.to_json()),
+        })
     }
 
     fn build_forced_aligner_prompt(
@@ -1158,7 +1374,7 @@ impl Qwen3AsrModel {
         audio_embeds: &Tensor,
         audio_pad_start: usize,
         audio_pad_len: usize,
-        cache: &mut Qwen3Cache,
+        cache: Option<&mut Qwen3Cache>,
     ) -> Result<Tensor> {
         let embeds = self.text_model.embeddings(input_ids)?;
         let seq_len = embeds.dim(1)?;
@@ -1206,7 +1422,7 @@ impl Qwen3AsrModel {
             None
         };
         self.text_model
-            .forward_with_embeds(&embeds, 0, Some(cache), position_ids.as_ref())
+            .forward_with_embeds(&embeds, 0, cache, position_ids.as_ref())
     }
 
     fn build_prompt(
@@ -2430,6 +2646,14 @@ fn qwen_asr_drop_last_mel_frame() -> bool {
     env_bool("IZWI_QWEN_ASR_DROP_LAST_MEL_FRAME").unwrap_or(false)
 }
 
+fn qwen3_forced_aligner_nar_no_cache_enabled(kind: DeviceKind) -> bool {
+    kind.is_metal() && env_bool("IZWI_QWEN3_FORCED_ALIGNER_NAR_NO_CACHE").unwrap_or(true)
+}
+
+fn qwen3_forced_aligner_fast_resample_enabled(kind: DeviceKind) -> bool {
+    kind.is_metal() && env_bool("IZWI_QWEN3_FORCED_ALIGNER_FAST_RESAMPLE").unwrap_or(true)
+}
+
 fn env_bool(name: &str) -> Option<bool> {
     std::env::var(name).ok().and_then(|raw| {
         let normalized = raw.trim().to_ascii_lowercase();
@@ -2503,6 +2727,43 @@ fn resample(audio: &[f32], src_rate: u32, dst_rate: u32) -> Result<Vec<f32>> {
             0.0
         });
     }
+    Ok(out)
+}
+
+fn resample_linear(audio: &[f32], src_rate: u32, dst_rate: u32) -> Result<Vec<f32>> {
+    if src_rate == dst_rate {
+        return Ok(audio.to_vec());
+    }
+    if src_rate == 0 || dst_rate == 0 {
+        return Err(Error::InvalidInput(format!(
+            "Invalid sample rate for resampling: {src_rate} -> {dst_rate}"
+        )));
+    }
+    if audio.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let out_len = ((audio.len() as u64)
+        .saturating_mul(dst_rate as u64)
+        .checked_div(src_rate as u64)
+        .unwrap_or(0) as usize)
+        .max(1);
+    if audio.len() == 1 {
+        return Ok(vec![audio[0]; out_len]);
+    }
+
+    let step = src_rate as f64 / dst_rate as f64;
+    let last_idx = audio.len() - 1;
+    let mut out = Vec::with_capacity(out_len);
+    for i in 0..out_len {
+        let src_pos = i as f64 * step;
+        let idx = src_pos.floor() as usize;
+        let frac = (src_pos - idx as f64) as f32;
+        let left = audio[idx.min(last_idx)];
+        let right = audio[(idx + 1).min(last_idx)];
+        out.push(left + (right - left) * frac);
+    }
+
     Ok(out)
 }
 
@@ -2756,6 +3017,7 @@ mod tests {
                 checkpoint_format: "gguf".to_string(),
                 flash_attention_requested: true,
                 flash_attention_compiled: true,
+                kv_cache_enabled: true,
                 kv_page_size: 256,
                 dense_decode_enabled: true,
                 dense_decode_max_tokens: 1024,
@@ -2939,6 +3201,15 @@ mod tests {
         for value in output {
             assert!((value - 0.75).abs() < 1e-3, "unexpected value: {value}");
         }
+    }
+
+    #[test]
+    fn resample_linear_downsamples_24khz_to_16khz_length() {
+        let input = vec![0.5f32; 24_000];
+        let output = resample_linear(&input, 24_000, 16_000).expect("linear resample");
+
+        assert_eq!(output.len(), 16_000);
+        assert!(output.iter().all(|value| (*value - 0.5).abs() < 1e-6));
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/qwen3/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/qwen3/asr/mod.rs
@@ -22,7 +22,7 @@ use crate::error::{Error, Result};
 use crate::kernels::buffer_pool::maybe_init_global_buffer_pool;
 use crate::model::ModelVariant;
 use crate::models::architectures::qwen3::core::{
-    Qwen3Cache, Qwen3Config, Qwen3Model, RopeScalingConfig,
+    Qwen3Cache, Qwen3Config, Qwen3ForwardDiagnostics, Qwen3Model, RopeScalingConfig,
 };
 use crate::models::shared::attention::flash::{
     flash_attention_compiled, flash_attention_requested,
@@ -245,6 +245,7 @@ struct Qwen3ForcedAlignDiagnostics {
     timestamp_positions: usize,
     timestamp_segment_time_ms: u32,
     execution: Qwen3AsrExecutionDiagnostics,
+    prefill_profile: Qwen3ForwardDiagnostics,
     timings: Qwen3ForcedAlignTimingDiagnostics,
 }
 
@@ -306,6 +307,17 @@ impl Qwen3ForcedAlignDiagnostics {
                 "postprocess": self.timings.postprocess_ms,
                 "decode": decode_ms,
                 "model_total": self.timings.total_ms,
+            },
+            "prefill_profile_ms": {
+                "input_norm": self.prefill_profile.input_norm_ms,
+                "attention": self.prefill_profile.attention_ms,
+                "attention_residual": self.prefill_profile.attention_residual_ms,
+                "post_attention_norm": self.prefill_profile.post_attention_norm_ms,
+                "mlp": self.prefill_profile.mlp_ms,
+                "mlp_residual": self.prefill_profile.mlp_residual_ms,
+                "layers_total": self.prefill_profile.layers_total_ms,
+                "final_norm": self.prefill_profile.final_norm_ms,
+                "lm_head": self.prefill_profile.lm_head_ms,
             }
         })
     }
@@ -1239,7 +1251,7 @@ impl Qwen3AsrModel {
             .map(|cache| self.execution_diagnostics(cache))
             .unwrap_or_else(|| self.execution_diagnostics_without_cache(prompt.ids.len()));
         let prefill_started = Instant::now();
-        let logits = self.forward_with_audio(
+        let (logits, prefill_profile) = self.forward_with_audio_profiled(
             &input_ids,
             &audio_embeds,
             prompt.audio_pad_start,
@@ -1304,6 +1316,7 @@ impl Qwen3AsrModel {
             timestamp_positions: timestamp_positions.len(),
             timestamp_segment_time_ms: segment_time_ms,
             execution,
+            prefill_profile,
             timings: Qwen3ForcedAlignTimingDiagnostics {
                 resample_ms,
                 mel_ms,
@@ -1376,6 +1389,33 @@ impl Qwen3AsrModel {
         audio_pad_len: usize,
         cache: Option<&mut Qwen3Cache>,
     ) -> Result<Tensor> {
+        let (embeds, position_ids) =
+            self.audio_conditioned_embeds(input_ids, audio_embeds, audio_pad_start, audio_pad_len)?;
+        self.text_model
+            .forward_with_embeds(&embeds, 0, cache, position_ids.as_ref())
+    }
+
+    fn forward_with_audio_profiled(
+        &self,
+        input_ids: &Tensor,
+        audio_embeds: &Tensor,
+        audio_pad_start: usize,
+        audio_pad_len: usize,
+        cache: Option<&mut Qwen3Cache>,
+    ) -> Result<(Tensor, Qwen3ForwardDiagnostics)> {
+        let (embeds, position_ids) =
+            self.audio_conditioned_embeds(input_ids, audio_embeds, audio_pad_start, audio_pad_len)?;
+        self.text_model
+            .forward_with_embeds_profiled(&embeds, 0, cache, position_ids.as_ref())
+    }
+
+    fn audio_conditioned_embeds(
+        &self,
+        input_ids: &Tensor,
+        audio_embeds: &Tensor,
+        audio_pad_start: usize,
+        audio_pad_len: usize,
+    ) -> Result<(Tensor, Option<Tensor>)> {
         let embeds = self.text_model.embeddings(input_ids)?;
         let seq_len = embeds.dim(1)?;
         let model_audio_len = audio_embeds.dim(1)?;
@@ -1421,8 +1461,7 @@ impl Qwen3AsrModel {
         } else {
             None
         };
-        self.text_model
-            .forward_with_embeds(&embeds, 0, cache, position_ids.as_ref())
+        Ok((embeds, position_ids))
     }
 
     fn build_prompt(

--- a/crates/izwi-core/src/models/architectures/qwen3/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/qwen3/asr/mod.rs
@@ -313,6 +313,12 @@ impl Qwen3ForcedAlignDiagnostics {
             "prefill_profile_ms": {
                 "input_norm": self.prefill_profile.input_norm_ms,
                 "attention": self.prefill_profile.attention_ms,
+                "attention_qkv_proj": self.prefill_profile.attention_qkv_proj_ms,
+                "attention_qk_norm": self.prefill_profile.attention_qk_norm_ms,
+                "attention_rope": self.prefill_profile.attention_rope_ms,
+                "attention_cache": self.prefill_profile.attention_cache_ms,
+                "attention_core": self.prefill_profile.attention_core_ms,
+                "attention_o_proj": self.prefill_profile.attention_o_proj_ms,
                 "attention_residual": self.prefill_profile.attention_residual_ms,
                 "post_attention_norm": self.prefill_profile.post_attention_norm_ms,
                 "mlp": self.prefill_profile.mlp_ms,

--- a/crates/izwi-core/src/models/architectures/qwen3/core.rs
+++ b/crates/izwi-core/src/models/architectures/qwen3/core.rs
@@ -25,6 +25,7 @@ use crate::models::shared::telemetry::{
 };
 use crate::models::shared::weights::gguf::GgufLoader;
 use crate::models::shared::weights::mlx;
+use std::time::Instant;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RopeScalingConfig {
@@ -554,6 +555,23 @@ impl Qwen3ProjectionDiagnostics {
                 .saturating_add(other.quantized_projection_count),
         }
     }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Qwen3ForwardDiagnostics {
+    pub input_norm_ms: f64,
+    pub attention_ms: f64,
+    pub attention_residual_ms: f64,
+    pub post_attention_norm_ms: f64,
+    pub mlp_ms: f64,
+    pub mlp_residual_ms: f64,
+    pub layers_total_ms: f64,
+    pub final_norm_ms: f64,
+    pub lm_head_ms: f64,
+}
+
+fn qwen3_elapsed_ms(started: Instant) -> f64 {
+    started.elapsed().as_secs_f64() * 1000.0
 }
 
 impl Qwen3Projection {
@@ -1199,15 +1217,74 @@ impl Qwen3Layer {
         cache: Option<&mut Qwen3Cache>,
         layer_idx: usize,
     ) -> Result<Tensor> {
+        self.forward_inner(x, start_pos, position_ids, cache, layer_idx, None)
+    }
+
+    fn forward_with_diagnostics(
+        &self,
+        x: &Tensor,
+        start_pos: usize,
+        position_ids: Option<&Tensor>,
+        cache: Option<&mut Qwen3Cache>,
+        layer_idx: usize,
+        diagnostics: &mut Qwen3ForwardDiagnostics,
+    ) -> Result<Tensor> {
+        self.forward_inner(
+            x,
+            start_pos,
+            position_ids,
+            cache,
+            layer_idx,
+            Some(diagnostics),
+        )
+    }
+
+    fn forward_inner(
+        &self,
+        x: &Tensor,
+        start_pos: usize,
+        position_ids: Option<&Tensor>,
+        cache: Option<&mut Qwen3Cache>,
+        layer_idx: usize,
+        mut diagnostics: Option<&mut Qwen3ForwardDiagnostics>,
+    ) -> Result<Tensor> {
+        let norm_started = diagnostics.as_ref().map(|_| Instant::now());
         let normed = self.input_layernorm.forward(x)?;
+        if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), norm_started) {
+            diag.input_norm_ms += qwen3_elapsed_ms(started);
+        }
+
+        let attention_started = diagnostics.as_ref().map(|_| Instant::now());
         let attn_out =
             self.self_attn
                 .forward(&normed, start_pos, position_ids, cache, layer_idx)?;
-        let x = x.broadcast_add(&attn_out)?;
+        if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), attention_started) {
+            diag.attention_ms += qwen3_elapsed_ms(started);
+        }
 
+        let residual_started = diagnostics.as_ref().map(|_| Instant::now());
+        let x = x.broadcast_add(&attn_out)?;
+        if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), residual_started) {
+            diag.attention_residual_ms += qwen3_elapsed_ms(started);
+        }
+
+        let norm_started = diagnostics.as_ref().map(|_| Instant::now());
         let normed = self.post_attention_layernorm.forward(&x)?;
+        if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), norm_started) {
+            diag.post_attention_norm_ms += qwen3_elapsed_ms(started);
+        }
+
+        let mlp_started = diagnostics.as_ref().map(|_| Instant::now());
         let mlp_out = self.mlp.forward(&normed)?;
+        if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), mlp_started) {
+            diag.mlp_ms += qwen3_elapsed_ms(started);
+        }
+
+        let residual_started = diagnostics.as_ref().map(|_| Instant::now());
         let x = x.broadcast_add(&mlp_out)?;
+        if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), residual_started) {
+            diag.mlp_residual_ms += qwen3_elapsed_ms(started);
+        }
         Ok(x)
     }
 }
@@ -1427,6 +1504,27 @@ impl Qwen3Model {
         self.logits_from_hidden(&hidden)
     }
 
+    pub fn forward_with_embeds_profiled(
+        &self,
+        embeds: &Tensor,
+        start_pos: usize,
+        mut cache: Option<&mut Qwen3Cache>,
+        position_ids: Option<&Tensor>,
+    ) -> Result<(Tensor, Qwen3ForwardDiagnostics)> {
+        let mut diagnostics = Qwen3ForwardDiagnostics::default();
+        let hidden = self.forward_hidden_with_embeds_inner(
+            embeds,
+            start_pos,
+            cache.as_deref_mut(),
+            position_ids,
+            Some(&mut diagnostics),
+        )?;
+        let lm_head_started = Instant::now();
+        let logits = self.logits_from_hidden(&hidden)?;
+        diagnostics.lm_head_ms += qwen3_elapsed_ms(lm_head_started);
+        Ok((logits, diagnostics))
+    }
+
     pub fn forward_hidden_with_embeds(
         &self,
         embeds: &Tensor,
@@ -1434,12 +1532,44 @@ impl Qwen3Model {
         mut cache: Option<&mut Qwen3Cache>,
         position_ids: Option<&Tensor>,
     ) -> Result<Tensor> {
+        self.forward_hidden_with_embeds_inner(
+            embeds,
+            start_pos,
+            cache.as_deref_mut(),
+            position_ids,
+            None,
+        )
+    }
+
+    fn forward_hidden_with_embeds_inner(
+        &self,
+        embeds: &Tensor,
+        start_pos: usize,
+        mut cache: Option<&mut Qwen3Cache>,
+        position_ids: Option<&Tensor>,
+        mut diagnostics: Option<&mut Qwen3ForwardDiagnostics>,
+    ) -> Result<Tensor> {
         let mut x = embeds.clone();
+        let layers_started = diagnostics.as_ref().map(|_| Instant::now());
         for (idx, layer) in self.layers.iter().enumerate() {
             let cache_ref = cache.as_deref_mut();
-            x = layer.forward(&x, start_pos, position_ids, cache_ref, idx)?;
+            x = match diagnostics.as_deref_mut() {
+                Some(diag) => {
+                    layer.forward_with_diagnostics(&x, start_pos, position_ids, cache_ref, idx, diag)?
+                }
+                None => layer.forward(&x, start_pos, position_ids, cache_ref, idx)?,
+            };
         }
-        self.norm.forward(&x).map_err(Error::from)
+        if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), layers_started) {
+            diag.layers_total_ms += qwen3_elapsed_ms(started);
+        }
+
+        let norm_started = diagnostics.as_ref().map(|_| Instant::now());
+        let x = self.norm.forward(&x)?;
+        if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), norm_started) {
+            diag.final_norm_ms += qwen3_elapsed_ms(started);
+        }
+        Ok(x)
     }
 
     pub fn logits_from_hidden(&self, hidden: &Tensor) -> Result<Tensor> {

--- a/crates/izwi-core/src/models/architectures/qwen3/core.rs
+++ b/crates/izwi-core/src/models/architectures/qwen3/core.rs
@@ -1525,6 +1525,24 @@ impl Qwen3Model {
         Ok((logits, diagnostics))
     }
 
+    pub fn forward_hidden_with_embeds_profiled(
+        &self,
+        embeds: &Tensor,
+        start_pos: usize,
+        mut cache: Option<&mut Qwen3Cache>,
+        position_ids: Option<&Tensor>,
+    ) -> Result<(Tensor, Qwen3ForwardDiagnostics)> {
+        let mut diagnostics = Qwen3ForwardDiagnostics::default();
+        let hidden = self.forward_hidden_with_embeds_inner(
+            embeds,
+            start_pos,
+            cache.as_deref_mut(),
+            position_ids,
+            Some(&mut diagnostics),
+        )?;
+        Ok((hidden, diagnostics))
+    }
+
     pub fn forward_hidden_with_embeds(
         &self,
         embeds: &Tensor,

--- a/crates/izwi-core/src/models/architectures/qwen3/core.rs
+++ b/crates/izwi-core/src/models/architectures/qwen3/core.rs
@@ -561,6 +561,12 @@ impl Qwen3ProjectionDiagnostics {
 pub struct Qwen3ForwardDiagnostics {
     pub input_norm_ms: f64,
     pub attention_ms: f64,
+    pub attention_qkv_proj_ms: f64,
+    pub attention_qk_norm_ms: f64,
+    pub attention_rope_ms: f64,
+    pub attention_cache_ms: f64,
+    pub attention_core_ms: f64,
+    pub attention_o_proj_ms: f64,
     pub attention_residual_ms: f64,
     pub post_attention_norm_ms: f64,
     pub mlp_ms: f64,
@@ -939,11 +945,13 @@ impl Qwen3Attention {
         position_ids: Option<&Tensor>,
         mut cache: Option<&mut Qwen3Cache>,
         layer_idx: usize,
+        mut diagnostics: Option<&mut Qwen3ForwardDiagnostics>,
     ) -> Result<Tensor> {
         let bsz = x.dim(0)?;
         let seq_len = x.dim(1)?;
         let use_batched = cache.is_none() && start_pos == 0 && bsz > 1;
 
+        let qkv_started = diagnostics.as_ref().map(|_| Instant::now());
         let mut q =
             self.q_proj
                 .forward(x)?
@@ -956,19 +964,37 @@ impl Qwen3Attention {
             self.v_proj
                 .forward(x)?
                 .reshape((bsz, seq_len, self.num_kv_heads, self.head_dim))?;
+        if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), qkv_started) {
+            diag.attention_qkv_proj_ms += qwen3_elapsed_ms(started);
+        }
 
+        let qk_norm_started = diagnostics.as_ref().map(|_| Instant::now());
         q = self.apply_qk_norm(q, &self.q_norm, self.num_heads, seq_len)?;
         k = self.apply_qk_norm(k, &self.k_norm, self.num_kv_heads, seq_len)?;
+        if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), qk_norm_started) {
+            diag.attention_qk_norm_ms += qwen3_elapsed_ms(started);
+        }
 
+        let rope_started = diagnostics.as_ref().map(|_| Instant::now());
         (q, k) = self.apply_rope_pair(q, k, start_pos, position_ids, cache.as_deref_mut())?;
+        if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), rope_started) {
+            diag.attention_rope_ms += qwen3_elapsed_ms(started);
+        }
 
+        let cache_started = diagnostics.as_ref().map(|_| Instant::now());
         let (k, v) = if let Some(cache) = cache {
             cache.append(layer_idx, k.clone(), v.clone())?;
 
             // Decode path hot loop: for single-token decode, avoid rematerializing full KV.
             if seq_len == 1 && start_pos > 0 {
                 if let Some((k_dense_h, v_dense_h)) = cache.dense_heads(layer_idx)? {
+                    if let (Some(diag), Some(started)) =
+                        (diagnostics.as_deref_mut(), cache_started)
+                    {
+                        diag.attention_cache_ms += qwen3_elapsed_ms(started);
+                    }
                     record_decode_attention_path(DecodeAttentionPath::Dense);
+                    let core_started = diagnostics.as_ref().map(|_| Instant::now());
                     let out = dense_decode_attention(
                         &q,
                         &k_dense_h,
@@ -978,9 +1004,20 @@ impl Qwen3Attention {
                         self.head_dim,
                     )?;
                     let out = out.reshape((bsz, seq_len, self.num_heads * self.head_dim))?;
-                    return self.o_proj.forward(&out).map_err(Error::from);
+                    if let (Some(diag), Some(started)) =
+                        (diagnostics.as_deref_mut(), core_started)
+                    {
+                        diag.attention_core_ms += qwen3_elapsed_ms(started);
+                    }
+                    return self.forward_o_proj(&out, diagnostics.as_deref_mut());
                 }
                 if let Some((k_pages, v_pages)) = cache.pages(layer_idx) {
+                    if let (Some(diag), Some(started)) =
+                        (diagnostics.as_deref_mut(), cache_started)
+                    {
+                        diag.attention_cache_ms += qwen3_elapsed_ms(started);
+                    }
+                    let core_started = diagnostics.as_ref().map(|_| Instant::now());
                     let out = paged_decode_attention(
                         &q,
                         k_pages,
@@ -990,7 +1027,12 @@ impl Qwen3Attention {
                         self.head_dim,
                     )?;
                     let out = out.reshape((bsz, seq_len, self.num_heads * self.head_dim))?;
-                    return self.o_proj.forward(&out).map_err(Error::from);
+                    if let (Some(diag), Some(started)) =
+                        (diagnostics.as_deref_mut(), core_started)
+                    {
+                        diag.attention_core_ms += qwen3_elapsed_ms(started);
+                    }
+                    return self.forward_o_proj(&out, diagnostics.as_deref_mut());
                 }
             }
 
@@ -998,7 +1040,11 @@ impl Qwen3Attention {
         } else {
             (k, v)
         };
+        if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), cache_started) {
+            diag.attention_cache_ms += qwen3_elapsed_ms(started);
+        }
 
+        let core_started = diagnostics.as_ref().map(|_| Instant::now());
         if use_batched {
             let k = repeat_kv(&k, self.num_heads, self.num_kv_heads)?;
             let v = repeat_kv(&v, self.num_heads, self.num_kv_heads)?;
@@ -1025,7 +1071,10 @@ impl Qwen3Attention {
             };
             let config = BatchedAttentionConfig::new(self.num_heads, self.head_dim);
             let out = batched_scaled_dot_product_attention(&input, &config)?;
-            return self.o_proj.forward(&out).map_err(Error::from);
+            if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), core_started) {
+                diag.attention_core_ms += qwen3_elapsed_ms(started);
+            }
+            return self.forward_o_proj(&out, diagnostics.as_deref_mut());
         }
 
         let q = q.transpose(1, 2)?; // [b, h, s, d]
@@ -1042,7 +1091,10 @@ impl Qwen3Attention {
                     seq_len,
                     self.num_heads * self.head_dim,
                 ))?;
-                return self.o_proj.forward(&out).map_err(Error::from);
+                if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), core_started) {
+                    diag.attention_core_ms += qwen3_elapsed_ms(started);
+                }
+                return self.forward_o_proj(&out, diagnostics.as_deref_mut());
             }
         }
 
@@ -1060,7 +1112,10 @@ impl Qwen3Attention {
                     seq_len,
                     self.num_heads * self.head_dim,
                 ))?;
-                return self.o_proj.forward(&out).map_err(Error::from);
+                if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), core_started) {
+                    diag.attention_core_ms += qwen3_elapsed_ms(started);
+                }
+                return self.forward_o_proj(&out, diagnostics.as_deref_mut());
             }
         }
 
@@ -1085,8 +1140,23 @@ impl Qwen3Attention {
         let out = out
             .transpose(1, 2)?
             .reshape((bsz, seq_len, self.num_heads * self.head_dim))?;
+        if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), core_started) {
+            diag.attention_core_ms += qwen3_elapsed_ms(started);
+        }
 
-        let out = self.o_proj.forward(&out)?;
+        self.forward_o_proj(&out, diagnostics.as_deref_mut())
+    }
+
+    fn forward_o_proj(
+        &self,
+        out: &Tensor,
+        diagnostics: Option<&mut Qwen3ForwardDiagnostics>,
+    ) -> Result<Tensor> {
+        let started = diagnostics.as_ref().map(|_| Instant::now());
+        let out = self.o_proj.forward(out)?;
+        if let (Some(diag), Some(started)) = (diagnostics, started) {
+            diag.attention_o_proj_ms += qwen3_elapsed_ms(started);
+        }
         Ok(out)
     }
 }
@@ -1255,9 +1325,15 @@ impl Qwen3Layer {
         }
 
         let attention_started = diagnostics.as_ref().map(|_| Instant::now());
-        let attn_out =
-            self.self_attn
-                .forward(&normed, start_pos, position_ids, cache, layer_idx)?;
+        let attn_out = match diagnostics.as_deref_mut() {
+            Some(diag) => {
+                self.self_attn
+                    .forward(&normed, start_pos, position_ids, cache, layer_idx, Some(diag))?
+            }
+            None => self
+                .self_attn
+                .forward(&normed, start_pos, position_ids, cache, layer_idx, None)?,
+        };
         if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), attention_started) {
             diag.attention_ms += qwen3_elapsed_ms(started);
         }

--- a/crates/izwi-core/src/models/architectures/qwen3/core.rs
+++ b/crates/izwi-core/src/models/architectures/qwen3/core.rs
@@ -839,6 +839,7 @@ impl Qwen3Attention {
         start_pos: usize,
         position_ids: Option<&Tensor>,
         cache: Option<&mut Qwen3Cache>,
+        forward_rope_pair: Option<&(Tensor, Tensor)>,
     ) -> Result<(Tensor, Tensor)> {
         let seq_len = q.dim(1)?;
         if k.dim(1)? != seq_len {
@@ -851,7 +852,9 @@ impl Qwen3Attention {
         let q = q.contiguous()?;
         let k = k.contiguous()?;
 
-        let (cos_half, sin_half) = if let Some(position_ids) = position_ids {
+        let (cos_half, sin_half) = if let Some((cos_half, sin_half)) = forward_rope_pair {
+            (cos_half.clone(), sin_half.clone())
+        } else if let Some(position_ids) = position_ids {
             if self.use_mrope {
                 build_mrope_cache_with_inv_freqs(
                     seq_len,
@@ -928,6 +931,57 @@ impl Qwen3Attention {
         ))
     }
 
+    fn build_forward_rope_pair(
+        &self,
+        seq_len: usize,
+        start_pos: usize,
+        device: &Device,
+        dtype: DType,
+        position_ids: Option<&Tensor>,
+    ) -> Result<(Tensor, Tensor)> {
+        if let Some(position_ids) = position_ids {
+            if self.use_mrope {
+                build_mrope_cache_with_inv_freqs(
+                    seq_len,
+                    self.head_dim,
+                    device,
+                    dtype,
+                    position_ids,
+                    self.mrope_section.as_deref().unwrap_or(&[]),
+                    &self.rope_inv_freqs,
+                )
+            } else {
+                build_rope_cache_with_inv_freqs(
+                    seq_len,
+                    start_pos,
+                    device,
+                    dtype,
+                    &self.rope_inv_freqs,
+                )
+            }
+        } else if self.use_mrope {
+            let mut data = Vec::with_capacity(3 * seq_len);
+            let base = start_pos as i64;
+            for _axis in 0..3 {
+                for idx in 0..seq_len {
+                    data.push(base + idx as i64);
+                }
+            }
+            let position_ids = Tensor::from_vec(data, (3, seq_len), device)?;
+            build_mrope_cache_with_inv_freqs(
+                seq_len,
+                self.head_dim,
+                device,
+                dtype,
+                &position_ids,
+                self.mrope_section.as_deref().unwrap_or(&[]),
+                &self.rope_inv_freqs,
+            )
+        } else {
+            build_rope_cache_with_inv_freqs(seq_len, start_pos, device, dtype, &self.rope_inv_freqs)
+        }
+    }
+
     fn should_try_rope_kernel(&self, dtype: DType) -> bool {
         if !self.rope_kernel_enabled {
             return false;
@@ -946,6 +1000,7 @@ impl Qwen3Attention {
         mut cache: Option<&mut Qwen3Cache>,
         layer_idx: usize,
         mut diagnostics: Option<&mut Qwen3ForwardDiagnostics>,
+        forward_rope_pair: Option<&(Tensor, Tensor)>,
     ) -> Result<Tensor> {
         let bsz = x.dim(0)?;
         let seq_len = x.dim(1)?;
@@ -976,7 +1031,14 @@ impl Qwen3Attention {
         }
 
         let rope_started = diagnostics.as_ref().map(|_| Instant::now());
-        (q, k) = self.apply_rope_pair(q, k, start_pos, position_ids, cache.as_deref_mut())?;
+        (q, k) = self.apply_rope_pair(
+            q,
+            k,
+            start_pos,
+            position_ids,
+            cache.as_deref_mut(),
+            forward_rope_pair,
+        )?;
         if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), rope_started) {
             diag.attention_rope_ms += qwen3_elapsed_ms(started);
         }
@@ -1286,8 +1348,17 @@ impl Qwen3Layer {
         position_ids: Option<&Tensor>,
         cache: Option<&mut Qwen3Cache>,
         layer_idx: usize,
+        forward_rope_pair: Option<&(Tensor, Tensor)>,
     ) -> Result<Tensor> {
-        self.forward_inner(x, start_pos, position_ids, cache, layer_idx, None)
+        self.forward_inner(
+            x,
+            start_pos,
+            position_ids,
+            cache,
+            layer_idx,
+            None,
+            forward_rope_pair,
+        )
     }
 
     fn forward_with_diagnostics(
@@ -1298,6 +1369,7 @@ impl Qwen3Layer {
         cache: Option<&mut Qwen3Cache>,
         layer_idx: usize,
         diagnostics: &mut Qwen3ForwardDiagnostics,
+        forward_rope_pair: Option<&(Tensor, Tensor)>,
     ) -> Result<Tensor> {
         self.forward_inner(
             x,
@@ -1306,6 +1378,7 @@ impl Qwen3Layer {
             cache,
             layer_idx,
             Some(diagnostics),
+            forward_rope_pair,
         )
     }
 
@@ -1317,6 +1390,7 @@ impl Qwen3Layer {
         cache: Option<&mut Qwen3Cache>,
         layer_idx: usize,
         mut diagnostics: Option<&mut Qwen3ForwardDiagnostics>,
+        forward_rope_pair: Option<&(Tensor, Tensor)>,
     ) -> Result<Tensor> {
         let norm_started = diagnostics.as_ref().map(|_| Instant::now());
         let normed = self.input_layernorm.forward(x)?;
@@ -1328,11 +1402,27 @@ impl Qwen3Layer {
         let attn_out = match diagnostics.as_deref_mut() {
             Some(diag) => {
                 self.self_attn
-                    .forward(&normed, start_pos, position_ids, cache, layer_idx, Some(diag))?
+                    .forward(
+                        &normed,
+                        start_pos,
+                        position_ids,
+                        cache,
+                        layer_idx,
+                        Some(diag),
+                        forward_rope_pair,
+                    )?
             }
             None => self
                 .self_attn
-                .forward(&normed, start_pos, position_ids, cache, layer_idx, None)?,
+                .forward(
+                    &normed,
+                    start_pos,
+                    position_ids,
+                    cache,
+                    layer_idx,
+                    None,
+                    forward_rope_pair,
+                )?,
         };
         if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), attention_started) {
             diag.attention_ms += qwen3_elapsed_ms(started);
@@ -1644,14 +1734,50 @@ impl Qwen3Model {
         mut diagnostics: Option<&mut Qwen3ForwardDiagnostics>,
     ) -> Result<Tensor> {
         let mut x = embeds.clone();
+        let forward_rope_started = diagnostics.as_ref().map(|_| Instant::now());
+        let forward_rope_pair = if cache.is_none() {
+            self.layers
+                .first()
+                .map(|layer| {
+                    layer.self_attn.build_forward_rope_pair(
+                        embeds.dim(1)?,
+                        start_pos,
+                        embeds.device(),
+                        embeds.dtype(),
+                        position_ids,
+                    )
+                })
+                .transpose()?
+        } else {
+            None
+        };
+        if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), forward_rope_started) {
+            diag.attention_rope_ms += qwen3_elapsed_ms(started);
+        }
+        let forward_rope_pair_ref = forward_rope_pair.as_ref();
         let layers_started = diagnostics.as_ref().map(|_| Instant::now());
         for (idx, layer) in self.layers.iter().enumerate() {
             let cache_ref = cache.as_deref_mut();
             x = match diagnostics.as_deref_mut() {
                 Some(diag) => {
-                    layer.forward_with_diagnostics(&x, start_pos, position_ids, cache_ref, idx, diag)?
+                    layer.forward_with_diagnostics(
+                        &x,
+                        start_pos,
+                        position_ids,
+                        cache_ref,
+                        idx,
+                        diag,
+                        forward_rope_pair_ref,
+                    )?
                 }
-                None => layer.forward(&x, start_pos, position_ids, cache_ref, idx)?,
+                None => layer.forward(
+                    &x,
+                    start_pos,
+                    position_ids,
+                    cache_ref,
+                    idx,
+                    forward_rope_pair_ref,
+                )?,
             };
         }
         if let (Some(diag), Some(started)) = (diagnostics.as_deref_mut(), layers_started) {

--- a/crates/izwi-core/src/models/architectures/sortformer/diarization/mod.rs
+++ b/crates/izwi-core/src/models/architectures/sortformer/diarization/mod.rs
@@ -659,7 +659,7 @@ fn sortformer_uses_selected_model_device_with_metal_override(
     kind: DeviceKind,
     metal_enabled: Option<bool>,
 ) -> bool {
-    kind.is_cuda() || (kind.is_metal() && metal_enabled.unwrap_or(false))
+    kind.is_cuda() || (kind.is_metal() && metal_enabled.unwrap_or(true))
 }
 
 fn sortformer_env_bool(name: &str) -> Option<bool> {
@@ -2949,12 +2949,12 @@ mod tests {
     }
 
     #[test]
-    fn sortformer_uses_metal_only_when_explicitly_enabled() {
+    fn sortformer_uses_metal_by_default_with_explicit_opt_out() {
         assert!(!sortformer_uses_selected_model_device_with_metal_override(
             DeviceKind::Cpu,
             Some(true),
         ));
-        assert!(!sortformer_uses_selected_model_device_with_metal_override(
+        assert!(sortformer_uses_selected_model_device_with_metal_override(
             DeviceKind::Metal,
             None,
         ));

--- a/crates/izwi-core/src/models/architectures/sortformer/diarization/mod.rs
+++ b/crates/izwi-core/src/models/architectures/sortformer/diarization/mod.rs
@@ -1527,8 +1527,8 @@ impl SortformerPreprocessor {
             }
             fft.process(&mut buffer);
             for k in 0..self.n_freqs {
-                let mag = (buffer[k].re * buffer[k].re + buffer[k].im * buffer[k].im).sqrt();
-                spectrum[frame_idx * self.n_freqs + k] = mag * mag;
+                spectrum[frame_idx * self.n_freqs + k] =
+                    buffer[k].re * buffer[k].re + buffer[k].im * buffer[k].im;
             }
         }
 
@@ -1741,11 +1741,11 @@ impl ConvSubsamplingDw {
         x = self.conv0.forward(&x)?;
         x = x.relu()?;
 
-        x = self.conv2.forward(&x)?;
+        x = forward_depthwise_conv2d(&self.conv2, &x)?;
         x = self.conv3.forward(&x)?;
         x = x.relu()?;
 
-        x = self.conv5.forward(&x)?;
+        x = forward_depthwise_conv2d(&self.conv5, &x)?;
         x = self.conv6.forward(&x)?;
         x = x.relu()?;
 
@@ -1757,6 +1757,25 @@ impl ConvSubsamplingDw {
         let encoded_len = subsampled_len_3x(feature_frames).min(t);
         Ok((x, encoded_len))
     }
+}
+
+fn forward_depthwise_conv2d(conv: &Conv2d, x: &Tensor) -> Result<Tensor> {
+    let Some(mut x) = metal_kernels::try_depthwise_conv2d(
+        x,
+        conv.weight(),
+        conv.config().padding,
+        conv.config().stride,
+        conv.config().dilation,
+    ) else {
+        return conv.forward(x).map_err(Error::from);
+    };
+
+    if let Some(bias) = conv.bias() {
+        let b = bias.dims1()?;
+        x = x.broadcast_add(&bias.reshape((1, b, 1, 1))?)?;
+    }
+
+    Ok(x)
 }
 
 fn subsampled_len_3x(mut len: usize) -> usize {

--- a/crates/izwi-core/src/models/architectures/sortformer/diarization/mod.rs
+++ b/crates/izwi-core/src/models/architectures/sortformer/diarization/mod.rs
@@ -45,6 +45,8 @@ struct SortformerTimingDiagnostics {
     transformer_forward_ms: f64,
     head_ms: f64,
     host_read_ms: f64,
+    device_sync_ms: f64,
+    host_copy_ms: f64,
     postprocess_ms: f64,
     model_total_ms: f64,
 }
@@ -119,6 +121,8 @@ impl SortformerDiarizationDiagnostics {
                 "transformer_forward": self.timings.transformer_forward_ms,
                 "head": self.timings.head_ms,
                 "host_read": self.timings.host_read_ms,
+                "device_sync": self.timings.device_sync_ms,
+                "host_copy": self.timings.host_copy_ms,
                 "postprocess": self.timings.postprocess_ms,
                 "model_total": self.timings.model_total_ms,
             },
@@ -838,10 +842,7 @@ impl SortformerInferenceModel {
         }
         let probs =
             self.forward_probabilities_with_diagnostics(&encoded, encoded_len, diagnostics)?;
-        let host_started = Instant::now();
-        let rows = tensor_to_probability_rows(&probs, encoded_len)?;
-        diagnostics.timings.host_read_ms += elapsed_ms(host_started);
-        Ok(rows)
+        tensor_to_probability_rows_with_diagnostics(&probs, encoded_len, diagnostics)
     }
 
     fn infer_speaker_probabilities_streaming_with_diagnostics(
@@ -867,9 +868,11 @@ impl SortformerInferenceModel {
                 continue;
             }
 
-            let host_started = Instant::now();
-            let chunk_rows = tensor_to_embedding_rows(&chunk_pre_encoded, chunk_pre_encoded_len)?;
-            diagnostics.timings.host_read_ms += elapsed_ms(host_started);
+            let chunk_rows = tensor_to_embedding_rows_with_diagnostics(
+                &chunk_pre_encoded,
+                chunk_pre_encoded_len,
+                diagnostics,
+            )?;
             let mut composite_rows =
                 Vec::with_capacity(state.spkcache.len() + state.fifo.len() + chunk_rows.len());
             composite_rows.extend(state.spkcache.iter().cloned());
@@ -892,9 +895,8 @@ impl SortformerInferenceModel {
             diagnostics.encoded_frames += encoded_len;
             let probs =
                 self.forward_probabilities_with_diagnostics(&encoded, encoded_len, diagnostics)?;
-            let host_started = Instant::now();
-            let pred_rows = tensor_to_probability_rows(&probs, encoded_len)?;
-            diagnostics.timings.host_read_ms += elapsed_ms(host_started);
+            let pred_rows =
+                tensor_to_probability_rows_with_diagnostics(&probs, encoded_len, diagnostics)?;
             let (updated_state, chunk_preds) = update_streaming_state(
                 state,
                 &chunk_rows,
@@ -1055,6 +1057,22 @@ fn tensor_to_embedding_rows(tensor: &Tensor, row_count: usize) -> Result<Vec<Vec
         .collect::<Vec<_>>())
 }
 
+fn tensor_to_embedding_rows_with_diagnostics(
+    tensor: &Tensor,
+    row_count: usize,
+    diagnostics: &mut SortformerDiarizationDiagnostics,
+) -> Result<Vec<Vec<f32>>> {
+    let sync_ms = synchronize_tensor_for_host_read(tensor)?;
+    diagnostics.timings.device_sync_ms += sync_ms;
+
+    let copy_started = Instant::now();
+    let rows = tensor_to_embedding_rows(tensor, row_count)?;
+    let copy_ms = elapsed_ms(copy_started);
+    diagnostics.timings.host_copy_ms += copy_ms;
+    diagnostics.timings.host_read_ms += sync_ms + copy_ms;
+    Ok(rows)
+}
+
 fn tensor_to_probability_rows(
     tensor: &Tensor,
     row_count: usize,
@@ -1076,6 +1094,33 @@ fn tensor_to_probability_rows(
         .chunks(MAX_SUPPORTED_SPEAKERS)
         .map(|chunk| [chunk[0], chunk[1], chunk[2], chunk[3]])
         .collect::<Vec<_>>())
+}
+
+fn tensor_to_probability_rows_with_diagnostics(
+    tensor: &Tensor,
+    row_count: usize,
+    diagnostics: &mut SortformerDiarizationDiagnostics,
+) -> Result<Vec<[f32; MAX_SUPPORTED_SPEAKERS]>> {
+    let sync_ms = synchronize_tensor_for_host_read(tensor)?;
+    diagnostics.timings.device_sync_ms += sync_ms;
+
+    let copy_started = Instant::now();
+    let rows = tensor_to_probability_rows(tensor, row_count)?;
+    let copy_ms = elapsed_ms(copy_started);
+    diagnostics.timings.host_copy_ms += copy_ms;
+    diagnostics.timings.host_read_ms += sync_ms + copy_ms;
+    Ok(rows)
+}
+
+fn synchronize_tensor_for_host_read(tensor: &Tensor) -> Result<f64> {
+    let device = tensor.device();
+    if !(device.is_metal() || device.is_cuda()) {
+        return Ok(0.0);
+    }
+
+    let started = Instant::now();
+    device.synchronize()?;
+    Ok(elapsed_ms(started))
 }
 
 fn tensor_from_embedding_rows(

--- a/crates/izwi-core/src/models/architectures/sortformer/diarization/mod.rs
+++ b/crates/izwi-core/src/models/architectures/sortformer/diarization/mod.rs
@@ -2,6 +2,7 @@ mod nemo;
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
+use std::time::Instant;
 
 use candle_core::{DType, Device, IndexOp, Tensor};
 use candle_nn::ops;
@@ -16,6 +17,7 @@ use rustfft::FftPlanner;
 use crate::backends::{DeviceKind, DeviceProfile};
 use crate::error::{Error, Result};
 use crate::model::ModelVariant;
+use crate::models::architectures::parakeet::asr::metal_kernels;
 use crate::models::shared::weights::mlx;
 use crate::runtime::{DiarizationConfig, DiarizationResult, DiarizationSegment};
 
@@ -30,6 +32,103 @@ const LOG_GUARD: f32 = 5.960_464_5e-8;
 const NORMALIZE_EPS: f32 = 1e-5;
 const TS_VAD_FRAME_LENGTH_SECS: f32 = 0.01;
 const TS_VAD_UNIT_FRAME_COUNT: usize = 8;
+
+#[derive(Debug, Clone, Default)]
+struct SortformerTimingDiagnostics {
+    resample_ms: f64,
+    feature_extract_ms: f64,
+    feature_upload_ms: f64,
+    pre_encode_ms: f64,
+    conformer_forward_ms: f64,
+    conformer_conv_ms: f64,
+    conformer_attention_ms: f64,
+    transformer_forward_ms: f64,
+    head_ms: f64,
+    host_read_ms: f64,
+    postprocess_ms: f64,
+    model_total_ms: f64,
+}
+
+#[derive(Debug, Clone)]
+struct SortformerDiarizationDiagnostics {
+    timings: SortformerTimingDiagnostics,
+    input_sample_rate: u32,
+    original_samples: usize,
+    resampled_samples: usize,
+    duration_secs: f32,
+    feature_frames: usize,
+    encoded_frames: usize,
+    prediction_frames: usize,
+    frame_stride_samples: usize,
+    streaming_chunks: usize,
+    backend: String,
+    streaming: bool,
+}
+
+impl SortformerDiarizationDiagnostics {
+    fn new(
+        input_sample_rate: u32,
+        original_samples: usize,
+        resampled_samples: usize,
+        duration_secs: f32,
+        backend: String,
+        streaming: bool,
+    ) -> Self {
+        Self {
+            timings: SortformerTimingDiagnostics::default(),
+            input_sample_rate,
+            original_samples,
+            resampled_samples,
+            duration_secs,
+            feature_frames: 0,
+            encoded_frames: 0,
+            prediction_frames: 0,
+            frame_stride_samples: 0,
+            streaming_chunks: 0,
+            backend,
+            streaming,
+        }
+    }
+
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "model_family": "sortformer_diarization",
+            "backend": self.backend,
+            "streaming": self.streaming,
+            "audio": {
+                "input_sample_rate": self.input_sample_rate,
+                "original_samples": self.original_samples,
+                "resampled_samples": self.resampled_samples,
+                "duration_secs": self.duration_secs,
+            },
+            "frames": {
+                "feature": self.feature_frames,
+                "encoded": self.encoded_frames,
+                "prediction": self.prediction_frames,
+                "frame_stride_samples": self.frame_stride_samples,
+                "streaming_chunks": self.streaming_chunks,
+            },
+            "timings_ms": {
+                "resample": self.timings.resample_ms,
+                "feature_extract": self.timings.feature_extract_ms,
+                "feature_upload": self.timings.feature_upload_ms,
+                "pre_encode": self.timings.pre_encode_ms,
+                "conformer_forward": self.timings.conformer_forward_ms,
+                "conformer_conv": self.timings.conformer_conv_ms,
+                "conformer_attention": self.timings.conformer_attention_ms,
+                "transformer_forward": self.timings.transformer_forward_ms,
+                "head": self.timings.head_ms,
+                "host_read": self.timings.host_read_ms,
+                "postprocess": self.timings.postprocess_ms,
+                "model_total": self.timings.model_total_ms,
+            },
+        })
+    }
+}
+
+fn elapsed_ms(started: Instant) -> f64 {
+    started.elapsed().as_secs_f64() * 1000.0
+}
 
 #[derive(Debug, Clone, serde::Deserialize)]
 struct SortformerModelConfig {
@@ -274,6 +373,7 @@ impl SortformerDiarizerModel {
         sample_rate: u32,
         config: &DiarizationConfig,
     ) -> Result<DiarizationResult> {
+        let model_started = Instant::now();
         if audio.is_empty() {
             return Err(Error::InvalidInput("Empty audio input".to_string()));
         }
@@ -281,31 +381,52 @@ impl SortformerDiarizerModel {
             return Err(Error::InvalidInput("Invalid sample rate: 0".to_string()));
         }
 
+        let resample_started = Instant::now();
         let samples = if sample_rate == TARGET_SAMPLE_RATE {
             audio.to_vec()
         } else {
             resample_linear(audio, sample_rate, TARGET_SAMPLE_RATE)
         };
+        let resample_ms = if sample_rate == TARGET_SAMPLE_RATE {
+            0.0
+        } else {
+            elapsed_ms(resample_started)
+        };
 
         let duration_secs = samples.len() as f32 / TARGET_SAMPLE_RATE as f32;
+        let mut diagnostics = SortformerDiarizationDiagnostics::new(
+            sample_rate,
+            audio.len(),
+            samples.len(),
+            duration_secs,
+            sortformer_device_backend(&self.model.device).to_string(),
+            self.model.streaming.is_some(),
+        );
+        diagnostics.timings.resample_ms = resample_ms;
         if samples.is_empty() {
+            diagnostics.timings.model_total_ms = elapsed_ms(model_started);
             return Ok(DiarizationResult {
                 segments: Vec::new(),
                 duration_secs,
                 speaker_count: 0,
+                diagnostics: Some(diagnostics.to_json()),
             });
         }
 
-        let (speaker_probs, frame_stride_samples) =
-            self.model.infer_speaker_probabilities(&samples)?;
+        let (speaker_probs, frame_stride_samples) = self
+            .model
+            .infer_speaker_probabilities_with_diagnostics(&samples, &mut diagnostics)?;
         if speaker_probs.is_empty() {
+            diagnostics.timings.model_total_ms = elapsed_ms(model_started);
             return Ok(DiarizationResult {
                 segments: Vec::new(),
                 duration_secs,
                 speaker_count: 0,
+                diagnostics: Some(diagnostics.to_json()),
             });
         }
 
+        let postprocess_started = Instant::now();
         let explicit_min_speech_ms = config
             .min_speech_duration_ms
             .filter(|value| value.is_finite())
@@ -425,10 +546,13 @@ impl SortformerDiarizerModel {
         }
 
         if raw_segments.is_empty() {
+            diagnostics.timings.postprocess_ms += elapsed_ms(postprocess_started);
+            diagnostics.timings.model_total_ms = elapsed_ms(model_started);
             return Ok(DiarizationResult {
                 segments: Vec::new(),
                 duration_secs,
                 speaker_count: 0,
+                diagnostics: Some(diagnostics.to_json()),
             });
         }
 
@@ -499,11 +623,14 @@ impl SortformerDiarizerModel {
             .map(|segment| segment.speaker.as_str())
             .collect::<std::collections::BTreeSet<_>>()
             .len();
+        diagnostics.timings.postprocess_ms += elapsed_ms(postprocess_started);
+        diagnostics.timings.model_total_ms = elapsed_ms(model_started);
 
         Ok(DiarizationResult {
             segments,
             duration_secs,
             speaker_count,
+            diagnostics: Some(diagnostics.to_json()),
         })
     }
 
@@ -521,7 +648,37 @@ fn sortformer_model_device(device_profile: &DeviceProfile) -> Device {
 }
 
 fn sortformer_uses_selected_model_device(kind: DeviceKind) -> bool {
-    kind.is_cuda()
+    sortformer_uses_selected_model_device_with_metal_override(
+        kind,
+        sortformer_env_bool("IZWI_SORTFORMER_ENABLE_METAL")
+            .or_else(|| sortformer_env_bool("IZWI_SORTFORMER_METAL")),
+    )
+}
+
+fn sortformer_uses_selected_model_device_with_metal_override(
+    kind: DeviceKind,
+    metal_enabled: Option<bool>,
+) -> bool {
+    kind.is_cuda() || (kind.is_metal() && metal_enabled.unwrap_or(false))
+}
+
+fn sortformer_env_bool(name: &str) -> Option<bool> {
+    let value = std::env::var(name).ok()?;
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+fn sortformer_device_backend(device: &Device) -> &'static str {
+    if device.is_cuda() {
+        "cuda"
+    } else if device.is_metal() {
+        "metal"
+    } else {
+        "cpu"
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -607,10 +764,12 @@ impl SortformerInferenceModel {
         })
     }
 
-    fn infer_speaker_probabilities(
+    fn infer_speaker_probabilities_with_diagnostics(
         &self,
         samples: &[f32],
+        diagnostics: &mut SortformerDiarizationDiagnostics,
     ) -> Result<(Vec<[f32; MAX_SUPPORTED_SPEAKERS]>, usize)> {
+        let feature_started = Instant::now();
         let normalized_storage;
         let feature_input = if self.streaming.is_some() {
             samples
@@ -632,55 +791,85 @@ impl SortformerInferenceModel {
         };
 
         let (features, feature_frames) = self.preprocessor.compute_features(feature_input)?;
+        diagnostics.feature_frames = feature_frames;
+        diagnostics.timings.feature_extract_ms += elapsed_ms(feature_started);
         if feature_frames == 0 {
+            diagnostics.frame_stride_samples = self.encoder.frame_stride_samples();
             return Ok((Vec::new(), self.encoder.frame_stride_samples()));
         }
+        let upload_started = Instant::now();
         let features = features
             .narrow(2, 0, feature_frames)?
             .to_device(&self.device)?;
+        diagnostics.timings.feature_upload_ms += elapsed_ms(upload_started);
 
         let out = if let Some(streaming_cfg) = self.streaming {
-            self.infer_speaker_probabilities_streaming(&features, feature_frames, streaming_cfg)?
+            self.infer_speaker_probabilities_streaming_with_diagnostics(
+                &features,
+                feature_frames,
+                streaming_cfg,
+                diagnostics,
+            )?
         } else {
-            self.infer_speaker_probabilities_offline(&features, feature_frames)?
+            self.infer_speaker_probabilities_offline_with_diagnostics(
+                &features,
+                feature_frames,
+                diagnostics,
+            )?
         };
 
+        diagnostics.frame_stride_samples = self.encoder.frame_stride_samples();
+        diagnostics.prediction_frames = out.len();
         Ok((out, self.encoder.frame_stride_samples()))
     }
 
-    fn infer_speaker_probabilities_offline(
+    fn infer_speaker_probabilities_offline_with_diagnostics(
         &self,
         features: &Tensor,
         feature_frames: usize,
+        diagnostics: &mut SortformerDiarizationDiagnostics,
     ) -> Result<Vec<[f32; MAX_SUPPORTED_SPEAKERS]>> {
-        let (encoded, encoded_len) = self.encoder.forward(features, feature_frames)?;
+        let (encoded, encoded_len) =
+            self.encoder
+                .forward_with_diagnostics(features, feature_frames, diagnostics)?;
+        diagnostics.encoded_frames = encoded_len;
         if encoded_len == 0 {
             return Ok(Vec::new());
         }
-        let probs = self.forward_probabilities(&encoded, encoded_len)?;
-        tensor_to_probability_rows(&probs, encoded_len)
+        let probs =
+            self.forward_probabilities_with_diagnostics(&encoded, encoded_len, diagnostics)?;
+        let host_started = Instant::now();
+        let rows = tensor_to_probability_rows(&probs, encoded_len)?;
+        diagnostics.timings.host_read_ms += elapsed_ms(host_started);
+        Ok(rows)
     }
 
-    fn infer_speaker_probabilities_streaming(
+    fn infer_speaker_probabilities_streaming_with_diagnostics(
         &self,
         features: &Tensor,
         feature_frames: usize,
         cfg: SortformerStreamingConfig,
+        diagnostics: &mut SortformerDiarizationDiagnostics,
     ) -> Result<Vec<[f32; MAX_SUPPORTED_SPEAKERS]>> {
         let mut state = SortformerStreamingState::new(cfg.fc_d_model);
         let mut total_preds = Vec::new();
         for plan in plan_streaming_feature_chunks(feature_frames, cfg) {
+            diagnostics.streaming_chunks += 1;
             let chunk = features
                 .i((.., .., plan.feature_start..plan.feature_end))?
                 .transpose(1, 2)?
                 .contiguous()?;
+            let pre_encode_started = Instant::now();
             let (chunk_pre_encoded, chunk_pre_encoded_len) =
                 self.encoder.pre_encode(&chunk, chunk.dim(1)?)?;
+            diagnostics.timings.pre_encode_ms += elapsed_ms(pre_encode_started);
             if chunk_pre_encoded_len == 0 {
                 continue;
             }
 
+            let host_started = Instant::now();
             let chunk_rows = tensor_to_embedding_rows(&chunk_pre_encoded, chunk_pre_encoded_len)?;
+            diagnostics.timings.host_read_ms += elapsed_ms(host_started);
             let mut composite_rows =
                 Vec::with_capacity(state.spkcache.len() + state.fifo.len() + chunk_rows.len());
             composite_rows.extend(state.spkcache.iter().cloned());
@@ -695,12 +884,17 @@ impl SortformerInferenceModel {
                 cfg.fc_d_model,
                 chunk_pre_encoded.device(),
             )?;
-            let (encoded, encoded_len) = self.encoder.forward_pre_encoded(
+            let (encoded, encoded_len) = self.encoder.forward_pre_encoded_with_diagnostics(
                 &composite,
                 state.spkcache.len() + state.fifo.len() + chunk_rows.len(),
+                diagnostics,
             )?;
-            let probs = self.forward_probabilities(&encoded, encoded_len)?;
+            diagnostics.encoded_frames += encoded_len;
+            let probs =
+                self.forward_probabilities_with_diagnostics(&encoded, encoded_len, diagnostics)?;
+            let host_started = Instant::now();
             let pred_rows = tensor_to_probability_rows(&probs, encoded_len)?;
+            diagnostics.timings.host_read_ms += elapsed_ms(host_started);
             let (updated_state, chunk_preds) = update_streaming_state(
                 state,
                 &chunk_rows,
@@ -716,11 +910,20 @@ impl SortformerInferenceModel {
         Ok(total_preds)
     }
 
-    fn forward_probabilities(&self, encoded: &Tensor, encoded_len: usize) -> Result<Tensor> {
+    fn forward_probabilities_with_diagnostics(
+        &self,
+        encoded: &Tensor,
+        encoded_len: usize,
+        diagnostics: &mut SortformerDiarizationDiagnostics,
+    ) -> Result<Tensor> {
         let mut x = encoded.i((.., ..encoded_len, ..))?;
+        let transformer_started = Instant::now();
         x = x.apply(&self.encoder_proj)?;
         x = self.transformer.forward(&x)?;
+        diagnostics.timings.transformer_forward_ms += elapsed_ms(transformer_started);
+        let head_started = Instant::now();
         let probs = self.head.forward(&x)?;
+        diagnostics.timings.head_ms += elapsed_ms(head_started);
         let (_, _, speaker_dim) = probs.dims3()?;
         if speaker_dim != MAX_SUPPORTED_SPEAKERS {
             return Err(Error::InferenceError(format!(
@@ -1370,6 +1573,19 @@ impl SortformerConformerEncoder {
         self.forward_pre_encoded(&x, encoded_len)
     }
 
+    fn forward_with_diagnostics(
+        &self,
+        features: &Tensor,
+        feature_frames: usize,
+        diagnostics: &mut SortformerDiarizationDiagnostics,
+    ) -> Result<(Tensor, usize)> {
+        let features_t = features.transpose(1, 2)?;
+        let pre_encode_started = Instant::now();
+        let (x, encoded_len) = self.pre_encode(&features_t, feature_frames)?;
+        diagnostics.timings.pre_encode_ms += elapsed_ms(pre_encode_started);
+        self.forward_pre_encoded_with_diagnostics(&x, encoded_len, diagnostics)
+    }
+
     fn pre_encode(&self, features_t: &Tensor, feature_frames: usize) -> Result<(Tensor, usize)> {
         self.pre_encode.forward(features_t, feature_frames)
     }
@@ -1379,6 +1595,24 @@ impl SortformerConformerEncoder {
         pre_encoded: &Tensor,
         encoded_len: usize,
     ) -> Result<(Tensor, usize)> {
+        self.forward_pre_encoded_inner(pre_encoded, encoded_len, None)
+    }
+
+    fn forward_pre_encoded_with_diagnostics(
+        &self,
+        pre_encoded: &Tensor,
+        encoded_len: usize,
+        diagnostics: &mut SortformerDiarizationDiagnostics,
+    ) -> Result<(Tensor, usize)> {
+        self.forward_pre_encoded_inner(pre_encoded, encoded_len, Some(diagnostics))
+    }
+
+    fn forward_pre_encoded_inner(
+        &self,
+        pre_encoded: &Tensor,
+        encoded_len: usize,
+        mut diagnostics: Option<&mut SortformerDiarizationDiagnostics>,
+    ) -> Result<(Tensor, usize)> {
         let mut x = if self.input_scale != 1.0 {
             pre_encoded.affine(self.input_scale, 0.0)?
         } else {
@@ -1386,8 +1620,15 @@ impl SortformerConformerEncoder {
         };
         let pos_len = x.dim(1)?;
         let pos_emb = build_rel_positional_embedding(pos_len, self.d_model, x.device())?;
+        let conformer_started = Instant::now();
         for layer in &self.layers {
-            x = layer.forward(&x, &pos_emb)?;
+            x = match diagnostics.as_deref_mut() {
+                Some(diag) => layer.forward_with_diagnostics(&x, &pos_emb, diag)?,
+                None => layer.forward(&x, &pos_emb)?,
+            };
+        }
+        if let Some(diag) = diagnostics.as_deref_mut() {
+            diag.timings.conformer_forward_ms += elapsed_ms(conformer_started);
         }
         Ok((x, encoded_len))
     }
@@ -1539,17 +1780,43 @@ impl ConformerLayer {
     }
 
     fn forward(&self, x: &Tensor, pos_emb: &Tensor) -> Result<Tensor> {
+        self.forward_inner(x, pos_emb, None)
+    }
+
+    fn forward_with_diagnostics(
+        &self,
+        x: &Tensor,
+        pos_emb: &Tensor,
+        diagnostics: &mut SortformerDiarizationDiagnostics,
+    ) -> Result<Tensor> {
+        self.forward_inner(x, pos_emb, Some(diagnostics))
+    }
+
+    fn forward_inner(
+        &self,
+        x: &Tensor,
+        pos_emb: &Tensor,
+        mut diagnostics: Option<&mut SortformerDiarizationDiagnostics>,
+    ) -> Result<Tensor> {
         let mut residual = x.clone();
 
         let ff1 = self.ff1.forward(&self.norm_ff1.forward(&residual)?)?;
         residual = residual.broadcast_add(&ff1.affine(0.5, 0.0)?)?;
 
+        let attention_started = Instant::now();
         let attn = self
             .self_attn
             .forward(&self.norm_self_att.forward(&residual)?, pos_emb)?;
+        if let Some(diag) = diagnostics.as_deref_mut() {
+            diag.timings.conformer_attention_ms += elapsed_ms(attention_started);
+        }
         residual = residual.broadcast_add(&attn)?;
 
+        let conv_started = Instant::now();
         let conv = self.conv.forward(&self.norm_conv.forward(&residual)?)?;
+        if let Some(diag) = diagnostics.as_deref_mut() {
+            diag.timings.conformer_conv_ms += elapsed_ms(conv_started);
+        }
         residual = residual.broadcast_add(&conv)?;
 
         let ff2 = self.ff2.forward(&self.norm_ff2.forward(&residual)?)?;
@@ -1585,6 +1852,8 @@ impl FeedForward {
 struct ConformerConv {
     pointwise_conv1: Conv1d,
     depthwise_conv: Conv1d,
+    folded_depthwise_weight: Tensor,
+    folded_depthwise_bias: Tensor,
     batch_norm: candle_nn::BatchNorm,
     pointwise_conv2: Conv1d,
     d_model: usize,
@@ -1619,6 +1888,8 @@ impl ConformerConv {
         )?;
 
         let batch_norm = batch_norm(d_model, 1e-5, vb.pp("batch_norm"))?;
+        let (folded_depthwise_weight, folded_depthwise_bias) =
+            fold_depthwise_conv1d_batch_norm(&depthwise_conv, &batch_norm)?;
 
         let pointwise_conv2 = mlx::load_conv1d(
             d_model,
@@ -1631,6 +1902,8 @@ impl ConformerConv {
         Ok(Self {
             pointwise_conv1,
             depthwise_conv,
+            folded_depthwise_weight,
+            folded_depthwise_bias,
             batch_norm,
             pointwise_conv2,
             d_model,
@@ -1645,13 +1918,61 @@ impl ConformerConv {
         let x_b = x.i((.., self.d_model.., ..))?;
         x = x_a.broadcast_mul(&ops::sigmoid(&x_b)?)?;
 
-        x = self.depthwise_conv.forward(&x)?;
-        x = self.batch_norm.forward_t(&x, false)?;
-        x = swish(&x)?;
+        if let Some(fused) = metal_kernels::try_depthwise_conv1d_bias_swish(
+            &x,
+            &self.folded_depthwise_weight,
+            &self.folded_depthwise_bias,
+            self.depthwise_conv.config().padding,
+            self.depthwise_conv.config().stride,
+            self.depthwise_conv.config().dilation,
+        ) {
+            x = fused;
+        } else {
+            x = if let Some(depthwise) = metal_kernels::try_depthwise_conv1d(
+                &x,
+                self.depthwise_conv.weight(),
+                self.depthwise_conv.config().padding,
+                self.depthwise_conv.config().stride,
+                self.depthwise_conv.config().dilation,
+            ) {
+                depthwise
+            } else {
+                self.depthwise_conv.forward(&x)?
+            };
+            x = self.batch_norm.forward_t(&x, false)?;
+            x = swish(&x)?;
+        }
         x = self.pointwise_conv2.forward(&x)?;
 
         x.transpose(1, 2).map_err(Error::from)
     }
+}
+
+fn fold_depthwise_conv1d_batch_norm(
+    conv: &Conv1d,
+    batch_norm: &candle_nn::BatchNorm,
+) -> Result<(Tensor, Tensor)> {
+    let std = (batch_norm.running_var() + batch_norm.eps())?.sqrt()?;
+    let (scale, batch_norm_bias) = match batch_norm.weight_and_bias() {
+        Some((weight, bias)) => (weight.broadcast_div(&std)?, bias.clone()),
+        None => (
+            std.recip()?,
+            Tensor::zeros(std.dim(0)?, std.dtype(), std.device())?,
+        ),
+    };
+    let channels = scale.dim(0)?;
+    let folded_weight = conv
+        .weight()
+        .broadcast_mul(&scale.reshape((channels, 1, 1))?)?;
+    let centered_bias = match conv.bias() {
+        Some(bias) => bias.broadcast_sub(batch_norm.running_mean())?,
+        None => batch_norm.running_mean().affine(-1.0, 0.0)?,
+    };
+    let folded_bias = scale
+        .broadcast_mul(&centered_bias)?
+        .broadcast_add(&batch_norm_bias)?;
+
+    Ok((folded_weight, folded_bias))
 }
 
 struct RelPosSelfAttention {
@@ -2628,10 +2949,27 @@ mod tests {
     }
 
     #[test]
-    fn sortformer_only_uses_selected_model_device_for_cuda() {
-        assert!(!sortformer_uses_selected_model_device(DeviceKind::Cpu));
-        assert!(!sortformer_uses_selected_model_device(DeviceKind::Metal));
-        assert!(sortformer_uses_selected_model_device(DeviceKind::Cuda));
+    fn sortformer_uses_metal_only_when_explicitly_enabled() {
+        assert!(!sortformer_uses_selected_model_device_with_metal_override(
+            DeviceKind::Cpu,
+            Some(true),
+        ));
+        assert!(!sortformer_uses_selected_model_device_with_metal_override(
+            DeviceKind::Metal,
+            None,
+        ));
+        assert!(!sortformer_uses_selected_model_device_with_metal_override(
+            DeviceKind::Metal,
+            Some(false),
+        ));
+        assert!(sortformer_uses_selected_model_device_with_metal_override(
+            DeviceKind::Metal,
+            Some(true),
+        ));
+        assert!(sortformer_uses_selected_model_device_with_metal_override(
+            DeviceKind::Cuda,
+            Some(false),
+        ));
     }
 
     #[test]

--- a/crates/izwi-core/src/models/registry.rs
+++ b/crates/izwi-core/src/models/registry.rs
@@ -27,8 +27,9 @@ use crate::models::architectures::parakeet::asr::{
     ParakeetAsrModel, ParakeetAsrTranscriptionOutput,
 };
 use crate::models::architectures::qwen3::asr::{
-    AsrDecodeState as Qwen3AsrDecodeState, AsrDecodeStep as Qwen3AsrDecodeStep,
-    AsrTranscriptionOutput as Qwen3AsrTranscriptionOutput, Qwen3AsrModel,
+    AsrAlignmentOutput as Qwen3AsrAlignmentOutput, AsrDecodeState as Qwen3AsrDecodeState,
+    AsrDecodeStep as Qwen3AsrDecodeStep, AsrTranscriptionOutput as Qwen3AsrTranscriptionOutput,
+    Qwen3AsrModel,
 };
 use crate::models::architectures::qwen3::chat::{
     ChatDecodeState as Qwen3ChatDecodeState, ChatGenerationOutput, Qwen3ChatModel,
@@ -559,6 +560,12 @@ pub struct NativeAsrTranscription {
     pub diagnostics: Option<serde_json::Value>,
 }
 
+#[derive(Debug, Clone)]
+pub struct NativeForcedAlignment {
+    pub alignments: Vec<(String, u32, u32)>,
+    pub diagnostics: Option<serde_json::Value>,
+}
+
 fn vibevoice_asr_options(options: NativeAsrGenerationOptions) -> VibeVoiceAsrGenerationOptions {
     VibeVoiceAsrGenerationOptions {
         max_new_tokens: options.max_new_tokens,
@@ -943,8 +950,28 @@ impl NativeAsrModel {
         reference_text: &str,
         language: Option<&str>,
     ) -> Result<Vec<(String, u32, u32)>> {
+        self.force_align_with_details(audio, sample_rate, reference_text, language)
+            .map(|output| output.alignments)
+    }
+
+    pub fn force_align_with_details(
+        &self,
+        audio: &[f32],
+        sample_rate: u32,
+        reference_text: &str,
+        language: Option<&str>,
+    ) -> Result<NativeForcedAlignment> {
         match self {
-            Self::Qwen3(model) => model.force_align(audio, sample_rate, reference_text, language),
+            Self::Qwen3(model) => {
+                let Qwen3AsrAlignmentOutput {
+                    alignments,
+                    diagnostics,
+                } = model.force_align_with_details(audio, sample_rate, reference_text, language)?;
+                Ok(NativeForcedAlignment {
+                    alignments,
+                    diagnostics,
+                })
+            }
             Self::Parakeet(_) => Err(Error::InvalidInput(
                 "Forced alignment is only available for Qwen3-ForcedAligner models".to_string(),
             )),

--- a/crates/izwi-core/src/runtime/asr.rs
+++ b/crates/izwi-core/src/runtime/asr.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use crate::catalog::{ModelFamily, parse_model_variant, resolve_asr_model_variant};
+use crate::catalog::{parse_model_variant, resolve_asr_model_variant, ModelFamily};
 use crate::engine::EngineCoreRequest;
 use crate::error::{Error, Result};
 use crate::model::{ModelResidencyLease, ModelVariant};
@@ -11,7 +11,7 @@ use crate::runtime::adapters::CapabilityKind;
 use crate::runtime::audio_io::{base64_decode, decode_audio_bytes};
 use crate::runtime::request::{AlignmentRuntimeRequest, AsrRuntimeRequest};
 use crate::runtime::service::RuntimeService;
-use crate::runtime::types::AsrTranscription;
+use crate::runtime::types::{AsrTranscription, ForcedAlignmentResult};
 
 #[derive(Clone, Copy)]
 enum AsrAudioInput<'a> {
@@ -978,6 +978,23 @@ impl RuntimeService {
         language: Option<&str>,
         model_id: Option<&str>,
     ) -> Result<Vec<(String, u32, u32)>> {
+        self.force_align_bytes_with_model_and_language_details(
+            audio_bytes,
+            reference_text,
+            language,
+            model_id,
+        )
+        .await
+        .map(|output| output.alignments)
+    }
+
+    pub async fn force_align_bytes_with_model_and_language_details(
+        &self,
+        audio_bytes: &[u8],
+        reference_text: &str,
+        language: Option<&str>,
+        model_id: Option<&str>,
+    ) -> Result<ForcedAlignmentResult> {
         let variant = resolve_forced_aligner_variant(model_id)?;
         let _runtime_request = AlignmentRuntimeRequest::from_bytes(
             variant,
@@ -1000,7 +1017,12 @@ impl RuntimeService {
             .ok_or_else(|| Error::ModelNotFound(variant.to_string()))?;
 
         let (samples, sample_rate) = decode_audio_bytes(audio_bytes)?;
-        model.force_align(&samples, sample_rate, reference_text, language)
+        let output =
+            model.force_align_with_details(&samples, sample_rate, reference_text, language)?;
+        Ok(ForcedAlignmentResult {
+            alignments: output.alignments,
+            diagnostics: output.diagnostics,
+        })
     }
 }
 

--- a/crates/izwi-core/src/runtime/diarization.rs
+++ b/crates/izwi-core/src/runtime/diarization.rs
@@ -115,13 +115,12 @@ impl RuntimeService {
         model_id: Option<&str>,
         config: &DiarizationConfig,
     ) -> Result<DiarizationResult> {
-        let runtime_request =
-            DiarizationRuntimeRequest::from_bytes(
-                resolve_diarization_model_variant(model_id),
-                audio_bytes.to_vec(),
-                config.clone(),
-            )?
-            .with_pipeline_models(model_id.map(ToOwned::to_owned), None, None, None);
+        let runtime_request = DiarizationRuntimeRequest::from_bytes(
+            resolve_diarization_model_variant(model_id),
+            audio_bytes.to_vec(),
+            config.clone(),
+        )?
+        .with_pipeline_models(model_id.map(ToOwned::to_owned), None, None, None);
         let audio = decode_pipeline_audio_bytes(audio_bytes)?;
         self.diarize_samples(
             &audio.samples,
@@ -167,19 +166,18 @@ impl RuntimeService {
         enable_llm_refinement: bool,
     ) -> Result<DiarizationTranscriptResult> {
         let pipeline = resolve_diarization_transcript_pipeline(diarization_model_id);
-        let runtime_request =
-            DiarizationRuntimeRequest::from_bytes(
-                pipeline.model_variant(),
-                audio_bytes.to_vec(),
-                config.clone(),
-            )?
-            .with_pipeline_models(
-                diarization_model_id.map(ToOwned::to_owned),
-                asr_model_id.map(ToOwned::to_owned),
-                aligner_model_id.map(ToOwned::to_owned),
-                llm_model_id.map(ToOwned::to_owned),
-            )
-            .with_llm_refinement(enable_llm_refinement);
+        let runtime_request = DiarizationRuntimeRequest::from_bytes(
+            pipeline.model_variant(),
+            audio_bytes.to_vec(),
+            config.clone(),
+        )?
+        .with_pipeline_models(
+            diarization_model_id.map(ToOwned::to_owned),
+            asr_model_id.map(ToOwned::to_owned),
+            aligner_model_id.map(ToOwned::to_owned),
+            llm_model_id.map(ToOwned::to_owned),
+        )
+        .with_llm_refinement(enable_llm_refinement);
         self.record_diarization_transcript_pipeline(runtime_request.enable_llm_refinement);
         let audio = decode_pipeline_audio_bytes(audio_bytes)?;
         if matches!(pipeline, DiarizationTranscriptPipeline::GraniteStandalone) {
@@ -199,10 +197,9 @@ impl RuntimeService {
 
         let asr_variant = resolve_asr_model_variant(runtime_request.asr_model_id.as_deref());
 
-        let aligner_variant =
-            crate::runtime::asr::resolve_forced_aligner_variant(
-                runtime_request.aligner_model_id.as_deref(),
-            )?;
+        let aligner_variant = crate::runtime::asr::resolve_forced_aligner_variant(
+            runtime_request.aligner_model_id.as_deref(),
+        )?;
         let aligner_lease = match self.load_model(aligner_variant).await {
             Ok(()) => Some(self.acquire_model_residency_lease(aligner_variant)),
             Err(err) => {
@@ -378,6 +375,7 @@ impl RuntimeService {
             segments: diarization.segments,
             words,
             utterances,
+            diarization_diagnostics: diarization.diagnostics,
             asr_text,
             raw_transcript,
             transcript,
@@ -503,7 +501,9 @@ fn resolve_chat_variant(model_id: Option<&str>) -> Result<ModelVariant> {
 
 fn resolve_diarization_transcript_pipeline(input: Option<&str>) -> DiarizationTranscriptPipeline {
     let Some(raw) = input else {
-        return DiarizationTranscriptPipeline::ClassicStack(resolve_diarization_model_variant(None));
+        return DiarizationTranscriptPipeline::ClassicStack(resolve_diarization_model_variant(
+            None,
+        ));
     };
 
     if let Ok(variant) = parse_model_variant(raw) {
@@ -583,6 +583,7 @@ fn granite_diarization_result_from_texts(
         segments,
         words,
         utterances,
+        diarization_diagnostics: None,
         asr_text: speaker_parsed.text,
         raw_transcript: raw_transcript.clone(),
         transcript: raw_transcript,
@@ -2142,7 +2143,10 @@ mod tests {
         assert_eq!(result.words[0].speaker, "SPEAKER_00");
         assert_eq!(result.words[2].speaker, "SPEAKER_01");
         assert_eq!(result.alignment_coverage, 0.0);
-        assert!(result.words.iter().all(|word| word.end_secs > word.start_secs));
+        assert!(result
+            .words
+            .iter()
+            .all(|word| word.end_secs > word.start_secs));
     }
 
     #[test]

--- a/crates/izwi-core/src/runtime/mod.rs
+++ b/crates/izwi-core/src/runtime/mod.rs
@@ -26,24 +26,24 @@ mod voice_session;
 
 pub use asr::{RuntimeAsrRealtimeEvent, RuntimeAsrRealtimeStream};
 pub use conformance::{
-    capability_conformance_cases, required_conformance_capabilities,
-    CapabilityConformanceCase, ConformanceCapability, ConformanceExecutionClass,
+    capability_conformance_cases, required_conformance_capabilities, CapabilityConformanceCase,
+    ConformanceCapability, ConformanceExecutionClass,
 };
 pub use service::RuntimeService;
 pub use telemetry::{
+    runtime_trace_contracts, sanitized_replay_record, trace_contract_for_phase,
     EngineRuntimeTelemetrySnapshot, InferenceBrokerRuntimeTelemetrySnapshot,
     PipelineRuntimeTelemetrySnapshot, ReplayRedaction, RuntimeReplayRecord,
     RuntimeTelemetrySnapshot, RuntimeTraceContract, RuntimeTracePhase,
     VoiceRuntimeTelemetrySnapshot, RUNTIME_REPLAY_REDACTION, RUNTIME_TRACE_CONTRACTS,
     TRACE_CAPABILITY, TRACE_CORRELATION_ID, TRACE_ERROR_KIND, TRACE_EXECUTION_TARGET,
     TRACE_MODEL_VARIANT, TRACE_PIPELINE_KIND, TRACE_PIPELINE_STAGE, TRACE_REQUEST_ID,
-    TRACE_STREAMING_MODE, runtime_trace_contracts, sanitized_replay_record,
-    trace_contract_for_phase,
+    TRACE_STREAMING_MODE,
 };
 pub use types::{
     AsrTranscription, AudioChunk, ChatGeneration, ChunkStats, DiarizationConfig, DiarizationResult,
     DiarizationSegment, DiarizationTranscriptResult, DiarizationUtterance, DiarizationWord,
-    GenerationConfig, GenerationRequest, GenerationResult, InferenceOptions,
+    ForcedAlignmentResult, GenerationConfig, GenerationRequest, GenerationResult, InferenceOptions,
     SpeechToSpeechGeneration,
 };
 pub use voice_metrics::{

--- a/crates/izwi-core/src/runtime/types.rs
+++ b/crates/izwi-core/src/runtime/types.rs
@@ -13,6 +13,12 @@ pub struct AsrTranscription {
     pub asr_diagnostics: Option<serde_json::Value>,
 }
 
+#[derive(Debug, Clone)]
+pub struct ForcedAlignmentResult {
+    pub alignments: Vec<(String, u32, u32)>,
+    pub diagnostics: Option<serde_json::Value>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DiarizationSegment {
     pub speaker: String,
@@ -27,6 +33,7 @@ pub struct DiarizationResult {
     pub segments: Vec<DiarizationSegment>,
     pub duration_secs: f32,
     pub speaker_count: usize,
+    pub diagnostics: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -58,6 +65,7 @@ pub struct DiarizationTranscriptResult {
     pub segments: Vec<DiarizationSegment>,
     pub words: Vec<DiarizationWord>,
     pub utterances: Vec<DiarizationUtterance>,
+    pub diarization_diagnostics: Option<serde_json::Value>,
     pub asr_text: String,
     pub raw_transcript: String,
     pub transcript: String,

--- a/crates/izwi-server/src/api/diarization/handlers.rs
+++ b/crates/izwi-server/src/api/diarization/handlers.rs
@@ -1,9 +1,9 @@
 use axum::{
-    Json, RequestExt,
     body::Body,
     extract::{Extension, Multipart, Path, Query, Request, State},
-    http::{HeaderValue, StatusCode, header},
+    http::{header, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
+    Json, RequestExt,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -14,7 +14,7 @@ use crate::api::audio_payload::{
     decode_base64_audio_payload, inspect_audio_payload_with_diagnostics,
     read_multipart_audio_base64_payload, read_multipart_audio_file_payload,
 };
-use crate::api::pagination::{CursorPagination, CursorPaginationQuery, encode_cursor};
+use crate::api::pagination::{encode_cursor, CursorPagination, CursorPaginationQuery};
 use crate::api::request_context::RequestContext;
 use crate::diarization_store::{
     CompleteDiarizationRecord, DiarizationProcessingStatus, DiarizationRecord,
@@ -25,8 +25,8 @@ use crate::diarization_store::{
 use crate::error::ApiError;
 use crate::state::AppState;
 use izwi_core::{
-    ChatMessage, ChatRole, DiarizationConfig, GenerationParams, RuntimeService,
-    parse_chat_model_variant,
+    parse_chat_model_variant, ChatMessage, ChatRole, DiarizationConfig, GenerationParams,
+    RuntimeService,
 };
 
 use super::AUDIO_UPLOAD_LIMIT_BYTES;
@@ -83,6 +83,7 @@ struct ParsedDiarizationCreateRequest {
     min_speech_duration_ms: Option<f64>,
     min_silence_duration_ms: Option<f64>,
     enable_llm_refinement: Option<bool>,
+    include_transcript: Option<bool>,
     stream: bool,
 }
 
@@ -107,6 +108,8 @@ struct JsonCreateRequest {
     min_silence_duration_ms: Option<f64>,
     #[serde(default)]
     enable_llm_refinement: Option<bool>,
+    #[serde(default, alias = "transcribe")]
+    include_transcript: Option<bool>,
     #[serde(default)]
     audio_mime_type: Option<String>,
     #[serde(default)]
@@ -365,6 +368,7 @@ async fn create_pending_record(
             words: Vec::new(),
             utterances: Vec::new(),
             speaker_name_overrides: BTreeMap::new(),
+            izwi_diarization_diagnostics: None,
             audio_mime_type: resolve_source_audio_mime_type(
                 parsed.audio_mime_type.as_deref(),
                 parsed.audio_filename.as_deref(),
@@ -393,6 +397,7 @@ struct GeneratedDiarizationArtifacts {
     segments: Vec<DiarizationSegmentRecord>,
     words: Vec<DiarizationWordRecord>,
     utterances: Vec<DiarizationUtteranceRecord>,
+    izwi_diarization_diagnostics: Option<serde_json::Value>,
 }
 
 fn spawn_diarization_processing_task(
@@ -478,6 +483,7 @@ fn spawn_diarization_processing_task(
                             segments: artifacts.segments,
                             words: artifacts.words,
                             utterances: artifacts.utterances,
+                            izwi_diarization_diagnostics: artifacts.izwi_diarization_diagnostics,
                         },
                     )
                     .await
@@ -526,6 +532,52 @@ async fn generate_diarization_artifacts(
 ) -> Result<GeneratedDiarizationArtifacts, ApiError> {
     let _permit = stateful_acquire(semaphore).await?;
     let started = Instant::now();
+    let diarization_config = DiarizationConfig {
+        min_speakers: parsed.min_speakers,
+        max_speakers: parsed.max_speakers,
+        min_speech_duration_ms: parsed.min_speech_duration_ms.map(|v| v as f32),
+        min_silence_duration_ms: parsed.min_silence_duration_ms.map(|v| v as f32),
+    };
+    if parsed.include_transcript == Some(false) {
+        let output = runtime
+            .diarize_bytes(audio_bytes, parsed.model_id.as_deref(), &diarization_config)
+            .await?;
+        let processing_time_ms = started.elapsed().as_secs_f64() * 1000.0;
+        let rtf = if output.duration_secs > 0.0 {
+            Some((processing_time_ms / 1000.0) / output.duration_secs as f64)
+        } else {
+            None
+        };
+        let (summary_status, summary_model_id) = initial_summary_state("");
+        return Ok(GeneratedDiarizationArtifacts {
+            duration_secs: output.duration_secs as f64,
+            processing_time_ms,
+            rtf,
+            speaker_count: output.speaker_count,
+            alignment_coverage: None,
+            unattributed_words: 0,
+            llm_refined: false,
+            asr_text: String::new(),
+            raw_transcript: String::new(),
+            transcript: String::new(),
+            summary_status,
+            summary_model_id,
+            segments: output
+                .segments
+                .into_iter()
+                .map(|segment| DiarizationSegmentRecord {
+                    speaker: segment.speaker,
+                    start: segment.start_secs,
+                    end: segment.end_secs,
+                    confidence: segment.confidence,
+                })
+                .collect(),
+            words: Vec::new(),
+            utterances: Vec::new(),
+            izwi_diarization_diagnostics: output.diagnostics,
+        });
+    }
+
     // Keep diarization processing unbounded by wall-clock timeout so valid
     // long jobs can finish and persist successfully.
     let output = runtime
@@ -535,12 +587,7 @@ async fn generate_diarization_artifacts(
             parsed.asr_model_id.as_deref(),
             parsed.aligner_model_id.as_deref(),
             parsed.llm_model_id.as_deref(),
-            &DiarizationConfig {
-                min_speakers: parsed.min_speakers,
-                max_speakers: parsed.max_speakers,
-                min_speech_duration_ms: parsed.min_speech_duration_ms.map(|v| v as f32),
-                min_silence_duration_ms: parsed.min_silence_duration_ms.map(|v| v as f32),
-            },
+            &diarization_config,
             parsed.enable_llm_refinement.unwrap_or(false),
         )
         .await?;
@@ -600,6 +647,7 @@ async fn generate_diarization_artifacts(
                 word_end: utterance.word_end,
             })
             .collect(),
+        izwi_diarization_diagnostics: output.diarization_diagnostics,
     })
 }
 
@@ -638,6 +686,7 @@ fn build_rerun_create_request(
                 .enable_llm_refinement
                 .unwrap_or(source_record.enable_llm_refinement),
         ),
+        include_transcript: Some(true),
         stream: false,
     }
 }
@@ -936,6 +985,7 @@ async fn parse_create_request(req: Request) -> Result<ParsedDiarizationCreateReq
             min_speech_duration_ms: payload.min_speech_duration_ms,
             min_silence_duration_ms: payload.min_silence_duration_ms,
             enable_llm_refinement: payload.enable_llm_refinement,
+            include_transcript: payload.include_transcript,
             stream: payload.stream.unwrap_or(false),
         });
     }
@@ -1076,6 +1126,15 @@ async fn parse_create_request(req: Request) -> Result<ParsedDiarizationCreateReq
                     })?;
                     out.enable_llm_refinement = Some(parse_truthy(text.as_str()));
                 }
+                "include_transcript" | "transcribe" => {
+                    let text = field.text().await.map_err(|err| {
+                        ApiError::bad_request(format!(
+                            "Failed reading multipart '{}' field: {err}",
+                            name
+                        ))
+                    })?;
+                    out.include_transcript = Some(parse_truthy(text.as_str()));
+                }
                 "stream" => {
                     let text = field.text().await.map_err(|err| {
                         ApiError::bad_request(format!(
@@ -1207,6 +1266,7 @@ mod tests {
             words: Vec::new(),
             utterances: Vec::new(),
             speaker_name_overrides: BTreeMap::new(),
+            izwi_diarization_diagnostics: None,
             audio_mime_type: "audio/wav".to_string(),
             audio_filename: Some("meeting.wav".to_string()),
         }

--- a/crates/izwi-server/src/api/openai/audio/align.rs
+++ b/crates/izwi-server/src/api/openai/audio/align.rs
@@ -1,11 +1,11 @@
 //! Forced alignment audio endpoint.
 
 use axum::{
-    Json, RequestExt,
     body::Body,
     extract::{Multipart, Request, State},
-    http::{StatusCode, header},
+    http::{header, StatusCode},
     response::Response,
+    Json, RequestExt,
 };
 use serde::Serialize;
 use std::time::Instant;
@@ -13,8 +13,8 @@ use utoipa::ToSchema;
 
 use super::resolve_audio_upload_limit_bytes;
 use crate::api::audio_payload::{
-    AudioPayload, decode_base64_audio_payload, inspect_audio_payload_with_diagnostics,
-    read_multipart_audio_base64_payload, read_multipart_audio_file_payload,
+    decode_base64_audio_payload, inspect_audio_payload_with_diagnostics,
+    read_multipart_audio_base64_payload, read_multipart_audio_file_payload, AudioPayload,
 };
 use crate::api::speech_text_upload::multipart_upload_api_error;
 use crate::error::ApiError;
@@ -70,6 +70,8 @@ pub struct VerboseAlignmentResponse {
     pub language: Option<String>,
     pub word_count: usize,
     pub processing_time_ms: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub izwi_asr_diagnostics: Option<serde_json::Value>,
 }
 
 pub async fn align(
@@ -101,9 +103,9 @@ pub async fn align(
 
     let _permit = state.acquire_permit().await;
     let started = Instant::now();
-    let raw_alignments = state
+    let alignment_output = state
         .runtime
-        .force_align_bytes_with_model_and_language(
+        .force_align_bytes_with_model_and_language_details(
             audio.bytes.as_slice(),
             text.as_str(),
             req.language.as_deref(),
@@ -112,7 +114,7 @@ pub async fn align(
         .await?;
     let processing_time_ms = started.elapsed().as_secs_f64() * 1000.0;
 
-    let alignments = alignment_words(raw_alignments);
+    let alignments = alignment_words(alignment_output.alignments);
     let duration = alignment_duration(&alignments);
 
     match response_format.as_str() {
@@ -127,6 +129,7 @@ pub async fn align(
             model: req.model,
             language: req.language,
             processing_time_ms,
+            izwi_asr_diagnostics: alignment_output.diagnostics,
         }),
         "text" => Ok(Response::builder()
             .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")

--- a/crates/izwi-server/src/db/migrator.rs
+++ b/crates/izwi-server/src/db/migrator.rs
@@ -189,6 +189,7 @@ const BASELINE_SCHEMA: &[&str] = &[
         words_json TEXT NOT NULL,
         utterances_json TEXT NOT NULL,
         speaker_name_overrides_json TEXT NOT NULL DEFAULT '{}',
+        diarization_diagnostics_json TEXT NULL,
         audio_mime_type TEXT NOT NULL,
         audio_filename TEXT NULL,
         audio_storage_path TEXT NOT NULL
@@ -415,6 +416,11 @@ const COMPATIBILITY_COLUMNS: &[CompatibilityColumn] = &[
         table: "diarization_records",
         column: "speaker_name_overrides_json",
         definition: "TEXT NOT NULL DEFAULT '{}'",
+    },
+    CompatibilityColumn {
+        table: "diarization_records",
+        column: "diarization_diagnostics_json",
+        definition: "TEXT NULL",
     },
     CompatibilityColumn {
         table: "diarization_records",

--- a/crates/izwi-server/src/db/schema_contract.rs
+++ b/crates/izwi-server/src/db/schema_contract.rs
@@ -1,5 +1,5 @@
 use crate::{db::raw, voice_defaults::DEFAULT_VOICE_PROFILE_ID};
-use anyhow::{Context, bail};
+use anyhow::{bail, Context};
 use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend};
 use std::collections::HashSet;
 
@@ -158,6 +158,7 @@ const REQUIRED_SCHEMA_TABLES: &[RequiredSchemaTable] = &[
             "words_json",
             "utterances_json",
             "speaker_name_overrides_json",
+            "diarization_diagnostics_json",
             "audio_mime_type",
             "audio_filename",
             "audio_storage_path",

--- a/crates/izwi-server/src/db/sqlite.rs
+++ b/crates/izwi-server/src/db/sqlite.rs
@@ -293,6 +293,7 @@ mod tests {
         ("speech_history_records", "processing_status"),
         ("speech_history_records", "processing_error"),
         ("diarization_records", "speaker_name_overrides_json"),
+        ("diarization_records", "diarization_diagnostics_json"),
         ("diarization_records", "processing_status"),
         ("diarization_records", "processing_error"),
         ("diarization_records", "summary_status"),

--- a/crates/izwi-server/src/diarization_store.rs
+++ b/crates/izwi-server/src/diarization_store.rs
@@ -5,6 +5,7 @@ use izwi_hooks::{HookMetadata, MediaNamespace, MediaStorageProvider};
 use sea_orm::sea_query::Expr;
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryResult, Set};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -165,6 +166,8 @@ pub struct DiarizationRecord {
     pub words: Vec<DiarizationWordRecord>,
     pub utterances: Vec<DiarizationUtteranceRecord>,
     pub speaker_name_overrides: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub izwi_diarization_diagnostics: Option<Value>,
     pub audio_mime_type: String,
     pub audio_filename: Option<String>,
 }
@@ -208,6 +211,7 @@ pub struct NewDiarizationRecord {
     pub words: Vec<DiarizationWordRecord>,
     pub utterances: Vec<DiarizationUtteranceRecord>,
     pub speaker_name_overrides: BTreeMap<String, String>,
+    pub izwi_diarization_diagnostics: Option<Value>,
     pub audio_mime_type: String,
     pub audio_filename: Option<String>,
     pub audio_bytes: Vec<u8>,
@@ -251,6 +255,7 @@ pub struct CompleteDiarizationRecord {
     pub segments: Vec<DiarizationSegmentRecord>,
     pub words: Vec<DiarizationWordRecord>,
     pub utterances: Vec<DiarizationUtteranceRecord>,
+    pub izwi_diarization_diagnostics: Option<Value>,
 }
 
 #[derive(Clone)]
@@ -472,6 +477,12 @@ impl DiarizationStore {
             serde_json::to_string(&record.utterances).context("Failed serializing utterances")?;
         let speaker_name_overrides_json = serde_json::to_string(&speaker_name_overrides)
             .context("Failed serializing speaker name overrides")?;
+        let diagnostics_json = record
+            .izwi_diarization_diagnostics
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .context("Failed serializing diarization diagnostics")?;
 
         if let Err(err) = diarization_records::Entity::insert(diarization_records::ActiveModel {
             id: Set(record_id.clone()),
@@ -510,6 +521,7 @@ impl DiarizationStore {
             words_json: Set(words_json),
             utterances_json: Set(utterances_json),
             speaker_name_overrides_json: Set(speaker_name_overrides_json),
+            diarization_diagnostics_json: Set(diagnostics_json),
             audio_mime_type: Set(audio_mime_type),
             audio_filename: Set(audio_filename),
             audio_storage_path: Set(audio_storage_path.clone()),
@@ -715,6 +727,12 @@ impl DiarizationStore {
             serde_json::to_string(&record.words).context("Failed serializing words")?;
         let utterances_json =
             serde_json::to_string(&record.utterances).context("Failed serializing utterances")?;
+        let diagnostics_json = record
+            .izwi_diarization_diagnostics
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .context("Failed serializing diarization diagnostics")?;
         let summary_model_id = sanitize_optional_text(record.summary_model_id.as_deref(), 160);
         let summary_text = sanitize_optional_text(record.summary_text.as_deref(), 20_000);
         let summary_error = sanitize_optional_text(record.summary_error.as_deref(), 1_000);
@@ -837,6 +855,10 @@ impl DiarizationStore {
                 diarization_records::Column::UtterancesJson,
                 Expr::value(utterances_json),
             )
+            .col_expr(
+                diarization_records::Column::DiarizationDiagnosticsJson,
+                Expr::value(diagnostics_json),
+            )
             .filter(diarization_records::Column::Id.eq(record_id.clone()))
             .filter(
                 diarization_records::Column::ProcessingStatus
@@ -934,6 +956,7 @@ const DIARIZATION_RECORD_COLUMNS: &str = r#"
     words_json,
     utterances_json,
     speaker_name_overrides_json,
+    diarization_diagnostics_json,
     audio_mime_type,
     audio_filename
 "#;
@@ -1035,6 +1058,7 @@ fn map_diarization_record(row: &QueryResult) -> anyhow::Result<DiarizationRecord
     let words_raw: String = row.try_get_by_index(29)?;
     let utterances_raw: String = row.try_get_by_index(30)?;
     let speaker_name_overrides = parse_json_map(row.try_get_by_index(31)?);
+    let izwi_diarization_diagnostics = parse_json_value(row.try_get_by_index(32)?);
     let segments: Vec<DiarizationSegmentRecord> = parse_json_vec(Some(segments_raw));
     let words: Vec<DiarizationWordRecord> = parse_json_vec(Some(words_raw));
     let utterances: Vec<DiarizationUtteranceRecord> = parse_json_vec(Some(utterances_raw));
@@ -1080,8 +1104,9 @@ fn map_diarization_record(row: &QueryResult) -> anyhow::Result<DiarizationRecord
         words,
         utterances,
         speaker_name_overrides,
-        audio_mime_type: row.try_get_by_index(32)?,
-        audio_filename: row.try_get_by_index(33)?,
+        izwi_diarization_diagnostics,
+        audio_mime_type: row.try_get_by_index(33)?,
+        audio_filename: row.try_get_by_index(34)?,
     })
 }
 
@@ -1096,6 +1121,10 @@ where
 fn parse_json_map(raw: Option<String>) -> BTreeMap<String, String> {
     raw.and_then(|value| serde_json::from_str::<BTreeMap<String, String>>(value.as_str()).ok())
         .unwrap_or_default()
+}
+
+fn parse_json_value(raw: Option<String>) -> Option<Value> {
+    raw.and_then(|value| serde_json::from_str::<Value>(value.as_str()).ok())
 }
 
 fn parse_processing_status(raw: Option<String>) -> DiarizationProcessingStatus {
@@ -1470,6 +1499,7 @@ mod tests {
                 },
             ],
             speaker_name_overrides: BTreeMap::new(),
+            izwi_diarization_diagnostics: None,
             audio_mime_type: "audio/wav".to_string(),
             audio_filename: Some("meeting.wav".to_string()),
             audio_bytes: vec![0_u8, 1_u8, 2_u8, 3_u8],
@@ -1505,6 +1535,7 @@ mod tests {
             segments: sample_record().segments,
             words: sample_record().words,
             utterances: sample_record().utterances,
+            izwi_diarization_diagnostics: None,
         }
     }
 

--- a/crates/izwi-server/src/entity/mod.rs
+++ b/crates/izwi-server/src/entity/mod.rs
@@ -212,6 +212,7 @@ pub mod diarization_records {
         pub words_json: String,
         pub utterances_json: String,
         pub speaker_name_overrides_json: String,
+        pub diarization_diagnostics_json: Option<String>,
         pub audio_mime_type: String,
         pub audio_filename: Option<String>,
         pub audio_storage_path: String,


### PR DESCRIPTION
Enables Sortformer Metal by default, adds targeted diagnostics, and optimizes Sortformer subsampling plus Qwen forced-alignment prompt/RoPE paths to reduce model latency on Metal.