### PR TITLE
Improve LFM2.5 Audio Metal runtime performance

### DIFF
--- a/crates/izwi-cli/src/commands/bench.rs
+++ b/crates/izwi-cli/src/commands/bench.rs
@@ -116,6 +116,7 @@ struct TtsBenchSample {
     audio_duration_secs: Option<f64>,
     rtf: Option<f64>,
     tokens_generated: Option<u64>,
+    diagnostics: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -145,6 +146,27 @@ struct AsrBenchResponse {
 struct AsrBenchSample {
     total_ms: f64,
     response: AsrBenchResponse,
+}
+
+#[derive(Debug, Clone)]
+struct TtsStageTimings {
+    prompt_build: Option<f64>,
+    prompt_embed: Option<f64>,
+    prefill: Option<f64>,
+    text_sampling: Option<f64>,
+    tokenizer_decode: Option<f64>,
+    text_forward: Option<f64>,
+    audio_head: Option<f64>,
+    audio_embed: Option<f64>,
+    audio_forward: Option<f64>,
+    main_backbone: Option<f64>,
+    detokenizer: Option<f64>,
+    model_total: Option<f64>,
+    prompt_tokens: Option<u64>,
+    generated_tokens: Option<u64>,
+    audio_frames: Option<u64>,
+    audio_head_calls: Option<u64>,
+    text_sample_calls: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -364,6 +386,8 @@ struct BenchmarkSample {
     audio_duration_secs: Option<f64>,
     rtf: Option<f64>,
     tokens_generated: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tts_diagnostics: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     asr_execution: Option<AsrExecutionDiagnostics>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1547,6 +1571,7 @@ async fn bench_chat(
                 audio_duration_secs: None,
                 rtf: None,
                 tokens_generated: None,
+                tts_diagnostics: None,
                 asr_execution: None,
                 asr_text: None,
                 asr_diagnostics: None,
@@ -1670,6 +1695,11 @@ async fn bench_tts(
             },
         )
         .collect();
+    let tts_stage_samples: Vec<TtsStageTimings> = samples
+        .iter()
+        .filter_map(|sample| sample.diagnostics.as_ref())
+        .filter_map(tts_stage_timings_from_diagnostics)
+        .collect();
     let avg = times.iter().sum::<f64>() / times.len() as f64;
     let min = times.iter().cloned().fold(f64::INFINITY, f64::min);
     let max = times.iter().cloned().fold(0.0, f64::max);
@@ -1723,6 +1753,7 @@ async fn bench_tts(
                 percentile(&tokens_per_second, 0.95)
             );
         }
+        print_tts_stage_timing_summary(&tts_stage_samples);
     }
     let metrics_after = fetch_runtime_metrics(server).await;
     if options.human_output() {
@@ -1794,6 +1825,7 @@ async fn bench_tts(
                 audio_duration_secs: sample.audio_duration_secs,
                 rtf: sample.rtf,
                 tokens_generated: sample.tokens_generated,
+                tts_diagnostics: sample.diagnostics.clone(),
                 asr_execution: None,
                 asr_text: None,
                 asr_diagnostics: None,
@@ -2060,6 +2092,7 @@ async fn bench_asr(
                 audio_duration_secs: sample.response.duration,
                 rtf: sample.response.rtf,
                 tokens_generated: None,
+                tts_diagnostics: None,
                 asr_execution: sample
                     .response
                     .izwi_asr_diagnostics
@@ -2214,6 +2247,14 @@ fn header_u64(response: &reqwest::Response, name: &'static str) -> Option<u64> {
         .and_then(|value| value.parse::<u64>().ok())
 }
 
+fn header_json(response: &reqwest::Response, name: &'static str) -> Option<serde_json::Value> {
+    response
+        .headers()
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| serde_json::from_str(value).ok())
+}
+
 async fn resolve_tts_bench_reference(
     speaker: Option<&str>,
     saved_voice_id: Option<&str>,
@@ -2316,6 +2357,7 @@ async fn run_tts_request(
         audio_duration_secs: header_f64(&response, "x-audio-duration-secs"),
         rtf: header_f64(&response, "x-rtf"),
         tokens_generated: header_u64(&response, "x-tokens-generated"),
+        diagnostics: header_json(&response, "x-izwi-tts-diagnostics"),
     })
 }
 
@@ -2649,6 +2691,43 @@ async fn fetch_runtime_metrics(server: &str) -> Option<RuntimeTelemetrySnapshot>
     }
 
     None
+}
+
+fn tts_stage_timings_from_diagnostics(diagnostics: &serde_json::Value) -> Option<TtsStageTimings> {
+    let timings = diagnostics.get("timings_ms")?.as_object()?;
+    let prompt = diagnostics.get("prompt");
+    let decode = diagnostics.get("decode");
+    let audio = diagnostics.get("audio");
+    Some(TtsStageTimings {
+        prompt_build: timings.get("prompt_build").and_then(|value| value.as_f64()),
+        prompt_embed: timings.get("prompt_embed").and_then(|value| value.as_f64()),
+        prefill: timings
+            .get("prefill")
+            .or_else(|| timings.get("main_prefill"))
+            .and_then(|value| value.as_f64()),
+        text_sampling: timings
+            .get("text_sampling")
+            .and_then(|value| value.as_f64()),
+        tokenizer_decode: timings
+            .get("tokenizer_decode")
+            .and_then(|value| value.as_f64()),
+        text_forward: timings.get("text_forward").and_then(|value| value.as_f64()),
+        audio_head: timings.get("audio_head").and_then(|value| value.as_f64()),
+        audio_embed: timings.get("audio_embed").and_then(|value| value.as_f64()),
+        audio_forward: timings
+            .get("audio_forward")
+            .and_then(|value| value.as_f64()),
+        main_backbone: timings
+            .get("main_backbone")
+            .and_then(|value| value.as_f64()),
+        detokenizer: timings.get("detokenizer").and_then(|value| value.as_f64()),
+        model_total: timings.get("model_total").and_then(|value| value.as_f64()),
+        prompt_tokens: diagnostic_u64(prompt, &["prompt_tokens", "tokens"]),
+        generated_tokens: diagnostic_u64(decode, &["generated_tokens"]),
+        audio_frames: diagnostic_u64(audio, &["audio_frames", "acoustic_frames"]),
+        audio_head_calls: diagnostic_u64(decode, &["audio_head_calls"]),
+        text_sample_calls: diagnostic_u64(decode, &["text_sample_calls"]),
+    })
 }
 
 fn asr_stage_timings_from_diagnostics(diagnostics: &serde_json::Value) -> Option<AsrStageTimings> {
@@ -3084,6 +3163,108 @@ fn summarize_bool_count(stage: &str, values: &[bool]) {
     }
     let enabled = values.iter().filter(|value| **value).count();
     println!("  {:<14} enabled: {}/{}", stage, enabled, values.len());
+}
+
+fn print_tts_stage_timing_summary(samples: &[TtsStageTimings]) {
+    if samples.is_empty() {
+        return;
+    }
+
+    let mut prompt_build = Vec::new();
+    let mut prompt_embed = Vec::new();
+    let mut prefill = Vec::new();
+    let mut text_sampling = Vec::new();
+    let mut tokenizer_decode = Vec::new();
+    let mut text_forward = Vec::new();
+    let mut audio_head = Vec::new();
+    let mut audio_embed = Vec::new();
+    let mut audio_forward = Vec::new();
+    let mut main_backbone = Vec::new();
+    let mut detokenizer = Vec::new();
+    let mut model_total = Vec::new();
+    let mut prompt_tokens = Vec::new();
+    let mut generated_tokens = Vec::new();
+    let mut audio_frames = Vec::new();
+    let mut audio_head_calls = Vec::new();
+    let mut text_sample_calls = Vec::new();
+
+    for sample in samples {
+        if let Some(value) = sample.prompt_build {
+            prompt_build.push(value);
+        }
+        if let Some(value) = sample.prompt_embed {
+            prompt_embed.push(value);
+        }
+        if let Some(value) = sample.prefill {
+            prefill.push(value);
+        }
+        if let Some(value) = sample.text_sampling {
+            text_sampling.push(value);
+        }
+        if let Some(value) = sample.tokenizer_decode {
+            tokenizer_decode.push(value);
+        }
+        if let Some(value) = sample.text_forward {
+            text_forward.push(value);
+        }
+        if let Some(value) = sample.audio_head {
+            audio_head.push(value);
+        }
+        if let Some(value) = sample.audio_embed {
+            audio_embed.push(value);
+        }
+        if let Some(value) = sample.audio_forward {
+            audio_forward.push(value);
+        }
+        if let Some(value) = sample.main_backbone {
+            main_backbone.push(value);
+        }
+        if let Some(value) = sample.detokenizer {
+            detokenizer.push(value);
+        }
+        if let Some(value) = sample.model_total {
+            model_total.push(value);
+        }
+        if let Some(value) = sample.prompt_tokens {
+            prompt_tokens.push(value);
+        }
+        if let Some(value) = sample.generated_tokens {
+            generated_tokens.push(value);
+        }
+        if let Some(value) = sample.audio_frames {
+            audio_frames.push(value);
+        }
+        if let Some(value) = sample.audio_head_calls {
+            audio_head_calls.push(value);
+        }
+        if let Some(value) = sample.text_sample_calls {
+            text_sample_calls.push(value);
+        }
+    }
+
+    println!(
+        "\n{}",
+        console::style("TTS Stage Timings (run-local):")
+            .bold()
+            .underlined()
+    );
+    summarize_stage("prompt_build", &prompt_build);
+    summarize_stage("prompt_embed", &prompt_embed);
+    summarize_stage("prefill", &prefill);
+    summarize_stage("text_sample", &text_sampling);
+    summarize_stage("tokenizer", &tokenizer_decode);
+    summarize_stage("text_forward", &text_forward);
+    summarize_stage("audio_head", &audio_head);
+    summarize_stage("audio_embed", &audio_embed);
+    summarize_stage("audio_forward", &audio_forward);
+    summarize_stage("main_backbone", &main_backbone);
+    summarize_stage("detokenizer", &detokenizer);
+    summarize_stage("model_total", &model_total);
+    summarize_count("prompt_tokens", &prompt_tokens);
+    summarize_count("gen_tokens", &generated_tokens);
+    summarize_count("audio_frames", &audio_frames);
+    summarize_count("audio_head", &audio_head_calls);
+    summarize_count("text_sample", &text_sample_calls);
 }
 
 fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
@@ -3871,6 +4052,48 @@ mod tests {
     }
 
     #[test]
+    fn lfm25_tts_stage_timing_collection_reads_diagnostics_header_shape() {
+        let diagnostics = serde_json::json!({
+            "model": "lfm25_audio",
+            "task": "tts",
+            "timings_ms": {
+                "prompt_build": 1.0,
+                "prompt_embed": 2.0,
+                "prefill": 3.0,
+                "text_sampling": 4.0,
+                "audio_head": 5.0,
+                "detokenizer": 6.0,
+                "model_total": 21.0
+            },
+            "prompt": {
+                "prompt_tokens": 11
+            },
+            "decode": {
+                "generated_tokens": 42,
+                "audio_head_calls": 7,
+                "text_sample_calls": 3
+            },
+            "audio": {
+                "audio_frames": 6
+            }
+        });
+
+        let timings = tts_stage_timings_from_diagnostics(&diagnostics)
+            .expect("LFM2.5 TTS diagnostics should parse");
+
+        assert_eq!(timings.prompt_build, Some(1.0));
+        assert_eq!(timings.prefill, Some(3.0));
+        assert_eq!(timings.audio_head, Some(5.0));
+        assert_eq!(timings.detokenizer, Some(6.0));
+        assert_eq!(timings.model_total, Some(21.0));
+        assert_eq!(timings.prompt_tokens, Some(11));
+        assert_eq!(timings.generated_tokens, Some(42));
+        assert_eq!(timings.audio_frames, Some(6));
+        assert_eq!(timings.audio_head_calls, Some(7));
+        assert_eq!(timings.text_sample_calls, Some(3));
+    }
+
+    #[test]
     fn whisper_stage_timing_collection_includes_chunk_model_diagnostics() {
         let diagnostics = serde_json::json!({
             "chunking": {
@@ -4216,6 +4439,7 @@ mod tests {
             audio_duration_secs: Some(10.0),
             rtf: Some(0.012),
             tokens_generated: None,
+            tts_diagnostics: None,
             asr_execution: None,
             asr_text: Some("hello granite".to_string()),
             asr_diagnostics: Some(diagnostics.clone()),

--- a/crates/izwi-cli/src/commands/bench.rs
+++ b/crates/izwi-cli/src/commands/bench.rs
@@ -195,6 +195,7 @@ struct AsrStageTimings {
     generated_tokens: Option<u64>,
     max_new_tokens: Option<u64>,
     rnnt_joint_steps: Option<u64>,
+    token_select_reads: Option<u64>,
     host_argmax_reads: Option<u64>,
     device_argmax_reads: Option<u64>,
     execution: Option<AsrExecutionDiagnostics>,
@@ -2788,6 +2789,7 @@ fn asr_stage_timings_from_diagnostics(diagnostics: &serde_json::Value) -> Option
             })
             .and_then(|value| value.as_u64()),
         rnnt_joint_steps: diagnostic_u64(decode, &["joint_steps", "rnnt_joint_steps"]),
+        token_select_reads: diagnostic_u64(decode, &["token_select_reads"]),
         host_argmax_reads: diagnostic_u64(decode, &["host_argmax_reads"]),
         device_argmax_reads: diagnostic_u64(decode, &["device_argmax_reads"]),
         execution,
@@ -3296,6 +3298,7 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
     let mut generated_tokens = Vec::new();
     let mut max_new_tokens = Vec::new();
     let mut rnnt_joint_steps = Vec::new();
+    let mut token_select_reads = Vec::new();
     let mut host_argmax_reads = Vec::new();
     let mut device_argmax_reads = Vec::new();
     let mut flash_attention_requested = Vec::new();
@@ -3406,6 +3409,9 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
         }
         if let Some(value) = sample.rnnt_joint_steps {
             rnnt_joint_steps.push(value);
+        }
+        if let Some(value) = sample.token_select_reads {
+            token_select_reads.push(value);
         }
         if let Some(value) = sample.host_argmax_reads {
             host_argmax_reads.push(value);
@@ -3548,6 +3554,7 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
         && generated_tokens.is_empty()
         && max_new_tokens.is_empty()
         && rnnt_joint_steps.is_empty()
+        && token_select_reads.is_empty()
         && host_argmax_reads.is_empty()
         && device_argmax_reads.is_empty()
         && flash_attention_requested.is_empty()
@@ -3619,6 +3626,7 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
     summarize_count("gen_tokens", &generated_tokens);
     summarize_count("max_new_tokens", &max_new_tokens);
     summarize_count("rnnt_steps", &rnnt_joint_steps);
+    summarize_count("token_select", &token_select_reads);
     summarize_count("host_argmax", &host_argmax_reads);
     summarize_count("dev_argmax", &device_argmax_reads);
     summarize_bool_count("flash_req", &flash_attention_requested);

--- a/crates/izwi-core/src/kernels/metal.rs
+++ b/crates/izwi-core/src/kernels/metal.rs
@@ -314,6 +314,7 @@ kernel void izwi_decode_gqa_attention_f32(
     constant uint& total_len [[buffer(6)]],
     constant uint& head_dim [[buffer(7)]],
     constant float& scale [[buffer(8)]],
+    constant uint& kv_capacity_len [[buffer(9)]],
     uint tid [[thread_index_in_threadgroup]],
     uint head [[threadgroup_position_in_grid]],
     uint threads_per_threadgroup [[threads_per_threadgroup]]
@@ -331,7 +332,7 @@ kernel void izwi_decode_gqa_attention_f32(
     for (uint pos = tid; pos < total_len; pos += threads_per_threadgroup) {
         float dot = 0.0f;
         const uint q_base = head * head_dim;
-        const uint k_base = (kv_head * total_len + pos) * head_dim;
+        const uint k_base = (kv_head * kv_capacity_len + pos) * head_dim;
         for (uint dim = 0; dim < head_dim; dim++) {
             dot += q[q_base + dim] * k[k_base + dim];
         }
@@ -372,7 +373,7 @@ kernel void izwi_decode_gqa_attention_f32(
         float acc = 0.0f;
         for (uint pos = 0; pos < total_len; pos++) {
             const float prob = scores[pos] * inv_sum;
-            const uint v_base = (kv_head * total_len + pos) * head_dim;
+            const uint v_base = (kv_head * kv_capacity_len + pos) * head_dim;
             acc += prob * v[v_base + dim];
         }
         output[out_base + dim] = acc;
@@ -389,6 +390,7 @@ kernel void izwi_decode_gqa_attention_f16(
     constant uint& total_len [[buffer(6)]],
     constant uint& head_dim [[buffer(7)]],
     constant float& scale [[buffer(8)]],
+    constant uint& kv_capacity_len [[buffer(9)]],
     uint tid [[thread_index_in_threadgroup]],
     uint head [[threadgroup_position_in_grid]],
     uint threads_per_threadgroup [[threads_per_threadgroup]]
@@ -406,7 +408,7 @@ kernel void izwi_decode_gqa_attention_f16(
     for (uint pos = tid; pos < total_len; pos += threads_per_threadgroup) {
         float dot = 0.0f;
         const uint q_base = head * head_dim;
-        const uint k_base = (kv_head * total_len + pos) * head_dim;
+        const uint k_base = (kv_head * kv_capacity_len + pos) * head_dim;
         for (uint dim = 0; dim < head_dim; dim++) {
             dot += float(q[q_base + dim]) * float(k[k_base + dim]);
         }
@@ -447,7 +449,7 @@ kernel void izwi_decode_gqa_attention_f16(
         float acc = 0.0f;
         for (uint pos = 0; pos < total_len; pos++) {
             const float prob = scores[pos] * inv_sum;
-            const uint v_base = (kv_head * total_len + pos) * head_dim;
+            const uint v_base = (kv_head * kv_capacity_len + pos) * head_dim;
             acc += prob * float(v[v_base + dim]);
         }
         output[out_base + dim] = half(acc);
@@ -1071,7 +1073,8 @@ fn rope_pair_bshd_pipeline(device: &MetalDevice, dtype: DType) -> CandleResult<C
 struct DecodeGqaAttentionOp {
     num_heads: usize,
     num_kv_heads: usize,
-    total_len: usize,
+    kv_len: usize,
+    kv_capacity_len: usize,
     head_dim: usize,
     scale: f32,
 }
@@ -1115,8 +1118,9 @@ impl CustomOp3 for DecodeGqaAttentionOp {
         }
         if self.num_heads == 0
             || self.num_kv_heads == 0
-            || self.total_len == 0
-            || self.total_len > 2048
+            || self.kv_len == 0
+            || self.kv_len > self.kv_capacity_len
+            || self.kv_len > 2048
             || self.head_dim == 0
             || self.num_heads % self.num_kv_heads != 0
         {
@@ -1127,7 +1131,7 @@ impl CustomOp3 for DecodeGqaAttentionOp {
         }
         let kv_elems = self
             .num_kv_heads
-            .saturating_mul(self.total_len)
+            .saturating_mul(self.kv_capacity_len)
             .saturating_mul(self.head_dim);
         if k_layout.shape().elem_count() != kv_elems || v_layout.shape().elem_count() != kv_elems {
             bail!("izwi-decode-gqa-attention-metal k/v shape mismatch")
@@ -1136,7 +1140,8 @@ impl CustomOp3 for DecodeGqaAttentionOp {
         if elem_count > u32::MAX as usize
             || self.num_heads > u32::MAX as usize
             || self.num_kv_heads > u32::MAX as usize
-            || self.total_len > u32::MAX as usize
+            || self.kv_len > u32::MAX as usize
+            || self.kv_capacity_len > u32::MAX as usize
             || self.head_dim > u32::MAX as usize
         {
             bail!("izwi-decode-gqa-attention-metal tensor is too large")
@@ -1167,9 +1172,10 @@ impl CustomOp3 for DecodeGqaAttentionOp {
         encoder.set_buffer(3, Some(&output), 0);
         encoder.set_bytes(4, &(self.num_heads as u32));
         encoder.set_bytes(5, &(self.num_kv_heads as u32));
-        encoder.set_bytes(6, &(self.total_len as u32));
+        encoder.set_bytes(6, &(self.kv_len as u32));
         encoder.set_bytes(7, &(self.head_dim as u32));
         encoder.set_bytes(8, &self.scale);
+        encoder.set_bytes(9, &(self.kv_capacity_len as u32));
 
         let threads_per_threadgroup = self
             .head_dim
@@ -1628,8 +1634,31 @@ pub fn try_fused_decode_gqa_attention(
     head_dim: usize,
     scale: f32,
 ) -> Option<Tensor> {
+    let total_len = k.dims4().ok()?.2;
+    try_fused_decode_gqa_attention_with_kv_len(
+        q,
+        k,
+        v,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        total_len,
+        scale,
+    )
+}
+
+pub fn try_fused_decode_gqa_attention_with_kv_len(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    kv_len: usize,
+    scale: f32,
+) -> Option<Tensor> {
     #[cfg(not(feature = "metal"))]
-    let _ = (q, k, v, num_heads, num_kv_heads, head_dim, scale);
+    let _ = (q, k, v, num_heads, num_kv_heads, head_dim, kv_len, scale);
 
     if !use_fused_kernels() {
         return None;
@@ -1638,8 +1667,8 @@ pub fn try_fused_decode_gqa_attention(
     #[cfg(feature = "metal")]
     {
         let (q_bsz, q_heads, q_seq, q_head_dim) = q.dims4().ok()?;
-        let (k_bsz, k_heads, total_len, k_head_dim) = k.dims4().ok()?;
-        let (v_bsz, v_heads, v_total_len, v_head_dim) = v.dims4().ok()?;
+        let (k_bsz, k_heads, kv_capacity_len, k_head_dim) = k.dims4().ok()?;
+        let (v_bsz, v_heads, v_capacity_len, v_head_dim) = v.dims4().ok()?;
         if q_bsz != 1
             || k_bsz != 1
             || v_bsz != 1
@@ -1650,9 +1679,10 @@ pub fn try_fused_decode_gqa_attention(
             || q_head_dim != head_dim
             || k_head_dim != head_dim
             || v_head_dim != head_dim
-            || total_len != v_total_len
-            || total_len == 0
-            || total_len > 2048
+            || kv_capacity_len != v_capacity_len
+            || kv_len == 0
+            || kv_len > kv_capacity_len
+            || kv_len > 2048
             || num_heads == 0
             || num_kv_heads == 0
             || num_heads % num_kv_heads != 0
@@ -1678,7 +1708,8 @@ pub fn try_fused_decode_gqa_attention(
                 &DecodeGqaAttentionOp {
                     num_heads,
                     num_kv_heads,
-                    total_len,
+                    kv_len,
+                    kv_capacity_len,
                     head_dim,
                     scale,
                 },
@@ -2369,6 +2400,52 @@ mod tests {
                 assert!(
                     (actual - expected).abs() <= tolerance,
                     "{dtype:?} mismatch at {idx}: {actual} != {expected}"
+                );
+            }
+
+            let k_padded = Tensor::from_vec(
+                vec![
+                    0.3f32, -0.5, 0.7, -0.9, //
+                    1.1, -1.3, 1.5, -1.7, //
+                    1.9, -2.1, 2.3, -2.5, //
+                    90.0, 91.0, 92.0, 93.0, //
+                    -90.0, -91.0, -92.0, -93.0,
+                ],
+                (1, 1, 5, 4),
+                &device,
+            )
+            .unwrap()
+            .to_dtype(dtype)
+            .unwrap();
+            let v_padded = Tensor::from_vec(
+                vec![
+                    -0.2f32, 0.4, -0.6, 0.8, //
+                    1.0, -1.2, 1.4, -1.6, //
+                    -1.8, 2.0, -2.2, 2.4, //
+                    80.0, 81.0, 82.0, 83.0, //
+                    -80.0, -81.0, -82.0, -83.0,
+                ],
+                (1, 1, 5, 4),
+                &device,
+            )
+            .unwrap()
+            .to_dtype(dtype)
+            .unwrap();
+            let padded_out = try_fused_decode_gqa_attention_with_kv_len(
+                &q, &k_padded, &v_padded, 2, 1, 4, 3, scale,
+            )
+            .expect("fused decode GQA attention should ignore padded cache tail");
+            let padded_out = padded_out
+                .to_dtype(DType::F32)
+                .unwrap()
+                .flatten_all()
+                .unwrap()
+                .to_vec1::<f32>()
+                .unwrap();
+            for (idx, (actual, expected)) in padded_out.iter().zip(reference.iter()).enumerate() {
+                assert!(
+                    (actual - expected).abs() <= tolerance,
+                    "{dtype:?} padded mismatch at {idx}: {actual} != {expected}"
                 );
             }
         }

--- a/crates/izwi-core/src/kernels/mod.rs
+++ b/crates/izwi-core/src/kernels/mod.rs
@@ -200,6 +200,36 @@ pub fn try_fused_decode_gqa_attention(
     None
 }
 
+pub fn try_fused_decode_gqa_attention_with_kv_len(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    kv_len: usize,
+    scale: f32,
+) -> Option<Tensor> {
+    if !use_fused_kernels_for_device(q.device()) {
+        return None;
+    }
+
+    if q.device().is_metal() {
+        return metal::try_fused_decode_gqa_attention_with_kv_len(
+            q,
+            k,
+            v,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            kv_len,
+            scale,
+        );
+    }
+
+    None
+}
+
 pub fn try_fused_gated_rms_norm(
     hidden: &Tensor,
     gate: &Tensor,

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/audio_output.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/audio_output.rs
@@ -20,7 +20,9 @@ use crate::models::shared::weights::gguf::GgufLoader;
 
 use super::cache::DenseKvCache;
 use super::config::Lfm25AudioDecoderConfig;
-use super::sampling::{sample_from_logits, Lfm25SamplingConfig, SimpleRng};
+use super::sampling::{
+    greedy_token_tensor_from_logits, sample_from_logits, Lfm25SamplingConfig, SimpleRng,
+};
 
 const DEPTHFORMER_HEADS: usize = 32;
 const DEPTHFORMER_KV_HEADS: usize = 8;
@@ -133,18 +135,19 @@ impl Lfm25AudioHead {
 
         let mut next_embed = Tensor::zeros(self.depthformer_dim, hidden.dtype(), hidden.device())?;
         let mut caches = self.depthformer.empty_cache();
-        let mut tokens = Vec::with_capacity(self.codebooks);
+        let mut samples = Vec::with_capacity(self.codebooks);
 
         for codebook_idx in 0..self.codebooks {
             let cur = depth_input.i(codebook_idx)?.broadcast_add(&next_embed)?;
             let cur = cur.unsqueeze(0)?.unsqueeze(0)?;
             let out = self.depthformer.forward_cached(&cur, &mut caches)?;
-            let token = self.depth_embeddings[codebook_idx].sample(&out, config, rng)?;
-            next_embed = self.depth_embeddings[codebook_idx].embed(token, hidden.device())?;
-            tokens.push(token);
+            let sample = self.depth_embeddings[codebook_idx].sample(&out, config, rng)?;
+            next_embed =
+                self.depth_embeddings[codebook_idx].embed_sample(&sample, hidden.device())?;
+            samples.push(sample);
         }
 
-        Ok(tokens)
+        materialize_codebook_samples(&samples)
     }
 }
 
@@ -539,6 +542,11 @@ struct CodebookEmbeddingHead {
     to_logits: QLinear,
 }
 
+enum CodebookSample {
+    Host(u32),
+    DeviceGreedy(Tensor),
+}
+
 impl CodebookEmbeddingHead {
     fn load(loader: &GgufLoader, device: &Device, idx: usize) -> Result<Self> {
         let embedding = load_embedding_any(
@@ -566,7 +574,18 @@ impl CodebookEmbeddingHead {
 
     fn embed(&self, token: u32, device: &Device) -> Result<Tensor> {
         let token = Tensor::from_vec(vec![token], (1,), device)?;
-        let embed = self.embedding.forward(&token)?;
+        self.embed_token_tensor(&token)
+    }
+
+    fn embed_sample(&self, sample: &CodebookSample, device: &Device) -> Result<Tensor> {
+        match sample {
+            CodebookSample::Host(token) => self.embed(*token, device),
+            CodebookSample::DeviceGreedy(token) => self.embed_token_tensor(token),
+        }
+    }
+
+    fn embed_token_tensor(&self, token: &Tensor) -> Result<Tensor> {
+        let embed = self.embedding.forward(token)?;
         embed.squeeze(0).map_err(Error::from)
     }
 
@@ -582,10 +601,46 @@ impl CodebookEmbeddingHead {
         hidden: &Tensor,
         config: &Lfm25SamplingConfig,
         rng: &mut SimpleRng,
-    ) -> Result<u32> {
+    ) -> Result<CodebookSample> {
         let logits = self.logits(hidden)?;
-        sample_from_logits(&logits, logits.dim(0)?, config, rng)
+        let vocab_limit = logits.dim(0)?;
+        if config.temperature <= 1e-5 {
+            if let Some(token) = greedy_token_tensor_from_logits(&logits, vocab_limit)? {
+                return Ok(CodebookSample::DeviceGreedy(token));
+            }
+        }
+        sample_from_logits(&logits, vocab_limit, config, rng).map(CodebookSample::Host)
     }
+}
+
+fn materialize_codebook_samples(samples: &[CodebookSample]) -> Result<Vec<u32>> {
+    if samples
+        .iter()
+        .all(|sample| matches!(sample, CodebookSample::DeviceGreedy(_)))
+    {
+        let tensors = samples
+            .iter()
+            .filter_map(|sample| match sample {
+                CodebookSample::DeviceGreedy(token) => Some(token),
+                CodebookSample::Host(_) => None,
+            })
+            .collect::<Vec<_>>();
+        if !tensors.is_empty() {
+            return Tensor::cat(&tensors, 0)?
+                .to_vec1::<u32>()
+                .map_err(Error::from);
+        }
+    }
+
+    samples
+        .iter()
+        .map(|sample| match sample {
+            CodebookSample::Host(token) => Ok(*token),
+            CodebookSample::DeviceGreedy(token) => {
+                token.squeeze(0)?.to_scalar::<u32>().map_err(Error::from)
+            }
+        })
+        .collect()
 }
 
 #[derive(Debug)]

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/audio_output.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/audio_output.rs
@@ -8,7 +8,7 @@ use candle_transformers::utils::repeat_kv as candle_repeat_kv;
 
 use crate::error::{Error, Result};
 use crate::kernels::{
-    try_fused_decode_gqa_attention, try_fused_qk_rms_norm, try_fused_rope_pair_bshd,
+    try_fused_decode_gqa_attention_with_kv_len, try_fused_qk_rms_norm, try_fused_rope_pair_bshd,
     try_fused_silu_mul_with_status,
 };
 use crate::models::shared::telemetry::{
@@ -18,6 +18,7 @@ use crate::models::shared::telemetry::{
 };
 use crate::models::shared::weights::gguf::GgufLoader;
 
+use super::cache::DenseKvCache;
 use super::config::Lfm25AudioDecoderConfig;
 use super::sampling::{sample_from_logits, Lfm25SamplingConfig, SimpleRng};
 
@@ -149,6 +150,7 @@ impl Lfm25AudioHead {
 
 struct Depthformer {
     layers: Vec<DepthformerBlock>,
+    cache_initial_capacity: usize,
 }
 
 impl Depthformer {
@@ -162,18 +164,19 @@ impl Depthformer {
                 cfg.depthformer_dim,
             )?);
         }
-        Ok(Self { layers })
+        Ok(Self {
+            layers,
+            cache_initial_capacity: cfg.codebooks.max(1),
+        })
     }
 
-    fn empty_cache(&self) -> Vec<Option<(Tensor, Tensor)>> {
-        vec![None; self.layers.len()]
+    fn empty_cache(&self) -> Vec<DenseKvCache> {
+        (0..self.layers.len())
+            .map(|_| DenseKvCache::new(self.cache_initial_capacity))
+            .collect()
     }
 
-    fn forward_cached(
-        &self,
-        x: &Tensor,
-        caches: &mut [Option<(Tensor, Tensor)>],
-    ) -> Result<Tensor> {
+    fn forward_cached(&self, x: &Tensor, caches: &mut [DenseKvCache]) -> Result<Tensor> {
         let mut hidden = x.clone();
         for (layer, cache) in self.layers.iter().zip(caches.iter_mut()) {
             hidden = layer.forward_cached(&hidden, cache)?;
@@ -219,7 +222,7 @@ impl DepthformerBlock {
         })
     }
 
-    fn forward_cached(&self, x: &Tensor, cache: &mut Option<(Tensor, Tensor)>) -> Result<Tensor> {
+    fn forward_cached(&self, x: &Tensor, cache: &mut DenseKvCache) -> Result<Tensor> {
         let hidden = self.attn.forward(&self.attn_norm.forward(x)?, cache)?;
         let hidden = hidden.broadcast_add(x)?;
         let ffn = self.mlp.forward(&self.ffn_norm.forward(&hidden)?)?;
@@ -349,7 +352,7 @@ impl DepthAttention {
         })
     }
 
-    fn forward(&self, hidden: &Tensor, cache: &mut Option<(Tensor, Tensor)>) -> Result<Tensor> {
+    fn forward(&self, hidden: &Tensor, cache: &mut DenseKvCache) -> Result<Tensor> {
         let (batch, seq_len, hidden_size) = hidden.dims3()?;
         let head_dim = hidden_size / DEPTHFORMER_HEADS;
         let kv_hidden = DEPTHFORMER_KV_HEADS * head_dim;
@@ -407,10 +410,7 @@ impl DepthAttention {
             (self.q_norm.forward(&q)?, self.k_norm.forward(&k)?)
         };
 
-        let index_pos = cache
-            .as_ref()
-            .map(|(keys, _values)| keys.dim(2).unwrap_or(0))
-            .unwrap_or(0);
+        let index_pos = cache.len();
         let (q, k) = if let Some((q, k)) =
             try_apply_rotary_emb_pair_bshd(&q, &k, &self.cos_sin, index_pos)?
         {
@@ -427,23 +427,24 @@ impl DepthAttention {
             )
         };
 
-        // KV cache in [b, h, s, d] layout — cat on dim 2 (seq)
-        let (all_k, all_v): (Tensor, Tensor) = if let Some((old_k, old_v)) = cache.as_ref() {
-            (Tensor::cat(&[old_k, &k], 2)?, Tensor::cat(&[old_v, &v], 2)?)
-        } else {
-            (k, v)
-        };
-        *cache = Some((all_k.clone(), all_v.clone()));
+        let super::cache::DenseKvCacheView {
+            current_k: all_k,
+            current_v: all_v,
+            full_k: cache_full_k,
+            full_v: cache_full_v,
+            valid_len: cache_valid_len,
+        } = cache.append(&k, &v)?;
 
         if batch == 1 && seq_len == 1 && q.device().is_metal() {
             record_fused_attention_attempt();
-            if let Some(out) = try_fused_decode_gqa_attention(
+            if let Some(out) = try_fused_decode_gqa_attention_with_kv_len(
                 &q.contiguous()?,
-                &all_k.contiguous()?,
-                &all_v.contiguous()?,
+                &cache_full_k,
+                &cache_full_v,
                 DEPTHFORMER_HEADS,
                 DEPTHFORMER_KV_HEADS,
                 head_dim,
+                cache_valid_len,
                 (1.0f64 / (head_dim as f64).sqrt()) as f32,
             ) {
                 record_fused_attention_success();

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/audio_output.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/audio_output.rs
@@ -3,12 +3,19 @@ use std::sync::Arc;
 use candle_core::{DType, Device, IndexOp, Tensor};
 use candle_nn::{Embedding, Module};
 use candle_transformers::models::with_tracing::QMatMul;
-use candle_transformers::quantized_nn::RmsNorm;
 
 use candle_transformers::utils::repeat_kv as candle_repeat_kv;
 
 use crate::error::{Error, Result};
-use crate::models::shared::telemetry::record_rope_kernel;
+use crate::kernels::{
+    try_fused_decode_gqa_attention, try_fused_qk_rms_norm, try_fused_rope_pair_bshd,
+    try_fused_silu_mul_with_status,
+};
+use crate::models::shared::telemetry::{
+    record_decode_attention_path, record_fused_attention_attempt, record_fused_attention_fallback,
+    record_fused_attention_success, record_rope_kernel, AttentionFallbackReason,
+    DecodeAttentionPath,
+};
 use crate::models::shared::weights::gguf::GgufLoader;
 
 use super::config::Lfm25AudioDecoderConfig;
@@ -176,9 +183,9 @@ impl Depthformer {
 }
 
 struct DepthformerBlock {
-    attn_norm: RmsNorm,
+    attn_norm: DepthRmsNorm,
     attn: DepthAttention,
-    ffn_norm: RmsNorm,
+    ffn_norm: DepthRmsNorm,
     mlp: DepthMlp,
 }
 
@@ -223,10 +230,37 @@ impl DepthformerBlock {
 struct DepthAttention {
     qkv: DepthQkvProjection,
     o_proj: QLinear,
-    q_norm: RmsNorm,
-    k_norm: RmsNorm,
+    q_norm: DepthRmsNorm,
+    k_norm: DepthRmsNorm,
+    qk_norm_weight: Tensor,
     cos: Tensor,
     sin: Tensor,
+    cos_sin: Tensor,
+}
+
+#[derive(Debug, Clone)]
+struct DepthRmsNorm {
+    weight: Tensor,
+    eps: f64,
+}
+
+impl DepthRmsNorm {
+    fn from_qtensor(weight: candle_core::quantized::QTensor, eps: f64) -> Result<Self> {
+        let weight = weight.dequantize(&weight.device()).map_err(Error::from)?;
+        Ok(Self { weight, eps })
+    }
+
+    fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        candle_nn::ops::rms_norm(input, &self.weight, self.eps as f32).map_err(Error::from)
+    }
+
+    fn eps(&self) -> f64 {
+        self.eps
+    }
+
+    fn weight(&self) -> &Tensor {
+        &self.weight
+    }
 }
 
 enum DepthQkvProjection {
@@ -299,15 +333,19 @@ impl DepthAttention {
                 format!("depthformer.layers.{idx}.operator.attention.k_layernorm.weight"),
             ],
         )?;
+        let qk_norm_weight = Tensor::cat(&[q_norm.weight(), k_norm.weight()], 0)?.contiguous()?;
         let (cos, sin) =
             precompute_freqs(dim / DEPTHFORMER_HEADS, DEPTHFORMER_ROPE_BASE, 32, device)?;
+        let cos_sin = Tensor::cat(&[&cos, &sin], 1)?.contiguous()?;
         Ok(Self {
             qkv,
             o_proj,
             q_norm,
             k_norm,
+            qk_norm_weight,
             cos,
             sin,
+            cos_sin,
         })
     }
 
@@ -344,30 +382,50 @@ impl DepthAttention {
             ),
         };
 
-        // reshape [b, s, hidden] -> [b, s, heads, head_dim] then transpose to [b, heads, s, head_dim]
+        // reshape [b, s, hidden] -> [b, s, heads, head_dim]
         let q = q_hidden
             .reshape((batch, seq_len, DEPTHFORMER_HEADS, head_dim))?
-            .transpose(1, 2)?
             .contiguous()?;
         let k = k_hidden
             .reshape((batch, seq_len, DEPTHFORMER_KV_HEADS, head_dim))?
-            .transpose(1, 2)?
             .contiguous()?;
         let v = v_hidden
             .reshape((batch, seq_len, DEPTHFORMER_KV_HEADS, head_dim))?
             .transpose(1, 2)?
             .contiguous()?;
 
-        // norm on last dim (head_dim), then RoPE — all in [b, h, s, d] layout
-        let q = self.q_norm.forward(&q)?;
-        let k = self.k_norm.forward(&k)?;
+        // norm on last dim (head_dim), then RoPE
+        let (q, k) = if seq_len == 1 && q.device().is_metal() {
+            if let Some((q, k)) =
+                try_fused_qk_rms_norm(&q, &k, &self.qk_norm_weight, self.q_norm.eps())
+            {
+                (q, k)
+            } else {
+                (self.q_norm.forward(&q)?, self.k_norm.forward(&k)?)
+            }
+        } else {
+            (self.q_norm.forward(&q)?, self.k_norm.forward(&k)?)
+        };
 
         let index_pos = cache
             .as_ref()
             .map(|(keys, _values)| keys.dim(2).unwrap_or(0))
             .unwrap_or(0);
-        let q = apply_rotary_emb(&q, &self.cos, &self.sin, index_pos)?;
-        let k = apply_rotary_emb(&k, &self.cos, &self.sin, index_pos)?;
+        let (q, k) = if let Some((q, k)) =
+            try_apply_rotary_emb_pair_bshd(&q, &k, &self.cos_sin, index_pos)?
+        {
+            (
+                q.transpose(1, 2)?.contiguous()?,
+                k.transpose(1, 2)?.contiguous()?,
+            )
+        } else {
+            let q = q.transpose(1, 2)?.contiguous()?;
+            let k = k.transpose(1, 2)?.contiguous()?;
+            (
+                apply_rotary_emb(&q, &self.cos, &self.sin, index_pos)?,
+                apply_rotary_emb(&k, &self.cos, &self.sin, index_pos)?,
+            )
+        };
 
         // KV cache in [b, h, s, d] layout — cat on dim 2 (seq)
         let (all_k, all_v): (Tensor, Tensor) = if let Some((old_k, old_v)) = cache.as_ref() {
@@ -376,6 +434,26 @@ impl DepthAttention {
             (k, v)
         };
         *cache = Some((all_k.clone(), all_v.clone()));
+
+        if batch == 1 && seq_len == 1 && q.device().is_metal() {
+            record_fused_attention_attempt();
+            if let Some(out) = try_fused_decode_gqa_attention(
+                &q.contiguous()?,
+                &all_k.contiguous()?,
+                &all_v.contiguous()?,
+                DEPTHFORMER_HEADS,
+                DEPTHFORMER_KV_HEADS,
+                head_dim,
+                (1.0f64 / (head_dim as f64).sqrt()) as f32,
+            ) {
+                record_fused_attention_success();
+                let out = out
+                    .transpose(1, 2)?
+                    .reshape((batch, seq_len, hidden_size))?;
+                return self.o_proj.forward(&out);
+            }
+            record_fused_attention_fallback(AttentionFallbackReason::UnsupportedBackend);
+        }
 
         // GQA repeat_kv directly on [b, h, s, d] layout
         let (key, value) = if DEPTHFORMER_HEADS != DEPTHFORMER_KV_HEADS {
@@ -387,6 +465,9 @@ impl DepthAttention {
         } else {
             (all_k, all_v)
         };
+        if seq_len == 1 {
+            record_decode_attention_path(DecodeAttentionPath::Dense);
+        }
         let scores = (q.matmul(&key.transpose(2, 3)?.contiguous()?)?
             / ((hidden_size / DEPTHFORMER_HEADS) as f64).sqrt())?;
         let scores = causal_mask(scores, index_pos)?;
@@ -439,15 +520,21 @@ impl DepthMlp {
     }
 
     fn forward(&self, hidden: &Tensor) -> Result<Tensor> {
-        let gate = candle_nn::ops::silu(&self.w1.forward(hidden)?)?;
+        let gate = self.w1.forward(hidden)?;
         let up = self.w3.forward(hidden)?;
-        self.w2.forward(&(&gate * &up)?)
+        let hidden = if let Some(fused) = try_fused_silu_mul_with_status(&gate, &up) {
+            fused.tensor
+        } else {
+            let gate = candle_nn::ops::silu(&gate)?;
+            gate.broadcast_mul(&up)?
+        };
+        self.w2.forward(&hidden)
     }
 }
 
 struct CodebookEmbeddingHead {
     embedding: Embedding,
-    norm: RmsNorm,
+    norm: DepthRmsNorm,
     to_logits: QLinear,
 }
 
@@ -537,12 +624,15 @@ fn load_embedding_any(loader: &GgufLoader, device: &Device, names: &[String]) ->
     Ok(Embedding::new(weight, dim))
 }
 
-fn load_rms_norm_any(loader: &GgufLoader, device: &Device, names: &[String]) -> Result<RmsNorm> {
-    RmsNorm::from_qtensor(
+fn load_rms_norm_any(
+    loader: &GgufLoader,
+    device: &Device,
+    names: &[String],
+) -> Result<DepthRmsNorm> {
+    DepthRmsNorm::from_qtensor(
         load_qtensor_any(loader, device, names)?,
         DEPTHFORMER_NORM_EPS,
     )
-    .map_err(Error::from)
 }
 
 fn load_qtensor_any(
@@ -599,6 +689,22 @@ fn apply_rotary_emb(x: &Tensor, cos: &Tensor, sin: &Tensor, index_pos: usize) ->
     let sin = sin.narrow(0, index_pos, seq_len)?;
     record_rope_kernel();
     candle_nn::rotary_emb::rope(&x.contiguous()?, &cos, &sin).map_err(Error::from)
+}
+
+fn try_apply_rotary_emb_pair_bshd(
+    q: &Tensor,
+    k: &Tensor,
+    cos_sin: &Tensor,
+    index_pos: usize,
+) -> Result<Option<(Tensor, Tensor)>> {
+    let (_, seq_len, _, _) = q.dims4()?;
+    let packed = cos_sin.narrow(0, index_pos, seq_len)?.contiguous()?;
+    if let Some((q, k)) = try_fused_rope_pair_bshd(&q.contiguous()?, &k.contiguous()?, &packed) {
+        record_rope_kernel();
+        record_rope_kernel();
+        return Ok(Some((q, k)));
+    }
+    Ok(None)
 }
 
 fn causal_mask(scores: Tensor, index_pos: usize) -> Result<Tensor> {

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/backbone.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/backbone.rs
@@ -9,7 +9,7 @@ use candle_transformers::utils::repeat_kv as candle_repeat_kv;
 
 use crate::error::{Error, Result};
 use crate::kernels::{
-    try_fused_decode_gqa_attention, try_fused_qk_rms_norm, try_fused_rope_pair_bshd,
+    try_fused_decode_gqa_attention_with_kv_len, try_fused_qk_rms_norm, try_fused_rope_pair_bshd,
     try_fused_silu_mul_with_status,
 };
 use crate::models::shared::attention::flash::{
@@ -22,6 +22,7 @@ use crate::models::shared::telemetry::{
 };
 use crate::models::shared::weights::gguf::GgufLoader;
 
+use super::cache::DenseKvCache;
 use super::config::Lfm2BackboneConfig;
 
 #[derive(Debug)]
@@ -48,7 +49,7 @@ struct AttentionLayer {
     sin: Tensor,
     cos_sin: Tensor,
     neg_inf: Tensor,
-    kv_cache: Option<(Tensor, Tensor)>,
+    kv_cache: DenseKvCache,
 }
 
 #[derive(Debug)]
@@ -259,19 +260,16 @@ impl AttentionLayer {
             )
         };
 
-        let (all_keys, all_values) = if let Some((cached_keys, cached_values)) = &self.kv_cache {
-            if index_pos == 0 {
-                (key_states, value_states)
-            } else {
-                (
-                    Tensor::cat(&[cached_keys, &key_states], 2)?,
-                    Tensor::cat(&[cached_values, &value_states], 2)?,
-                )
-            }
-        } else {
-            (key_states, value_states)
-        };
-        self.kv_cache = Some((all_keys.clone(), all_values.clone()));
+        if index_pos == 0 {
+            self.kv_cache.reset();
+        }
+        let super::cache::DenseKvCacheView {
+            current_k: all_keys,
+            current_v: all_values,
+            full_k: cache_full_keys,
+            full_v: cache_full_values,
+            valid_len: cache_valid_len,
+        } = self.kv_cache.append(&key_states, &value_states)?;
 
         if query_states.device().is_cuda() && flash_attention_requested() {
             let cuda_options =
@@ -295,13 +293,14 @@ impl AttentionLayer {
 
         if batch_size == 1 && seq_len == 1 && mask.is_none() && query_states.device().is_metal() {
             record_fused_attention_attempt();
-            if let Some(attn_output) = try_fused_decode_gqa_attention(
+            if let Some(attn_output) = try_fused_decode_gqa_attention_with_kv_len(
                 &query_states.contiguous()?,
-                &all_keys.contiguous()?,
-                &all_values.contiguous()?,
+                &cache_full_keys,
+                &cache_full_values,
                 self.n_head,
                 self.n_kv_head,
                 self.head_dim,
+                cache_valid_len,
                 (1.0f64 / (self.head_dim as f64).sqrt()) as f32,
             ) {
                 record_fused_attention_success();
@@ -347,7 +346,7 @@ impl AttentionLayer {
     }
 
     fn reset_state(&mut self) {
-        self.kv_cache = None;
+        self.kv_cache.reset();
     }
 }
 
@@ -649,7 +648,7 @@ impl QuantizedLfm2Backbone {
                     sin: sin.clone(),
                     cos_sin: cos_sin.clone(),
                     neg_inf: neg_inf.clone(),
-                    kv_cache: None,
+                    kv_cache: DenseKvCache::new(1),
                 })
             } else {
                 LayerKind::ShortConv(ShortConvLayer {

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/backbone.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/backbone.rs
@@ -4,15 +4,22 @@ use std::sync::Arc;
 use candle_core::{DType, Device, IndexOp, Tensor};
 use candle_nn::{Conv1d, Conv1dConfig, Embedding, Module};
 use candle_transformers::models::with_tracing::QMatMul;
-use candle_transformers::quantized_nn::RmsNorm;
 
 use candle_transformers::utils::repeat_kv as candle_repeat_kv;
 
 use crate::error::{Error, Result};
+use crate::kernels::{
+    try_fused_decode_gqa_attention, try_fused_qk_rms_norm, try_fused_rope_pair_bshd,
+    try_fused_silu_mul_with_status,
+};
 use crate::models::shared::attention::flash::{
     flash_attention_requested, try_fused_self_attention_with_options, CudaFlashAttentionOptions,
 };
-use crate::models::shared::telemetry::record_rope_kernel;
+use crate::models::shared::telemetry::{
+    record_decode_attention_path, record_fused_attention_attempt, record_fused_attention_fallback,
+    record_fused_attention_success, record_rope_kernel, AttentionFallbackReason,
+    DecodeAttentionPath,
+};
 use crate::models::shared::weights::gguf::GgufLoader;
 
 use super::config::Lfm2BackboneConfig;
@@ -30,14 +37,16 @@ struct AttentionLayer {
     wk: QMatMul,
     wv: QMatMul,
     wo: QMatMul,
-    q_norm: RmsNorm,
-    k_norm: RmsNorm,
+    q_norm: LfmRmsNorm,
+    k_norm: LfmRmsNorm,
+    qk_norm_weight: Tensor,
     n_head: usize,
     n_kv_head: usize,
     head_dim: usize,
     sliding_window: Option<usize>,
     cos: Tensor,
     sin: Tensor,
+    cos_sin: Tensor,
     neg_inf: Tensor,
     kv_cache: Option<(Tensor, Tensor)>,
 }
@@ -59,8 +68,8 @@ enum LayerKind {
 
 #[derive(Debug)]
 struct LayerWeights {
-    operator_norm: RmsNorm,
-    ffn_norm: RmsNorm,
+    operator_norm: LfmRmsNorm,
+    ffn_norm: LfmRmsNorm,
     mlp: Mlp,
     kind: LayerKind,
 }
@@ -76,9 +85,34 @@ pub struct QuantizedLfm2Backbone {
     token_embeddings: Embedding,
     output_head: ProjectionHead,
     layers: Vec<LayerWeights>,
-    norm: RmsNorm,
+    norm: LfmRmsNorm,
     masks: HashMap<usize, Tensor>,
     vocab_size: usize,
+}
+
+#[derive(Debug, Clone)]
+struct LfmRmsNorm {
+    weight: Tensor,
+    eps: f64,
+}
+
+impl LfmRmsNorm {
+    fn from_qtensor(weight: candle_core::quantized::QTensor, eps: f64) -> Result<Self> {
+        let weight = weight.dequantize(&weight.device()).map_err(Error::from)?;
+        Ok(Self { weight, eps })
+    }
+
+    fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        candle_nn::ops::rms_norm(input, &self.weight, self.eps as f32).map_err(Error::from)
+    }
+
+    fn eps(&self) -> f64 {
+        self.eps
+    }
+
+    fn weight(&self) -> &Tensor {
+        &self.weight
+    }
 }
 
 impl Mlp {
@@ -120,9 +154,15 @@ impl Mlp {
     }
 
     fn forward(&self, hidden_states: &Tensor) -> Result<Tensor> {
-        let gate = candle_nn::ops::silu(&self.gate.forward(hidden_states)?)?;
+        let gate = self.gate.forward(hidden_states)?;
         let up = self.up.forward(hidden_states)?;
-        self.down.forward(&(&gate * &up)?).map_err(Error::from)
+        let hidden = if let Some(fused) = try_fused_silu_mul_with_status(&gate, &up) {
+            fused.tensor
+        } else {
+            let gate = candle_nn::ops::silu(&gate)?;
+            gate.broadcast_mul(&up)?
+        };
+        self.down.forward(&hidden).map_err(Error::from)
     }
 }
 
@@ -133,6 +173,23 @@ impl AttentionLayer {
         let sin = self.sin.narrow(0, index_pos, seq_len)?;
         record_rope_kernel();
         candle_nn::rotary_emb::rope(&x.contiguous()?, &cos, &sin).map_err(Error::from)
+    }
+
+    fn try_apply_rotary_emb_pair_bshd(
+        &self,
+        q: &Tensor,
+        k: &Tensor,
+        index_pos: usize,
+    ) -> Result<Option<(Tensor, Tensor)>> {
+        let (_, seq_len, _, _) = q.dims4()?;
+        let packed = self.cos_sin.narrow(0, index_pos, seq_len)?.contiguous()?;
+        if let Some((q, k)) = try_fused_rope_pair_bshd(&q.contiguous()?, &k.contiguous()?, &packed)
+        {
+            record_rope_kernel();
+            record_rope_kernel();
+            return Ok(Some((q, k)));
+        }
+        Ok(None)
     }
 
     fn forward(
@@ -162,14 +219,45 @@ impl AttentionLayer {
             self.head_dim,
         ))?;
 
-        let query_states = query_states.transpose(1, 2)?.contiguous()?;
-        let key_states = key_states.transpose(1, 2)?.contiguous()?;
         let value_states = value_states.transpose(1, 2)?.contiguous()?;
 
-        let query_states = self.q_norm.forward(&query_states)?;
-        let key_states = self.k_norm.forward(&key_states)?;
-        let query_states = self.apply_rotary_emb(&query_states, index_pos)?;
-        let key_states = self.apply_rotary_emb(&key_states, index_pos)?;
+        let query_states = query_states.contiguous()?;
+        let key_states = key_states.contiguous()?;
+        let (query_states, key_states) = if seq_len == 1 && query_states.device().is_metal() {
+            if let Some((query_states, key_states)) = try_fused_qk_rms_norm(
+                &query_states,
+                &key_states,
+                &self.qk_norm_weight,
+                self.q_norm.eps(),
+            ) {
+                (query_states, key_states)
+            } else {
+                (
+                    self.q_norm.forward(&query_states)?,
+                    self.k_norm.forward(&key_states)?,
+                )
+            }
+        } else {
+            (
+                self.q_norm.forward(&query_states)?,
+                self.k_norm.forward(&key_states)?,
+            )
+        };
+        let (query_states, key_states) = if let Some((query_states, key_states)) =
+            self.try_apply_rotary_emb_pair_bshd(&query_states, &key_states, index_pos)?
+        {
+            (
+                query_states.transpose(1, 2)?.contiguous()?,
+                key_states.transpose(1, 2)?.contiguous()?,
+            )
+        } else {
+            let query_states = query_states.transpose(1, 2)?.contiguous()?;
+            let key_states = key_states.transpose(1, 2)?.contiguous()?;
+            (
+                self.apply_rotary_emb(&query_states, index_pos)?,
+                self.apply_rotary_emb(&key_states, index_pos)?,
+            )
+        };
 
         let (all_keys, all_values) = if let Some((cached_keys, cached_values)) = &self.kv_cache {
             if index_pos == 0 {
@@ -205,6 +293,27 @@ impl AttentionLayer {
             }
         }
 
+        if batch_size == 1 && seq_len == 1 && mask.is_none() && query_states.device().is_metal() {
+            record_fused_attention_attempt();
+            if let Some(attn_output) = try_fused_decode_gqa_attention(
+                &query_states.contiguous()?,
+                &all_keys.contiguous()?,
+                &all_values.contiguous()?,
+                self.n_head,
+                self.n_kv_head,
+                self.head_dim,
+                (1.0f64 / (self.head_dim as f64).sqrt()) as f32,
+            ) {
+                record_fused_attention_success();
+                let attn_output =
+                    attn_output
+                        .transpose(1, 2)?
+                        .reshape((batch_size, seq_len, hidden_size))?;
+                return self.wo.forward(&attn_output).map_err(Error::from);
+            }
+            record_fused_attention_fallback(AttentionFallbackReason::UnsupportedBackend);
+        }
+
         let (key_states, value_states) = if self.n_head != self.n_kv_head {
             let repeats = self.n_head / self.n_kv_head;
             (
@@ -223,6 +332,9 @@ impl AttentionLayer {
         } else {
             attn_weights
         };
+        if seq_len == 1 {
+            record_decode_attention_path(DecodeAttentionPath::Dense);
+        }
         let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
         let attn_output = attn_weights
             .contiguous()?
@@ -379,6 +491,7 @@ impl QuantizedLfm2Backbone {
             cfg.context_length,
             device,
         )?;
+        let cos_sin = Tensor::cat(&[&cos, &sin], 1)?.contiguous()?;
         let neg_inf = Tensor::new(f32::NEG_INFINITY, device)?;
 
         let token_embedding_q = load_qtensor_any(
@@ -403,7 +516,7 @@ impl QuantizedLfm2Backbone {
         }
 
         let token_embeddings = Embedding::new(token_embeddings_weight, hidden_size);
-        let norm = RmsNorm::from_qtensor(
+        let norm = LfmRmsNorm::from_qtensor(
             load_qtensor_any(
                 loader,
                 device,
@@ -417,15 +530,14 @@ impl QuantizedLfm2Backbone {
                 ],
             )?,
             cfg.attention_layer_norm_rms_epsilon,
-        )
-        .map_err(Error::from)?;
+        )?;
         let output_head = ProjectionHead::load(loader, device)?;
 
         let mut layers = Vec::with_capacity(cfg.block_count);
         for layer_idx in 0..cfg.block_count {
             let prefix = format!("blk.{layer_idx}");
             let legacy_prefix = format!("lfm.layers.{layer_idx}");
-            let operator_norm = RmsNorm::from_qtensor(
+            let operator_norm = LfmRmsNorm::from_qtensor(
                 load_qtensor_any(
                     loader,
                     device,
@@ -437,9 +549,8 @@ impl QuantizedLfm2Backbone {
                     ],
                 )?,
                 cfg.attention_layer_norm_rms_epsilon,
-            )
-            .map_err(Error::from)?;
-            let ffn_norm = RmsNorm::from_qtensor(
+            )?;
+            let ffn_norm = LfmRmsNorm::from_qtensor(
                 load_qtensor_any(
                     loader,
                     device,
@@ -450,8 +561,7 @@ impl QuantizedLfm2Backbone {
                     ],
                 )?,
                 cfg.attention_layer_norm_rms_epsilon,
-            )
-            .map_err(Error::from)?;
+            )?;
             let mlp =
                 Mlp::load_with_prefixes(loader, device, &[prefix.clone(), legacy_prefix.clone()])?;
 
@@ -463,6 +573,34 @@ impl QuantizedLfm2Backbone {
                 > 0;
             let kind = if is_attention {
                 let n_kv_head = cfg.attention_head_count_kv[layer_idx];
+                let q_norm = LfmRmsNorm::from_qtensor(
+                    load_qtensor_any(
+                        loader,
+                        device,
+                        &[
+                            format!("{prefix}.attn_q_norm.weight"),
+                            format!("{prefix}.self_attn.q_layernorm.weight"),
+                            format!("{prefix}.attention.q_norm.weight"),
+                            format!("{legacy_prefix}.self_attn.q_layernorm.weight"),
+                        ],
+                    )?,
+                    cfg.attention_layer_norm_rms_epsilon,
+                )?;
+                let k_norm = LfmRmsNorm::from_qtensor(
+                    load_qtensor_any(
+                        loader,
+                        device,
+                        &[
+                            format!("{prefix}.attn_k_norm.weight"),
+                            format!("{prefix}.self_attn.k_layernorm.weight"),
+                            format!("{prefix}.attention.k_norm.weight"),
+                            format!("{legacy_prefix}.self_attn.k_layernorm.weight"),
+                        ],
+                    )?,
+                    cfg.attention_layer_norm_rms_epsilon,
+                )?;
+                let qk_norm_weight =
+                    Tensor::cat(&[q_norm.weight(), k_norm.weight()], 0)?.contiguous()?;
                 LayerKind::Attention(AttentionLayer {
                     wq: load_qmatmul_any(
                         loader,
@@ -500,40 +638,16 @@ impl QuantizedLfm2Backbone {
                             format!("{legacy_prefix}.self_attn.out_proj.weight"),
                         ],
                     )?,
-                    q_norm: RmsNorm::from_qtensor(
-                        load_qtensor_any(
-                            loader,
-                            device,
-                            &[
-                                format!("{prefix}.attn_q_norm.weight"),
-                                format!("{prefix}.self_attn.q_layernorm.weight"),
-                                format!("{prefix}.attention.q_norm.weight"),
-                                format!("{legacy_prefix}.self_attn.q_layernorm.weight"),
-                            ],
-                        )?,
-                        cfg.attention_layer_norm_rms_epsilon,
-                    )
-                    .map_err(Error::from)?,
-                    k_norm: RmsNorm::from_qtensor(
-                        load_qtensor_any(
-                            loader,
-                            device,
-                            &[
-                                format!("{prefix}.attn_k_norm.weight"),
-                                format!("{prefix}.self_attn.k_layernorm.weight"),
-                                format!("{prefix}.attention.k_norm.weight"),
-                                format!("{legacy_prefix}.self_attn.k_layernorm.weight"),
-                            ],
-                        )?,
-                        cfg.attention_layer_norm_rms_epsilon,
-                    )
-                    .map_err(Error::from)?,
+                    q_norm,
+                    k_norm,
+                    qk_norm_weight,
                     n_head: cfg.attention_head_count,
                     n_kv_head,
                     head_dim: cfg.embedding_length / cfg.attention_head_count,
                     sliding_window: cfg.attention_sliding_window,
                     cos: cos.clone(),
                     sin: sin.clone(),
+                    cos_sin: cos_sin.clone(),
                     neg_inf: neg_inf.clone(),
                     kv_cache: None,
                 })

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/cache.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/cache.rs
@@ -1,0 +1,109 @@
+use candle_core::Tensor;
+use candle_nn::kv_cache::KvCache;
+
+use crate::error::{Error, Result};
+
+#[derive(Debug, Clone)]
+pub(super) struct DenseKvCache {
+    inner: Option<KvCache>,
+    min_initial_capacity: usize,
+}
+
+#[derive(Debug)]
+pub(super) struct DenseKvCacheView {
+    pub current_k: Tensor,
+    pub current_v: Tensor,
+    pub full_k: Tensor,
+    pub full_v: Tensor,
+    pub valid_len: usize,
+}
+
+impl DenseKvCache {
+    pub fn new(min_initial_capacity: usize) -> Self {
+        Self {
+            inner: None,
+            min_initial_capacity: min_initial_capacity.max(1),
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.inner = None;
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner
+            .as_ref()
+            .map(KvCache::current_seq_len)
+            .unwrap_or(0)
+    }
+
+    pub fn append(&mut self, k: &Tensor, v: &Tensor) -> Result<DenseKvCacheView> {
+        let append_tokens = k.dim(2)?;
+        if append_tokens == 0 {
+            return Err(Error::InferenceError(
+                "Cannot append empty LFM2.5 Audio K/V cache chunk".to_string(),
+            ));
+        }
+
+        if self.inner.is_none() {
+            let initial_capacity = append_tokens.max(self.min_initial_capacity);
+            self.inner = Some(KvCache::new(2, initial_capacity));
+        }
+
+        let cache = self.inner.as_mut().ok_or_else(|| {
+            Error::InferenceError("LFM2.5 Audio K/V cache was not initialized".to_string())
+        })?;
+        let (current_k, current_v) = cache.append(k, v)?;
+        let full_k = cache
+            .k_cache()
+            .all_data()
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| Error::InferenceError("LFM2.5 key cache is empty".to_string()))?;
+        let full_v = cache
+            .v_cache()
+            .all_data()
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| Error::InferenceError("LFM2.5 value cache is empty".to_string()))?;
+
+        Ok(DenseKvCacheView {
+            current_k,
+            current_v,
+            full_k,
+            full_v,
+            valid_len: cache.current_seq_len(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dense_kv_cache_uses_observed_first_append_capacity() {
+        let device = candle_core::Device::Cpu;
+        let mut cache = DenseKvCache::new(1);
+        let k = Tensor::zeros((1, 2, 3, 4), candle_core::DType::F32, &device).unwrap();
+        let v = Tensor::zeros((1, 2, 3, 4), candle_core::DType::F32, &device).unwrap();
+        let view = cache.append(&k, &v).unwrap();
+
+        assert_eq!(view.valid_len, 3);
+        assert_eq!(view.current_k.dims(), &[1, 2, 3, 4]);
+        assert_eq!(view.full_k.dims(), &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn dense_kv_cache_can_reserve_small_inner_loop_capacity() {
+        let device = candle_core::Device::Cpu;
+        let mut cache = DenseKvCache::new(8);
+        let k = Tensor::zeros((1, 2, 1, 4), candle_core::DType::F32, &device).unwrap();
+        let v = Tensor::zeros((1, 2, 1, 4), candle_core::DType::F32, &device).unwrap();
+        let view = cache.append(&k, &v).unwrap();
+
+        assert_eq!(view.valid_len, 1);
+        assert_eq!(view.current_k.dims(), &[1, 2, 1, 4]);
+        assert_eq!(view.full_k.dims(), &[1, 2, 8, 4]);
+    }
+}

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/detokenizer.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/detokenizer.rs
@@ -1,9 +1,9 @@
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use candle_core::{DType, Device, IndexOp, Tensor};
 use candle_nn::{Embedding, Module};
 use rustfft::num_complex::Complex;
-use rustfft::FftPlanner;
+use rustfft::{Fft, FftPlanner};
 
 use crate::error::{Error, Result};
 use crate::models::shared::weights::gguf::GgufLoader;
@@ -15,6 +15,8 @@ pub struct Lfm25AudioDetokenizer {
     fused_embedding: Embedding,
     backbone: Mutex<QuantizedLfm2Backbone>,
     istft_window: Vec<f32>,
+    istft_window_sq: Vec<f32>,
+    ifft: Arc<dyn Fft<f32>>,
     upsample_factor: usize,
     n_fft: usize,
     hop_length: usize,
@@ -30,13 +32,8 @@ impl Lfm25AudioDetokenizer {
         decoder_config: &Lfm25AudioDecoderConfig,
         device: &Device,
     ) -> Result<Self> {
-        let fused_embedding = load_embedding_any(
-            decoder_loader,
-            device,
-            &[
-                "emb.emb.weight".to_string(),
-            ],
-        )?;
+        let fused_embedding =
+            load_embedding_any(decoder_loader, device, &["emb.emb.weight".to_string()])?;
         let backbone = QuantizedLfm2Backbone::load(backbone_loader, backbone_config, device)?;
         let istft_window = load_vector_any(
             decoder_loader,
@@ -45,6 +42,12 @@ impl Lfm25AudioDetokenizer {
             decoder_config.output_n_fft,
         )?
         .to_vec1::<f32>()?;
+        let istft_window_sq = istft_window
+            .iter()
+            .map(|value| value * value)
+            .collect::<Vec<_>>();
+        let mut planner = FftPlanner::<f32>::new();
+        let ifft = planner.plan_fft_inverse(decoder_config.output_n_fft);
         let codebook_offsets = (0..decoder_config.codebooks)
             .map(|idx| {
                 u32::try_from(idx * (LFM25_AUDIO_AUDIO_VOCAB_SIZE - 1)).map_err(|_| {
@@ -59,6 +62,8 @@ impl Lfm25AudioDetokenizer {
             fused_embedding,
             backbone: Mutex::new(backbone),
             istft_window,
+            istft_window_sq,
+            ifft,
             upsample_factor: decoder_config.detokenizer_upsample_factor,
             n_fft: decoder_config.output_n_fft,
             hop_length: decoder_config.output_hop_length,
@@ -136,7 +141,7 @@ impl Lfm25AudioDetokenizer {
 
     fn projected_to_waveform(&self, projected: &Tensor) -> Result<Vec<f32>> {
         let projected = projected.i(0)?.to_dtype(DType::F32)?;
-        let (frames, width) = projected.dims2()?;
+        let (_frames, width) = projected.dims2()?;
         let freq_bins = self.n_fft / 2 + 1;
         if width != freq_bins * 2 {
             return Err(Error::InferenceError(format!(
@@ -145,27 +150,12 @@ impl Lfm25AudioDetokenizer {
             )));
         }
 
-        let log_abs = projected.narrow(1, 0, freq_bins)?.to_vec2::<f32>()?;
-        let angle = projected
-            .narrow(1, freq_bins, freq_bins)?
-            .to_vec2::<f32>()?;
-
-        let mut spectrum = vec![vec![Complex::<f32>::new(0.0, 0.0); frames]; freq_bins];
-        for frame_idx in 0..frames {
-            for freq_idx in 0..freq_bins {
-                spectrum[freq_idx][frame_idx] = Complex::from_polar(
-                    log_abs[frame_idx][freq_idx].exp(),
-                    angle[frame_idx][freq_idx],
-                );
-            }
-        }
-
-        self.istft_same(&spectrum)
+        let projected = projected.to_vec2::<f32>()?;
+        self.istft_same(&projected, freq_bins)
     }
 
-    fn istft_same(&self, spectrum: &[Vec<Complex<f32>>]) -> Result<Vec<f32>> {
-        let freq_bins = spectrum.len();
-        let frames = spectrum.first().map(Vec::len).unwrap_or(0);
+    fn istft_same(&self, projected: &[Vec<f32>], freq_bins: usize) -> Result<Vec<f32>> {
+        let frames = projected.len();
         if freq_bins != self.n_fft / 2 + 1 || frames == 0 {
             return Ok(Vec::new());
         }
@@ -174,26 +164,26 @@ impl Lfm25AudioDetokenizer {
         let output_size = (frames - 1) * self.hop_length + self.n_fft;
         let mut output = vec![0.0f32; output_size];
         let mut envelope = vec![0.0f32; output_size];
-
-        let mut planner = FftPlanner::<f32>::new();
-        let ifft = planner.plan_fft_inverse(self.n_fft);
+        let mut full = vec![Complex::<f32>::new(0.0, 0.0); self.n_fft];
 
         for frame_idx in 0..frames {
-            let mut full = vec![Complex::<f32>::new(0.0, 0.0); self.n_fft];
+            full.fill(Complex::new(0.0, 0.0));
+            let frame = &projected[frame_idx];
             for freq_idx in 0..freq_bins {
-                full[freq_idx] = spectrum[freq_idx][frame_idx];
+                full[freq_idx] =
+                    Complex::from_polar(frame[freq_idx].exp(), frame[freq_bins + freq_idx]);
             }
             for freq_idx in 1..(freq_bins - 1) {
-                full[self.n_fft - freq_idx] = spectrum[freq_idx][frame_idx].conj();
+                full[self.n_fft - freq_idx] = full[freq_idx].conj();
             }
 
-            ifft.process(&mut full);
+            self.ifft.process(&mut full);
             for sample_idx in 0..self.n_fft {
                 let sample =
                     full[sample_idx].re / self.n_fft as f32 * self.istft_window[sample_idx];
                 let out_idx = frame_idx * self.hop_length + sample_idx;
                 output[out_idx] += sample;
-                envelope[out_idx] += self.istft_window[sample_idx] * self.istft_window[sample_idx];
+                envelope[out_idx] += self.istft_window_sq[sample_idx];
             }
         }
 

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/mod.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/mod.rs
@@ -3,6 +3,7 @@
 mod audio_output;
 mod backbone;
 mod bundle;
+mod cache;
 mod config;
 mod conformer;
 mod detokenizer;

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::Mutex;
 use std::time::Instant;
 
-use candle_core::{DType, IndexOp, Tensor, D};
+use candle_core::{IndexOp, Tensor};
 use tracing::info;
 
 use crate::backends::{BackendKind, DeviceProfile};
@@ -21,7 +21,9 @@ use super::config::{
 use super::conformer::Lfm25AudioEncoder;
 use super::detokenizer::Lfm25AudioDetokenizer;
 use super::preprocessor::Lfm25AudioPreprocessor;
-use super::sampling::{sample_from_logits, Lfm25AudioGenerationConfig, SimpleRng};
+use super::sampling::{
+    greedy_from_logits, sample_from_logits, Lfm25AudioGenerationConfig, SimpleRng,
+};
 use super::tokenizer::Lfm25TextTokenizer;
 use super::LFM25_AUDIO_DEFAULT_INTERLEAVED_SYSTEM_PROMPT;
 
@@ -88,7 +90,7 @@ struct Lfm25AsrProfile {
     decode_token_tensor_ms: f64,
     decode_forward_ms: f64,
     tokenizer_decode_ms: f64,
-    host_argmax_reads: u64,
+    token_select_reads: u64,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -291,9 +293,9 @@ impl Lfm25AudioModel {
             let decode_started = Instant::now();
             while generated_ids.len() < max_new_tokens {
                 let argmax_started = Instant::now();
-                let next = argmax(&logits, vocab_limit)?;
+                let next = greedy_from_logits(&logits, vocab_limit)?;
                 profile.decode_argmax_ms += elapsed_ms(argmax_started);
-                profile.host_argmax_reads = profile.host_argmax_reads.saturating_add(1);
+                profile.token_select_reads = profile.token_select_reads.saturating_add(1);
                 if next == specials.im_end
                     || next == specials.eos
                     || specials.eos_alt == Some(next)
@@ -342,6 +344,15 @@ impl Lfm25AudioModel {
         })?;
         let main_backbone_ms = elapsed_ms(main_started);
         let model_total_ms = elapsed_ms(total_started);
+        let device_token_select_reads =
+            if self.device.device.is_metal() || self.device.device.is_cuda() {
+                profile.token_select_reads
+            } else {
+                0
+            };
+        let host_argmax_reads = profile
+            .token_select_reads
+            .saturating_sub(device_token_select_reads);
         output.diagnostics = Some(serde_json::json!({
             "model": "lfm25_audio",
             "task": "asr",
@@ -379,7 +390,9 @@ impl Lfm25AudioModel {
             "decode": {
                 "generated_tokens": output.tokens_generated,
                 "max_new_tokens": max_new_tokens,
-                "host_argmax_reads": profile.host_argmax_reads,
+                "token_select_reads": profile.token_select_reads,
+                "device_argmax_reads": device_token_select_reads,
+                "host_argmax_reads": host_argmax_reads,
                 "profile": {
                     "enabled": true,
                     "sampling_ms": profile.decode_argmax_ms,
@@ -1036,45 +1049,6 @@ fn last_hidden_state(hidden_states: &Tensor) -> Result<Tensor> {
     let seq_len = hidden_states.dim(1)?;
     hidden_states
         .i((0, seq_len.saturating_sub(1)))
-        .map_err(Error::from)
-}
-
-fn argmax(logits: &Tensor, vocab_limit: usize) -> Result<u32> {
-    if vocab_limit == 0 {
-        return Err(Error::InferenceError(
-            "Cannot sample from zero-sized vocabulary".to_string(),
-        ));
-    }
-
-    let logits = match logits.rank() {
-        1 => {
-            let vocab = logits.dim(0)?;
-            logits.narrow(0, 0, vocab.min(vocab_limit))?
-        }
-        2 => {
-            let (batch, vocab) = logits.dims2()?;
-            if batch != 1 {
-                return Err(Error::InferenceError(format!(
-                    "Unexpected batched logits for argmax: expected batch=1, got {batch}"
-                )));
-            }
-            logits.i(0)?.narrow(0, 0, vocab.min(vocab_limit))?
-        }
-        rank => {
-            return Err(Error::InferenceError(format!(
-                "Unexpected logits rank for argmax: {rank}"
-            )));
-        }
-    };
-
-    let idx = logits.argmax(D::Minus1)?;
-    let idx = if idx.rank() == 0 {
-        idx
-    } else {
-        idx.squeeze(0)?
-    };
-    idx.to_dtype(DType::U32)?
-        .to_scalar::<u32>()
         .map_err(Error::from)
 }
 

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::sync::Mutex;
+use std::time::Instant;
 
 use candle_core::{DType, IndexOp, Tensor, D};
 use tracing::info;
@@ -33,6 +34,7 @@ pub struct Lfm25AudioTextOutput {
     pub text: String,
     pub prompt_tokens: usize,
     pub tokens_generated: usize,
+    pub diagnostics: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone)]
@@ -43,6 +45,7 @@ pub struct Lfm25AudioGenerationOutput {
     pub audio_frames_generated: usize,
     pub samples: Vec<f32>,
     pub sample_rate: u32,
+    pub diagnostics: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -73,6 +76,33 @@ pub struct Lfm25AudioModel {
     audio_head: Lfm25AudioHead,
     detokenizer: Lfm25AudioDetokenizer,
     main_backbone: Mutex<QuantizedLfm2Backbone>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct Lfm25AsrProfile {
+    prompt_embed_ms: f64,
+    prompt_concat_ms: f64,
+    main_prefill_ms: f64,
+    decode_loop_ms: f64,
+    decode_argmax_ms: f64,
+    decode_token_tensor_ms: f64,
+    decode_forward_ms: f64,
+    tokenizer_decode_ms: f64,
+    host_argmax_reads: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct Lfm25TtsProfile {
+    prompt_embed_ms: f64,
+    main_prefill_ms: f64,
+    text_sampling_ms: f64,
+    tokenizer_decode_ms: f64,
+    text_forward_ms: f64,
+    audio_head_ms: f64,
+    audio_embed_ms: f64,
+    audio_forward_ms: f64,
+    audio_head_calls: u64,
+    text_sample_calls: u64,
 }
 
 impl Lfm25AudioModel {
@@ -204,6 +234,8 @@ impl Lfm25AudioModel {
             return Err(Error::InvalidInput("Empty audio input".to_string()));
         }
 
+        let total_started = Instant::now();
+        let resample_started = Instant::now();
         let mono_16khz = if sample_rate == super::config::LFM25_AUDIO_INPUT_SAMPLE_RATE {
             audio.to_vec()
         } else {
@@ -213,32 +245,55 @@ impl Lfm25AudioModel {
                 super::config::LFM25_AUDIO_INPUT_SAMPLE_RATE,
             )
         };
+        let resample_ms = elapsed_ms(resample_started);
 
+        let feature_started = Instant::now();
         let (features, feature_frames) = self
             .preprocessor
             .compute_features(&mono_16khz, &self.device.device)?;
+        let feature_extract_ms = elapsed_ms(feature_started);
+
+        let encoder_started = Instant::now();
         let audio_embeds = self.encoder.encode(&features, feature_frames)?;
+        let encoder_forward_ms = elapsed_ms(encoder_started);
+        let audio_tokens = audio_embeds.dim(1)?;
+
+        let prompt_started = Instant::now();
         let (prefix_ids, suffix_ids) = self.build_asr_prompt_segments()?;
+        let prompt_build_ms = elapsed_ms(prompt_started);
         let vocab_limit = self.tokenizer.vocab_size();
         let specials = self.tokenizer.specials().clone();
 
-        self.with_main_backbone(|main_backbone| {
+        let main_started = Instant::now();
+        let (mut output, profile) = self.with_main_backbone(|main_backbone| {
+            let mut profile = Lfm25AsrProfile::default();
             main_backbone.reset_state();
 
+            let prompt_embed_started = Instant::now();
             let prefix_embeds = embed_token_ids(main_backbone, &self.device.device, &prefix_ids)?;
             let suffix_embeds = embed_token_ids(main_backbone, &self.device.device, &suffix_ids)?;
+            profile.prompt_embed_ms = elapsed_ms(prompt_embed_started);
+
+            let prompt_concat_started = Instant::now();
             let prompt_embeds = Tensor::cat(&[&prefix_embeds, &audio_embeds, &suffix_embeds], 1)?;
             let prompt_tokens = prompt_embeds.dim(1)?;
+            profile.prompt_concat_ms = elapsed_ms(prompt_concat_started);
 
+            let prefill_started = Instant::now();
             let hidden = main_backbone.forward_embeds(&prompt_embeds, 0)?;
             let mut logits = main_backbone.project_last_hidden(&hidden)?;
+            profile.main_prefill_ms = elapsed_ms(prefill_started);
             let mut position = prompt_tokens;
             let mut generated_ids = Vec::new();
             let mut assembled = String::new();
             let max_new_tokens = max_new_tokens.max(1);
 
+            let decode_started = Instant::now();
             while generated_ids.len() < max_new_tokens {
+                let argmax_started = Instant::now();
                 let next = argmax(&logits, vocab_limit)?;
+                profile.decode_argmax_ms += elapsed_ms(argmax_started);
+                profile.host_argmax_reads = profile.host_argmax_reads.saturating_add(1);
                 if next == specials.im_end
                     || next == specials.eos
                     || specials.eos_alt == Some(next)
@@ -249,7 +304,9 @@ impl Lfm25AudioModel {
                 }
 
                 generated_ids.push(next);
+                let tokenizer_started = Instant::now();
                 let decoded = self.tokenizer.decode_text(&generated_ids)?;
+                profile.tokenizer_decode_ms += elapsed_ms(tokenizer_started);
                 let delta = text_delta(&assembled, &decoded);
                 if !delta.is_empty() {
                     for ch in delta.chars() {
@@ -263,17 +320,77 @@ impl Lfm25AudioModel {
                     break;
                 }
 
+                let token_tensor_started = Instant::now();
                 let next_tensor = Tensor::from_vec(vec![next], (1, 1), &self.device.device)?;
+                profile.decode_token_tensor_ms += elapsed_ms(token_tensor_started);
+                let decode_forward_started = Instant::now();
                 logits = main_backbone.forward_tokens(&next_tensor, position)?;
+                profile.decode_forward_ms += elapsed_ms(decode_forward_started);
                 position += 1;
             }
+            profile.decode_loop_ms = elapsed_ms(decode_started);
 
-            Ok(Lfm25AudioTextOutput {
-                text: assembled.trim().to_string(),
-                prompt_tokens,
-                tokens_generated: generated_ids.len(),
-            })
-        })
+            Ok((
+                Lfm25AudioTextOutput {
+                    text: assembled.trim().to_string(),
+                    prompt_tokens,
+                    tokens_generated: generated_ids.len(),
+                    diagnostics: None,
+                },
+                profile,
+            ))
+        })?;
+        let main_backbone_ms = elapsed_ms(main_started);
+        let model_total_ms = elapsed_ms(total_started);
+        output.diagnostics = Some(serde_json::json!({
+            "model": "lfm25_audio",
+            "task": "asr",
+            "timings_ms": {
+                "resample": resample_ms,
+                "feature_extract": feature_extract_ms,
+                "mel": feature_extract_ms,
+                "encoder_forward": encoder_forward_ms,
+                "audio_encode": encoder_forward_ms,
+                "prompt_build": prompt_build_ms,
+                "prompt_embed": profile.prompt_embed_ms,
+                "prompt_concat": profile.prompt_concat_ms,
+                "prefill": profile.main_prefill_ms,
+                "main_prefill": profile.main_prefill_ms,
+                "decode": profile.decode_loop_ms,
+                "decode_argmax": profile.decode_argmax_ms,
+                "decode_token_tensor": profile.decode_token_tensor_ms,
+                "decode_forward": profile.decode_forward_ms,
+                "tokenizer_decode": profile.tokenizer_decode_ms,
+                "main_backbone": main_backbone_ms,
+                "model_total": model_total_ms
+            },
+            "prompt": {
+                "prompt_tokens": output.prompt_tokens,
+                "prefix_tokens": prefix_ids.len(),
+                "suffix_tokens": suffix_ids.len()
+            },
+            "audio": {
+                "input_samples": audio.len(),
+                "input_sample_rate": sample_rate,
+                "resampled_samples": mono_16khz.len(),
+                "feature_frames": feature_frames,
+                "audio_tokens": audio_tokens
+            },
+            "decode": {
+                "generated_tokens": output.tokens_generated,
+                "max_new_tokens": max_new_tokens,
+                "host_argmax_reads": profile.host_argmax_reads,
+                "profile": {
+                    "enabled": true,
+                    "sampling_ms": profile.decode_argmax_ms,
+                    "token_tensor_ms": profile.decode_token_tensor_ms,
+                    "decoder_forward_ms": profile.decode_forward_ms,
+                    "tokenizer_decode_ms": profile.tokenizer_decode_ms,
+                    "step_total_ms": profile.decode_loop_ms
+                }
+            }
+        }));
+        Ok(output)
     }
 
     pub fn generate_sequential(
@@ -306,22 +423,31 @@ impl Lfm25AudioModel {
         generation_config: &Lfm25AudioGenerationConfig,
         on_text_delta: &mut dyn FnMut(&str),
     ) -> Result<Lfm25AudioGenerationOutput> {
+        let total_started = Instant::now();
+        let prompt_build_started = Instant::now();
         let prompt_ids = self.build_chat_prompt(messages)?;
+        let prompt_build_ms = elapsed_ms(prompt_build_started);
         let vocab_limit = self.tokenizer.vocab_size();
         let specials = self.tokenizer.specials().clone();
         let codebooks = self.decoder_config.codebooks;
 
-        let (text, prompt_tokens, tokens_generated, audio_codes) =
-            self.with_main_backbone(|main_backbone| {
+        let main_started = Instant::now();
+        let (text, prompt_tokens, tokens_generated, audio_codes, profile) = self
+            .with_main_backbone(|main_backbone| {
+                let mut profile = Lfm25TtsProfile::default();
                 let mut rng = SimpleRng::new(generation_config.seed);
                 main_backbone.reset_state();
 
+                let prompt_embed_started = Instant::now();
                 let prompt_embeds =
                     embed_token_ids(main_backbone, &self.device.device, &prompt_ids)?;
+                profile.prompt_embed_ms = elapsed_ms(prompt_embed_started);
                 let prompt_tokens = prompt_embeds.dim(1)?;
+                let prefill_started = Instant::now();
                 let prompt_hidden = main_backbone.forward_embeds(&prompt_embeds, 0)?;
                 let mut last_hidden = last_hidden_state(&prompt_hidden)?;
                 let mut logits = main_backbone.project_last_hidden(&prompt_hidden)?;
+                profile.main_prefill_ms = elapsed_ms(prefill_started);
                 let mut position = prompt_tokens;
                 let mut visible_text_ids = Vec::new();
                 let mut visible_text = String::new();
@@ -332,12 +458,15 @@ impl Lfm25AudioModel {
 
                 while tokens_generated < max_new_tokens {
                     if !in_audio {
+                        let sampling_started = Instant::now();
                         let next = sample_from_logits(
                             &logits,
                             vocab_limit,
                             &generation_config.text,
                             &mut rng,
                         )?;
+                        profile.text_sampling_ms += elapsed_ms(sampling_started);
+                        profile.text_sample_calls = profile.text_sample_calls.saturating_add(1);
                         tokens_generated += 1;
 
                         if next == specials.im_end
@@ -351,7 +480,9 @@ impl Lfm25AudioModel {
                             in_audio = true;
                         } else if next != specials.text_end {
                             visible_text_ids.push(next);
+                            let tokenizer_started = Instant::now();
                             let decoded = self.tokenizer.decode_text(&visible_text_ids)?;
+                            profile.tokenizer_decode_ms += elapsed_ms(tokenizer_started);
                             let delta = text_delta(&visible_text, &decoded);
                             if !delta.is_empty() {
                                 for ch in delta.chars() {
@@ -362,22 +493,27 @@ impl Lfm25AudioModel {
                             visible_text = decoded;
                         }
 
+                        let text_forward_started = Instant::now();
                         let next_embed =
                             embed_token_ids(main_backbone, &self.device.device, &[next])?;
                         let step_hidden = main_backbone.forward_embeds(&next_embed, position)?;
                         position += 1;
                         last_hidden = last_hidden_state(&step_hidden)?;
                         logits = main_backbone.project_last_hidden(&step_hidden)?;
+                        profile.text_forward_ms += elapsed_ms(text_forward_started);
 
                         if has_token_repetition_loop(&visible_text_ids) {
                             break;
                         }
                     } else {
+                        let audio_head_started = Instant::now();
                         let frame = self.audio_head.sample_audio_frame(
                             &last_hidden,
                             &generation_config.audio,
                             &mut rng,
                         )?;
+                        profile.audio_head_ms += elapsed_ms(audio_head_started);
+                        profile.audio_head_calls = profile.audio_head_calls.saturating_add(1);
                         tokens_generated += 1;
                         let is_end =
                             frame.first().copied() == Some(self.audio_head.audio_end_token_id());
@@ -387,12 +523,16 @@ impl Lfm25AudioModel {
                             }
                         }
 
+                        let audio_embed_started = Instant::now();
                         let audio_embed = self
                             .audio_head
                             .embed_audio_frame(&frame, &self.device.device)?;
+                        profile.audio_embed_ms += elapsed_ms(audio_embed_started);
+                        let audio_forward_started = Instant::now();
                         let step_hidden = main_backbone.forward_embeds(&audio_embed, position)?;
                         position += 1;
                         last_hidden = last_hidden_state(&step_hidden)?;
+                        profile.audio_forward_ms += elapsed_ms(audio_forward_started);
 
                         if is_end {
                             in_audio = false;
@@ -406,17 +546,57 @@ impl Lfm25AudioModel {
                     prompt_tokens,
                     tokens_generated,
                     audio_codes,
+                    profile,
                 ))
             })?;
+        let main_backbone_ms = elapsed_ms(main_started);
 
+        let detokenizer_started = Instant::now();
         let samples = self.detokenizer.decode(&audio_codes, &self.device.device)?;
+        let detokenizer_ms = elapsed_ms(detokenizer_started);
+        let model_total_ms = elapsed_ms(total_started);
+        let audio_frames_generated = audio_codes.first().map(Vec::len).unwrap_or(0);
+        let samples_len = samples.len();
         Ok(Lfm25AudioGenerationOutput {
             text,
             prompt_tokens,
             tokens_generated,
-            audio_frames_generated: audio_codes.first().map(Vec::len).unwrap_or(0),
+            audio_frames_generated,
             samples,
             sample_rate: self.decoder_config.output_sample_rate,
+            diagnostics: Some(serde_json::json!({
+                "model": "lfm25_audio",
+                "task": "tts",
+                "timings_ms": {
+                    "prompt_build": prompt_build_ms,
+                    "prompt_embed": profile.prompt_embed_ms,
+                    "prefill": profile.main_prefill_ms,
+                    "main_prefill": profile.main_prefill_ms,
+                    "text_sampling": profile.text_sampling_ms,
+                    "tokenizer_decode": profile.tokenizer_decode_ms,
+                    "text_forward": profile.text_forward_ms,
+                    "audio_head": profile.audio_head_ms,
+                    "audio_embed": profile.audio_embed_ms,
+                    "audio_forward": profile.audio_forward_ms,
+                    "main_backbone": main_backbone_ms,
+                    "detokenizer": detokenizer_ms,
+                    "model_total": model_total_ms
+                },
+                "prompt": {
+                    "prompt_tokens": prompt_tokens
+                },
+                "decode": {
+                    "generated_tokens": tokens_generated,
+                    "max_new_tokens": max_new_tokens,
+                    "text_sample_calls": profile.text_sample_calls,
+                    "audio_head_calls": profile.audio_head_calls
+                },
+                "audio": {
+                    "audio_frames": audio_frames_generated,
+                    "sample_rate": self.decoder_config.output_sample_rate,
+                    "samples": samples_len
+                }
+            })),
         })
     }
 
@@ -624,6 +804,7 @@ impl Lfm25AudioModel {
             audio_frames_generated: audio_codes.first().map(Vec::len).unwrap_or(0),
             samples,
             sample_rate: self.decoder_config.output_sample_rate,
+            diagnostics: None,
         })
     }
 
@@ -845,6 +1026,10 @@ fn embed_token_ids(
 ) -> Result<Tensor> {
     let ids = Tensor::from_vec(token_ids.to_vec(), (1, token_ids.len()), device)?;
     backbone.embed_tokens(&ids)
+}
+
+fn elapsed_ms(started: Instant) -> f64 {
+    started.elapsed().as_secs_f64() * 1000.0
 }
 
 fn last_hidden_state(hidden_states: &Tensor) -> Result<Tensor> {

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/preprocessor.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/preprocessor.rs
@@ -1,6 +1,8 @@
+use std::sync::Arc;
+
 use candle_core::{Device, Tensor};
 use rustfft::num_complex::Complex;
-use rustfft::FftPlanner;
+use rustfft::{Fft, FftPlanner};
 
 use crate::error::{Error, Result};
 
@@ -15,23 +17,32 @@ const F_MAX: f32 = 8_000.0;
 const NORMALIZE_EPS: f32 = 1e-5;
 
 pub struct Lfm25AudioPreprocessor {
-    mel_filterbank: Vec<Vec<f32>>,
+    mel_filterbank_spans: Vec<MelFilterSpan>,
     window: Vec<f32>,
+    fft: Arc<dyn Fft<f32>>,
+}
+
+struct MelFilterSpan {
+    start: usize,
+    weights: Vec<f32>,
 }
 
 impl Lfm25AudioPreprocessor {
     pub fn load() -> Result<Self> {
-        let mel_filterbank = create_mel_filterbank(
+        let mel_filterbank_spans = sparse_mel_filterbank(&create_mel_filterbank(
             LFM25_AUDIO_INPUT_N_FFT / 2 + 1,
             NUM_MEL_BINS,
             LFM25_AUDIO_INPUT_SAMPLE_RATE as f32,
             F_MIN,
             F_MAX,
-        );
+        ));
         let window = hann_window_padded(LFM25_AUDIO_INPUT_N_FFT, LFM25_AUDIO_INPUT_WIN_LENGTH);
+        let mut planner = FftPlanner::<f32>::new();
+        let fft = planner.plan_fft_forward(LFM25_AUDIO_INPUT_N_FFT);
         Ok(Self {
-            mel_filterbank,
+            mel_filterbank_spans,
             window,
+            fft,
         })
     }
 
@@ -41,87 +52,50 @@ impl Lfm25AudioPreprocessor {
         }
 
         let effective_frames = effective_frame_count(waveform.len());
-        let stft = self.stft(waveform)?;
-        let power = self.power_spectrogram(&stft);
-        let mel = self.apply_mel_filterbank(&power);
-        let mut log_mel = self.log_mel(&mel);
-        normalize_per_feature(&mut log_mel, effective_frames);
-
-        let total_frames = log_mel.len().max(1);
-        let mut flat = Vec::with_capacity(NUM_MEL_BINS * total_frames);
-        for mel_idx in 0..NUM_MEL_BINS {
-            for frame in &log_mel {
-                flat.push(frame[mel_idx]);
-            }
-        }
-
-        let features = Tensor::from_vec(flat, (1, NUM_MEL_BINS, total_frames), device)?;
-        Ok((features, effective_frames.min(total_frames)))
-    }
-
-    fn stft(&self, waveform: &[f32]) -> Result<Vec<Vec<Complex<f32>>>> {
-        let mut planner = FftPlanner::<f32>::new();
-        let fft = planner.plan_fft_forward(LFM25_AUDIO_INPUT_N_FFT);
-
         let padded = reflect_pad_center(waveform, LFM25_AUDIO_INPUT_N_FFT / 2);
-        let num_frames = if padded.len() >= LFM25_AUDIO_INPUT_N_FFT {
+        let total_frames = if padded.len() >= LFM25_AUDIO_INPUT_N_FFT {
             (padded.len() - LFM25_AUDIO_INPUT_N_FFT) / LFM25_AUDIO_INPUT_HOP_LENGTH + 1
         } else {
             1
         };
 
-        let mut frames = Vec::with_capacity(num_frames);
-        for frame_idx in 0..num_frames {
+        let mut log_mel = Vec::with_capacity(total_frames * NUM_MEL_BINS);
+        let mut frame = vec![Complex::<f32>::new(0.0, 0.0); LFM25_AUDIO_INPUT_N_FFT];
+        for frame_idx in 0..total_frames {
             let start = frame_idx * LFM25_AUDIO_INPUT_HOP_LENGTH;
-            let end = (start + LFM25_AUDIO_INPUT_N_FFT).min(padded.len());
+            let frame_len = padded
+                .len()
+                .saturating_sub(start)
+                .min(LFM25_AUDIO_INPUT_N_FFT);
+            for (sample_idx, slot) in frame.iter_mut().enumerate() {
+                if sample_idx < frame_len {
+                    slot.re = padded[start + sample_idx] * self.window[sample_idx];
+                } else {
+                    slot.re = 0.0;
+                }
+                slot.im = 0.0;
+            }
 
-            let mut frame: Vec<Complex<f32>> = padded[start..end]
-                .iter()
-                .zip(self.window.iter())
-                .map(|(&sample, &window)| Complex::new(sample * window, 0.0))
-                .collect();
-            frame.resize(LFM25_AUDIO_INPUT_N_FFT, Complex::new(0.0, 0.0));
-            fft.process(&mut frame);
-            frames.push(frame);
+            self.fft.process(&mut frame);
+            for filter in &self.mel_filterbank_spans {
+                let mut sum = 0.0f32;
+                for (offset, weight) in filter.weights.iter().copied().enumerate() {
+                    sum += frame[filter.start + offset].norm_sqr() * weight;
+                }
+                log_mel.push(sum.max(1e-10).ln());
+            }
+        }
+        normalize_flat_per_feature(&mut log_mel, total_frames, effective_frames, NUM_MEL_BINS);
+
+        let mut flat = Vec::with_capacity(NUM_MEL_BINS * total_frames);
+        for mel_idx in 0..NUM_MEL_BINS {
+            for frame_idx in 0..total_frames {
+                flat.push(log_mel[frame_idx * NUM_MEL_BINS + mel_idx]);
+            }
         }
 
-        Ok(frames)
-    }
-
-    fn power_spectrogram(&self, stft: &[Vec<Complex<f32>>]) -> Vec<Vec<f32>> {
-        stft.iter()
-            .map(|frame| {
-                frame[..LFM25_AUDIO_INPUT_N_FFT / 2 + 1]
-                    .iter()
-                    .map(|value| value.norm_sqr())
-                    .collect()
-            })
-            .collect()
-    }
-
-    fn apply_mel_filterbank(&self, power_spec: &[Vec<f32>]) -> Vec<Vec<f32>> {
-        power_spec
-            .iter()
-            .map(|frame| {
-                self.mel_filterbank
-                    .iter()
-                    .map(|mel_filter| {
-                        frame
-                            .iter()
-                            .zip(mel_filter.iter())
-                            .map(|(&power, &weight)| power * weight)
-                            .sum::<f32>()
-                    })
-                    .collect()
-            })
-            .collect()
-    }
-
-    fn log_mel(&self, mel_spec: &[Vec<f32>]) -> Vec<Vec<f32>> {
-        mel_spec
-            .iter()
-            .map(|frame| frame.iter().map(|&x| x.max(1e-10).ln()).collect())
-            .collect()
+        let features = Tensor::from_vec(flat, (1, NUM_MEL_BINS, total_frames), device)?;
+        Ok((features, effective_frames.min(total_frames)))
     }
 }
 
@@ -163,6 +137,46 @@ fn normalize_per_feature(log_mel: &mut [Vec<f32>], effective_frames: usize) {
         }
         for frame in &mut log_mel[usable_frames..] {
             frame[mel_idx] = 0.0;
+        }
+    }
+}
+
+fn normalize_flat_per_feature(
+    log_mel: &mut [f32],
+    total_frames: usize,
+    effective_frames: usize,
+    mel_bins: usize,
+) {
+    if total_frames == 0 || mel_bins == 0 {
+        return;
+    }
+
+    let usable_frames = effective_frames.min(total_frames).max(1);
+    for mel_idx in 0..mel_bins {
+        let mean = (0..usable_frames)
+            .map(|frame_idx| log_mel[frame_idx * mel_bins + mel_idx])
+            .sum::<f32>()
+            / usable_frames as f32;
+
+        let variance = if usable_frames > 1 {
+            (0..usable_frames)
+                .map(|frame_idx| {
+                    let delta = log_mel[frame_idx * mel_bins + mel_idx] - mean;
+                    delta * delta
+                })
+                .sum::<f32>()
+                / (usable_frames - 1) as f32
+        } else {
+            0.0
+        };
+        let inv_std = 1.0 / (variance + NORMALIZE_EPS).sqrt();
+
+        for frame_idx in 0..usable_frames {
+            let idx = frame_idx * mel_bins + mel_idx;
+            log_mel[idx] = (log_mel[idx] - mean) * inv_std;
+        }
+        for frame_idx in usable_frames..total_frames {
+            log_mel[frame_idx * mel_bins + mel_idx] = 0.0;
         }
     }
 }
@@ -227,6 +241,26 @@ fn create_mel_filterbank(
     }
 
     filters
+}
+
+fn sparse_mel_filterbank(filters: &[Vec<f32>]) -> Vec<MelFilterSpan> {
+    filters
+        .iter()
+        .map(|filter| {
+            let start = filter.iter().position(|weight| *weight != 0.0);
+            let end = filter.iter().rposition(|weight| *weight != 0.0);
+            match (start, end) {
+                (Some(start), Some(end)) if start <= end => MelFilterSpan {
+                    start,
+                    weights: filter[start..=end].to_vec(),
+                },
+                _ => MelFilterSpan {
+                    start: 0,
+                    weights: Vec::new(),
+                },
+            }
+        })
+        .collect()
 }
 
 fn reflect_pad_center(waveform: &[f32], pad: usize) -> Vec<f32> {

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/sampling.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/sampling.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use candle_core::{DType, IndexOp, Tensor};
+use candle_core::{DType, IndexOp, Tensor, D};
 
 use crate::error::{Error, Result};
 
@@ -68,13 +68,14 @@ pub fn sample_from_logits(
     config: &Lfm25SamplingConfig,
     rng: &mut SimpleRng,
 ) -> Result<u32> {
-    let mut values = logits_to_vec(logits)?;
-    clamp_logits_to_vocab(&mut values, vocab_limit);
+    let logits = logits_row(logits)?;
+    let vocab_limit = effective_vocab_limit(&logits, vocab_limit)?;
 
     if config.temperature <= 1e-5 {
-        return argmax_values(&values);
+        return greedy_from_logits_row(&logits, vocab_limit);
     }
 
+    let mut values = logits_to_vec(&logits.narrow(0, 0, vocab_limit)?)?;
     let temperature = config.temperature.max(1e-5);
     for value in &mut values {
         if value.is_finite() {
@@ -150,9 +151,15 @@ pub fn sample_from_logits(
         .ok_or_else(|| Error::InferenceError("Failed to sample LFM2.5 Audio token".to_string()))
 }
 
-fn logits_to_vec(logits: &Tensor) -> Result<Vec<f32>> {
-    let logits = match logits.rank() {
-        1 => logits.clone(),
+pub fn greedy_from_logits(logits: &Tensor, vocab_limit: usize) -> Result<u32> {
+    let logits = logits_row(logits)?;
+    let vocab_limit = effective_vocab_limit(&logits, vocab_limit)?;
+    greedy_from_logits_row(&logits, vocab_limit)
+}
+
+fn logits_row(logits: &Tensor) -> Result<Tensor> {
+    match logits.rank() {
+        1 => Ok(logits.clone()),
         2 => {
             let (rows, _cols) = logits.dims2()?;
             if rows != 1 {
@@ -161,25 +168,57 @@ fn logits_to_vec(logits: &Tensor) -> Result<Vec<f32>> {
                     logits.shape().dims()
                 )));
             }
-            logits.i(0)?
+            Ok(logits.i(0)?)
         }
         rank => {
             return Err(Error::InferenceError(format!(
                 "Unexpected LFM2.5 Audio logits rank for sampling: {rank}"
             )));
         }
-    };
+    }
+}
 
+fn logits_to_vec(logits: &Tensor) -> Result<Vec<f32>> {
     logits
         .to_dtype(DType::F32)?
         .to_vec1::<f32>()
         .map_err(Error::from)
 }
 
-fn clamp_logits_to_vocab(values: &mut [f32], vocab_size: usize) {
-    if vocab_size < values.len() {
-        values[vocab_size..].fill(f32::NEG_INFINITY);
+fn effective_vocab_limit(logits: &Tensor, vocab_limit: usize) -> Result<usize> {
+    let vocab = logits.dim(0)?;
+    let limit = vocab.min(vocab_limit);
+    if limit == 0 {
+        return Err(Error::InferenceError(
+            "Cannot sample from zero-sized LFM2.5 Audio vocabulary".to_string(),
+        ));
     }
+    Ok(limit)
+}
+
+fn greedy_from_logits_row(logits: &Tensor, vocab_limit: usize) -> Result<u32> {
+    if logits.device().is_metal() || logits.device().is_cuda() {
+        return argmax_row_device(logits, vocab_limit);
+    }
+    argmax_row_host(logits, vocab_limit)
+}
+
+fn argmax_row_device(logits: &Tensor, vocab_limit: usize) -> Result<u32> {
+    let logits = logits.narrow(0, 0, vocab_limit)?;
+    let idx = logits.argmax(D::Minus1)?;
+    let idx = if idx.rank() == 0 {
+        idx
+    } else {
+        idx.squeeze(0)?
+    };
+    idx.to_dtype(DType::U32)?
+        .to_scalar::<u32>()
+        .map_err(Error::from)
+}
+
+fn argmax_row_host(logits: &Tensor, vocab_limit: usize) -> Result<u32> {
+    let values = logits_to_vec(&logits.narrow(0, 0, vocab_limit)?)?;
+    argmax_values(&values)
 }
 
 fn argmax_values(values: &[f32]) -> Result<u32> {
@@ -217,6 +256,28 @@ mod tests {
         let config = Lfm25SamplingConfig::default();
         let token =
             sample_from_logits(&logits, 3, &config, &mut SimpleRng::new(7)).expect("sample token");
+        assert_eq!(token, 1);
+    }
+
+    #[test]
+    fn greedy_sampling_respects_vocab_limit() {
+        let logits = Tensor::from_vec(vec![0.1f32, 0.9, 7.0], (3,), &candle_core::Device::Cpu)
+            .expect("logits");
+        let token = greedy_from_logits(&logits, 2).expect("sample token");
+        assert_eq!(token, 1);
+    }
+
+    #[test]
+    fn non_greedy_sampling_respects_vocab_limit() {
+        let logits = Tensor::from_vec(vec![0.1f32, 0.9, 7.0], (3,), &candle_core::Device::Cpu)
+            .expect("logits");
+        let config = Lfm25SamplingConfig {
+            temperature: 1.0,
+            top_k: 1,
+            top_p: 1.0,
+        };
+        let token =
+            sample_from_logits(&logits, 2, &config, &mut SimpleRng::new(7)).expect("sample token");
         assert_eq!(token, 1);
     }
 }

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/sampling.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/sampling.rs
@@ -157,6 +157,26 @@ pub fn greedy_from_logits(logits: &Tensor, vocab_limit: usize) -> Result<u32> {
     greedy_from_logits_row(&logits, vocab_limit)
 }
 
+pub fn greedy_token_tensor_from_logits(
+    logits: &Tensor,
+    vocab_limit: usize,
+) -> Result<Option<Tensor>> {
+    let logits = logits_row(logits)?;
+    let vocab_limit = effective_vocab_limit(&logits, vocab_limit)?;
+    if !(logits.device().is_metal() || logits.device().is_cuda()) {
+        return Ok(None);
+    }
+
+    let logits = logits.narrow(0, 0, vocab_limit)?;
+    let idx = logits.argmax(D::Minus1)?;
+    let idx = if idx.rank() == 0 {
+        idx.unsqueeze(0)?
+    } else {
+        idx.reshape((1,))?
+    };
+    idx.to_dtype(DType::U32).map(Some).map_err(Error::from)
+}
+
 fn logits_row(logits: &Tensor) -> Result<Tensor> {
     match logits.rank() {
         1 => Ok(logits.clone()),
@@ -204,16 +224,10 @@ fn greedy_from_logits_row(logits: &Tensor, vocab_limit: usize) -> Result<u32> {
 }
 
 fn argmax_row_device(logits: &Tensor, vocab_limit: usize) -> Result<u32> {
-    let logits = logits.narrow(0, 0, vocab_limit)?;
-    let idx = logits.argmax(D::Minus1)?;
-    let idx = if idx.rank() == 0 {
-        idx
-    } else {
-        idx.squeeze(0)?
-    };
-    idx.to_dtype(DType::U32)?
-        .to_scalar::<u32>()
-        .map_err(Error::from)
+    let idx = greedy_token_tensor_from_logits(logits, vocab_limit)?.ok_or_else(|| {
+        Error::InferenceError("Device argmax requested for non-device logits".to_string())
+    })?;
+    idx.squeeze(0)?.to_scalar::<u32>().map_err(Error::from)
 }
 
 fn argmax_row_host(logits: &Tensor, vocab_limit: usize) -> Result<u32> {
@@ -265,6 +279,15 @@ mod tests {
             .expect("logits");
         let token = greedy_from_logits(&logits, 2).expect("sample token");
         assert_eq!(token, 1);
+    }
+
+    #[test]
+    fn greedy_token_tensor_returns_none_for_cpu_logits() {
+        let logits = Tensor::from_vec(vec![0.1f32, 0.9, 7.0], (3,), &candle_core::Device::Cpu)
+            .expect("logits");
+        assert!(greedy_token_tensor_from_logits(&logits, 2)
+            .expect("device token path")
+            .is_none());
     }
 
     #[test]

--- a/crates/izwi-core/src/models/registry.rs
+++ b/crates/izwi-core/src/models/registry.rs
@@ -504,6 +504,7 @@ pub struct NativeAudioChatGeneration {
     pub audio_frames_generated: usize,
     pub samples: Vec<f32>,
     pub sample_rate: u32,
+    pub diagnostics: Option<serde_json::Value>,
 }
 
 pub enum NativeAsrDecodeState {
@@ -1150,6 +1151,7 @@ impl NativeAudioChatModel {
                     audio_frames_generated: output.audio_frames_generated,
                     samples: output.samples,
                     sample_rate: output.sample_rate,
+                    diagnostics: output.diagnostics,
                 })
             }
         }
@@ -1188,6 +1190,7 @@ impl NativeAudioChatModel {
                     audio_frames_generated: output.audio_frames_generated,
                     samples: output.samples,
                     sample_rate: output.sample_rate,
+                    diagnostics: output.diagnostics,
                 })
             }
         }
@@ -1210,7 +1213,7 @@ impl NativeAudioChatModel {
                 Ok(NativeAsrTranscription {
                     text: output.text,
                     language: None,
-                    diagnostics: None,
+                    diagnostics: output.diagnostics,
                 })
             }
         }

--- a/crates/izwi-core/src/runtime/asr.rs
+++ b/crates/izwi-core/src/runtime/asr.rs
@@ -237,7 +237,7 @@ impl RuntimeService {
             } else {
                 0.0
             },
-            asr_diagnostics: None,
+            asr_diagnostics: output.diagnostics,
         })
     }
 

--- a/crates/izwi-core/src/runtime/kokoro.rs
+++ b/crates/izwi-core/src/runtime/kokoro.rs
@@ -70,6 +70,7 @@ impl RuntimeService {
             sample_rate: result.sample_rate,
             total_tokens: result.tokens_generated,
             total_time_ms,
+            diagnostics: None,
         })
     }
 

--- a/crates/izwi-core/src/runtime/tts.rs
+++ b/crates/izwi-core/src/runtime/tts.rs
@@ -137,6 +137,7 @@ impl RuntimeService {
             sample_rate: output.sample_rate,
             total_tokens: output.tokens_generated,
             total_time_ms,
+            diagnostics: output.diagnostics,
         })
     }
 
@@ -212,6 +213,7 @@ impl RuntimeService {
             sample_rate,
             total_tokens: output.frames_generated,
             total_time_ms,
+            diagnostics: None,
         })
     }
 
@@ -284,6 +286,7 @@ impl RuntimeService {
             sample_rate: output.sample_rate,
             total_tokens: output.frames_generated,
             total_time_ms,
+            diagnostics: None,
         })
     }
 
@@ -387,6 +390,7 @@ impl RuntimeService {
             sample_rate,
             total_tokens,
             total_time_ms,
+            diagnostics: None,
         })
     }
 

--- a/crates/izwi-core/src/runtime/types.rs
+++ b/crates/izwi-core/src/runtime/types.rs
@@ -324,6 +324,7 @@ pub struct GenerationResult {
     pub sample_rate: u32,
     pub total_tokens: usize,
     pub total_time_ms: f32,
+    pub diagnostics: Option<serde_json::Value>,
 }
 
 impl GenerationResult {

--- a/crates/izwi-server/src/api/openai/audio/speech.rs
+++ b/crates/izwi-server/src/api/openai/audio/speech.rs
@@ -1,11 +1,11 @@
 //! OpenAI-compatible speech synthesis endpoints.
 
 use axum::{
-    Json,
     body::Body,
     extract::{Extension, State},
-    http::{StatusCode, header},
+    http::{header, StatusCode},
     response::Response,
+    Json,
 };
 use base64::Engine;
 use serde::{Deserialize, Serialize};
@@ -22,11 +22,11 @@ use izwi_core::audio::{AudioEncoder, AudioFormat};
 use izwi_core::runtime_models::architectures::vibevoice::tts::vibevoice_tts_auto_max_frames_for_text;
 use izwi_core::runtime_models::architectures::voxtral::tts::voxtral_tts_auto_max_frames_for_text;
 use izwi_core::{
-    AudioChunk, GenerationConfig, GenerationRequest, ModelVariant, parse_tts_model_variant,
+    parse_tts_model_variant, AudioChunk, GenerationConfig, GenerationRequest, ModelVariant,
 };
 
 const DEFAULT_STREAM_EVENT_QUEUE_CAPACITY: usize = 32;
-const SPEECH_RESPONSE_EXPOSED_HEADERS: &str = "X-Generation-Time-Ms, X-Audio-Duration-Secs, X-RTF, X-Tokens-Generated, X-Audio-Sample-Rate, X-Requested-Response-Format, X-Actual-Response-Format, X-Response-Format-Fallback";
+const SPEECH_RESPONSE_EXPOSED_HEADERS: &str = "X-Generation-Time-Ms, X-Audio-Duration-Secs, X-RTF, X-Tokens-Generated, X-Audio-Sample-Rate, X-Izwi-Tts-Diagnostics, X-Requested-Response-Format, X-Actual-Response-Format, X-Response-Format-Fallback";
 
 /// OpenAI-compatible speech synthesis request.
 #[derive(Debug, Deserialize)]
@@ -210,6 +210,9 @@ pub async fn speech(
                     "299 Izwi \"Requested response_format returned {actual_format}; fallback was explicitly enabled\""
                 ),
             );
+    }
+    if let Some(diagnostics) = result.diagnostics.as_ref() {
+        builder = builder.header("X-Izwi-Tts-Diagnostics", diagnostics.to_string());
     }
     Ok(builder.body(Body::from(audio_bytes)).unwrap())
 }

--- a/crates/izwi-server/src/api/tts_long_form.rs
+++ b/crates/izwi-server/src/api/tts_long_form.rs
@@ -230,6 +230,7 @@ pub async fn generate_long_form_tts(
         sample_rate,
         total_tokens,
         total_time_ms,
+        diagnostics: None,
     })
 }
 


### PR DESCRIPTION
Adds LFM2.5 ASR/TTS telemetry, fused Metal decode kernels, reduced sampling syncs, bounded KV cache growth, and reused DSP FFT workspaces for faster Metal/CPU inference.