### PR TITLE
Make ASR transcript summaries opt-in

### DIFF
--- a/crates/izwi-server/src/api/openapi.rs
+++ b/crates/izwi-server/src/api/openapi.rs
@@ -361,6 +361,7 @@ fn add_scalar_navigation_paths(doc: &mut Value) {
         "speech-to-text job",
         "List or create canonical saved transcription and diarization jobs.",
     );
+    add_speech_text_jobs_create_request_body(paths);
     add_get_patch_put_delete_member(
         paths,
         "/v1/speech-to-text/jobs/{record_id}",
@@ -1041,6 +1042,182 @@ fn add_collection(
         description,
         preview_response(),
     );
+}
+
+fn add_speech_text_jobs_create_request_body(paths: &mut Map<String, Value>) {
+    let Some(operation) = paths
+        .get_mut("/v1/speech-to-text/jobs")
+        .and_then(|path| path.get_mut("post"))
+    else {
+        return;
+    };
+
+    operation["requestBody"] = json!({
+        "required": true,
+        "content": {
+            "application/json": {
+                "schema": speech_text_job_create_json_schema()
+            },
+            "multipart/form-data": {
+                "schema": speech_text_job_create_multipart_schema()
+            }
+        }
+    });
+}
+
+fn speech_text_job_create_json_schema() -> Value {
+    json!({
+        "type": "object",
+        "description": "Preview saved speech-to-text job creation request. Use job_kind=transcription for transcription jobs or job_kind=diarization for diarization jobs.",
+        "properties": speech_text_job_create_properties(false),
+    })
+}
+
+fn speech_text_job_create_multipart_schema() -> Value {
+    let mut properties = speech_text_job_create_properties(true);
+    properties.insert(
+        "file".to_string(),
+        json!({
+            "type": "string",
+            "format": "binary",
+            "description": "Audio file to upload."
+        }),
+    );
+    json!({
+        "type": "object",
+        "description": "Preview saved speech-to-text job multipart creation request.",
+        "properties": properties,
+    })
+}
+
+fn speech_text_job_create_properties(include_form_aliases: bool) -> Map<String, Value> {
+    let mut properties = Map::new();
+    properties.insert(
+        "audio_base64".to_string(),
+        json!({
+            "type": "string",
+            "description": "Base64 encoded audio payload."
+        }),
+    );
+    properties.insert(
+        "model".to_string(),
+        json!({
+            "type": "string",
+            "description": "Transcription ASR model or diarization model."
+        }),
+    );
+    properties.insert(
+        "model_id".to_string(),
+        json!({
+            "type": "string",
+            "description": "Alias for model on transcription jobs."
+        }),
+    );
+    properties.insert(
+        "aligner_model".to_string(),
+        json!({
+            "type": "string",
+            "description": "Optional forced aligner model for transcription timestamps or diarization alignment."
+        }),
+    );
+    properties.insert(
+        "aligner_model_id".to_string(),
+        json!({
+            "type": "string",
+            "description": "Alias for aligner_model."
+        }),
+    );
+    properties.insert(
+        "language".to_string(),
+        json!({
+            "type": "string",
+            "description": "Optional transcription language hint."
+        }),
+    );
+    properties.insert(
+        "include_timestamps".to_string(),
+        json!({
+            "type": "boolean",
+            "default": false,
+            "description": "For transcription jobs, include word and segment timestamps when an aligner is available."
+        }),
+    );
+    properties.insert(
+        "generate_summary".to_string(),
+        json!({
+            "type": "boolean",
+            "default": false,
+            "description": "For transcription jobs, generate an AI summary after the transcript is ready. Defaults to false."
+        }),
+    );
+    properties.insert(
+        "stream".to_string(),
+        json!({
+            "type": "boolean",
+            "default": false,
+            "description": "For transcription jobs, stream creation progress as server-sent events."
+        }),
+    );
+    properties.insert(
+        "asr_model".to_string(),
+        json!({
+            "type": "string",
+            "description": "Optional diarization ASR model override."
+        }),
+    );
+    properties.insert(
+        "llm_model".to_string(),
+        json!({
+            "type": "string",
+            "description": "Optional diarization transcript-refinement model."
+        }),
+    );
+    properties.insert(
+        "enable_llm_refinement".to_string(),
+        json!({
+            "type": "boolean",
+            "description": "For diarization jobs, enable optional LLM transcript refinement."
+        }),
+    );
+    properties.insert(
+        "min_speakers".to_string(),
+        json!({
+            "type": "integer",
+            "description": "Optional diarization minimum speaker count."
+        }),
+    );
+    properties.insert(
+        "max_speakers".to_string(),
+        json!({
+            "type": "integer",
+            "description": "Optional diarization maximum speaker count."
+        }),
+    );
+    properties.insert(
+        "min_speech_duration_ms".to_string(),
+        json!({
+            "type": "number",
+            "description": "Optional diarization VAD minimum speech-duration tuning."
+        }),
+    );
+    properties.insert(
+        "min_silence_duration_ms".to_string(),
+        json!({
+            "type": "number",
+            "description": "Optional diarization VAD minimum silence-duration tuning."
+        }),
+    );
+    if include_form_aliases {
+        properties.insert(
+            "word_timestamps".to_string(),
+            json!({
+                "type": "boolean",
+                "default": false,
+                "description": "Alias for include_timestamps."
+            }),
+        );
+    }
+    properties
 }
 
 fn add_collection_with_params(
@@ -2079,6 +2256,29 @@ mod tests {
                     .get(field)
                     .is_some(),
                 "TranscriptionMultipartRequest should document {field}"
+            );
+        }
+    }
+
+    #[test]
+    fn openapi_documents_speech_text_job_generate_summary_field() {
+        let openapi = document();
+        let content = openapi["paths"]["/v1/speech-to-text/jobs"]["post"]["requestBody"]["content"]
+            .as_object()
+            .expect("speech-text create request body content should exist");
+
+        for content_type in ["application/json", "multipart/form-data"] {
+            let generate_summary =
+                &content[content_type]["schema"]["properties"]["generate_summary"];
+            assert_eq!(
+                generate_summary["type"].as_str(),
+                Some("boolean"),
+                "{content_type} generate_summary should be boolean"
+            );
+            assert_eq!(
+                generate_summary["default"].as_bool(),
+                Some(false),
+                "{content_type} generate_summary should default false"
             );
         }
     }

--- a/crates/izwi-server/src/api/transcription/handlers.rs
+++ b/crates/izwi-server/src/api/transcription/handlers.rs
@@ -59,6 +59,7 @@ struct ParsedTranscriptionCreateRequest {
     language: Option<String>,
     include_timestamps: bool,
     stream: bool,
+    generate_summary: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -78,6 +79,8 @@ struct JsonCreateRequest {
     word_timestamps: Option<bool>,
     #[serde(default)]
     stream: Option<bool>,
+    #[serde(default)]
+    generate_summary: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -337,6 +340,7 @@ fn spawn_transcription_processing_task(
         let aligner_model_id = parsed.aligner_model_id.clone();
         let requested_language = parsed.language.clone();
         let include_timestamps = parsed.include_timestamps;
+        let generate_summary = parsed.generate_summary;
         let correlation_id_ref = correlation_id.clone();
         let audio_bytes = match transcription_store.get_audio(record_id.clone()).await {
             Ok(Some(audio)) => audio.audio_bytes,
@@ -417,7 +421,7 @@ fn spawn_transcription_processing_task(
                     None
                 };
                 let (summary_status, summary_model_id) =
-                    initial_summary_state(artifacts.text.as_str());
+                    initial_summary_state(artifacts.text.as_str(), generate_summary);
 
                 match transcription_store
                     .complete_record(
@@ -598,6 +602,7 @@ async fn parse_create_request(req: Request) -> Result<ParsedTranscriptionCreateR
                 .or(payload.word_timestamps)
                 .unwrap_or(false),
             stream: payload.stream.unwrap_or(false),
+            generate_summary: payload.generate_summary.unwrap_or(false),
         });
     }
 
@@ -684,6 +689,14 @@ async fn parse_create_request(req: Request) -> Result<ParsedTranscriptionCreateR
                         ))
                     })?;
                     out.stream = parse_bool(text.as_str());
+                }
+                "generate_summary" => {
+                    let text = field.text().await.map_err(|e| {
+                        ApiError::bad_request(format!(
+                            "Failed reading multipart 'generate_summary' field: {e}"
+                        ))
+                    })?;
+                    out.generate_summary = parse_bool(text.as_str());
                 }
                 _ => {}
             }
@@ -840,8 +853,11 @@ fn should_break_segment(
             && previous_token.ends_with(['.', '!', '?']))
 }
 
-fn initial_summary_state(transcription: &str) -> (TranscriptionSummaryStatus, Option<String>) {
-    if transcription.trim().is_empty() {
+fn initial_summary_state(
+    transcription: &str,
+    generate_summary: bool,
+) -> (TranscriptionSummaryStatus, Option<String>) {
+    if !generate_summary || transcription.trim().is_empty() {
         (TranscriptionSummaryStatus::NotRequested, None)
     } else {
         (
@@ -1100,11 +1116,14 @@ mod tests {
         transcription_summary_params, TranscriptionSummaryStatus, TranscriptionWordRecord,
     };
 
-    fn wav_data_url(content_type: &str) -> String {
-        let wav = AudioEncoder::new(16_000, 1)
+    fn wav_bytes() -> Vec<u8> {
+        AudioEncoder::new(16_000, 1)
             .encode(&[0.0, 0.1, -0.1, 0.0], AudioFormat::Wav)
-            .expect("wav should encode");
-        let b64 = base64::engine::general_purpose::STANDARD.encode(wav);
+            .expect("wav should encode")
+    }
+
+    fn wav_data_url(content_type: &str) -> String {
+        let b64 = base64::engine::general_purpose::STANDARD.encode(wav_bytes());
         format!("data:{content_type};base64, {b64}\n")
     }
 
@@ -1128,6 +1147,60 @@ mod tests {
         assert!(!parsed.audio_bytes.is_empty());
         assert_eq!(parsed.audio_mime_type.as_deref(), Some("audio/wav"));
         assert_eq!(parsed.model_id.as_deref(), Some("Parakeet-TDT-0.6B-v3"));
+        assert!(!parsed.generate_summary);
+    }
+
+    #[tokio::test]
+    async fn json_create_request_accepts_generate_summary_true() {
+        let request = axum::http::Request::builder()
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                serde_json::json!({
+                    "audio_base64": wav_data_url("audio/wav"),
+                    "model": "Parakeet-TDT-0.6B-v3",
+                    "generate_summary": true
+                })
+                .to_string(),
+            ))
+            .expect("request should build");
+
+        let parsed = parse_create_request(request)
+            .await
+            .expect("request should parse");
+
+        assert!(parsed.generate_summary);
+    }
+
+    #[tokio::test]
+    async fn multipart_create_request_accepts_generate_summary_true() {
+        let boundary = "izwi-transcription-boundary";
+        let mut body = Vec::new();
+        body.extend_from_slice(
+            format!(
+                "--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"clip.wav\"\r\nContent-Type: audio/wav\r\n\r\n"
+            )
+            .as_bytes(),
+        );
+        body.extend_from_slice(&wav_bytes());
+        body.extend_from_slice(
+            format!(
+                "\r\n--{boundary}\r\nContent-Disposition: form-data; name=\"generate_summary\"\r\n\r\ntrue\r\n--{boundary}--\r\n"
+            )
+            .as_bytes(),
+        );
+        let request = axum::http::Request::builder()
+            .header(
+                header::CONTENT_TYPE,
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(Body::from(body))
+            .expect("request should build");
+
+        let parsed = parse_create_request(request)
+            .await
+            .expect("request should parse");
+
+        assert!(parsed.generate_summary);
     }
 
     #[tokio::test]
@@ -1219,12 +1292,16 @@ mod tests {
     }
 
     #[test]
-    fn defaults_summary_state_to_pending_for_non_empty_transcriptions() {
-        let (status, model_id) = initial_summary_state("hello world");
+    fn defaults_summary_state_to_not_requested_for_non_empty_transcriptions() {
+        let (status, model_id) = initial_summary_state("hello world", false);
+        assert_eq!(status, TranscriptionSummaryStatus::NotRequested);
+        assert_eq!(model_id, None);
+
+        let (status, model_id) = initial_summary_state("hello world", true);
         assert_eq!(status, TranscriptionSummaryStatus::Pending);
         assert_eq!(model_id.as_deref(), Some("Qwen3.5-4B"));
 
-        let (status, model_id) = initial_summary_state("   ");
+        let (status, model_id) = initial_summary_state("   ", true);
         assert_eq!(status, TranscriptionSummaryStatus::NotRequested);
         assert_eq!(model_id, None);
     }

--- a/docs/user/api.md
+++ b/docs/user/api.md
@@ -537,6 +537,13 @@ Canonical saved transcription and diarization job routes:
 
 The `job_kind` query parameter is important for shared IDs and for clients that want a specific record family.
 
+For transcription job creation, JSON and multipart requests accept
+`generate_summary`. It defaults to `false`; set it to `true` to generate an AI
+summary automatically after the transcript finishes. Records created without an
+automatic summary can still use
+`POST /v1/speech-to-text/jobs/{record_id}/summary/regenerate?job_kind=transcription`
+later.
+
 ### Diarization Records
 
 Persisted diarization routes:

--- a/ui/src/features/transcription/components/NewTranscriptionModal.tsx
+++ b/ui/src/features/transcription/components/NewTranscriptionModal.tsx
@@ -97,6 +97,7 @@ export function NewTranscriptionModal({
   const [selectedLanguage, setSelectedLanguage] = useState("English");
   const [includeTimestamps, setIncludeTimestamps] = useState(false);
   const [streamingEnabled, setStreamingEnabled] = useState(true);
+  const [generateSummary, setGenerateSummary] = useState(false);
   const [isDraggingFile, setIsDraggingFile] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -235,6 +236,7 @@ export function NewTranscriptionModal({
             : undefined,
           language: selectedLanguage,
           include_timestamps: includeTimestamps,
+          generate_summary: generateSummary,
         };
         const record = streamingEnabled
           ? await new Promise<TranscriptionRecord>((resolve, reject) => {
@@ -357,6 +359,7 @@ export function NewTranscriptionModal({
     },
     [
       includeTimestamps,
+      generateSummary,
       onClose,
       onCreated,
       onStreamingDelta,
@@ -654,6 +657,31 @@ export function NewTranscriptionModal({
                     checked={streamingEnabled}
                     onChange={(event) =>
                       handleStreamingEnabledChange(event.target.checked)
+                    }
+                    className="peer sr-only"
+                    disabled={isSubmitting}
+                  />
+                  <span className="flex h-5 w-5 items-center justify-center rounded-md border border-[var(--border-strong)] bg-[var(--bg-surface-0)] text-white transition peer-checked:border-[var(--status-info-text)] peer-checked:bg-[var(--status-info-text)] peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-ring/45 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-background peer-disabled:opacity-50">
+                    <Check className="h-3.5 w-3.5 opacity-0 transition peer-checked:opacity-100" />
+                  </span>
+                </div>
+              </label>
+
+              <label className="flex items-start justify-between gap-3 rounded-2xl border border-[var(--border-muted)] bg-[var(--bg-surface-1)] p-3.5">
+                <div className="min-w-0">
+                  <div className="text-sm font-semibold text-[var(--text-primary)]">
+                    Generate summary
+                  </div>
+                  <div className="mt-0.5 text-[13px] leading-5 text-[var(--text-muted)]">
+                    Create an AI summary after the transcript is ready.
+                  </div>
+                </div>
+                <div className="relative mt-0.5 shrink-0">
+                  <input
+                    type="checkbox"
+                    checked={generateSummary}
+                    onChange={(event) =>
+                      setGenerateSummary(event.target.checked)
                     }
                     className="peer sr-only"
                     disabled={isSubmitting}

--- a/ui/src/features/transcription/route.test.tsx
+++ b/ui/src/features/transcription/route.test.tsx
@@ -843,6 +843,12 @@ describe("TranscriptionPage detail route", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /New transcript/i }));
 
+    const generateSummary = screen.getByLabelText(
+      /Generate summary/i,
+    ) as HTMLInputElement;
+    expect(generateSummary).not.toBeChecked();
+    fireEvent.click(generateSummary);
+
     const fileInput = document.querySelector(
       'input[type="file"]',
     ) as HTMLInputElement | null;
@@ -855,7 +861,12 @@ describe("TranscriptionPage detail route", () => {
     });
 
     await waitFor(() =>
-      expect(apiMocks.createTranscriptionRecordStream).toHaveBeenCalled(),
+      expect(apiMocks.createTranscriptionRecordStream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          generate_summary: true,
+        }),
+        expect.any(Object),
+      ),
     );
     await waitFor(() =>
       expect(apiMocks.getTranscriptionRecord).toHaveBeenCalledWith(
@@ -949,6 +960,7 @@ describe("TranscriptionPage detail route", () => {
       expect(apiMocks.createTranscriptionRecordStream).toHaveBeenCalledWith(
         expect.objectContaining({
           audio_filename: "Aliko Dangote.mp3",
+          generate_summary: false,
         }),
         expect.objectContaining({
           onUploadProgress: expect.any(Function),

--- a/ui/src/shared/api/audio.test.ts
+++ b/ui/src/shared/api/audio.test.ts
@@ -382,7 +382,7 @@ describe("AudioApiClient.updateDiarizationRecord", () => {
     );
   });
 
-  it("posts transcription records with optional timestamp settings", async () => {
+  it("posts transcription records with optional timestamp and summary settings", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -421,6 +421,7 @@ describe("AudioApiClient.updateDiarizationRecord", () => {
       aligner_model_id: "Qwen3-ForcedAligner-0.6B",
       language: "English",
       include_timestamps: true,
+      generate_summary: true,
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -433,6 +434,48 @@ describe("AudioApiClient.updateDiarizationRecord", () => {
           aligner_model: "Qwen3-ForcedAligner-0.6B",
           language: "English",
           include_timestamps: true,
+          generate_summary: true,
+          stream: false,
+        }),
+      }),
+    );
+  });
+
+  it("defaults transcription summary generation to false in JSON requests", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ...createdTranscriptionRecord,
+          processing_status: "pending",
+        }),
+        {
+          status: 202,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      ),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new AudioApiClient(new ApiHttpClient("http://localhost/v1"));
+    await client.createTranscriptionRecord({
+      audio_base64: "UklGRg==",
+      model_id: "Parakeet-TDT-0.6B-v3",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost/v1/speech-to-text/jobs?job_kind=transcription",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          audio_base64: "UklGRg==",
+          model: "Parakeet-TDT-0.6B-v3",
+          aligner_model: undefined,
+          language: undefined,
+          include_timestamps: false,
+          generate_summary: false,
           stream: false,
         }),
       }),
@@ -848,6 +891,7 @@ describe("AudioApiClient.updateDiarizationRecord", () => {
         }),
         audio_filename: "stream.wav",
         model_id: "Parakeet-TDT-0.6B-v3",
+        generate_summary: true,
       },
       {
         onUploadProgress,
@@ -861,6 +905,8 @@ describe("AudioApiClient.updateDiarizationRecord", () => {
     expect(xhr.url).toBe(
       "http://localhost/v1/speech-to-text/jobs?job_kind=transcription",
     );
+    expect(xhr.body).toBeInstanceOf(FormData);
+    expect((xhr.body as FormData).get("generate_summary")).toBe("true");
     xhr.emitUploadProgress(4, 8);
     xhr.appendResponse(
       `data: ${JSON.stringify({

--- a/ui/src/shared/api/audio.ts
+++ b/ui/src/shared/api/audio.ts
@@ -574,6 +574,7 @@ export interface SpeechTextTranscriptionJobCreateRequest
   aligner_model_id?: string;
   language?: string;
   include_timestamps?: boolean;
+  generate_summary?: boolean;
   stream?: boolean;
 }
 
@@ -677,6 +678,7 @@ export interface TranscriptionRecordCreateRequest {
   aligner_model_id?: string;
   language?: string;
   include_timestamps?: boolean;
+  generate_summary?: boolean;
 }
 
 type TranscriptionRecordStreamEvent =
@@ -2889,6 +2891,9 @@ export class AudioApiClient {
       if (request.include_timestamps) {
         form.append("include_timestamps", "true");
       }
+      if (request.generate_summary) {
+        form.append("generate_summary", "true");
+      }
       if (stream) {
         form.append("stream", "true");
       }
@@ -2913,6 +2918,7 @@ export class AudioApiClient {
         aligner_model: request.aligner_model_id,
         language: request.language,
         include_timestamps: Boolean(request.include_timestamps),
+        generate_summary: Boolean(request.generate_summary),
         stream,
       }),
     };


### PR DESCRIPTION
Adds default-false generate_summary support across saved transcription job API, ASR modal checkbox/client serialization, OpenAPI/docs, and tests.