### PR TITLE
Accelerate Kokoro-82M TTS on Metal and CPU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3722,6 +3722,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_distr 0.4.3",
+ "rayon",
  "reqwest 0.11.27",
  "rubato 0.15.0",
  "rustfft",

--- a/crates/izwi-cli/src/app/cli.rs
+++ b/crates/izwi-cli/src/app/cli.rs
@@ -523,6 +523,10 @@ pub enum BenchCommands {
         )]
         text: String,
 
+        /// Speaker voice or VibeVoice speaker label
+        #[arg(short, long)]
+        speaker: Option<String>,
+
         /// Saved reference voice ID
         #[arg(long, value_name = "ID")]
         saved_voice_id: Option<String>,

--- a/crates/izwi-cli/src/commands/bench.rs
+++ b/crates/izwi-cli/src/commands/bench.rs
@@ -120,6 +120,7 @@ struct TtsBenchSample {
 
 #[derive(Debug, Clone, Default)]
 struct TtsBenchReference {
+    speaker: Option<String>,
     saved_voice_id: Option<String>,
     reference_audio_base64: Option<String>,
     reference_audio_path: Option<String>,
@@ -309,6 +310,7 @@ struct BenchmarkRunConfig {
     system: Option<String>,
     max_tokens: Option<usize>,
     text: Option<String>,
+    speaker: Option<String>,
     file: Option<String>,
     saved_voice_id: Option<String>,
     reference_audio: Option<String>,
@@ -395,6 +397,7 @@ struct BenchmarkManifestCase {
     system: Option<String>,
     max_tokens: Option<usize>,
     text: Option<String>,
+    speaker: Option<String>,
     file: Option<String>,
     saved_voice_id: Option<String>,
     reference_audio: Option<String>,
@@ -415,6 +418,7 @@ struct BenchmarkManifestMatrix {
     system: Option<Vec<String>>,
     max_tokens: Option<Vec<usize>>,
     text: Option<Vec<String>>,
+    speaker: Option<Vec<String>>,
     file: Option<Vec<String>>,
     saved_voice_id: Option<Vec<String>>,
     reference_audio: Option<Vec<String>>,
@@ -440,6 +444,7 @@ enum MatrixValue {
     System(String),
     MaxTokens(usize),
     Text(String),
+    Speaker(String),
     File(String),
     SavedVoiceId(String),
     ReferenceAudio(String),
@@ -557,6 +562,7 @@ pub async fn execute(
             model,
             iterations,
             text,
+            speaker,
             saved_voice_id,
             reference_audio,
             reference_text,
@@ -568,6 +574,7 @@ pub async fn execute(
             &model,
             iterations,
             &text,
+            speaker.as_deref(),
             saved_voice_id.as_deref(),
             reference_audio.as_deref(),
             reference_text.as_deref(),
@@ -732,6 +739,7 @@ impl MatrixValue {
             MatrixValue::System(value) => case.system = Some(value.clone()),
             MatrixValue::MaxTokens(value) => case.max_tokens = Some(*value),
             MatrixValue::Text(value) => case.text = Some(value.clone()),
+            MatrixValue::Speaker(value) => case.speaker = Some(value.clone()),
             MatrixValue::File(value) => case.file = Some(value.clone()),
             MatrixValue::SavedVoiceId(value) => case.saved_voice_id = Some(value.clone()),
             MatrixValue::ReferenceAudio(value) => case.reference_audio = Some(value.clone()),
@@ -748,6 +756,7 @@ impl MatrixValue {
             | MatrixValue::Prompt(value)
             | MatrixValue::System(value)
             | MatrixValue::Text(value)
+            | MatrixValue::Speaker(value)
             | MatrixValue::File(value)
             | MatrixValue::SavedVoiceId(value)
             | MatrixValue::ReferenceAudio(value)
@@ -789,6 +798,12 @@ impl BenchmarkManifestMatrix {
             MatrixValue::MaxTokens,
         )?;
         add_matrix_dimension(&mut dimensions, "text", &self.text, MatrixValue::Text)?;
+        add_matrix_dimension(
+            &mut dimensions,
+            "speaker",
+            &self.speaker,
+            MatrixValue::Speaker,
+        )?;
         add_matrix_dimension(&mut dimensions, "file", &self.file, MatrixValue::File)?;
         add_matrix_dimension(
             &mut dimensions,
@@ -1142,6 +1157,7 @@ async fn bench_manifest(
                     model,
                     case.iterations.unwrap_or(10),
                     text,
+                    case.speaker.as_deref(),
                     case.saved_voice_id.as_deref(),
                     reference_audio.as_deref(),
                     case.reference_text.as_deref(),
@@ -1485,6 +1501,7 @@ async fn bench_chat(
             system: system.as_deref().map(|value| value.to_string()),
             max_tokens: Some(max_tokens),
             text: None,
+            speaker: None,
             file: None,
             saved_voice_id: None,
             reference_audio: None,
@@ -1548,6 +1565,7 @@ async fn bench_tts(
     model: &str,
     iterations: u32,
     text: &str,
+    speaker: Option<&str>,
     saved_voice_id: Option<&str>,
     reference_audio: Option<&Path>,
     reference_text: Option<&str>,
@@ -1575,6 +1593,7 @@ async fn bench_tts(
     let run_start = Instant::now();
     let metrics_before = fetch_runtime_metrics(server).await;
     let reference = resolve_tts_bench_reference(
+        speaker,
         saved_voice_id,
         reference_audio,
         reference_text,
@@ -1730,6 +1749,7 @@ async fn bench_tts(
             system: None,
             max_tokens: None,
             text: Some(text.as_ref().clone()),
+            speaker: reference.speaker.clone(),
             file: None,
             saved_voice_id: reference.saved_voice_id.clone(),
             reference_audio: reference.reference_audio_path.clone(),
@@ -1998,6 +2018,7 @@ async fn bench_asr(
             system: None,
             max_tokens,
             text: None,
+            speaker: None,
             file: Some(audio_file.display().to_string()),
             saved_voice_id: None,
             reference_audio: None,
@@ -2143,6 +2164,7 @@ async fn bench_throughput(
             system: None,
             max_tokens: None,
             text: None,
+            speaker: None,
             file: None,
             saved_voice_id: None,
             reference_audio: None,
@@ -2193,11 +2215,13 @@ fn header_u64(response: &reqwest::Response, name: &'static str) -> Option<u64> {
 }
 
 async fn resolve_tts_bench_reference(
+    speaker: Option<&str>,
     saved_voice_id: Option<&str>,
     reference_audio: Option<&Path>,
     reference_text: Option<&str>,
     reference_text_file: Option<&Path>,
 ) -> Result<TtsBenchReference> {
+    let speaker = normalize_optional_bench_text(speaker);
     let saved_voice_id = normalize_optional_bench_text(saved_voice_id);
     let reference_text = normalize_optional_bench_text(reference_text);
     if reference_text.is_some() && reference_text_file.is_some() {
@@ -2240,6 +2264,7 @@ async fn resolve_tts_bench_reference(
     };
 
     Ok(TtsBenchReference {
+        speaker,
         saved_voice_id,
         reference_audio_base64,
         reference_audio_path,
@@ -2267,21 +2292,7 @@ async fn run_tts_request(
     reference: &TtsBenchReference,
 ) -> Result<TtsBenchSample> {
     let client = http::client(Some(std::time::Duration::from_secs(300)))?;
-    let mut request_body = serde_json::json!({
-        "model": model,
-        "input": text,
-        "voice": "default",
-        "response_format": "wav",
-    });
-    if let Some(saved_voice_id) = reference.saved_voice_id.as_deref() {
-        request_body["saved_voice_id"] = serde_json::Value::String(saved_voice_id.to_string());
-    }
-    if let Some(reference_audio) = reference.reference_audio_base64.as_deref() {
-        request_body["reference_audio"] = serde_json::Value::String(reference_audio.to_string());
-    }
-    if let Some(reference_text) = reference.reference_text.as_deref() {
-        request_body["reference_text"] = serde_json::Value::String(reference_text.to_string());
-    }
+    let request_body = build_tts_bench_request_body(model, text, reference);
 
     let response = client
         .post(format!("{}/v1/audio/speech", server))
@@ -2306,6 +2317,31 @@ async fn run_tts_request(
         rtf: header_f64(&response, "x-rtf"),
         tokens_generated: header_u64(&response, "x-tokens-generated"),
     })
+}
+
+fn build_tts_bench_request_body(
+    model: &str,
+    text: &str,
+    reference: &TtsBenchReference,
+) -> serde_json::Value {
+    let mut request_body = serde_json::json!({
+        "model": model,
+        "input": text,
+        "response_format": "wav",
+    });
+    if let Some(speaker) = reference.speaker.as_deref() {
+        request_body["voice"] = serde_json::Value::String(speaker.to_string());
+    }
+    if let Some(saved_voice_id) = reference.saved_voice_id.as_deref() {
+        request_body["saved_voice_id"] = serde_json::Value::String(saved_voice_id.to_string());
+    }
+    if let Some(reference_audio) = reference.reference_audio_base64.as_deref() {
+        request_body["reference_audio"] = serde_json::Value::String(reference_audio.to_string());
+    }
+    if let Some(reference_text) = reference.reference_text.as_deref() {
+        request_body["reference_text"] = serde_json::Value::String(reference_text.to_string());
+    }
+    request_body
 }
 
 async fn run_asr_request(
@@ -4203,10 +4239,15 @@ mod tests {
             .await
             .expect("write text");
 
-        let reference =
-            resolve_tts_bench_reference(None, Some(audio.as_path()), None, Some(text.as_path()))
-                .await
-                .expect("reference should resolve");
+        let reference = resolve_tts_bench_reference(
+            None,
+            None,
+            Some(audio.as_path()),
+            None,
+            Some(text.as_path()),
+        )
+        .await
+        .expect("reference should resolve");
 
         assert_eq!(
             reference.reference_audio_base64.as_deref(),
@@ -4218,12 +4259,14 @@ mod tests {
             Some(expected_path.as_str())
         );
         assert_eq!(reference.reference_text.as_deref(), Some("reference words"));
+        assert!(reference.speaker.is_none());
         assert!(reference.saved_voice_id.is_none());
     }
 
     #[tokio::test]
     async fn tts_bench_reference_rejects_mixed_saved_and_direct_reference() {
         let err = resolve_tts_bench_reference(
+            None,
             Some("voice-1"),
             Some(Path::new("reference.wav")),
             Some("reference words"),
@@ -4235,6 +4278,36 @@ mod tests {
         assert!(err
             .to_string()
             .contains("Use either --saved-voice-id or --reference-audio/--reference-text"));
+    }
+
+    #[tokio::test]
+    async fn tts_bench_reference_trims_speaker() {
+        let reference = resolve_tts_bench_reference(Some(" af_bella "), None, None, None, None)
+            .await
+            .expect("speaker should resolve");
+
+        assert_eq!(reference.speaker.as_deref(), Some("af_bella"));
+    }
+
+    #[test]
+    fn tts_bench_request_omits_voice_without_speaker() {
+        let body =
+            build_tts_bench_request_body("Kokoro-82M", "hello", &TtsBenchReference::default());
+
+        assert!(body.get("voice").is_none());
+    }
+
+    #[test]
+    fn tts_bench_request_includes_speaker_when_provided() {
+        let reference = TtsBenchReference {
+            speaker: Some("af_bella".to_string()),
+            ..TtsBenchReference::default()
+        };
+        let body = build_tts_bench_request_body("Kokoro-82M", "hello", &reference);
+
+        assert_eq!(body["voice"], "af_bella");
+        assert_eq!(body["model"], "Kokoro-82M");
+        assert_eq!(body["input"], "hello");
     }
 
     #[test]
@@ -4430,6 +4503,34 @@ concurrent = [1, 1]
 
         let err = expand_manifest_cases(&manifest).expect_err("duplicate matrix names should fail");
         assert!(format!("{err}").contains("duplicate case name `chat-short[concurrent=1]`"));
+    }
+
+    #[test]
+    fn manifest_matrix_expands_tts_speaker_cases() {
+        let manifest: BenchmarkManifest = toml::from_str(
+            r#"
+[[benchmarks]]
+name = "kokoro"
+command = "tts"
+model = "Kokoro-82M"
+
+[benchmarks.matrix]
+speaker = ["af_bella", "am_adam"]
+"#,
+        )
+        .expect("manifest should parse");
+
+        let cases = expand_manifest_cases(&manifest).expect("matrix should expand");
+        let names: Vec<_> = cases
+            .iter()
+            .map(|case| case.name.as_deref().expect("expanded cases are named"))
+            .collect();
+        assert_eq!(
+            names,
+            vec!["kokoro[speaker=af_bella]", "kokoro[speaker=am_adam]"]
+        );
+        assert_eq!(cases[0].speaker.as_deref(), Some("af_bella"));
+        assert_eq!(cases[1].speaker.as_deref(), Some("am_adam"));
     }
 
     #[test]

--- a/crates/izwi-core/Cargo.toml
+++ b/crates/izwi-core/Cargo.toml
@@ -43,6 +43,7 @@ tar = "0.4"
 rand = "0.8"
 rand_chacha = "0.3"
 rand_distr = "0.4"
+rayon = "1.11"
 
 anyhow = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use candle_core::{DType, Tensor};
+use candle_core::{CpuStorage, CustomOp2, DType, Layout, Result as CandleResult, Shape, Tensor};
 use candle_nn::{
     ops, Conv1d, Conv1dConfig, ConvTranspose1d, ConvTranspose1dConfig, Module, VarBuilder,
 };
@@ -39,12 +39,10 @@ fn log_kokoro_profile(stage: &str, dur: Duration) {
 
 fn kokoro_cpu_resblocks_parallel_enabled() -> bool {
     match std::env::var("IZWI_KOKORO_CPU_RESBLOCKS") {
-        Ok(value) => {
-            !matches!(
-                value.trim().to_ascii_lowercase().as_str(),
-                "0" | "false" | "off" | "serial" | "sequential"
-            )
-        }
+        Ok(value) => !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "serial" | "sequential"
+        ),
         Err(_) => true,
     }
 }
@@ -495,10 +493,7 @@ impl KokoroIstftGenerator {
     }
 
     fn run_stage_resblocks(&self, base: usize, x: &Tensor, style: &Tensor) -> Result<Tensor> {
-        if x.device().is_cpu()
-            && self.num_kernels > 1
-            && kokoro_cpu_resblocks_parallel_enabled()
-        {
+        if x.device().is_cpu() && self.num_kernels > 1 && kokoro_cpu_resblocks_parallel_enabled() {
             return self.run_stage_resblocks_parallel_cpu(base, x, style);
         }
         let mut xs = self.resblocks[base].forward(x, style)?;
@@ -798,7 +793,87 @@ fn get_padding(kernel_size: usize, dilation: usize) -> usize {
         / 2
 }
 
+#[derive(Debug, Clone, Copy)]
+struct Snake1dCpuOp;
+
+impl CustomOp2 for Snake1dCpuOp {
+    fn name(&self) -> &'static str {
+        "kokoro-snake1d-cpu"
+    }
+
+    fn cpu_fwd(
+        &self,
+        x_storage: &CpuStorage,
+        x_layout: &Layout,
+        alpha_storage: &CpuStorage,
+        alpha_layout: &Layout,
+    ) -> CandleResult<(CpuStorage, Shape)> {
+        let x = match x_storage {
+            CpuStorage::F32(values) => values,
+            _ => candle_core::bail!("kokoro-snake1d-cpu only supports F32 input"),
+        };
+        let alpha = match alpha_storage {
+            CpuStorage::F32(values) => values,
+            _ => candle_core::bail!("kokoro-snake1d-cpu only supports F32 alpha"),
+        };
+        let x = match x_layout.contiguous_offsets() {
+            Some((start, end)) => &x[start..end],
+            None => candle_core::bail!("kokoro-snake1d-cpu requires contiguous input"),
+        };
+        let alpha = match alpha_layout.contiguous_offsets() {
+            Some((start, end)) => &alpha[start..end],
+            None => candle_core::bail!("kokoro-snake1d-cpu requires contiguous alpha"),
+        };
+
+        let dims = x_layout.shape().dims();
+        if dims.len() != 3 {
+            candle_core::bail!("kokoro-snake1d-cpu expects [B,C,T] input")
+        }
+        let batch = dims[0];
+        let channels = dims[1];
+        let time = dims[2];
+        let alpha_dims = alpha_layout.shape().dims();
+        let alpha_by_channel = match alpha_dims {
+            [1] => false,
+            [c] if *c == channels => true,
+            [1, c, 1] if *c == channels => true,
+            [c, 1] if *c == channels => true,
+            _ => candle_core::bail!(
+                "kokoro-snake1d-cpu alpha shape {:?} cannot broadcast to {:?}",
+                alpha_dims,
+                dims
+            ),
+        };
+        if !alpha_by_channel && alpha.len() != 1 {
+            candle_core::bail!("kokoro-snake1d-cpu scalar alpha has invalid storage length")
+        }
+
+        let mut out = vec![0.0f32; x.len()];
+        for b in 0..batch {
+            for c in 0..channels {
+                let a = if alpha_by_channel { alpha[c] } else { alpha[0] };
+                for t in 0..time {
+                    let idx = (b * channels + c) * time + t;
+                    let v = x[idx];
+                    let s = (v * a).sin();
+                    out[idx] = v + (s * s) / a;
+                }
+            }
+        }
+        Ok((CpuStorage::F32(out), x_layout.shape().clone()))
+    }
+}
+
 fn snake1d(x: &Tensor, alpha: &Tensor) -> Result<Tensor> {
+    if x.device().is_cpu() && x.dtype() == DType::F32 && alpha.dtype() == DType::F32 {
+        if let Ok(out) = x.apply_op2_no_bwd(alpha, &Snake1dCpuOp) {
+            return Ok(out);
+        }
+    }
+    snake1d_candle(x, alpha)
+}
+
+fn snake1d_candle(x: &Tensor, alpha: &Tensor) -> Result<Tensor> {
     let ax = x.broadcast_mul(alpha).map_err(Error::from)?;
     let sin_sq = ax.sin().map_err(Error::from)?.sqr().map_err(Error::from)?;
     let scaled = sin_sq.broadcast_div(alpha).map_err(Error::from)?;
@@ -1048,6 +1123,36 @@ mod tests {
         assert_eq!(y[0], 1.0);
         assert_eq!(y[4], 2.0);
         assert_eq!(y[8], 3.0);
+    }
+
+    #[test]
+    fn kokoro_snake1d_cpu_matches_candle_expression() {
+        let device = candle_core::Device::Cpu;
+        let x = Tensor::from_vec(
+            vec![-0.4f32, 0.0, 0.25, 0.7, -1.2, 0.3, 0.9, 1.4],
+            (1, 2, 4),
+            &device,
+        )
+        .expect("x tensor");
+        let alpha = Tensor::from_vec(vec![0.7f32, 1.3], (1, 2, 1), &device).expect("alpha tensor");
+
+        let fused = snake1d(&x, &alpha)
+            .expect("fused snake")
+            .flatten_all()
+            .expect("flatten fused")
+            .to_vec1::<f32>()
+            .expect("fused values");
+        let reference = snake1d_candle(&x, &alpha)
+            .expect("reference snake")
+            .flatten_all()
+            .expect("flatten reference")
+            .to_vec1::<f32>()
+            .expect("reference values");
+
+        assert_eq!(fused.len(), reference.len());
+        for (got, expected) in fused.iter().zip(reference.iter()) {
+            assert!((got - expected).abs() < 1e-6, "{got} != {expected}");
+        }
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
@@ -29,6 +29,16 @@ fn kokoro_profile_enabled() -> bool {
     std::env::var_os("IZWI_KOKORO_PROFILE").is_some()
 }
 
+fn kokoro_profile_sync_enabled() -> bool {
+    std::env::var_os("IZWI_KOKORO_PROFILE_SYNC").is_some()
+}
+
+fn sync_kokoro_profile_tensor(tensor: &Tensor) {
+    if kokoro_profile_sync_enabled() {
+        let _ = tensor.device().synchronize();
+    }
+}
+
 fn log_kokoro_profile(stage: &str, dur: Duration) {
     if kokoro_profile_enabled() {
         eprintln!(
@@ -391,11 +401,14 @@ impl KokoroIstftGenerator {
             let t_stage_leaky = if profile { Some(Instant::now()) } else { None };
             x = ops::leaky_relu(&x, 0.1).map_err(Error::from)?;
             if let Some(t) = t_stage_leaky {
+                sync_kokoro_profile_tensor(&x);
                 log_kokoro_profile(&format!("generator.stage.{i}.leaky_relu"), t.elapsed());
             }
             let t_stage_branches = if profile { Some(Instant::now()) } else { None };
             let (x_up, x_source) = self.run_stage_branches(i, &x, &har, style)?;
             if let Some(t) = t_stage_branches {
+                sync_kokoro_profile_tensor(&x_up);
+                sync_kokoro_profile_tensor(&x_source);
                 log_kokoro_profile(&format!("generator.stage.{i}.branches"), t.elapsed());
             }
             x = x_up;
@@ -406,6 +419,7 @@ impl KokoroIstftGenerator {
                 match_time_add(&x, &x_source)?
             };
             if let Some(t) = t_stage_add {
+                sync_kokoro_profile_tensor(&x);
                 log_kokoro_profile(&format!("generator.stage.{i}.pad_add"), t.elapsed());
             }
 
@@ -413,11 +427,13 @@ impl KokoroIstftGenerator {
             let t_stage_resblocks = if profile { Some(Instant::now()) } else { None };
             let xs = self.run_stage_resblocks(base, &x, style)?;
             if let Some(t) = t_stage_resblocks {
+                sync_kokoro_profile_tensor(&xs);
                 log_kokoro_profile(&format!("generator.stage.{i}.resblocks"), t.elapsed());
             }
             let t_stage_avg = if profile { Some(Instant::now()) } else { None };
             x = (xs / self.num_kernels as f64).map_err(Error::from)?;
             if let Some(t) = t_stage_avg {
+                sync_kokoro_profile_tensor(&x);
                 log_kokoro_profile(&format!("generator.stage.{i}.average"), t.elapsed());
             }
             if let Some(t) = stage_t0 {
@@ -431,6 +447,9 @@ impl KokoroIstftGenerator {
         let t2 = Instant::now();
         x = ops::leaky_relu(&x, 0.01).map_err(Error::from)?;
         x = self.conv_post.forward(&x).map_err(Error::from)?;
+        if profile {
+            sync_kokoro_profile_tensor(&x);
+        }
         let (_b, c, _t) = x.dims3().map_err(Error::from)?;
         let n_bins = self.cfg.gen_istft_n_fft / 2 + 1;
         if c < n_bins * 2 {
@@ -451,6 +470,8 @@ impl KokoroIstftGenerator {
             .sin()
             .map_err(Error::from)?;
         if profile {
+            sync_kokoro_profile_tensor(&spec);
+            sync_kokoro_profile_tensor(&phase);
             log_kokoro_profile("generator.conv_post_spec_phase", t2.elapsed());
         }
         let t3 = Instant::now();

--- a/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
@@ -627,7 +627,13 @@ impl KokoroIstftGenerator {
             );
         }
         let t1 = if profile { Some(Instant::now()) } else { None };
-        x_source = self.noise_res[i].forward(&x_source, style)?;
+        let source_res_prefix = if profile {
+            Some(format!("generator.stage.{i}.branch.source_res"))
+        } else {
+            None
+        };
+        x_source =
+            self.noise_res[i].forward_profiled(&x_source, style, source_res_prefix.as_deref())?;
         if let Some(t) = t1 {
             sync_kokoro_profile_tensor(&x_source);
             log_kokoro_profile(
@@ -723,9 +729,27 @@ impl KokoroIstftGenerator {
         if x.device().is_cpu() && self.num_kernels > 1 && kokoro_cpu_resblocks_parallel_enabled() {
             return self.run_stage_resblocks_parallel_cpu(base, x, style);
         }
-        let mut xs = self.resblocks[base].forward(x, style)?;
+        let profile = kokoro_profile_enabled();
+        let mut xs = if profile {
+            self.resblocks[base].forward_profiled(
+                x,
+                style,
+                Some(&format!("generator.resblock.{base}")),
+            )?
+        } else {
+            self.resblocks[base].forward(x, style)?
+        };
         for j in 1..self.num_kernels {
-            let y = self.resblocks[base + j].forward(x, style)?;
+            let idx = base + j;
+            let y = if profile {
+                self.resblocks[idx].forward_profiled(
+                    x,
+                    style,
+                    Some(&format!("generator.resblock.{idx}")),
+                )?
+            } else {
+                self.resblocks[idx].forward(x, style)?
+            };
             xs = (xs + y).map_err(Error::from)?;
         }
         Ok(xs)
@@ -1059,13 +1083,48 @@ impl AdaInResBlock1 {
     }
 
     fn forward(&self, x: &Tensor, style: &Tensor) -> Result<Tensor> {
+        self.forward_profiled(x, style, None)
+    }
+
+    fn forward_profiled(
+        &self,
+        x: &Tensor,
+        style: &Tensor,
+        profile_prefix: Option<&str>,
+    ) -> Result<Tensor> {
+        let profile = profile_prefix.is_some() && kokoro_profile_enabled();
         let mut x = x.clone();
         for j in 0..3 {
+            let t_adain1 = if profile { Some(Instant::now()) } else { None };
             let mut xt = self.adain1[j].forward_snake(&x, style, &self.alpha1[j])?;
+            if let (Some(prefix), Some(t)) = (profile_prefix, t_adain1) {
+                sync_kokoro_profile_tensor(&xt);
+                log_kokoro_profile(&format!("{prefix}.iter.{j}.adain1_snake"), t.elapsed());
+            }
+            let t_conv1 = if profile { Some(Instant::now()) } else { None };
             xt = self.convs1[j].forward(&xt).map_err(Error::from)?;
+            if let (Some(prefix), Some(t)) = (profile_prefix, t_conv1) {
+                sync_kokoro_profile_tensor(&xt);
+                log_kokoro_profile(&format!("{prefix}.iter.{j}.conv1"), t.elapsed());
+            }
+            let t_adain2 = if profile { Some(Instant::now()) } else { None };
             xt = self.adain2[j].forward_snake(&xt, style, &self.alpha2[j])?;
+            if let (Some(prefix), Some(t)) = (profile_prefix, t_adain2) {
+                sync_kokoro_profile_tensor(&xt);
+                log_kokoro_profile(&format!("{prefix}.iter.{j}.adain2_snake"), t.elapsed());
+            }
+            let t_conv2 = if profile { Some(Instant::now()) } else { None };
             xt = self.convs2[j].forward(&xt).map_err(Error::from)?;
+            if let (Some(prefix), Some(t)) = (profile_prefix, t_conv2) {
+                sync_kokoro_profile_tensor(&xt);
+                log_kokoro_profile(&format!("{prefix}.iter.{j}.conv2"), t.elapsed());
+            }
+            let t_add = if profile { Some(Instant::now()) } else { None };
             x = (xt + x).map_err(Error::from)?;
+            if let (Some(prefix), Some(t)) = (profile_prefix, t_add) {
+                sync_kokoro_profile_tensor(&x);
+                log_kokoro_profile(&format!("{prefix}.iter.{j}.residual_add"), t.elapsed());
+            }
         }
         Ok(x)
     }

--- a/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
@@ -47,6 +47,16 @@ fn kokoro_cpu_resblocks_parallel_enabled() -> bool {
     }
 }
 
+fn kokoro_cpu_stage_branches_parallel_enabled() -> bool {
+    match std::env::var("IZWI_KOKORO_CPU_STAGE_BRANCHES") {
+        Ok(value) => !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "serial" | "sequential"
+        ),
+        Err(_) => true,
+    }
+}
+
 #[derive(Debug)]
 pub struct KokoroDecoder {
     f0_conv: Conv1d,
@@ -377,9 +387,8 @@ impl KokoroIstftGenerator {
         let mut x = x.clone();
         for i in 0..self.num_upsamples {
             x = ops::leaky_relu(&x, 0.1).map_err(Error::from)?;
-            let mut x_source = self.noise_convs[i].forward(&har).map_err(Error::from)?;
-            x_source = self.noise_res[i].forward(&x_source, style)?;
-            x = self.ups[i].forward(&x).map_err(Error::from)?;
+            let (x_up, x_source) = self.run_stage_branches(i, &x, &har, style)?;
+            x = x_up;
             if i + 1 == self.num_upsamples {
                 x = reflection_pad_left1(&x)?;
             }
@@ -490,6 +499,74 @@ impl KokoroIstftGenerator {
             log_kokoro_profile("generator.harmonic.total", t0.elapsed());
         }
         Ok(har_t)
+    }
+
+    fn run_stage_branches(
+        &self,
+        i: usize,
+        x: &Tensor,
+        har: &Tensor,
+        style: &Tensor,
+    ) -> Result<(Tensor, Tensor)> {
+        if x.device().is_cpu() && kokoro_cpu_stage_branches_parallel_enabled() {
+            return self.run_stage_branches_parallel_cpu(i, x, har, style);
+        }
+
+        let mut x_source = self.noise_convs[i].forward(har).map_err(Error::from)?;
+        x_source = self.noise_res[i].forward(&x_source, style)?;
+        let x_up = self.ups[i].forward(x).map_err(Error::from)?;
+        Ok((x_up, x_source))
+    }
+
+    fn run_stage_branches_parallel_cpu(
+        &self,
+        i: usize,
+        x: &Tensor,
+        har: &Tensor,
+        style: &Tensor,
+    ) -> Result<(Tensor, Tensor)> {
+        thread::scope(|scope| {
+            let noise_conv = &self.noise_convs[i];
+            let noise_res = &self.noise_res[i];
+            let up = &self.ups[i];
+            let har = har.clone();
+            let style = style.clone();
+            let x = x.clone();
+
+            let source_handle = scope.spawn(move || {
+                let mut x_source = noise_conv.forward(&har).map_err(|e| e.to_string())?;
+                x_source = noise_res
+                    .forward(&x_source, &style)
+                    .map_err(|e| e.to_string())?;
+                Ok::<Tensor, String>(x_source)
+            });
+            let up_handle = scope.spawn(move || {
+                up.forward(&x)
+                    .map_err(Error::from)
+                    .map_err(|e| e.to_string())
+            });
+
+            let x_source = match source_handle.join() {
+                Ok(Ok(t)) => t,
+                Ok(Err(msg)) => return Err(Error::InferenceError(msg)),
+                Err(_) => {
+                    return Err(Error::InferenceError(
+                        "Kokoro generator source branch worker thread panicked".to_string(),
+                    ))
+                }
+            };
+            let x_up = match up_handle.join() {
+                Ok(Ok(t)) => t,
+                Ok(Err(msg)) => return Err(Error::InferenceError(msg)),
+                Err(_) => {
+                    return Err(Error::InferenceError(
+                        "Kokoro generator upsample branch worker thread panicked".to_string(),
+                    ))
+                }
+            };
+
+            Ok((x_up, x_source))
+        })
     }
 
     fn run_stage_resblocks(&self, base: usize, x: &Tensor, style: &Tensor) -> Result<Tensor> {

--- a/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
@@ -386,17 +386,41 @@ impl KokoroIstftGenerator {
         let t1 = Instant::now();
         let mut x = x.clone();
         for i in 0..self.num_upsamples {
+            let stage_t0 = if profile { Some(Instant::now()) } else { None };
+            let t_stage_leaky = if profile { Some(Instant::now()) } else { None };
             x = ops::leaky_relu(&x, 0.1).map_err(Error::from)?;
+            if let Some(t) = t_stage_leaky {
+                log_kokoro_profile(&format!("generator.stage.{i}.leaky_relu"), t.elapsed());
+            }
+            let t_stage_branches = if profile { Some(Instant::now()) } else { None };
             let (x_up, x_source) = self.run_stage_branches(i, &x, &har, style)?;
+            if let Some(t) = t_stage_branches {
+                log_kokoro_profile(&format!("generator.stage.{i}.branches"), t.elapsed());
+            }
             x = x_up;
+            let t_stage_add = if profile { Some(Instant::now()) } else { None };
             if i + 1 == self.num_upsamples {
                 x = reflection_pad_left1(&x)?;
             }
             x = match_time_add(&x, &x_source)?;
+            if let Some(t) = t_stage_add {
+                log_kokoro_profile(&format!("generator.stage.{i}.pad_add"), t.elapsed());
+            }
 
             let base = i * self.num_kernels;
+            let t_stage_resblocks = if profile { Some(Instant::now()) } else { None };
             let xs = self.run_stage_resblocks(base, &x, style)?;
+            if let Some(t) = t_stage_resblocks {
+                log_kokoro_profile(&format!("generator.stage.{i}.resblocks"), t.elapsed());
+            }
+            let t_stage_avg = if profile { Some(Instant::now()) } else { None };
             x = (xs / self.num_kernels as f64).map_err(Error::from)?;
+            if let Some(t) = t_stage_avg {
+                log_kokoro_profile(&format!("generator.stage.{i}.average"), t.elapsed());
+            }
+            if let Some(t) = stage_t0 {
+                log_kokoro_profile(&format!("generator.stage.{i}.total"), t.elapsed());
+            }
         }
         if profile {
             log_kokoro_profile("generator.neural_upsample", t1.elapsed());

--- a/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
@@ -559,9 +559,31 @@ impl KokoroIstftGenerator {
             return self.run_stage_branches_parallel_cpu(i, x, har, style);
         }
 
+        let profile = kokoro_profile_enabled();
+        let t0 = if profile { Some(Instant::now()) } else { None };
         let mut x_source = self.noise_convs[i].forward(har).map_err(Error::from)?;
+        if let Some(t) = t0 {
+            sync_kokoro_profile_tensor(&x_source);
+            log_kokoro_profile(
+                &format!("generator.stage.{i}.branch.source_conv"),
+                t.elapsed(),
+            );
+        }
+        let t1 = if profile { Some(Instant::now()) } else { None };
         x_source = self.noise_res[i].forward(&x_source, style)?;
+        if let Some(t) = t1 {
+            sync_kokoro_profile_tensor(&x_source);
+            log_kokoro_profile(
+                &format!("generator.stage.{i}.branch.source_res"),
+                t.elapsed(),
+            );
+        }
+        let t2 = if profile { Some(Instant::now()) } else { None };
         let x_up = self.ups[i].forward(x).map_err(Error::from)?;
+        if let Some(t) = t2 {
+            sync_kokoro_profile_tensor(&x_up);
+            log_kokoro_profile(&format!("generator.stage.{i}.branch.upsample"), t.elapsed());
+        }
         Ok((x_up, x_source))
     }
 

--- a/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use candle_core::{DType, Tensor};
+use candle_core::{CpuStorage, CustomOp2, DType, Layout, Result as CandleResult, Shape, Tensor};
 use candle_nn::{
     ops, Conv1d, Conv1dConfig, ConvTranspose1d, ConvTranspose1dConfig, Module, VarBuilder,
 };
@@ -13,6 +13,7 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use rand_distr::Distribution;
 use rand_distr::StandardNormal;
+use rayon::prelude::*;
 use rustfft::num_complex::Complex32;
 use rustfft::{Fft, FftPlanner};
 
@@ -399,10 +400,11 @@ impl KokoroIstftGenerator {
             }
             x = x_up;
             let t_stage_add = if profile { Some(Instant::now()) } else { None };
-            if i + 1 == self.num_upsamples {
-                x = reflection_pad_left1(&x)?;
-            }
-            x = match_time_add(&x, &x_source)?;
+            x = if i + 1 == self.num_upsamples {
+                reflection_pad_left1_match_time_add(&x, &x_source)?
+            } else {
+                match_time_add(&x, &x_source)?
+            };
             if let Some(t) = t_stage_add {
                 log_kokoro_profile(&format!("generator.stage.{i}.pad_add"), t.elapsed());
             }
@@ -940,6 +942,106 @@ fn reflection_pad_left1(x: &Tensor) -> Result<Tensor> {
     Tensor::cat(&[left, x.clone()], 2).map_err(Error::from)
 }
 
+fn reflection_pad_left1_match_time_add(a: &Tensor, b: &Tensor) -> Result<Tensor> {
+    if a.device().is_cpu() {
+        if let Ok(out) = a.apply_op2_no_bwd(b, &ReflectionPadLeft1AddCpuOp) {
+            return Ok(out);
+        }
+    }
+    let padded = reflection_pad_left1(a)?;
+    match_time_add(&padded, b)
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ReflectionPadLeft1AddCpuOp;
+
+impl CustomOp2 for ReflectionPadLeft1AddCpuOp {
+    fn name(&self) -> &'static str {
+        "kokoro-reflection-pad-left1-add-cpu"
+    }
+
+    fn cpu_fwd(
+        &self,
+        a_storage: &CpuStorage,
+        a_layout: &Layout,
+        b_storage: &CpuStorage,
+        b_layout: &Layout,
+    ) -> CandleResult<(CpuStorage, Shape)> {
+        let a = match a_storage {
+            CpuStorage::F32(values) => values,
+            _ => candle_core::bail!("kokoro-reflection-pad-left1-add-cpu only supports F32 lhs"),
+        };
+        let b = match b_storage {
+            CpuStorage::F32(values) => values,
+            _ => candle_core::bail!("kokoro-reflection-pad-left1-add-cpu only supports F32 rhs"),
+        };
+        let a = match a_layout.contiguous_offsets() {
+            Some((start, end)) => &a[start..end],
+            None => {
+                candle_core::bail!("kokoro-reflection-pad-left1-add-cpu requires contiguous lhs")
+            }
+        };
+        let b = match b_layout.contiguous_offsets() {
+            Some((start, end)) => &b[start..end],
+            None => {
+                candle_core::bail!("kokoro-reflection-pad-left1-add-cpu requires contiguous rhs")
+            }
+        };
+
+        let a_dims = a_layout.shape().dims();
+        let b_dims = b_layout.shape().dims();
+        if a_dims.len() != 3 || b_dims.len() != 3 {
+            candle_core::bail!("kokoro-reflection-pad-left1-add-cpu expects [B,C,T] tensors")
+        }
+        let batch = a_dims[0];
+        let channels = a_dims[1];
+        let a_time = a_dims[2];
+        let b_time = b_dims[2];
+        if b_dims[0] != batch || b_dims[1] != channels {
+            candle_core::bail!(
+                "kokoro-reflection-pad-left1-add-cpu shape mismatch {:?} vs {:?}",
+                a_dims,
+                b_dims
+            )
+        }
+        if a_time < 2 {
+            candle_core::bail!("kokoro-reflection-pad-left1-add-cpu requires lhs time >= 2")
+        }
+        let out_time = (a_time + 1).min(b_time);
+        if out_time == 0 {
+            candle_core::bail!("kokoro-reflection-pad-left1-add-cpu requires non-empty output")
+        }
+        let expected_a = batch * channels * a_time;
+        let expected_b = batch * channels * b_time;
+        if a.len() != expected_a || b.len() != expected_b {
+            candle_core::bail!(
+                "kokoro-reflection-pad-left1-add-cpu storage length mismatch: lhs={}, rhs={}, expected lhs={}, rhs={}",
+                a.len(),
+                b.len(),
+                expected_a,
+                expected_b
+            )
+        }
+
+        let mut out = vec![0.0f32; batch * channels * out_time];
+        out.par_chunks_mut(out_time)
+            .enumerate()
+            .for_each(|(row, out_row)| {
+                let a_base = row * a_time;
+                let b_base = row * b_time;
+                for t in 0..out_time {
+                    let a_t = if t == 0 { 1 } else { t - 1 };
+                    out_row[t] = a[a_base + a_t] + b[b_base + t];
+                }
+            });
+
+        Ok((
+            CpuStorage::F32(out),
+            Shape::from((batch, channels, out_time)),
+        ))
+    }
+}
+
 fn match_time_add(a: &Tensor, b: &Tensor) -> Result<Tensor> {
     let (ba, ca, ta) = a.dims3().map_err(Error::from)?;
     let (bb, cb, tb) = b.dims3().map_err(Error::from)?;
@@ -1194,6 +1296,32 @@ mod tests {
         let down = linear_resample_time_time_major(&input, 8, 2, 3);
         let up = linear_resample_time_time_major(&down, 2, 8, 3);
         assert!(up.iter().all(|v| (*v - 1.25).abs() < 1e-5));
+    }
+
+    #[test]
+    fn kokoro_reflection_pad_left1_add_cpu_matches_expression() {
+        let device = candle_core::Device::Cpu;
+        let a_values = (0..2 * 3 * 4).map(|v| v as f32 * 0.25).collect::<Vec<_>>();
+        let b_values = (0..2 * 3 * 5)
+            .map(|v| 10.0 + v as f32 * 0.5)
+            .collect::<Vec<_>>();
+        let a = Tensor::from_vec(a_values, (2, 3, 4), &device).expect("lhs");
+        let b = Tensor::from_vec(b_values, (2, 3, 5), &device).expect("rhs");
+
+        let reference = match_time_add(&reflection_pad_left1(&a).expect("pad"), &b)
+            .expect("reference")
+            .flatten_all()
+            .expect("flatten reference")
+            .to_vec1::<f32>()
+            .expect("reference values");
+        let fused = reflection_pad_left1_match_time_add(&a, &b)
+            .expect("fused")
+            .flatten_all()
+            .expect("flatten fused")
+            .to_vec1::<f32>()
+            .expect("fused values");
+
+        assert_eq!(fused, reference);
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use candle_core::{CpuStorage, CustomOp2, DType, Layout, Result as CandleResult, Shape, Tensor};
+use candle_core::{DType, Tensor};
 use candle_nn::{
     ops, Conv1d, Conv1dConfig, ConvTranspose1d, ConvTranspose1dConfig, Module, VarBuilder,
 };
@@ -625,11 +625,9 @@ impl AdaInResBlock1 {
     fn forward(&self, x: &Tensor, style: &Tensor) -> Result<Tensor> {
         let mut x = x.clone();
         for j in 0..3 {
-            let mut xt = self.adain1[j].forward(&x, style)?;
-            xt = snake1d(&xt, &self.alpha1[j])?;
+            let mut xt = self.adain1[j].forward_snake(&x, style, &self.alpha1[j])?;
             xt = self.convs1[j].forward(&xt).map_err(Error::from)?;
-            xt = self.adain2[j].forward(&xt, style)?;
-            xt = snake1d(&xt, &self.alpha2[j])?;
+            xt = self.adain2[j].forward_snake(&xt, style, &self.alpha2[j])?;
             xt = self.convs2[j].forward(&xt).map_err(Error::from)?;
             x = (xt + x).map_err(Error::from)?;
         }
@@ -791,93 +789,6 @@ fn get_padding(kernel_size: usize, dilation: usize) -> usize {
         .saturating_mul(dilation)
         .saturating_sub(dilation))
         / 2
-}
-
-#[derive(Debug, Clone, Copy)]
-struct Snake1dCpuOp;
-
-impl CustomOp2 for Snake1dCpuOp {
-    fn name(&self) -> &'static str {
-        "kokoro-snake1d-cpu"
-    }
-
-    fn cpu_fwd(
-        &self,
-        x_storage: &CpuStorage,
-        x_layout: &Layout,
-        alpha_storage: &CpuStorage,
-        alpha_layout: &Layout,
-    ) -> CandleResult<(CpuStorage, Shape)> {
-        let x = match x_storage {
-            CpuStorage::F32(values) => values,
-            _ => candle_core::bail!("kokoro-snake1d-cpu only supports F32 input"),
-        };
-        let alpha = match alpha_storage {
-            CpuStorage::F32(values) => values,
-            _ => candle_core::bail!("kokoro-snake1d-cpu only supports F32 alpha"),
-        };
-        let x = match x_layout.contiguous_offsets() {
-            Some((start, end)) => &x[start..end],
-            None => candle_core::bail!("kokoro-snake1d-cpu requires contiguous input"),
-        };
-        let alpha = match alpha_layout.contiguous_offsets() {
-            Some((start, end)) => &alpha[start..end],
-            None => candle_core::bail!("kokoro-snake1d-cpu requires contiguous alpha"),
-        };
-
-        let dims = x_layout.shape().dims();
-        if dims.len() != 3 {
-            candle_core::bail!("kokoro-snake1d-cpu expects [B,C,T] input")
-        }
-        let batch = dims[0];
-        let channels = dims[1];
-        let time = dims[2];
-        let alpha_dims = alpha_layout.shape().dims();
-        let alpha_by_channel = match alpha_dims {
-            [1] => false,
-            [c] if *c == channels => true,
-            [1, c, 1] if *c == channels => true,
-            [c, 1] if *c == channels => true,
-            _ => candle_core::bail!(
-                "kokoro-snake1d-cpu alpha shape {:?} cannot broadcast to {:?}",
-                alpha_dims,
-                dims
-            ),
-        };
-        if !alpha_by_channel && alpha.len() != 1 {
-            candle_core::bail!("kokoro-snake1d-cpu scalar alpha has invalid storage length")
-        }
-
-        let mut out = vec![0.0f32; x.len()];
-        for b in 0..batch {
-            for c in 0..channels {
-                let a = if alpha_by_channel { alpha[c] } else { alpha[0] };
-                for t in 0..time {
-                    let idx = (b * channels + c) * time + t;
-                    let v = x[idx];
-                    let s = (v * a).sin();
-                    out[idx] = v + (s * s) / a;
-                }
-            }
-        }
-        Ok((CpuStorage::F32(out), x_layout.shape().clone()))
-    }
-}
-
-fn snake1d(x: &Tensor, alpha: &Tensor) -> Result<Tensor> {
-    if x.device().is_cpu() && x.dtype() == DType::F32 && alpha.dtype() == DType::F32 {
-        if let Ok(out) = x.apply_op2_no_bwd(alpha, &Snake1dCpuOp) {
-            return Ok(out);
-        }
-    }
-    snake1d_candle(x, alpha)
-}
-
-fn snake1d_candle(x: &Tensor, alpha: &Tensor) -> Result<Tensor> {
-    let ax = x.broadcast_mul(alpha).map_err(Error::from)?;
-    let sin_sq = ax.sin().map_err(Error::from)?.sqr().map_err(Error::from)?;
-    let scaled = sin_sq.broadcast_div(alpha).map_err(Error::from)?;
-    x.broadcast_add(&scaled).map_err(Error::from)
 }
 
 fn upsample_nearest_1d(x: &Tensor, factor: usize) -> Result<Tensor> {
@@ -1123,36 +1034,6 @@ mod tests {
         assert_eq!(y[0], 1.0);
         assert_eq!(y[4], 2.0);
         assert_eq!(y[8], 3.0);
-    }
-
-    #[test]
-    fn kokoro_snake1d_cpu_matches_candle_expression() {
-        let device = candle_core::Device::Cpu;
-        let x = Tensor::from_vec(
-            vec![-0.4f32, 0.0, 0.25, 0.7, -1.2, 0.3, 0.9, 1.4],
-            (1, 2, 4),
-            &device,
-        )
-        .expect("x tensor");
-        let alpha = Tensor::from_vec(vec![0.7f32, 1.3], (1, 2, 1), &device).expect("alpha tensor");
-
-        let fused = snake1d(&x, &alpha)
-            .expect("fused snake")
-            .flatten_all()
-            .expect("flatten fused")
-            .to_vec1::<f32>()
-            .expect("fused values");
-        let reference = snake1d_candle(&x, &alpha)
-            .expect("reference snake")
-            .flatten_all()
-            .expect("flatten reference")
-            .to_vec1::<f32>()
-            .expect("reference values");
-
-        assert_eq!(fused.len(), reference.len());
-        for (got, expected) in fused.iter().zip(reference.iter()) {
-            assert!((got - expected).abs() < 1e-6, "{got} != {expected}");
-        }
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
@@ -125,6 +125,16 @@ fn kokoro_cpu_stage_branches_parallel_enabled() -> bool {
     }
 }
 
+fn kokoro_metal_harmonic_overlap_enabled() -> bool {
+    match std::env::var("IZWI_KOKORO_METAL_HARMONIC_OVERLAP") {
+        Ok(value) => !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "serial" | "sequential"
+        ),
+        Err(_) => true,
+    }
+}
+
 #[derive(Debug)]
 pub struct KokoroDecoder {
     f0_conv: Conv1d,
@@ -217,49 +227,81 @@ impl KokoroDecoder {
         style: &Tensor,    // [B, 128]
         rng_seed: Option<u64>,
     ) -> Result<Vec<f32>> {
-        let profile = kokoro_profile_enabled();
-        let t0 = Instant::now();
-        let f0 = self
-            .f0_conv
-            .forward(&f0_curve.unsqueeze(1).map_err(Error::from)?)
-            .map_err(Error::from)?;
-        let n = self
-            .n_conv
-            .forward(&n_curve.unsqueeze(1).map_err(Error::from)?)
-            .map_err(Error::from)?;
-        if profile {
-            log_kokoro_profile("decoder.f0n_conv", t0.elapsed());
-        }
+        thread::scope(|scope| {
+            let profile = kokoro_profile_enabled();
+            let t0 = Instant::now();
+            let overlap_harmonic =
+                asr.device().is_metal() && kokoro_metal_harmonic_overlap_enabled();
+            let harmonic_handle = if overlap_harmonic {
+                let generator = &self.generator;
+                Some(scope.spawn(move || {
+                    generator
+                        .harmonic_features(f0_curve, f0_curve.device(), rng_seed)
+                        .map_err(|e| e.to_string())
+                }))
+            } else {
+                None
+            };
 
-        let t1 = Instant::now();
-        let x = Tensor::cat(&[asr.clone(), f0.clone(), n.clone()], 1).map_err(Error::from)?;
-        let mut x = self.encode.forward(&x, style)?;
-        let asr_res = self.asr_res.forward(asr).map_err(Error::from)?;
-
-        let mut still_concat_res = true;
-        for block in &self.decode {
-            if still_concat_res {
-                x = Tensor::cat(&[x, asr_res.clone(), f0.clone(), n.clone()], 1)
-                    .map_err(Error::from)?;
+            let f0 = self
+                .f0_conv
+                .forward(&f0_curve.unsqueeze(1).map_err(Error::from)?)
+                .map_err(Error::from)?;
+            let n = self
+                .n_conv
+                .forward(&n_curve.unsqueeze(1).map_err(Error::from)?)
+                .map_err(Error::from)?;
+            if profile {
+                log_kokoro_profile("decoder.f0n_conv", t0.elapsed());
             }
-            x = block.forward(&x, style)?;
-            let (_b, _c, t) = x.dims3().map_err(Error::from)?;
-            let (_, _, asr_t) = asr_res.dims3().map_err(Error::from)?;
-            if t > asr_t {
-                still_concat_res = false;
-            }
-        }
-        if profile {
-            log_kokoro_profile("decoder.encode_decode_blocks", t1.elapsed());
-        }
 
-        let t2 = Instant::now();
-        let out = self.generator.forward(&x, style, f0_curve, rng_seed)?;
-        if profile {
-            log_kokoro_profile("decoder.generator_total", t2.elapsed());
-            log_kokoro_profile("decoder.total", t0.elapsed());
-        }
-        Ok(out)
+            let t1 = Instant::now();
+            let x = Tensor::cat(&[asr.clone(), f0.clone(), n.clone()], 1).map_err(Error::from)?;
+            let mut x = self.encode.forward(&x, style)?;
+            let asr_res = self.asr_res.forward(asr).map_err(Error::from)?;
+
+            let mut still_concat_res = true;
+            for block in &self.decode {
+                if still_concat_res {
+                    x = Tensor::cat(&[x, asr_res.clone(), f0.clone(), n.clone()], 1)
+                        .map_err(Error::from)?;
+                }
+                x = block.forward(&x, style)?;
+                let (_b, _c, t) = x.dims3().map_err(Error::from)?;
+                let (_, _, asr_t) = asr_res.dims3().map_err(Error::from)?;
+                if t > asr_t {
+                    still_concat_res = false;
+                }
+            }
+            if profile {
+                log_kokoro_profile("decoder.encode_decode_blocks", t1.elapsed());
+            }
+
+            let t2 = Instant::now();
+            let out = if let Some(handle) = harmonic_handle {
+                let t_join = if profile { Some(Instant::now()) } else { None };
+                let har = match handle.join() {
+                    Ok(Ok(t)) => t,
+                    Ok(Err(msg)) => return Err(Error::InferenceError(msg)),
+                    Err(_) => {
+                        return Err(Error::InferenceError(
+                            "Kokoro harmonic feature worker thread panicked".to_string(),
+                        ))
+                    }
+                };
+                if let Some(t) = t_join {
+                    log_kokoro_profile("decoder.harmonic_overlap_join", t.elapsed());
+                }
+                self.generator.forward_with_harmonic(&x, style, &har)?
+            } else {
+                self.generator.forward(&x, style, f0_curve, rng_seed)?
+            };
+            if profile {
+                log_kokoro_profile("decoder.generator_total", t2.elapsed());
+                log_kokoro_profile("decoder.total", t0.elapsed());
+            }
+            Ok(out)
+        })
     }
 }
 
@@ -450,7 +492,15 @@ impl KokoroIstftGenerator {
         if profile {
             log_kokoro_profile("generator.harmonic_features", t0.elapsed());
         }
+        let out = self.forward_with_harmonic(x, style, &har)?;
+        if profile {
+            log_kokoro_profile("generator.total", t0.elapsed());
+        }
+        Ok(out)
+    }
 
+    fn forward_with_harmonic(&self, x: &Tensor, style: &Tensor, har: &Tensor) -> Result<Vec<f32>> {
+        let profile = kokoro_profile_enabled();
         let t1 = Instant::now();
         let mut x = x.clone();
         for i in 0..self.num_upsamples {
@@ -535,7 +585,6 @@ impl KokoroIstftGenerator {
         self.stft.inverse(&spec, &phase).inspect(|_| {
             if profile {
                 log_kokoro_profile("generator.istft_inverse", t3.elapsed());
-                log_kokoro_profile("generator.total", t0.elapsed());
             }
         })
     }

--- a/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
@@ -31,8 +31,8 @@ use crate::error::{Error, Result};
 
 use super::config::{KokoroConfig, KokoroIstftNetConfig};
 use super::prosody::{
-    load_plain_conv1d, load_weight_norm_conv1d, load_weight_norm_conv_transpose1d, AdaIN1d,
-    AdainResBlk1d,
+    load_plain_conv1d, load_weight_norm_conv1d, load_weight_norm_conv1d_no_bias,
+    load_weight_norm_conv_transpose1d, AdaIN1d, AdainResBlk1d,
 };
 
 #[cfg(feature = "metal")]
@@ -1009,7 +1009,7 @@ impl AdaInResBlock1 {
         let mut alpha2 = Vec::with_capacity(3);
         for j in 0..3 {
             let d1 = dilations[j];
-            convs1.push(load_weight_norm_conv1d(
+            convs1.push(load_weight_norm_conv1d_no_bias(
                 vb.pp(format!("convs1.{j}")),
                 Conv1dConfig {
                     padding: get_padding(kernel_size, d1),

--- a/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
@@ -37,6 +37,18 @@ fn log_kokoro_profile(stage: &str, dur: Duration) {
     }
 }
 
+fn kokoro_cpu_resblocks_parallel_enabled() -> bool {
+    match std::env::var("IZWI_KOKORO_CPU_RESBLOCKS") {
+        Ok(value) => {
+            !matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "0" | "false" | "off" | "serial" | "sequential"
+            )
+        }
+        Err(_) => true,
+    }
+}
+
 #[derive(Debug)]
 pub struct KokoroDecoder {
     f0_conv: Conv1d,
@@ -483,7 +495,10 @@ impl KokoroIstftGenerator {
     }
 
     fn run_stage_resblocks(&self, base: usize, x: &Tensor, style: &Tensor) -> Result<Tensor> {
-        if x.device().is_cpu() && self.num_kernels > 1 {
+        if x.device().is_cpu()
+            && self.num_kernels > 1
+            && kokoro_cpu_resblocks_parallel_enabled()
+        {
             return self.run_stage_resblocks_parallel_cpu(base, x, style);
         }
         let mut xs = self.resblocks[base].forward(x, style)?;

--- a/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
@@ -549,6 +549,7 @@ impl KokoroIstftGenerator {
         har: &Tensor,
         style: &Tensor,
     ) -> Result<(Tensor, Tensor)> {
+        let profile = kokoro_profile_enabled();
         thread::scope(|scope| {
             let noise_conv = &self.noise_convs[i];
             let noise_res = &self.noise_res[i];
@@ -558,16 +559,39 @@ impl KokoroIstftGenerator {
             let x = x.clone();
 
             let source_handle = scope.spawn(move || {
+                let t0 = if profile { Some(Instant::now()) } else { None };
                 let mut x_source = noise_conv.forward(&har).map_err(|e| e.to_string())?;
+                if let Some(t) = t0 {
+                    log_kokoro_profile(
+                        &format!("generator.stage.{i}.branch.source_conv"),
+                        t.elapsed(),
+                    );
+                }
+                let t1 = if profile { Some(Instant::now()) } else { None };
                 x_source = noise_res
                     .forward(&x_source, &style)
                     .map_err(|e| e.to_string())?;
+                if let Some(t) = t1 {
+                    log_kokoro_profile(
+                        &format!("generator.stage.{i}.branch.source_res"),
+                        t.elapsed(),
+                    );
+                }
                 Ok::<Tensor, String>(x_source)
             });
             let up_handle = scope.spawn(move || {
-                up.forward(&x)
+                let t0 = if profile { Some(Instant::now()) } else { None };
+                let out = up
+                    .forward(&x)
                     .map_err(Error::from)
-                    .map_err(|e| e.to_string())
+                    .map_err(|e| e.to_string());
+                if let Some(t) = t0 {
+                    log_kokoro_profile(
+                        &format!("generator.stage.{i}.branch.upsample"),
+                        t.elapsed(),
+                    );
+                }
+                out
             });
 
             let x_source = match source_handle.join() {

--- a/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/decoder.rs
@@ -1,10 +1,20 @@
+#[cfg(feature = "metal")]
+use std::collections::HashMap;
 use std::f32::consts::PI;
 use std::fmt;
 use std::sync::Arc;
+#[cfg(feature = "metal")]
+use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
+#[cfg(feature = "metal")]
+use candle_core::CustomOp3;
+#[cfg(feature = "metal")]
+use candle_core::{backend::BackendStorage, MetalStorage};
 use candle_core::{CpuStorage, CustomOp2, DType, Layout, Result as CandleResult, Shape, Tensor};
+#[cfg(feature = "metal")]
+use candle_metal_kernels::metal::{ComputePipeline, Device as MetalDevice};
 use candle_nn::{
     ops, Conv1d, Conv1dConfig, ConvTranspose1d, ConvTranspose1dConfig, Module, VarBuilder,
 };
@@ -24,6 +34,53 @@ use super::prosody::{
     load_plain_conv1d, load_weight_norm_conv1d, load_weight_norm_conv_transpose1d, AdaIN1d,
     AdainResBlk1d,
 };
+
+#[cfg(feature = "metal")]
+const KOKORO_DECODER_METAL_SOURCE: &str = r#"
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void kokoro_conv_transpose1d_stride_f32(
+    device const float* input [[buffer(0)]],
+    device const float* weight [[buffer(1)]],
+    device const float* bias [[buffer(2)]],
+    device float* output [[buffer(3)]],
+    constant uint& batch [[buffer(4)]],
+    constant uint& c_in [[buffer(5)]],
+    constant uint& c_out [[buffer(6)]],
+    constant uint& l_in [[buffer(7)]],
+    constant uint& l_out [[buffer(8)]],
+    constant uint& k_size [[buffer(9)]],
+    constant uint& stride [[buffer(10)]],
+    constant uint& padding [[buffer(11)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    const uint total = batch * c_out * l_out;
+    if (gid >= total) {
+        return;
+    }
+
+    const uint out_t = gid % l_out;
+    const uint out_c = (gid / l_out) % c_out;
+    const uint b = gid / (l_out * c_out);
+    const uint padded_t = out_t + padding;
+    const uint first_k = padded_t % stride;
+
+    float acc = bias[out_c];
+    for (uint in_c = 0; in_c < c_in; ++in_c) {
+        const uint input_base = (b * c_in + in_c) * l_in;
+        const uint weight_base = (in_c * c_out + out_c) * k_size;
+        for (uint k = first_k; k < k_size; k += stride) {
+            const uint numerator = padded_t - k;
+            const uint in_t = numerator / stride;
+            if (in_t < l_in) {
+                acc += input[input_base + in_t] * weight[weight_base + k];
+            }
+        }
+    }
+    output[gid] = acc;
+}
+"#;
 
 fn kokoro_profile_enabled() -> bool {
     std::env::var_os("IZWI_KOKORO_PROFILE").is_some()
@@ -579,7 +636,7 @@ impl KokoroIstftGenerator {
             );
         }
         let t2 = if profile { Some(Instant::now()) } else { None };
-        let x_up = self.ups[i].forward(x).map_err(Error::from)?;
+        let x_up = kokoro_upsample_conv_transpose1d(&self.ups[i], x)?;
         if let Some(t) = t2 {
             sync_kokoro_profile_tensor(&x_up);
             log_kokoro_profile(&format!("generator.stage.{i}.branch.upsample"), t.elapsed());
@@ -709,6 +766,215 @@ impl KokoroIstftGenerator {
         }
         Ok(acc)
     }
+}
+
+fn kokoro_upsample_conv_transpose1d(up: &ConvTranspose1d, x: &Tensor) -> Result<Tensor> {
+    #[cfg(feature = "metal")]
+    {
+        let cfg = *up.config();
+        if x.device().is_metal()
+            && x.dtype() == DType::F32
+            && cfg.groups == 1
+            && cfg.dilation == 1
+            && cfg.output_padding == 0
+            && matches!((cfg.stride, cfg.padding), (10, 5) | (6, 3))
+        {
+            if let Some(bias) = up.bias() {
+                let op = KokoroConvTranspose1dStrideMetalOp {
+                    stride: cfg.stride,
+                    padding: cfg.padding,
+                };
+                if let Ok(out) = x.apply_op3_no_bwd(up.weight(), bias, &op) {
+                    return Ok(out);
+                }
+            }
+        }
+    }
+
+    up.forward(x).map_err(Error::from)
+}
+
+#[cfg(feature = "metal")]
+#[derive(Debug, Clone, Copy)]
+struct KokoroConvTranspose1dStrideMetalOp {
+    stride: usize,
+    padding: usize,
+}
+
+#[cfg(feature = "metal")]
+impl CustomOp3 for KokoroConvTranspose1dStrideMetalOp {
+    fn name(&self) -> &'static str {
+        "kokoro-conv-transpose1d-stride-metal"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _s1: &CpuStorage,
+        _l1: &Layout,
+        _s2: &CpuStorage,
+        _l2: &Layout,
+        _s3: &CpuStorage,
+        _l3: &Layout,
+    ) -> CandleResult<(CpuStorage, Shape)> {
+        candle_core::bail!("kokoro-conv-transpose1d-stride-metal requires Metal tensors")
+    }
+
+    fn metal_fwd(
+        &self,
+        input_storage: &MetalStorage,
+        input_layout: &Layout,
+        weight_storage: &MetalStorage,
+        weight_layout: &Layout,
+        bias_storage: &MetalStorage,
+        bias_layout: &Layout,
+    ) -> CandleResult<(MetalStorage, Shape)> {
+        if input_storage.dtype() != DType::F32
+            || weight_storage.dtype() != DType::F32
+            || bias_storage.dtype() != DType::F32
+        {
+            candle_core::bail!("kokoro-conv-transpose1d-stride-metal only supports F32 tensors")
+        }
+        if !input_layout.is_contiguous()
+            || !weight_layout.is_contiguous()
+            || !bias_layout.is_contiguous()
+        {
+            candle_core::bail!("kokoro-conv-transpose1d-stride-metal requires contiguous tensors")
+        }
+        let input_dims = input_layout.shape().dims();
+        let weight_dims = weight_layout.shape().dims();
+        let bias_dims = bias_layout.shape().dims();
+        if input_dims.len() != 3 || weight_dims.len() != 3 {
+            candle_core::bail!("kokoro-conv-transpose1d-stride-metal expects rank-3 tensors")
+        }
+        let batch = input_dims[0];
+        let c_in = input_dims[1];
+        let l_in = input_dims[2];
+        let weight_c_in = weight_dims[0];
+        let c_out = weight_dims[1];
+        let k_size = weight_dims[2];
+        if weight_c_in != c_in {
+            candle_core::bail!(
+                "kokoro-conv-transpose1d-stride-metal channel mismatch: input={c_in}, weight={weight_c_in}"
+            )
+        }
+        match bias_dims {
+            [b] if *b == c_out => {}
+            other => candle_core::bail!(
+                "kokoro-conv-transpose1d-stride-metal bias shape {:?} does not match c_out={c_out}",
+                other
+            ),
+        }
+        if !matches!(
+            (self.stride, self.padding, k_size),
+            (10, 5, 20) | (6, 3, 12)
+        ) {
+            candle_core::bail!(
+                "kokoro-conv-transpose1d-stride-metal unsupported stride/padding/kernel: {}/{}/{}",
+                self.stride,
+                self.padding,
+                k_size
+            )
+        }
+        let l_out = (l_in - 1)
+            .saturating_mul(self.stride)
+            .saturating_sub(2 * self.padding)
+            .saturating_add(k_size);
+        let elem_count = batch.saturating_mul(c_out).saturating_mul(l_out);
+        if elem_count > u32::MAX as usize
+            || batch > u32::MAX as usize
+            || c_in > u32::MAX as usize
+            || c_out > u32::MAX as usize
+            || l_in > u32::MAX as usize
+            || l_out > u32::MAX as usize
+            || k_size > u32::MAX as usize
+        {
+            candle_core::bail!("kokoro-conv-transpose1d-stride-metal tensor is too large")
+        }
+
+        let device = input_storage.device().clone();
+        let output = device.new_buffer(elem_count, DType::F32, "kokoro-conv-transpose1d")?;
+        let encoder = device.command_encoder()?;
+        encoder.set_label("kokoro-conv-transpose1d");
+        let pipeline = kokoro_conv_transpose1d_stride_pipeline(device.metal_device())?;
+        encoder.set_compute_pipeline_state(&pipeline);
+
+        encoder.set_buffer(
+            0,
+            Some(input_storage.buffer()),
+            input_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_buffer(
+            1,
+            Some(weight_storage.buffer()),
+            weight_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_buffer(
+            2,
+            Some(bias_storage.buffer()),
+            bias_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_buffer(3, Some(&output), 0);
+        encoder.set_bytes(4, &(batch as u32));
+        encoder.set_bytes(5, &(c_in as u32));
+        encoder.set_bytes(6, &(c_out as u32));
+        encoder.set_bytes(7, &(l_in as u32));
+        encoder.set_bytes(8, &(l_out as u32));
+        encoder.set_bytes(9, &(k_size as u32));
+        encoder.set_bytes(10, &(self.stride as u32));
+        encoder.set_bytes(11, &(self.padding as u32));
+
+        let threads_per_threadgroup = pipeline.max_total_threads_per_threadgroup().min(256).max(1);
+        encoder.dispatch_threads(
+            objc2_metal::MTLSize {
+                width: elem_count,
+                height: 1,
+                depth: 1,
+            },
+            objc2_metal::MTLSize {
+                width: threads_per_threadgroup,
+                height: 1,
+                depth: 1,
+            },
+        );
+
+        Ok((
+            MetalStorage::new(output, device, elem_count, DType::F32),
+            Shape::from((batch, c_out, l_out)),
+        ))
+    }
+}
+
+#[cfg(feature = "metal")]
+fn kokoro_conv_transpose1d_stride_pipeline(device: &MetalDevice) -> CandleResult<ComputePipeline> {
+    static PIPELINES: OnceLock<Mutex<HashMap<u64, ComputePipeline>>> = OnceLock::new();
+    let registry_id = device.registry_id();
+    let pipelines = PIPELINES.get_or_init(|| Mutex::new(HashMap::new()));
+
+    if let Some(pipeline) = pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .get(&registry_id)
+        .cloned()
+    {
+        return Ok(pipeline);
+    }
+
+    let library = device
+        .new_library_with_source(KOKORO_DECODER_METAL_SOURCE, None)
+        .map_err(candle_core::Error::wrap)?;
+    let function = library
+        .get_function("kokoro_conv_transpose1d_stride_f32", None)
+        .map_err(candle_core::Error::wrap)?;
+    let pipeline = device
+        .new_compute_pipeline_state_with_function(&function)
+        .map_err(candle_core::Error::wrap)?;
+
+    pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .insert(registry_id, pipeline.clone());
+
+    Ok(pipeline)
 }
 
 #[derive(Debug)]

--- a/crates/izwi-core/src/models/architectures/kokoro/mod.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/mod.rs
@@ -16,6 +16,7 @@ pub use config::KokoroConfig;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::thread;
 use std::time::{Duration, Instant};
 
 use candle_core::pickle::read_pth_tensor_info;
@@ -54,6 +55,16 @@ fn log_kokoro_profile(stage: &str, dur: Duration) {
             "kokoro profile: {stage} = {:.2} ms",
             dur.as_secs_f64() * 1_000.0
         );
+    }
+}
+
+fn kokoro_cpu_predecoder_parallel_enabled() -> bool {
+    match std::env::var("IZWI_KOKORO_CPU_PREDECODER") {
+        Ok(value) => !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "serial" | "sequential"
+        ),
+        Err(_) => true,
     }
 }
 
@@ -387,6 +398,19 @@ impl KokoroTtsModel {
         prepared: &KokoroPreparedRequest,
     ) -> Result<KokoroProsodyDebugOutput> {
         let input_ids = self.build_model_input_ids(prepared)?;
+        self.run_bert_prosody_debug_for_input(&input_ids, prepared)
+    }
+
+    fn run_bert_prosody(&self, prepared: &KokoroPreparedRequest) -> Result<KokoroProsodyOutput> {
+        let input_ids = self.build_model_input_ids(prepared)?;
+        self.run_bert_prosody_for_input(&input_ids, prepared)
+    }
+
+    fn run_bert_prosody_debug_for_input(
+        &self,
+        input_ids: &Tensor,
+        prepared: &KokoroPreparedRequest,
+    ) -> Result<KokoroProsodyDebugOutput> {
         let bert_hidden = self.bert.forward(&input_ids, None)?;
         let d_en = self
             .bert_encoder
@@ -398,9 +422,12 @@ impl KokoroTtsModel {
             .forward_debug(&d_en, &prepared.ref_style, prepared.speed)
     }
 
-    fn run_bert_prosody(&self, prepared: &KokoroPreparedRequest) -> Result<KokoroProsodyOutput> {
-        let input_ids = self.build_model_input_ids(prepared)?;
-        let bert_hidden = self.bert.forward(&input_ids, None)?;
+    fn run_bert_prosody_for_input(
+        &self,
+        input_ids: &Tensor,
+        prepared: &KokoroPreparedRequest,
+    ) -> Result<KokoroProsodyOutput> {
+        let bert_hidden = self.bert.forward(input_ids, None)?;
         let d_en = self
             .bert_encoder
             .forward(&bert_hidden)
@@ -430,9 +457,8 @@ impl KokoroTtsModel {
 
     fn run_predecoder(&self, prepared: &KokoroPreparedRequest) -> Result<KokoroPredecoderOutput> {
         let input_ids = self.build_model_input_ids(prepared)?;
-        let prosody = self.run_bert_prosody(prepared)?;
+        let (prosody, t_en) = self.run_predecoder_branches(&input_ids, prepared)?;
         let pred_aln = build_alignment_matrix(&prosody.duration_frames, &self.device.device)?;
-        let t_en = self.text_encoder.forward(&input_ids)?;
         let asr = t_en
             .contiguous()
             .map_err(Error::from)?
@@ -443,6 +469,60 @@ impl KokoroTtsModel {
             prosody,
             text_encoder_shape,
             asr,
+        })
+    }
+
+    fn run_predecoder_branches(
+        &self,
+        input_ids: &Tensor,
+        prepared: &KokoroPreparedRequest,
+    ) -> Result<(KokoroProsodyOutput, Tensor)> {
+        if input_ids.device().is_cpu() && kokoro_cpu_predecoder_parallel_enabled() {
+            return self.run_predecoder_branches_parallel_cpu(input_ids, prepared);
+        }
+
+        let prosody = self.run_bert_prosody_for_input(input_ids, prepared)?;
+        let t_en = self.text_encoder.forward(input_ids)?;
+        Ok((prosody, t_en))
+    }
+
+    fn run_predecoder_branches_parallel_cpu(
+        &self,
+        input_ids: &Tensor,
+        prepared: &KokoroPreparedRequest,
+    ) -> Result<(KokoroProsodyOutput, Tensor)> {
+        thread::scope(|scope| {
+            let prosody_handle = scope.spawn(|| {
+                self.run_bert_prosody_for_input(input_ids, prepared)
+                    .map_err(|e| e.to_string())
+            });
+            let text_handle = scope.spawn(|| {
+                self.text_encoder
+                    .forward(input_ids)
+                    .map_err(Error::from)
+                    .map_err(|e| e.to_string())
+            });
+
+            let prosody = match prosody_handle.join() {
+                Ok(Ok(t)) => t,
+                Ok(Err(msg)) => return Err(Error::InferenceError(msg)),
+                Err(_) => {
+                    return Err(Error::InferenceError(
+                        "Kokoro predecoder prosody worker thread panicked".to_string(),
+                    ))
+                }
+            };
+            let t_en = match text_handle.join() {
+                Ok(Ok(t)) => t,
+                Ok(Err(msg)) => return Err(Error::InferenceError(msg)),
+                Err(_) => {
+                    return Err(Error::InferenceError(
+                        "Kokoro predecoder text encoder worker thread panicked".to_string(),
+                    ))
+                }
+            };
+
+            Ok((prosody, t_en))
         })
     }
 

--- a/crates/izwi-core/src/models/architectures/kokoro/mod.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/mod.rs
@@ -387,9 +387,7 @@ impl KokoroTtsModel {
         prepared: &KokoroPreparedRequest,
     ) -> Result<KokoroProsodyDebugOutput> {
         let input_ids = self.build_model_input_ids(prepared)?;
-        let (_b, seq_len) = input_ids.dims2().map_err(Error::from)?;
-        let attention_mask = Tensor::ones((1, seq_len), DType::U32, &self.device.device)?;
-        let bert_hidden = self.bert.forward(&input_ids, Some(&attention_mask))?;
+        let bert_hidden = self.bert.forward(&input_ids, None)?;
         let d_en = self
             .bert_encoder
             .forward(&bert_hidden)
@@ -402,9 +400,7 @@ impl KokoroTtsModel {
 
     fn run_bert_prosody(&self, prepared: &KokoroPreparedRequest) -> Result<KokoroProsodyOutput> {
         let input_ids = self.build_model_input_ids(prepared)?;
-        let (_b, seq_len) = input_ids.dims2().map_err(Error::from)?;
-        let attention_mask = Tensor::ones((1, seq_len), DType::U32, &self.device.device)?;
-        let bert_hidden = self.bert.forward(&input_ids, Some(&attention_mask))?;
+        let bert_hidden = self.bert.forward(&input_ids, None)?;
         let d_en = self
             .bert_encoder
             .forward(&bert_hidden)

--- a/crates/izwi-core/src/models/architectures/kokoro/prosody.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/prosody.rs
@@ -6,6 +6,7 @@ use candle_nn::{
     ops, Conv1d, Conv1dConfig, ConvTranspose1d, ConvTranspose1dConfig, Linear, Module, VarBuilder,
 };
 use candle_nn::{LSTMConfig, RNN};
+use rayon::prelude::*;
 
 use crate::error::{Error, Result};
 
@@ -491,9 +492,12 @@ impl CustomOp3 for AdaIN1dCpuOp {
 
         let mut out = vec![0.0f32; x.len()];
         let denom_scale = (time - 1) as f32;
-        for b in 0..batch {
-            for c in 0..channels {
-                let base = (b * channels + c) * time;
+        out.par_chunks_mut(time)
+            .enumerate()
+            .for_each(|(row, out_row)| {
+                let b = row / channels;
+                let c = row % channels;
+                let base = row * time;
                 let values = &x[base..base + time];
                 let mean = values.iter().copied().sum::<f32>() / time as f32;
                 let var = values
@@ -509,11 +513,10 @@ impl CustomOp3 for AdaIN1dCpuOp {
                 let scale = gamma[affine_idx] + 1.0;
                 let bias = beta[affine_idx];
                 for t in 0..time {
-                    let v = x[base + t];
-                    out[base + t] = (v - mean) * inv_std * scale + bias;
+                    let v = values[t];
+                    out_row[t] = (v - mean) * inv_std * scale + bias;
                 }
-            }
-        }
+            });
         Ok((CpuStorage::F32(out), x_layout.shape().clone()))
     }
 }
@@ -609,10 +612,12 @@ impl CustomOp3 for AdaIN1dSnakeCpuOp {
 
         let mut out = vec![0.0f32; x.len()];
         let denom_scale = (time - 1) as f32;
-        for b in 0..batch {
-            let h_base = b * channels * 2;
-            for c in 0..channels {
-                let base = (b * channels + c) * time;
+        out.par_chunks_mut(time)
+            .enumerate()
+            .for_each(|(row, out_row)| {
+                let b = row / channels;
+                let c = row % channels;
+                let base = row * time;
                 let values = &x[base..base + time];
                 let mean = values.iter().copied().sum::<f32>() / time as f32;
                 let var = values
@@ -624,17 +629,16 @@ impl CustomOp3 for AdaIN1dSnakeCpuOp {
                     .sum::<f32>()
                     / denom_scale;
                 let inv_std = 1.0f32 / (var + self.eps as f32).sqrt();
+                let h_base = b * channels * 2;
                 let scale = h[h_base + c] + 1.0;
                 let bias = h[h_base + channels + c];
                 let alpha = if alpha_by_channel { alpha[c] } else { alpha[0] };
                 for t in 0..time {
-                    let v = x[base + t];
-                    let y = (v - mean) * inv_std * scale + bias;
+                    let y = (values[t] - mean) * inv_std * scale + bias;
                     let s = (y * alpha).sin();
-                    out[base + t] = y + (s * s) / alpha;
+                    out_row[t] = y + (s * s) / alpha;
                 }
-            }
-        }
+            });
         Ok((CpuStorage::F32(out), x_layout.shape().clone()))
     }
 }

--- a/crates/izwi-core/src/models/architectures/kokoro/prosody.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/prosody.rs
@@ -394,6 +394,34 @@ impl AdaIN1d {
             .broadcast_add(&beta)
             .map_err(Error::from)
     }
+
+    pub(crate) fn forward_snake(
+        &self,
+        x: &Tensor,
+        style: &Tensor,
+        alpha: &Tensor,
+    ) -> Result<Tensor> {
+        let (_b, c, _t) = x.dims3().map_err(Error::from)?;
+        if c != self.channels {
+            return Err(Error::InferenceError(format!(
+                "AdaIN1d expected channels {}, got {}",
+                self.channels, c
+            )));
+        }
+        let h = self.fc.forward(style).map_err(Error::from)?;
+        if x.device().is_cpu()
+            && x.dtype() == DType::F32
+            && h.dtype() == DType::F32
+            && alpha.dtype() == DType::F32
+        {
+            if let Ok(out) = x.apply_op3_no_bwd(&h, alpha, &AdaIN1dSnakeCpuOp { eps: self.eps }) {
+                return Ok(out);
+            }
+        }
+
+        let normalized = self.forward(x, style)?;
+        snake1d_expr(&normalized, alpha)
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -504,6 +532,132 @@ fn validate_adain_affine_shape(
             dims
         ),
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AdaIN1dSnakeCpuOp {
+    eps: f64,
+}
+
+impl CustomOp3 for AdaIN1dSnakeCpuOp {
+    fn name(&self) -> &'static str {
+        "kokoro-adain1d-snake-cpu"
+    }
+
+    fn cpu_fwd(
+        &self,
+        x_storage: &CpuStorage,
+        x_layout: &Layout,
+        h_storage: &CpuStorage,
+        h_layout: &Layout,
+        alpha_storage: &CpuStorage,
+        alpha_layout: &Layout,
+    ) -> CandleResult<(CpuStorage, Shape)> {
+        let x = match x_storage {
+            CpuStorage::F32(values) => values,
+            _ => candle_core::bail!("kokoro-adain1d-snake-cpu only supports F32 input"),
+        };
+        let h = match h_storage {
+            CpuStorage::F32(values) => values,
+            _ => candle_core::bail!("kokoro-adain1d-snake-cpu only supports F32 affine"),
+        };
+        let alpha = match alpha_storage {
+            CpuStorage::F32(values) => values,
+            _ => candle_core::bail!("kokoro-adain1d-snake-cpu only supports F32 alpha"),
+        };
+        let x = match x_layout.contiguous_offsets() {
+            Some((start, end)) => &x[start..end],
+            None => candle_core::bail!("kokoro-adain1d-snake-cpu requires contiguous input"),
+        };
+        let h = match h_layout.contiguous_offsets() {
+            Some((start, end)) => &h[start..end],
+            None => candle_core::bail!("kokoro-adain1d-snake-cpu requires contiguous affine"),
+        };
+        let alpha = match alpha_layout.contiguous_offsets() {
+            Some((start, end)) => &alpha[start..end],
+            None => candle_core::bail!("kokoro-adain1d-snake-cpu requires contiguous alpha"),
+        };
+
+        let dims = x_layout.shape().dims();
+        if dims.len() != 3 {
+            candle_core::bail!("kokoro-adain1d-snake-cpu expects [B,C,T] input")
+        }
+        let batch = dims[0];
+        let channels = dims[1];
+        let time = dims[2];
+        if time < 2 {
+            candle_core::bail!("kokoro-adain1d-snake-cpu requires time length >= 2")
+        }
+        match h_layout.shape().dims() {
+            [b, two_c] if *b == batch && *two_c == channels * 2 => {}
+            other => candle_core::bail!(
+                "kokoro-adain1d-snake-cpu affine shape {:?} cannot broadcast to [{batch},{channels},T]",
+                other
+            ),
+        }
+        let alpha_by_channel = validate_snake_alpha_shape(alpha_layout.shape().dims(), channels)?;
+        if alpha_by_channel && alpha.len() != channels {
+            candle_core::bail!(
+                "kokoro-adain1d-snake-cpu alpha storage length {}, expected {}",
+                alpha.len(),
+                channels
+            )
+        }
+        if !alpha_by_channel && alpha.len() != 1 {
+            candle_core::bail!("kokoro-adain1d-snake-cpu scalar alpha has invalid storage length")
+        }
+
+        let mut out = vec![0.0f32; x.len()];
+        let denom_scale = (time - 1) as f32;
+        for b in 0..batch {
+            let h_base = b * channels * 2;
+            for c in 0..channels {
+                let base = (b * channels + c) * time;
+                let values = &x[base..base + time];
+                let mean = values.iter().copied().sum::<f32>() / time as f32;
+                let var = values
+                    .iter()
+                    .map(|v| {
+                        let d = *v - mean;
+                        d * d
+                    })
+                    .sum::<f32>()
+                    / denom_scale;
+                let inv_std = 1.0f32 / (var + self.eps as f32).sqrt();
+                let scale = h[h_base + c] + 1.0;
+                let bias = h[h_base + channels + c];
+                let alpha = if alpha_by_channel { alpha[c] } else { alpha[0] };
+                for t in 0..time {
+                    let v = x[base + t];
+                    let y = (v - mean) * inv_std * scale + bias;
+                    let s = (y * alpha).sin();
+                    out[base + t] = y + (s * s) / alpha;
+                }
+            }
+        }
+        Ok((CpuStorage::F32(out), x_layout.shape().clone()))
+    }
+}
+
+fn validate_snake_alpha_shape(dims: &[usize], channels: usize) -> CandleResult<bool> {
+    match dims {
+        [1] => Ok(false),
+        [c] if *c == channels => Ok(true),
+        [1, c, 1] if *c == channels => Ok(true),
+        [c, 1] if *c == channels => Ok(true),
+        _ => candle_core::bail!(
+            "kokoro-adain1d-snake-cpu alpha shape {:?} cannot broadcast to channel count {}",
+            dims,
+            channels
+        ),
+    }
+}
+
+fn snake1d_expr(x: &Tensor, alpha: &Tensor) -> Result<Tensor> {
+    let ax = x.broadcast_mul(alpha).map_err(Error::from)?;
+    let sin_sq = ax.sin().map_err(Error::from)?.sqr().map_err(Error::from)?;
+    let scaled = sin_sq.broadcast_div(alpha).map_err(Error::from)?;
+    x.broadcast_add(&scaled).map_err(Error::from)
 }
 
 #[derive(Debug)]
@@ -826,6 +980,64 @@ mod tests {
             .expect("mul gamma")
             .broadcast_add(&beta)
             .expect("add beta")
+            .flatten_all()
+            .expect("flatten reference")
+            .to_vec1::<f32>()
+            .expect("reference values");
+
+        assert_eq!(fused.len(), reference.len());
+        for (got, expected) in fused.iter().zip(reference.iter()) {
+            assert!((got - expected).abs() < 1e-5, "{got} != {expected}");
+        }
+    }
+
+    #[test]
+    fn adain1d_snake_cpu_op_matches_separate_expression() {
+        let device = candle_core::Device::Cpu;
+        let eps = 1e-5;
+        let x = Tensor::from_vec(
+            vec![-0.4f32, 0.0, 0.25, 0.7, -1.2, 0.3, 0.9, 1.4],
+            (1, 2, 4),
+            &device,
+        )
+        .expect("x tensor");
+        let affine = Tensor::from_vec(vec![0.2f32, -0.15, 0.05, -0.2], (1, 4), &device)
+            .expect("affine tensor");
+        let alpha = Tensor::from_vec(vec![0.7f32, 1.3], (1, 2, 1), &device).expect("alpha tensor");
+
+        let fused = x
+            .apply_op3_no_bwd(&affine, &alpha, &AdaIN1dSnakeCpuOp { eps })
+            .expect("fused adain snake")
+            .flatten_all()
+            .expect("flatten fused")
+            .to_vec1::<f32>()
+            .expect("fused values");
+
+        let gamma = affine
+            .narrow(1, 0, 2)
+            .expect("gamma")
+            .unsqueeze(2)
+            .expect("gamma unsqueeze");
+        let beta = affine
+            .narrow(1, 2, 2)
+            .expect("beta")
+            .unsqueeze(2)
+            .expect("beta unsqueeze");
+        let mean = x.mean_keepdim(2).expect("mean");
+        let var = x.var_keepdim(2).expect("var");
+        let denom = (var + eps).expect("eps").sqrt().expect("sqrt");
+        let xhat = x
+            .broadcast_sub(&mean)
+            .expect("sub mean")
+            .broadcast_div(&denom)
+            .expect("div denom");
+        let adain = xhat
+            .broadcast_mul(&(gamma + 1.0f64).expect("gamma plus one"))
+            .expect("mul gamma")
+            .broadcast_add(&beta)
+            .expect("add beta");
+        let reference = snake1d_expr(&adain, &alpha)
+            .expect("snake")
             .flatten_all()
             .expect("flatten reference")
             .to_vec1::<f32>()

--- a/crates/izwi-core/src/models/architectures/kokoro/prosody.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/prosody.rs
@@ -1,6 +1,15 @@
+#[cfg(feature = "metal")]
+use std::collections::HashMap;
+#[cfg(feature = "metal")]
+use std::sync::{Mutex, OnceLock};
+
+#[cfg(feature = "metal")]
+use candle_core::{backend::BackendStorage, MetalStorage};
 use candle_core::{
     CpuStorage, CustomOp3, DType, IndexOp, Layout, Result as CandleResult, Shape, Tensor,
 };
+#[cfg(feature = "metal")]
+use candle_metal_kernels::metal::{ComputePipeline, Device as MetalDevice};
 use candle_nn::rnn::Direction;
 use candle_nn::{
     ops, Conv1d, Conv1dConfig, ConvTranspose1d, ConvTranspose1dConfig, Linear, Module, VarBuilder,
@@ -11,6 +20,76 @@ use rayon::prelude::*;
 use crate::error::{Error, Result};
 
 use super::config::KokoroConfig;
+
+#[cfg(feature = "metal")]
+const KOKORO_PROSODY_METAL_SOURCE: &str = r#"
+#include <metal_stdlib>
+using namespace metal;
+
+constant uint KOKORO_ADAIN_THREADS = 256;
+
+kernel void kokoro_adain1d_snake_f32(
+    device const float* input [[buffer(0)]],
+    device const float* affine [[buffer(1)]],
+    device const float* alpha [[buffer(2)]],
+    device float* output [[buffer(3)]],
+    constant uint& rows [[buffer(4)]],
+    constant uint& channels [[buffer(5)]],
+    constant uint& time [[buffer(6)]],
+    constant uint& alpha_by_channel [[buffer(7)]],
+    constant float& eps [[buffer(8)]],
+    uint gid [[thread_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]]
+) {
+    const uint row = gid / KOKORO_ADAIN_THREADS;
+    if (row >= rows || tid >= KOKORO_ADAIN_THREADS) {
+        return;
+    }
+
+    const uint channel = row % channels;
+    const uint batch = row / channels;
+    const uint base = row * time;
+
+    threadgroup float sums[KOKORO_ADAIN_THREADS];
+    threadgroup float sum_sqs[KOKORO_ADAIN_THREADS];
+
+    float sum = 0.0f;
+    float sum_sq = 0.0f;
+    for (uint t = tid; t < time; t += KOKORO_ADAIN_THREADS) {
+        const float v = input[base + t];
+        sum += v;
+        sum_sq += v * v;
+    }
+    sums[tid] = sum;
+    sum_sqs[tid] = sum_sq;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint stride = KOKORO_ADAIN_THREADS / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            sums[tid] += sums[tid + stride];
+            sum_sqs[tid] += sum_sqs[tid + stride];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    const float total = sums[0];
+    const float total_sq = sum_sqs[0];
+    const float mean = total / float(time);
+    const float denom = max(float(time - 1), 1.0f);
+    const float var = max((total_sq - total * total / float(time)) / denom, 0.0f);
+    const float inv_std = rsqrt(var + eps);
+    const uint affine_base = batch * channels * 2;
+    const float scale = affine[affine_base + channel] + 1.0f;
+    const float bias = affine[affine_base + channels + channel];
+    const float a = alpha_by_channel != 0 ? alpha[channel] : alpha[0];
+
+    for (uint t = tid; t < time; t += KOKORO_ADAIN_THREADS) {
+        const float y = (input[base + t] - mean) * inv_std * scale + bias;
+        const float s = sin(y * a);
+        output[base + t] = y + (s * s) / a;
+    }
+}
+"#;
 
 #[derive(Debug, Clone)]
 pub struct KokoroProsodyDebugOutput {
@@ -410,6 +489,16 @@ impl AdaIN1d {
             )));
         }
         let h = self.fc.forward(style).map_err(Error::from)?;
+        #[cfg(feature = "metal")]
+        if x.device().is_metal()
+            && x.dtype() == DType::F32
+            && h.dtype() == DType::F32
+            && alpha.dtype() == DType::F32
+        {
+            if let Ok(out) = x.apply_op3_no_bwd(&h, alpha, &AdaIN1dSnakeMetalOp { eps: self.eps }) {
+                return Ok(out);
+            }
+        }
         if x.device().is_cpu()
             && x.dtype() == DType::F32
             && h.dtype() == DType::F32
@@ -540,6 +629,167 @@ fn validate_adain_affine_shape(
 #[derive(Debug, Clone, Copy)]
 struct AdaIN1dSnakeCpuOp {
     eps: f64,
+}
+
+#[cfg(feature = "metal")]
+#[derive(Debug, Clone, Copy)]
+struct AdaIN1dSnakeMetalOp {
+    eps: f64,
+}
+
+#[cfg(feature = "metal")]
+impl CustomOp3 for AdaIN1dSnakeMetalOp {
+    fn name(&self) -> &'static str {
+        "kokoro-adain1d-snake-metal"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _s1: &CpuStorage,
+        _l1: &Layout,
+        _s2: &CpuStorage,
+        _l2: &Layout,
+        _s3: &CpuStorage,
+        _l3: &Layout,
+    ) -> CandleResult<(CpuStorage, Shape)> {
+        candle_core::bail!("kokoro-adain1d-snake-metal requires Metal tensors")
+    }
+
+    fn metal_fwd(
+        &self,
+        x_storage: &MetalStorage,
+        x_layout: &Layout,
+        h_storage: &MetalStorage,
+        h_layout: &Layout,
+        alpha_storage: &MetalStorage,
+        alpha_layout: &Layout,
+    ) -> CandleResult<(MetalStorage, Shape)> {
+        if x_storage.dtype() != DType::F32
+            || h_storage.dtype() != DType::F32
+            || alpha_storage.dtype() != DType::F32
+        {
+            candle_core::bail!("kokoro-adain1d-snake-metal only supports F32 tensors")
+        }
+        if !x_layout.is_contiguous() || !h_layout.is_contiguous() || !alpha_layout.is_contiguous() {
+            candle_core::bail!("kokoro-adain1d-snake-metal requires contiguous tensors")
+        }
+
+        let dims = x_layout.shape().dims();
+        if dims.len() != 3 {
+            candle_core::bail!("kokoro-adain1d-snake-metal expects [B,C,T] input")
+        }
+        let batch = dims[0];
+        let channels = dims[1];
+        let time = dims[2];
+        if time < 2 {
+            candle_core::bail!("kokoro-adain1d-snake-metal requires time length >= 2")
+        }
+        match h_layout.shape().dims() {
+            [b, two_c] if *b == batch && *two_c == channels * 2 => {}
+            other => candle_core::bail!(
+                "kokoro-adain1d-snake-metal affine shape {:?} cannot broadcast to [{batch},{channels},T]",
+                other
+            ),
+        }
+        let alpha_by_channel = validate_snake_alpha_shape(alpha_layout.shape().dims(), channels)?;
+        let alpha_len = alpha_layout.shape().elem_count();
+        if alpha_by_channel && alpha_len != channels {
+            candle_core::bail!(
+                "kokoro-adain1d-snake-metal alpha storage length {}, expected {}",
+                alpha_len,
+                channels
+            )
+        }
+        if !alpha_by_channel && alpha_len != 1 {
+            candle_core::bail!("kokoro-adain1d-snake-metal scalar alpha has invalid storage length")
+        }
+
+        let rows = batch.saturating_mul(channels);
+        let elem_count = rows.saturating_mul(time);
+        if rows > u32::MAX as usize || channels > u32::MAX as usize || time > u32::MAX as usize {
+            candle_core::bail!("kokoro-adain1d-snake-metal tensor is too large")
+        }
+
+        let device = x_storage.device().clone();
+        let output = device.new_buffer(elem_count, DType::F32, "kokoro-adain1d-snake")?;
+        let encoder = device.command_encoder()?;
+        encoder.set_label("kokoro-adain1d-snake");
+        let pipeline = adain1d_snake_pipeline(device.metal_device())?;
+        encoder.set_compute_pipeline_state(&pipeline);
+
+        encoder.set_buffer(
+            0,
+            Some(x_storage.buffer()),
+            x_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_buffer(
+            1,
+            Some(h_storage.buffer()),
+            h_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_buffer(
+            2,
+            Some(alpha_storage.buffer()),
+            alpha_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_buffer(3, Some(&output), 0);
+        encoder.set_bytes(4, &(rows as u32));
+        encoder.set_bytes(5, &(channels as u32));
+        encoder.set_bytes(6, &(time as u32));
+        encoder.set_bytes(7, &(u32::from(alpha_by_channel)));
+        encoder.set_bytes(8, &(self.eps as f32));
+
+        encoder.dispatch_threads(
+            objc2_metal::MTLSize {
+                width: rows * 256,
+                height: 1,
+                depth: 1,
+            },
+            objc2_metal::MTLSize {
+                width: 256,
+                height: 1,
+                depth: 1,
+            },
+        );
+
+        Ok((
+            MetalStorage::new(output, device, elem_count, DType::F32),
+            x_layout.shape().clone(),
+        ))
+    }
+}
+
+#[cfg(feature = "metal")]
+fn adain1d_snake_pipeline(device: &MetalDevice) -> CandleResult<ComputePipeline> {
+    static PIPELINES: OnceLock<Mutex<HashMap<u64, ComputePipeline>>> = OnceLock::new();
+    let registry_id = device.registry_id();
+    let pipelines = PIPELINES.get_or_init(|| Mutex::new(HashMap::new()));
+
+    if let Some(pipeline) = pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .get(&registry_id)
+        .cloned()
+    {
+        return Ok(pipeline);
+    }
+
+    let library = device
+        .new_library_with_source(KOKORO_PROSODY_METAL_SOURCE, None)
+        .map_err(candle_core::Error::wrap)?;
+    let function = library
+        .get_function("kokoro_adain1d_snake_f32", None)
+        .map_err(candle_core::Error::wrap)?;
+    let pipeline = device
+        .new_compute_pipeline_state_with_function(&function)
+        .map_err(candle_core::Error::wrap)?;
+
+    pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .insert(registry_id, pipeline.clone());
+
+    Ok(pipeline)
 }
 
 impl CustomOp3 for AdaIN1dSnakeCpuOp {

--- a/crates/izwi-core/src/models/architectures/kokoro/prosody.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/prosody.rs
@@ -685,7 +685,7 @@ impl AdainResBlk1d {
         vb: VarBuilder,
     ) -> Result<Self> {
         let learned_sc = dim_in != dim_out;
-        let conv1 = load_weight_norm_conv1d(
+        let conv1 = load_weight_norm_conv1d_no_bias(
             vb.pp("conv1"),
             Conv1dConfig {
                 padding: 1,
@@ -902,6 +902,17 @@ pub(crate) fn load_weight_norm_conv1d(vb: VarBuilder, cfg: Conv1dConfig) -> Resu
     };
     let w = fuse_weight_norm_dim0(&wv, &wg)?;
     Ok(Conv1d::new(w, b, cfg))
+}
+
+pub(crate) fn load_weight_norm_conv1d_no_bias(vb: VarBuilder, cfg: Conv1dConfig) -> Result<Conv1d> {
+    let wv = vb
+        .get_unchecked_dtype("weight_v", DType::F32)
+        .map_err(Error::from)?;
+    let wg = vb
+        .get_unchecked_dtype("weight_g", DType::F32)
+        .map_err(Error::from)?;
+    let w = fuse_weight_norm_dim0(&wv, &wg)?;
+    Ok(Conv1d::new(w, None, cfg))
 }
 
 pub(crate) fn load_weight_norm_conv_transpose1d(

--- a/crates/izwi-core/src/models/architectures/kokoro/prosody.rs
+++ b/crates/izwi-core/src/models/architectures/kokoro/prosody.rs
@@ -1,4 +1,6 @@
-use candle_core::{DType, IndexOp, Tensor};
+use candle_core::{
+    CpuStorage, CustomOp3, DType, IndexOp, Layout, Result as CandleResult, Shape, Tensor,
+};
 use candle_nn::rnn::Direction;
 use candle_nn::{
     ops, Conv1d, Conv1dConfig, ConvTranspose1d, ConvTranspose1dConfig, Linear, Module, VarBuilder,
@@ -363,6 +365,21 @@ impl AdaIN1d {
                 self.channels, c
             )));
         }
+        let h = self.fc.forward(style).map_err(Error::from)?;
+        let chunks = h.chunk(2, 1).map_err(Error::from)?;
+        let gamma = chunks[0].unsqueeze(2).map_err(Error::from)?;
+        let beta = chunks[1].unsqueeze(2).map_err(Error::from)?;
+
+        if x.device().is_cpu()
+            && x.dtype() == DType::F32
+            && gamma.dtype() == DType::F32
+            && beta.dtype() == DType::F32
+        {
+            if let Ok(out) = x.apply_op3_no_bwd(&gamma, &beta, &AdaIN1dCpuOp { eps: self.eps }) {
+                return Ok(out);
+            }
+        }
+
         let mean = x.mean_keepdim(2).map_err(Error::from)?;
         let var = x.var_keepdim(2).map_err(Error::from)?;
         let denom = (var + self.eps)
@@ -372,15 +389,120 @@ impl AdaIN1d {
         let xhat = (x.broadcast_sub(&mean).map_err(Error::from)?)
             .broadcast_div(&denom)
             .map_err(Error::from)?;
-
-        let h = self.fc.forward(style).map_err(Error::from)?;
-        let chunks = h.chunk(2, 1).map_err(Error::from)?;
-        let gamma = chunks[0].unsqueeze(2).map_err(Error::from)?;
-        let beta = chunks[1].unsqueeze(2).map_err(Error::from)?;
         xhat.broadcast_mul(&(gamma + 1.0f64).map_err(Error::from)?)
             .map_err(Error::from)?
             .broadcast_add(&beta)
             .map_err(Error::from)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AdaIN1dCpuOp {
+    eps: f64,
+}
+
+impl CustomOp3 for AdaIN1dCpuOp {
+    fn name(&self) -> &'static str {
+        "kokoro-adain1d-cpu"
+    }
+
+    fn cpu_fwd(
+        &self,
+        x_storage: &CpuStorage,
+        x_layout: &Layout,
+        gamma_storage: &CpuStorage,
+        gamma_layout: &Layout,
+        beta_storage: &CpuStorage,
+        beta_layout: &Layout,
+    ) -> CandleResult<(CpuStorage, Shape)> {
+        let x = match x_storage {
+            CpuStorage::F32(values) => values,
+            _ => candle_core::bail!("kokoro-adain1d-cpu only supports F32 input"),
+        };
+        let gamma = match gamma_storage {
+            CpuStorage::F32(values) => values,
+            _ => candle_core::bail!("kokoro-adain1d-cpu only supports F32 gamma"),
+        };
+        let beta = match beta_storage {
+            CpuStorage::F32(values) => values,
+            _ => candle_core::bail!("kokoro-adain1d-cpu only supports F32 beta"),
+        };
+        let x = match x_layout.contiguous_offsets() {
+            Some((start, end)) => &x[start..end],
+            None => candle_core::bail!("kokoro-adain1d-cpu requires contiguous input"),
+        };
+        let gamma = match gamma_layout.contiguous_offsets() {
+            Some((start, end)) => &gamma[start..end],
+            None => candle_core::bail!("kokoro-adain1d-cpu requires contiguous gamma"),
+        };
+        let beta = match beta_layout.contiguous_offsets() {
+            Some((start, end)) => &beta[start..end],
+            None => candle_core::bail!("kokoro-adain1d-cpu requires contiguous beta"),
+        };
+
+        let dims = x_layout.shape().dims();
+        if dims.len() != 3 {
+            candle_core::bail!("kokoro-adain1d-cpu expects [B,C,T] input")
+        }
+        let batch = dims[0];
+        let channels = dims[1];
+        let time = dims[2];
+        if time < 2 {
+            candle_core::bail!("kokoro-adain1d-cpu requires time length >= 2")
+        }
+        validate_adain_affine_shape(gamma_layout.shape().dims(), batch, channels, "gamma")?;
+        validate_adain_affine_shape(beta_layout.shape().dims(), batch, channels, "beta")?;
+        if gamma.len() != batch * channels || beta.len() != batch * channels {
+            candle_core::bail!(
+                "kokoro-adain1d-cpu affine storage length mismatch: gamma={}, beta={}, expected={}",
+                gamma.len(),
+                beta.len(),
+                batch * channels
+            )
+        }
+
+        let mut out = vec![0.0f32; x.len()];
+        let denom_scale = (time - 1) as f32;
+        for b in 0..batch {
+            for c in 0..channels {
+                let base = (b * channels + c) * time;
+                let values = &x[base..base + time];
+                let mean = values.iter().copied().sum::<f32>() / time as f32;
+                let var = values
+                    .iter()
+                    .map(|v| {
+                        let d = *v - mean;
+                        d * d
+                    })
+                    .sum::<f32>()
+                    / denom_scale;
+                let inv_std = 1.0f32 / (var + self.eps as f32).sqrt();
+                let affine_idx = b * channels + c;
+                let scale = gamma[affine_idx] + 1.0;
+                let bias = beta[affine_idx];
+                for t in 0..time {
+                    let v = x[base + t];
+                    out[base + t] = (v - mean) * inv_std * scale + bias;
+                }
+            }
+        }
+        Ok((CpuStorage::F32(out), x_layout.shape().clone()))
+    }
+}
+
+fn validate_adain_affine_shape(
+    dims: &[usize],
+    batch: usize,
+    channels: usize,
+    name: &str,
+) -> CandleResult<()> {
+    match dims {
+        [b, c, 1] if *b == batch && *c == channels => Ok(()),
+        [b, c] if *b == batch && *c == channels => Ok(()),
+        _ => candle_core::bail!(
+            "kokoro-adain1d-cpu {name} shape {:?} cannot broadcast to [{batch},{channels},T]",
+            dims
+        ),
     }
 }
 
@@ -663,4 +785,55 @@ pub(crate) fn fuse_weight_norm_dim0(weight_v: &Tensor, weight_g: &Tensor) -> Res
     .map_err(Error::from)?;
     let scale = weight_g.broadcast_div(&norm).map_err(Error::from)?;
     weight_v.broadcast_mul(&scale).map_err(Error::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adain1d_cpu_op_matches_candle_expression() {
+        let device = candle_core::Device::Cpu;
+        let eps = 1e-5;
+        let x = Tensor::from_vec(
+            vec![-0.4f32, 0.0, 0.25, 0.7, -1.2, 0.3, 0.9, 1.4],
+            (1, 2, 4),
+            &device,
+        )
+        .expect("x tensor");
+        let gamma =
+            Tensor::from_vec(vec![0.2f32, -0.15], (1, 2, 1), &device).expect("gamma tensor");
+        let beta = Tensor::from_vec(vec![0.05f32, -0.2], (1, 2, 1), &device).expect("beta tensor");
+
+        let fused = x
+            .apply_op3_no_bwd(&gamma, &beta, &AdaIN1dCpuOp { eps })
+            .expect("fused adain")
+            .flatten_all()
+            .expect("flatten fused")
+            .to_vec1::<f32>()
+            .expect("fused values");
+
+        let mean = x.mean_keepdim(2).expect("mean");
+        let var = x.var_keepdim(2).expect("var");
+        let denom = (var + eps).expect("eps").sqrt().expect("sqrt");
+        let xhat = x
+            .broadcast_sub(&mean)
+            .expect("sub mean")
+            .broadcast_div(&denom)
+            .expect("div denom");
+        let reference = xhat
+            .broadcast_mul(&(gamma + 1.0f64).expect("gamma plus one"))
+            .expect("mul gamma")
+            .broadcast_add(&beta)
+            .expect("add beta")
+            .flatten_all()
+            .expect("flatten reference")
+            .to_vec1::<f32>()
+            .expect("reference values");
+
+        assert_eq!(fused.len(), reference.len());
+        for (got, expected) in fused.iter().zip(reference.iter()) {
+            assert!((got - expected).abs() < 1e-5, "{got} != {expected}");
+        }
+    }
 }

--- a/crates/izwi-core/src/runtime/kokoro.rs
+++ b/crates/izwi-core/src/runtime/kokoro.rs
@@ -1,6 +1,7 @@
 //! Kokoro TTS runtime helpers (isolated from generic runtime routing).
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use tokio::sync::mpsc;
 use tracing::info;
@@ -53,6 +54,7 @@ impl RuntimeService {
 
         let opts = &request.config.options;
         let speaker = opts.speaker.as_deref().or(opts.voice.as_deref());
+        let started = Instant::now();
         let result = synthesize_kokoro_with_fallback(
             model.clone(),
             &request.text,
@@ -60,13 +62,14 @@ impl RuntimeService {
             request.language.as_deref(),
             opts.speed,
         )?;
+        let total_time_ms = started.elapsed().as_secs_f32() * 1000.0;
 
         Ok(GenerationResult {
             request_id: request.id,
             samples: result.samples,
             sample_rate: result.sample_rate,
             total_tokens: result.tokens_generated,
-            total_time_ms: 0.0,
+            total_time_ms,
         })
     }
 


### PR DESCRIPTION
Adds Kokoro profiling plus fused/parallel CPU and Metal kernels across Snake, AdaIN, upsampling, harmonic/prosody, and generator paths, reducing short-text latency from ~920ms to ~500ms while preserving existing streaming semantics.