### PR TITLE
Optimize and harden LFM2.5 Audio inference

### DIFF
--- a/crates/izwi-cli/src/commands/bench.rs
+++ b/crates/izwi-cli/src/commands/bench.rs
@@ -3158,8 +3158,11 @@ fn asr_decode_profile_from_diagnostics(
             .get("step_total_ms")
             .and_then(|value| value.as_f64()),
         step_total_p95_ms: None,
-        loop_argmax_ms: None,
-        loop_scalar_read_ms: profile.get("sampling_ms").and_then(|value| value.as_f64()),
+        loop_argmax_ms: profile.get("argmax_ms").and_then(|value| value.as_f64()),
+        loop_scalar_read_ms: profile
+            .get("host_read_ms")
+            .or_else(|| profile.get("sampling_ms"))
+            .and_then(|value| value.as_f64()),
         loop_model_forward_ms: profile
             .get("decoder_forward_ms")
             .and_then(|value| value.as_f64()),

--- a/crates/izwi-cli/src/commands/bench.rs
+++ b/crates/izwi-cli/src/commands/bench.rs
@@ -165,6 +165,8 @@ struct TtsStageTimings {
     audio_head_sample: Option<f64>,
     audio_head_embed_step: Option<f64>,
     audio_head_materialize: Option<f64>,
+    audio_head_materialize_pack: Option<f64>,
+    audio_head_materialize_readback: Option<f64>,
     audio_embed: Option<f64>,
     audio_forward: Option<f64>,
     main_backbone: Option<f64>,
@@ -2761,6 +2763,12 @@ fn tts_stage_timings_from_diagnostics(diagnostics: &serde_json::Value) -> Option
         audio_head_materialize: timings
             .get("audio_head_materialize")
             .and_then(|value| value.as_f64()),
+        audio_head_materialize_pack: timings
+            .get("audio_head_materialize_pack")
+            .and_then(|value| value.as_f64()),
+        audio_head_materialize_readback: timings
+            .get("audio_head_materialize_readback")
+            .and_then(|value| value.as_f64()),
         audio_embed: timings.get("audio_embed").and_then(|value| value.as_f64()),
         audio_forward: timings
             .get("audio_forward")
@@ -3278,6 +3286,8 @@ fn print_tts_stage_timing_summary(samples: &[TtsStageTimings]) {
     let mut audio_head_sample = Vec::new();
     let mut audio_head_embed_step = Vec::new();
     let mut audio_head_materialize = Vec::new();
+    let mut audio_head_materialize_pack = Vec::new();
+    let mut audio_head_materialize_readback = Vec::new();
     let mut audio_embed = Vec::new();
     let mut audio_forward = Vec::new();
     let mut main_backbone = Vec::new();
@@ -3342,6 +3352,12 @@ fn print_tts_stage_timing_summary(samples: &[TtsStageTimings]) {
         }
         if let Some(value) = sample.audio_head_materialize {
             audio_head_materialize.push(value);
+        }
+        if let Some(value) = sample.audio_head_materialize_pack {
+            audio_head_materialize_pack.push(value);
+        }
+        if let Some(value) = sample.audio_head_materialize_readback {
+            audio_head_materialize_readback.push(value);
         }
         if let Some(value) = sample.audio_embed {
             audio_embed.push(value);
@@ -3420,6 +3436,8 @@ fn print_tts_stage_timing_summary(samples: &[TtsStageTimings]) {
     summarize_stage("ah_sample", &audio_head_sample);
     summarize_stage("ah_embed", &audio_head_embed_step);
     summarize_stage("ah_material", &audio_head_materialize);
+    summarize_stage("ah_pack", &audio_head_materialize_pack);
+    summarize_stage("ah_read", &audio_head_materialize_readback);
     summarize_stage("audio_embed", &audio_embed);
     summarize_stage("audio_forward", &audio_forward);
     summarize_stage("main_backbone", &main_backbone);
@@ -4287,6 +4305,8 @@ mod tests {
                 "audio_head_depthformer": 5.2,
                 "audio_head_sample": 5.3,
                 "audio_head_materialize": 5.4,
+                "audio_head_materialize_pack": 5.41,
+                "audio_head_materialize_readback": 5.42,
                 "detokenizer": 6.0,
                 "detokenizer_backbone": 6.1,
                 "detokenizer_readback": 6.2,
@@ -4317,6 +4337,8 @@ mod tests {
         assert_eq!(timings.audio_head_depthformer, Some(5.2));
         assert_eq!(timings.audio_head_sample, Some(5.3));
         assert_eq!(timings.audio_head_materialize, Some(5.4));
+        assert_eq!(timings.audio_head_materialize_pack, Some(5.41));
+        assert_eq!(timings.audio_head_materialize_readback, Some(5.42));
         assert_eq!(timings.detokenizer, Some(6.0));
         assert_eq!(timings.detokenizer_backbone, Some(6.1));
         assert_eq!(timings.detokenizer_readback, Some(6.2));

--- a/crates/izwi-cli/src/commands/bench.rs
+++ b/crates/izwi-cli/src/commands/bench.rs
@@ -157,15 +157,31 @@ struct TtsStageTimings {
     tokenizer_decode: Option<f64>,
     text_forward: Option<f64>,
     audio_head: Option<f64>,
+    audio_head_depth_linear: Option<f64>,
+    audio_head_depth_reshape: Option<f64>,
+    audio_head_cache_setup: Option<f64>,
+    audio_head_codebook_input: Option<f64>,
+    audio_head_depthformer: Option<f64>,
+    audio_head_sample: Option<f64>,
+    audio_head_embed_step: Option<f64>,
+    audio_head_materialize: Option<f64>,
     audio_embed: Option<f64>,
     audio_forward: Option<f64>,
     main_backbone: Option<f64>,
     detokenizer: Option<f64>,
+    detokenizer_embedding: Option<f64>,
+    detokenizer_upsample: Option<f64>,
+    detokenizer_backbone: Option<f64>,
+    detokenizer_projection: Option<f64>,
+    detokenizer_waveform_prepare: Option<f64>,
+    detokenizer_readback: Option<f64>,
+    detokenizer_istft: Option<f64>,
     model_total: Option<f64>,
     prompt_tokens: Option<u64>,
     generated_tokens: Option<u64>,
     audio_frames: Option<u64>,
     audio_head_calls: Option<u64>,
+    audio_head_codebook_steps: Option<u64>,
     text_sample_calls: Option<u64>,
 }
 
@@ -187,8 +203,15 @@ struct AsrStageTimings {
     mel: Option<f64>,
     mel_flatten_upload: Option<f64>,
     audio_encode: Option<f64>,
+    prompt_embed: Option<f64>,
+    prompt_concat: Option<f64>,
     prefill: Option<f64>,
     decode: Option<f64>,
+    decode_argmax: Option<f64>,
+    decode_token_tensor: Option<f64>,
+    decode_forward: Option<f64>,
+    tokenizer_decode: Option<f64>,
+    main_backbone: Option<f64>,
     model_total: Option<f64>,
     prompt_tokens: Option<u64>,
     audio_tokens: Option<u64>,
@@ -2714,6 +2737,30 @@ fn tts_stage_timings_from_diagnostics(diagnostics: &serde_json::Value) -> Option
             .and_then(|value| value.as_f64()),
         text_forward: timings.get("text_forward").and_then(|value| value.as_f64()),
         audio_head: timings.get("audio_head").and_then(|value| value.as_f64()),
+        audio_head_depth_linear: timings
+            .get("audio_head_depth_linear")
+            .and_then(|value| value.as_f64()),
+        audio_head_depth_reshape: timings
+            .get("audio_head_depth_reshape")
+            .and_then(|value| value.as_f64()),
+        audio_head_cache_setup: timings
+            .get("audio_head_cache_setup")
+            .and_then(|value| value.as_f64()),
+        audio_head_codebook_input: timings
+            .get("audio_head_codebook_input")
+            .and_then(|value| value.as_f64()),
+        audio_head_depthformer: timings
+            .get("audio_head_depthformer")
+            .and_then(|value| value.as_f64()),
+        audio_head_sample: timings
+            .get("audio_head_sample")
+            .and_then(|value| value.as_f64()),
+        audio_head_embed_step: timings
+            .get("audio_head_embed_step")
+            .and_then(|value| value.as_f64()),
+        audio_head_materialize: timings
+            .get("audio_head_materialize")
+            .and_then(|value| value.as_f64()),
         audio_embed: timings.get("audio_embed").and_then(|value| value.as_f64()),
         audio_forward: timings
             .get("audio_forward")
@@ -2722,11 +2769,33 @@ fn tts_stage_timings_from_diagnostics(diagnostics: &serde_json::Value) -> Option
             .get("main_backbone")
             .and_then(|value| value.as_f64()),
         detokenizer: timings.get("detokenizer").and_then(|value| value.as_f64()),
+        detokenizer_embedding: timings
+            .get("detokenizer_embedding")
+            .and_then(|value| value.as_f64()),
+        detokenizer_upsample: timings
+            .get("detokenizer_upsample")
+            .and_then(|value| value.as_f64()),
+        detokenizer_backbone: timings
+            .get("detokenizer_backbone")
+            .and_then(|value| value.as_f64()),
+        detokenizer_projection: timings
+            .get("detokenizer_projection")
+            .and_then(|value| value.as_f64()),
+        detokenizer_waveform_prepare: timings
+            .get("detokenizer_waveform_prepare")
+            .and_then(|value| value.as_f64()),
+        detokenizer_readback: timings
+            .get("detokenizer_readback")
+            .and_then(|value| value.as_f64()),
+        detokenizer_istft: timings
+            .get("detokenizer_istft")
+            .and_then(|value| value.as_f64()),
         model_total: timings.get("model_total").and_then(|value| value.as_f64()),
         prompt_tokens: diagnostic_u64(prompt, &["prompt_tokens", "tokens"]),
         generated_tokens: diagnostic_u64(decode, &["generated_tokens"]),
         audio_frames: diagnostic_u64(audio, &["audio_frames", "acoustic_frames"]),
         audio_head_calls: diagnostic_u64(decode, &["audio_head_calls"]),
+        audio_head_codebook_steps: diagnostic_u64(decode, &["audio_head_codebook_steps"]),
         text_sample_calls: diagnostic_u64(decode, &["text_sample_calls"]),
     })
 }
@@ -2769,8 +2838,27 @@ fn asr_stage_timings_from_diagnostics(diagnostics: &serde_json::Value) -> Option
             .get("mel_flatten_upload")
             .and_then(|value| value.as_f64()),
         audio_encode: timings.get("audio_encode").and_then(|value| value.as_f64()),
+        prompt_embed: timings.get("prompt_embed").and_then(|value| value.as_f64()),
+        prompt_concat: timings
+            .get("prompt_concat")
+            .and_then(|value| value.as_f64()),
         prefill: timings.get("prefill").and_then(|value| value.as_f64()),
         decode: timings.get("decode").and_then(|value| value.as_f64()),
+        decode_argmax: timings
+            .get("decode_argmax")
+            .and_then(|value| value.as_f64()),
+        decode_token_tensor: timings
+            .get("decode_token_tensor")
+            .and_then(|value| value.as_f64()),
+        decode_forward: timings
+            .get("decode_forward")
+            .and_then(|value| value.as_f64()),
+        tokenizer_decode: timings
+            .get("tokenizer_decode")
+            .and_then(|value| value.as_f64()),
+        main_backbone: timings
+            .get("main_backbone")
+            .and_then(|value| value.as_f64()),
         model_total: timings.get("model_total").and_then(|value| value.as_f64()),
         prompt_tokens: diagnostic_u64(prompt, &["prompt_tokens", "tokens"]),
         audio_tokens: diagnostic_u64(audio, &["audio_tokens", "acoustic_frames"]),
@@ -3179,15 +3267,31 @@ fn print_tts_stage_timing_summary(samples: &[TtsStageTimings]) {
     let mut tokenizer_decode = Vec::new();
     let mut text_forward = Vec::new();
     let mut audio_head = Vec::new();
+    let mut audio_head_depth_linear = Vec::new();
+    let mut audio_head_depth_reshape = Vec::new();
+    let mut audio_head_cache_setup = Vec::new();
+    let mut audio_head_codebook_input = Vec::new();
+    let mut audio_head_depthformer = Vec::new();
+    let mut audio_head_sample = Vec::new();
+    let mut audio_head_embed_step = Vec::new();
+    let mut audio_head_materialize = Vec::new();
     let mut audio_embed = Vec::new();
     let mut audio_forward = Vec::new();
     let mut main_backbone = Vec::new();
     let mut detokenizer = Vec::new();
+    let mut detokenizer_embedding = Vec::new();
+    let mut detokenizer_upsample = Vec::new();
+    let mut detokenizer_backbone = Vec::new();
+    let mut detokenizer_projection = Vec::new();
+    let mut detokenizer_waveform_prepare = Vec::new();
+    let mut detokenizer_readback = Vec::new();
+    let mut detokenizer_istft = Vec::new();
     let mut model_total = Vec::new();
     let mut prompt_tokens = Vec::new();
     let mut generated_tokens = Vec::new();
     let mut audio_frames = Vec::new();
     let mut audio_head_calls = Vec::new();
+    let mut audio_head_codebook_steps = Vec::new();
     let mut text_sample_calls = Vec::new();
 
     for sample in samples {
@@ -3212,6 +3316,30 @@ fn print_tts_stage_timing_summary(samples: &[TtsStageTimings]) {
         if let Some(value) = sample.audio_head {
             audio_head.push(value);
         }
+        if let Some(value) = sample.audio_head_depth_linear {
+            audio_head_depth_linear.push(value);
+        }
+        if let Some(value) = sample.audio_head_depth_reshape {
+            audio_head_depth_reshape.push(value);
+        }
+        if let Some(value) = sample.audio_head_cache_setup {
+            audio_head_cache_setup.push(value);
+        }
+        if let Some(value) = sample.audio_head_codebook_input {
+            audio_head_codebook_input.push(value);
+        }
+        if let Some(value) = sample.audio_head_depthformer {
+            audio_head_depthformer.push(value);
+        }
+        if let Some(value) = sample.audio_head_sample {
+            audio_head_sample.push(value);
+        }
+        if let Some(value) = sample.audio_head_embed_step {
+            audio_head_embed_step.push(value);
+        }
+        if let Some(value) = sample.audio_head_materialize {
+            audio_head_materialize.push(value);
+        }
         if let Some(value) = sample.audio_embed {
             audio_embed.push(value);
         }
@@ -3223,6 +3351,27 @@ fn print_tts_stage_timing_summary(samples: &[TtsStageTimings]) {
         }
         if let Some(value) = sample.detokenizer {
             detokenizer.push(value);
+        }
+        if let Some(value) = sample.detokenizer_embedding {
+            detokenizer_embedding.push(value);
+        }
+        if let Some(value) = sample.detokenizer_upsample {
+            detokenizer_upsample.push(value);
+        }
+        if let Some(value) = sample.detokenizer_backbone {
+            detokenizer_backbone.push(value);
+        }
+        if let Some(value) = sample.detokenizer_projection {
+            detokenizer_projection.push(value);
+        }
+        if let Some(value) = sample.detokenizer_waveform_prepare {
+            detokenizer_waveform_prepare.push(value);
+        }
+        if let Some(value) = sample.detokenizer_readback {
+            detokenizer_readback.push(value);
+        }
+        if let Some(value) = sample.detokenizer_istft {
+            detokenizer_istft.push(value);
         }
         if let Some(value) = sample.model_total {
             model_total.push(value);
@@ -3238,6 +3387,9 @@ fn print_tts_stage_timing_summary(samples: &[TtsStageTimings]) {
         }
         if let Some(value) = sample.audio_head_calls {
             audio_head_calls.push(value);
+        }
+        if let Some(value) = sample.audio_head_codebook_steps {
+            audio_head_codebook_steps.push(value);
         }
         if let Some(value) = sample.text_sample_calls {
             text_sample_calls.push(value);
@@ -3257,15 +3409,31 @@ fn print_tts_stage_timing_summary(samples: &[TtsStageTimings]) {
     summarize_stage("tokenizer", &tokenizer_decode);
     summarize_stage("text_forward", &text_forward);
     summarize_stage("audio_head", &audio_head);
+    summarize_stage("ah_depth_lin", &audio_head_depth_linear);
+    summarize_stage("ah_reshape", &audio_head_depth_reshape);
+    summarize_stage("ah_cache", &audio_head_cache_setup);
+    summarize_stage("ah_input", &audio_head_codebook_input);
+    summarize_stage("ah_depthform", &audio_head_depthformer);
+    summarize_stage("ah_sample", &audio_head_sample);
+    summarize_stage("ah_embed", &audio_head_embed_step);
+    summarize_stage("ah_material", &audio_head_materialize);
     summarize_stage("audio_embed", &audio_embed);
     summarize_stage("audio_forward", &audio_forward);
     summarize_stage("main_backbone", &main_backbone);
     summarize_stage("detokenizer", &detokenizer);
+    summarize_stage("detok_embed", &detokenizer_embedding);
+    summarize_stage("detok_up", &detokenizer_upsample);
+    summarize_stage("detok_backbn", &detokenizer_backbone);
+    summarize_stage("detok_proj", &detokenizer_projection);
+    summarize_stage("detok_prep", &detokenizer_waveform_prepare);
+    summarize_stage("detok_read", &detokenizer_readback);
+    summarize_stage("detok_istft", &detokenizer_istft);
     summarize_stage("model_total", &model_total);
     summarize_count("prompt_tokens", &prompt_tokens);
     summarize_count("gen_tokens", &generated_tokens);
     summarize_count("audio_frames", &audio_frames);
     summarize_count("audio_head", &audio_head_calls);
+    summarize_count("ah_codebooks", &audio_head_codebook_steps);
     summarize_count("text_sample", &text_sample_calls);
 }
 
@@ -3290,8 +3458,15 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
     let mut mel = Vec::new();
     let mut mel_flatten_upload = Vec::new();
     let mut audio_encode = Vec::new();
+    let mut prompt_embed = Vec::new();
+    let mut prompt_concat = Vec::new();
     let mut prefill = Vec::new();
     let mut decode = Vec::new();
+    let mut decode_argmax = Vec::new();
+    let mut decode_token_tensor = Vec::new();
+    let mut decode_forward = Vec::new();
+    let mut tokenizer_decode = Vec::new();
+    let mut main_backbone = Vec::new();
     let mut model_total = Vec::new();
     let mut prompt_tokens = Vec::new();
     let mut audio_tokens = Vec::new();
@@ -3386,11 +3561,32 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
         if let Some(value) = sample.audio_encode {
             audio_encode.push(value);
         }
+        if let Some(value) = sample.prompt_embed {
+            prompt_embed.push(value);
+        }
+        if let Some(value) = sample.prompt_concat {
+            prompt_concat.push(value);
+        }
         if let Some(value) = sample.prefill {
             prefill.push(value);
         }
         if let Some(value) = sample.decode {
             decode.push(value);
+        }
+        if let Some(value) = sample.decode_argmax {
+            decode_argmax.push(value);
+        }
+        if let Some(value) = sample.decode_token_tensor {
+            decode_token_tensor.push(value);
+        }
+        if let Some(value) = sample.decode_forward {
+            decode_forward.push(value);
+        }
+        if let Some(value) = sample.tokenizer_decode {
+            tokenizer_decode.push(value);
+        }
+        if let Some(value) = sample.main_backbone {
+            main_backbone.push(value);
         }
         if let Some(value) = sample.model_total {
             model_total.push(value);
@@ -3546,8 +3742,15 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
         && mel.is_empty()
         && mel_flatten_upload.is_empty()
         && audio_encode.is_empty()
+        && prompt_embed.is_empty()
+        && prompt_concat.is_empty()
         && prefill.is_empty()
         && decode.is_empty()
+        && decode_argmax.is_empty()
+        && decode_token_tensor.is_empty()
+        && decode_forward.is_empty()
+        && tokenizer_decode.is_empty()
+        && main_backbone.is_empty()
         && model_total.is_empty()
         && prompt_tokens.is_empty()
         && audio_tokens.is_empty()
@@ -3618,8 +3821,15 @@ fn print_asr_stage_timing_summary(samples: &[AsrStageTimings]) {
     summarize_stage("mel", &mel);
     summarize_stage("mel_flat_upload", &mel_flatten_upload);
     summarize_stage("audio_encode", &audio_encode);
+    summarize_stage("prompt_embed", &prompt_embed);
+    summarize_stage("prompt_concat", &prompt_concat);
     summarize_stage("prefill", &prefill);
     summarize_stage("decode", &decode);
+    summarize_stage("decode_argmax", &decode_argmax);
+    summarize_stage("token_tensor", &decode_token_tensor);
+    summarize_stage("decode_fwd", &decode_forward);
+    summarize_stage("tokenizer", &tokenizer_decode);
+    summarize_stage("main_backbone", &main_backbone);
     summarize_stage("model_total", &model_total);
     summarize_count("prompt_tokens", &prompt_tokens);
     summarize_count("audio_tokens", &audio_tokens);
@@ -4070,7 +4280,14 @@ mod tests {
                 "prefill": 3.0,
                 "text_sampling": 4.0,
                 "audio_head": 5.0,
+                "audio_head_depth_linear": 5.1,
+                "audio_head_depthformer": 5.2,
+                "audio_head_sample": 5.3,
+                "audio_head_materialize": 5.4,
                 "detokenizer": 6.0,
+                "detokenizer_backbone": 6.1,
+                "detokenizer_readback": 6.2,
+                "detokenizer_istft": 6.3,
                 "model_total": 21.0
             },
             "prompt": {
@@ -4079,6 +4296,7 @@ mod tests {
             "decode": {
                 "generated_tokens": 42,
                 "audio_head_calls": 7,
+                "audio_head_codebook_steps": 56,
                 "text_sample_calls": 3
             },
             "audio": {
@@ -4092,12 +4310,20 @@ mod tests {
         assert_eq!(timings.prompt_build, Some(1.0));
         assert_eq!(timings.prefill, Some(3.0));
         assert_eq!(timings.audio_head, Some(5.0));
+        assert_eq!(timings.audio_head_depth_linear, Some(5.1));
+        assert_eq!(timings.audio_head_depthformer, Some(5.2));
+        assert_eq!(timings.audio_head_sample, Some(5.3));
+        assert_eq!(timings.audio_head_materialize, Some(5.4));
         assert_eq!(timings.detokenizer, Some(6.0));
+        assert_eq!(timings.detokenizer_backbone, Some(6.1));
+        assert_eq!(timings.detokenizer_readback, Some(6.2));
+        assert_eq!(timings.detokenizer_istft, Some(6.3));
         assert_eq!(timings.model_total, Some(21.0));
         assert_eq!(timings.prompt_tokens, Some(11));
         assert_eq!(timings.generated_tokens, Some(42));
         assert_eq!(timings.audio_frames, Some(6));
         assert_eq!(timings.audio_head_calls, Some(7));
+        assert_eq!(timings.audio_head_codebook_steps, Some(56));
         assert_eq!(timings.text_sample_calls, Some(3));
     }
 
@@ -4173,8 +4399,15 @@ mod tests {
                 "mel": 12.5,
                 "mel_flatten_upload": 0.75,
                 "audio_encode": 820.0,
+                "prompt_embed": 4.0,
+                "prompt_concat": 5.0,
                 "prefill": 1080.0,
                 "decode": 21230.0,
+                "decode_argmax": 77.0,
+                "decode_token_tensor": 2.0,
+                "decode_forward": 700.0,
+                "tokenizer_decode": 9.0,
+                "main_backbone": 1800.0,
                 "model_total": 22360.0
             }
         });
@@ -4185,8 +4418,15 @@ mod tests {
         assert_eq!(samples[0].mel, Some(12.5));
         assert_eq!(samples[0].mel_flatten_upload, Some(0.75));
         assert_eq!(samples[0].audio_encode, Some(820.0));
+        assert_eq!(samples[0].prompt_embed, Some(4.0));
+        assert_eq!(samples[0].prompt_concat, Some(5.0));
         assert_eq!(samples[0].prefill, Some(1080.0));
         assert_eq!(samples[0].decode, Some(21230.0));
+        assert_eq!(samples[0].decode_argmax, Some(77.0));
+        assert_eq!(samples[0].decode_token_tensor, Some(2.0));
+        assert_eq!(samples[0].decode_forward, Some(700.0));
+        assert_eq!(samples[0].tokenizer_decode, Some(9.0));
+        assert_eq!(samples[0].main_backbone, Some(1800.0));
         assert_eq!(samples[0].prompt_tokens, Some(482));
         assert_eq!(samples[0].audio_tokens, Some(355));
         assert_eq!(samples[0].generated_tokens, Some(93));

--- a/crates/izwi-core/src/engine/executor/handler_audio_chat.rs
+++ b/crates/izwi-core/src/engine/executor/handler_audio_chat.rs
@@ -65,7 +65,9 @@ impl NativeExecutor {
             })
         })?;
 
-        let input_transcription = Self::run_blocking(|| model.transcribe(&samples, sample_rate))?;
+        let input_transcription = Self::run_blocking(|| {
+            model.transcribe_long_form_with_callback(&samples, sample_rate, None, &mut |_delta| {})
+        })?;
         let output = Self::run_blocking(|| {
             if let Some(tx) = stream_tx.as_ref() {
                 let stream_sequence = std::cell::Cell::new(0usize);

--- a/crates/izwi-core/src/kernels/metal.rs
+++ b/crates/izwi-core/src/kernels/metal.rs
@@ -478,6 +478,33 @@ kernel void izwi_lfm_shortconv_decode3_f32(
         cache[cache_base + 2] * conv[conv_base + 1] +
         bx[gid] * conv[conv_base + 2];
 }
+
+kernel void izwi_lfm_shortconv_sequence3_f32(
+    device const float* bx [[buffer(0)]],
+    device const float* conv [[buffer(1)]],
+    device float* output [[buffer(2)]],
+    constant uint& hidden_size [[buffer(3)]],
+    constant uint& seq_len [[buffer(4)]],
+    constant uint& elem_count [[buffer(5)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= elem_count) {
+        return;
+    }
+
+    const uint t = gid % seq_len;
+    const uint h = (gid / seq_len) % hidden_size;
+    const uint row_base = gid - t;
+    const uint conv_base = h * 3;
+    float value = bx[gid] * conv[conv_base + 2];
+    if (t >= 1) {
+        value += bx[row_base + t - 1] * conv[conv_base + 1];
+    }
+    if (t >= 2) {
+        value += bx[row_base + t - 2] * conv[conv_base];
+    }
+    output[gid] = value;
+}
 "#;
 
 #[cfg(feature = "metal")]
@@ -1110,6 +1137,14 @@ struct LfmShortConvDecode3Op {
 }
 
 #[cfg(feature = "metal")]
+#[derive(Debug, Clone, Copy)]
+struct LfmShortConvSequence3Op {
+    batch_size: usize,
+    hidden_size: usize,
+    seq_len: usize,
+}
+
+#[cfg(feature = "metal")]
 impl CustomOp3 for DecodeGqaAttentionOp {
     fn name(&self) -> &'static str {
         "izwi-decode-gqa-attention-metal"
@@ -1395,6 +1430,130 @@ fn lfm_shortconv_decode3_pipeline(device: &MetalDevice) -> CandleResult<ComputeP
         .map_err(candle_core::Error::wrap)?;
     let function = library
         .get_function("izwi_lfm_shortconv_decode3_f32", None)
+        .map_err(candle_core::Error::wrap)?;
+    let pipeline = device
+        .new_compute_pipeline_state_with_function(&function)
+        .map_err(candle_core::Error::wrap)?;
+
+    pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .insert(registry_id, pipeline.clone());
+
+    Ok(pipeline)
+}
+
+#[cfg(feature = "metal")]
+impl CustomOp2 for LfmShortConvSequence3Op {
+    fn name(&self) -> &'static str {
+        "izwi-lfm-shortconv-sequence3-metal"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _s1: &CpuStorage,
+        _l1: &Layout,
+        _s2: &CpuStorage,
+        _l2: &Layout,
+    ) -> CandleResult<(CpuStorage, Shape)> {
+        bail!("izwi-lfm-shortconv-sequence3-metal requires Metal tensors")
+    }
+
+    fn metal_fwd(
+        &self,
+        bx_storage: &MetalStorage,
+        bx_layout: &Layout,
+        conv_storage: &MetalStorage,
+        conv_layout: &Layout,
+    ) -> CandleResult<(MetalStorage, Shape)> {
+        if bx_storage.dtype() != DType::F32 || conv_storage.dtype() != DType::F32 {
+            bail!("izwi-lfm-shortconv-sequence3-metal only supports F32 tensors")
+        }
+        if !bx_layout.is_contiguous() || !conv_layout.is_contiguous() {
+            bail!("izwi-lfm-shortconv-sequence3-metal requires contiguous tensors")
+        }
+        if self.batch_size == 0 || self.hidden_size == 0 || self.seq_len == 0 {
+            bail!("izwi-lfm-shortconv-sequence3-metal requires non-empty dimensions")
+        }
+        let elem_count = self
+            .batch_size
+            .saturating_mul(self.hidden_size)
+            .saturating_mul(self.seq_len);
+        if bx_layout.shape().elem_count() != elem_count
+            || conv_layout.shape().elem_count() != self.hidden_size.saturating_mul(3)
+        {
+            bail!("izwi-lfm-shortconv-sequence3-metal input shape mismatch")
+        }
+        if elem_count > u32::MAX as usize
+            || self.hidden_size > u32::MAX as usize
+            || self.seq_len > u32::MAX as usize
+        {
+            bail!("izwi-lfm-shortconv-sequence3-metal tensor is too large")
+        }
+
+        let device = bx_storage.device().clone();
+        let output = device.new_buffer(elem_count, DType::F32, "izwi-lfm-shortconv-sequence3")?;
+        let encoder = device.command_encoder()?;
+        encoder.set_label("izwi-lfm-shortconv-sequence3");
+        let pipeline = lfm_shortconv_sequence3_pipeline(device.metal_device())?;
+        encoder.set_compute_pipeline_state(&pipeline);
+
+        encoder.set_buffer(
+            0,
+            Some(bx_storage.buffer()),
+            bx_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_buffer(
+            1,
+            Some(conv_storage.buffer()),
+            conv_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_buffer(2, Some(&output), 0);
+        encoder.set_bytes(3, &(self.hidden_size as u32));
+        encoder.set_bytes(4, &(self.seq_len as u32));
+        encoder.set_bytes(5, &(elem_count as u32));
+
+        let threads_per_threadgroup = pipeline.max_total_threads_per_threadgroup().min(256).max(1);
+        encoder.dispatch_threads(
+            objc2_metal::MTLSize {
+                width: elem_count,
+                height: 1,
+                depth: 1,
+            },
+            objc2_metal::MTLSize {
+                width: threads_per_threadgroup,
+                height: 1,
+                depth: 1,
+            },
+        );
+
+        Ok((
+            MetalStorage::new(output, device, elem_count, DType::F32),
+            Shape::from((self.batch_size, self.hidden_size, self.seq_len)),
+        ))
+    }
+}
+
+#[cfg(feature = "metal")]
+fn lfm_shortconv_sequence3_pipeline(device: &MetalDevice) -> CandleResult<ComputePipeline> {
+    static PIPELINES: OnceLock<Mutex<HashMap<u64, ComputePipeline>>> = OnceLock::new();
+    let registry_id = device.registry_id();
+    let pipelines = PIPELINES.get_or_init(|| Mutex::new(HashMap::new()));
+
+    if let Some(pipeline) = pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .get(&registry_id)
+        .cloned()
+    {
+        return Ok(pipeline);
+    }
+
+    let library = device
+        .new_library_with_source(IZWI_METAL_SOURCE, None)
+        .map_err(candle_core::Error::wrap)?;
+    let function = library
+        .get_function("izwi_lfm_shortconv_sequence3_f32", None)
         .map_err(candle_core::Error::wrap)?;
     let pipeline = device
         .new_compute_pipeline_state_with_function(&function)
@@ -1933,6 +2092,47 @@ pub fn try_lfm_shortconv_decode3(cache: &Tensor, bx: &Tensor, conv: &Tensor) -> 
     None
 }
 
+pub fn try_lfm_shortconv_sequence3(bx: &Tensor, conv: &Tensor) -> Option<Tensor> {
+    #[cfg(not(feature = "metal"))]
+    let _ = (bx, conv);
+
+    if !use_fused_kernels() {
+        return None;
+    }
+
+    #[cfg(feature = "metal")]
+    {
+        let (batch_size, hidden_size, seq_len) = bx.dims3().ok()?;
+        let (conv_hidden, conv_len) = conv.dims2().ok()?;
+        if seq_len == 0
+            || conv_len != 3
+            || conv_hidden != hidden_size
+            || !bx.device().is_metal()
+            || !conv.device().is_metal()
+            || !bx.device().same_device(conv.device())
+            || bx.dtype() != DType::F32
+            || conv.dtype() != DType::F32
+            || !bx.is_contiguous()
+            || !conv.is_contiguous()
+        {
+            return None;
+        }
+        return bx
+            .apply_op2_no_bwd(
+                conv,
+                &LfmShortConvSequence3Op {
+                    batch_size,
+                    hidden_size,
+                    seq_len,
+                },
+            )
+            .ok();
+    }
+
+    #[allow(unreachable_code)]
+    None
+}
+
 /// Try fused gated RMS normalization.
 ///
 /// Computes: rms_norm(x) * silu(gate)
@@ -2245,6 +2445,8 @@ pub fn use_fused_kernels() -> bool {
 mod tests {
     use super::*;
     use candle_core::{DType, Device, Tensor};
+    #[cfg(all(feature = "metal", target_os = "macos"))]
+    use candle_nn::Module;
 
     #[test]
     fn test_l2_norm_matches_reference() {
@@ -2386,6 +2588,15 @@ mod tests {
         assert!(try_lfm_shortconv_decode3(&cache, &bx, &conv).is_none());
     }
 
+    #[test]
+    fn lfm_shortconv_sequence3_returns_none_on_cpu() {
+        let device = Device::Cpu;
+        let bx = Tensor::zeros((1, 2, 4), DType::F32, &device).unwrap();
+        let conv = Tensor::zeros((2, 3), DType::F32, &device).unwrap();
+
+        assert!(try_lfm_shortconv_sequence3(&bx, &conv).is_none());
+    }
+
     #[cfg(all(feature = "metal", target_os = "macos"))]
     #[test]
     fn metal_lfm_shortconv_decode3_matches_reference_if_available() {
@@ -2423,6 +2634,53 @@ mod tests {
             assert!(
                 (actual - expected).abs() <= 1e-5,
                 "shortconv mismatch at {idx}: {actual} != {expected}"
+            );
+        }
+    }
+
+    #[cfg(all(feature = "metal", target_os = "macos"))]
+    #[test]
+    fn metal_lfm_shortconv_sequence3_matches_reference_if_available() {
+        let Ok(device) = Device::new_metal(0) else {
+            return;
+        };
+        let bx = Tensor::from_vec(
+            vec![
+                1.0f32, 2.0, 3.0, 4.0, //
+                5.0, 6.0, 7.0, 8.0,
+            ],
+            (1, 2, 4),
+            &device,
+        )
+        .unwrap();
+        let conv = Tensor::from_vec(
+            vec![
+                0.5f32, 1.5, 2.5, //
+                -1.0, 0.25, 0.75,
+            ],
+            (2, 3),
+            &device,
+        )
+        .unwrap();
+
+        let out = try_lfm_shortconv_sequence3(&bx, &conv)
+            .expect("shortconv sequence3 should run on Metal");
+        let conv_ref = candle_nn::Conv1d::new(
+            conv.reshape((2, 1, 3)).unwrap().contiguous().unwrap(),
+            None,
+            candle_nn::Conv1dConfig {
+                padding: 2,
+                groups: 2,
+                ..Default::default()
+            },
+        );
+        let reference = conv_ref.forward(&bx).unwrap().narrow(2, 0, 4).unwrap();
+        let actual = out.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let expected = reference.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        for (idx, (actual, expected)) in actual.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (actual - expected).abs() <= 1e-5,
+                "shortconv sequence mismatch at {idx}: {actual} != {expected}"
             );
         }
     }

--- a/crates/izwi-core/src/kernels/metal.rs
+++ b/crates/izwi-core/src/kernels/metal.rs
@@ -479,6 +479,27 @@ kernel void izwi_lfm_shortconv_decode3_f32(
         bx[gid] * conv[conv_base + 2];
 }
 
+kernel void izwi_lfm_shortconv_update3_f32(
+    device const float* cache [[buffer(0)]],
+    device const float* bx [[buffer(1)]],
+    device float* output [[buffer(2)]],
+    constant uint& hidden_size [[buffer(3)]],
+    constant uint& elem_count [[buffer(4)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= elem_count) {
+        return;
+    }
+
+    const uint h = gid % hidden_size;
+    const uint b = gid / hidden_size;
+    const uint cache_base = ((b * hidden_size) + h) * 3;
+    const uint out_base = cache_base;
+    output[out_base] = cache[cache_base + 1];
+    output[out_base + 1] = cache[cache_base + 2];
+    output[out_base + 2] = bx[gid];
+}
+
 kernel void izwi_lfm_shortconv_sequence3_f32(
     device const float* bx [[buffer(0)]],
     device const float* conv [[buffer(1)]],
@@ -1138,6 +1159,13 @@ struct LfmShortConvDecode3Op {
 
 #[cfg(feature = "metal")]
 #[derive(Debug, Clone, Copy)]
+struct LfmShortConvUpdate3Op {
+    batch_size: usize,
+    hidden_size: usize,
+}
+
+#[cfg(feature = "metal")]
+#[derive(Debug, Clone, Copy)]
 struct LfmShortConvSequence3Op {
     batch_size: usize,
     hidden_size: usize,
@@ -1430,6 +1458,127 @@ fn lfm_shortconv_decode3_pipeline(device: &MetalDevice) -> CandleResult<ComputeP
         .map_err(candle_core::Error::wrap)?;
     let function = library
         .get_function("izwi_lfm_shortconv_decode3_f32", None)
+        .map_err(candle_core::Error::wrap)?;
+    let pipeline = device
+        .new_compute_pipeline_state_with_function(&function)
+        .map_err(candle_core::Error::wrap)?;
+
+    pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .insert(registry_id, pipeline.clone());
+
+    Ok(pipeline)
+}
+
+#[cfg(feature = "metal")]
+impl CustomOp2 for LfmShortConvUpdate3Op {
+    fn name(&self) -> &'static str {
+        "izwi-lfm-shortconv-update3-metal"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _s1: &CpuStorage,
+        _l1: &Layout,
+        _s2: &CpuStorage,
+        _l2: &Layout,
+    ) -> CandleResult<(CpuStorage, Shape)> {
+        bail!("izwi-lfm-shortconv-update3-metal requires Metal tensors")
+    }
+
+    fn metal_fwd(
+        &self,
+        cache_storage: &MetalStorage,
+        cache_layout: &Layout,
+        bx_storage: &MetalStorage,
+        bx_layout: &Layout,
+    ) -> CandleResult<(MetalStorage, Shape)> {
+        if cache_storage.dtype() != DType::F32 || bx_storage.dtype() != DType::F32 {
+            bail!("izwi-lfm-shortconv-update3-metal only supports F32 tensors")
+        }
+        if !cache_layout.is_contiguous() || !bx_layout.is_contiguous() {
+            bail!("izwi-lfm-shortconv-update3-metal requires contiguous tensors")
+        }
+        if self.batch_size == 0 || self.hidden_size == 0 {
+            bail!("izwi-lfm-shortconv-update3-metal requires non-empty dimensions")
+        }
+        let elem_count = self.batch_size.saturating_mul(self.hidden_size);
+        if cache_layout.shape().elem_count() != elem_count.saturating_mul(3)
+            || bx_layout.shape().elem_count() != elem_count
+        {
+            bail!("izwi-lfm-shortconv-update3-metal input shape mismatch")
+        }
+        if elem_count > u32::MAX as usize || self.hidden_size > u32::MAX as usize {
+            bail!("izwi-lfm-shortconv-update3-metal tensor is too large")
+        }
+
+        let device = cache_storage.device().clone();
+        let output = device.new_buffer(
+            elem_count.saturating_mul(3),
+            DType::F32,
+            "izwi-lfm-shortconv-update3",
+        )?;
+        let encoder = device.command_encoder()?;
+        encoder.set_label("izwi-lfm-shortconv-update3");
+        let pipeline = lfm_shortconv_update3_pipeline(device.metal_device())?;
+        encoder.set_compute_pipeline_state(&pipeline);
+
+        encoder.set_buffer(
+            0,
+            Some(cache_storage.buffer()),
+            cache_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_buffer(
+            1,
+            Some(bx_storage.buffer()),
+            bx_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_buffer(2, Some(&output), 0);
+        encoder.set_bytes(3, &(self.hidden_size as u32));
+        encoder.set_bytes(4, &(elem_count as u32));
+
+        let threads_per_threadgroup = pipeline.max_total_threads_per_threadgroup().min(256).max(1);
+        encoder.dispatch_threads(
+            objc2_metal::MTLSize {
+                width: elem_count,
+                height: 1,
+                depth: 1,
+            },
+            objc2_metal::MTLSize {
+                width: threads_per_threadgroup,
+                height: 1,
+                depth: 1,
+            },
+        );
+
+        Ok((
+            MetalStorage::new(output, device, elem_count.saturating_mul(3), DType::F32),
+            Shape::from((self.batch_size, self.hidden_size, 3)),
+        ))
+    }
+}
+
+#[cfg(feature = "metal")]
+fn lfm_shortconv_update3_pipeline(device: &MetalDevice) -> CandleResult<ComputePipeline> {
+    static PIPELINES: OnceLock<Mutex<HashMap<u64, ComputePipeline>>> = OnceLock::new();
+    let registry_id = device.registry_id();
+    let pipelines = PIPELINES.get_or_init(|| Mutex::new(HashMap::new()));
+
+    if let Some(pipeline) = pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .get(&registry_id)
+        .cloned()
+    {
+        return Ok(pipeline);
+    }
+
+    let library = device
+        .new_library_with_source(IZWI_METAL_SOURCE, None)
+        .map_err(candle_core::Error::wrap)?;
+    let function = library
+        .get_function("izwi_lfm_shortconv_update3_f32", None)
         .map_err(candle_core::Error::wrap)?;
     let pipeline = device
         .new_compute_pipeline_state_with_function(&function)
@@ -2092,6 +2241,47 @@ pub fn try_lfm_shortconv_decode3(cache: &Tensor, bx: &Tensor, conv: &Tensor) -> 
     None
 }
 
+pub fn try_lfm_shortconv_update3(cache: &Tensor, bx: &Tensor) -> Option<Tensor> {
+    #[cfg(not(feature = "metal"))]
+    let _ = (cache, bx);
+
+    if !use_fused_kernels() {
+        return None;
+    }
+
+    #[cfg(feature = "metal")]
+    {
+        let (batch_size, hidden_size, cache_len) = cache.dims3().ok()?;
+        let (bx_batch, bx_hidden, bx_len) = bx.dims3().ok()?;
+        if cache_len != 3
+            || bx_len != 1
+            || bx_batch != batch_size
+            || bx_hidden != hidden_size
+            || !cache.device().is_metal()
+            || !bx.device().is_metal()
+            || !cache.device().same_device(bx.device())
+            || cache.dtype() != DType::F32
+            || bx.dtype() != DType::F32
+            || !cache.is_contiguous()
+            || !bx.is_contiguous()
+        {
+            return None;
+        }
+        return cache
+            .apply_op2_no_bwd(
+                bx,
+                &LfmShortConvUpdate3Op {
+                    batch_size,
+                    hidden_size,
+                },
+            )
+            .ok();
+    }
+
+    #[allow(unreachable_code)]
+    None
+}
+
 pub fn try_lfm_shortconv_sequence3(bx: &Tensor, conv: &Tensor) -> Option<Tensor> {
     #[cfg(not(feature = "metal"))]
     let _ = (bx, conv);
@@ -2597,6 +2787,15 @@ mod tests {
         assert!(try_lfm_shortconv_sequence3(&bx, &conv).is_none());
     }
 
+    #[test]
+    fn lfm_shortconv_update3_returns_none_on_cpu() {
+        let device = Device::Cpu;
+        let cache = Tensor::zeros((1, 2, 3), DType::F32, &device).unwrap();
+        let bx = Tensor::zeros((1, 2, 1), DType::F32, &device).unwrap();
+
+        assert!(try_lfm_shortconv_update3(&cache, &bx).is_none());
+    }
+
     #[cfg(all(feature = "metal", target_os = "macos"))]
     #[test]
     fn metal_lfm_shortconv_decode3_matches_reference_if_available() {
@@ -2636,6 +2835,34 @@ mod tests {
                 "shortconv mismatch at {idx}: {actual} != {expected}"
             );
         }
+    }
+
+    #[cfg(all(feature = "metal", target_os = "macos"))]
+    #[test]
+    fn metal_lfm_shortconv_update3_matches_reference_if_available() {
+        let Ok(device) = Device::new_metal(0) else {
+            return;
+        };
+        let cache = Tensor::from_vec(
+            vec![
+                1.0f32, 2.0, 3.0, //
+                4.0, 5.0, 6.0,
+            ],
+            (1, 2, 3),
+            &device,
+        )
+        .unwrap();
+        let bx = Tensor::from_vec(vec![7.0f32, 8.0], (1, 2, 1), &device).unwrap();
+
+        let out =
+            try_lfm_shortconv_update3(&cache, &bx).expect("shortconv update3 should run on Metal");
+        let tail = cache.narrow(2, 1, 2).unwrap();
+        let reference = Tensor::cat(&[&tail, &bx], 2).unwrap();
+
+        assert_eq!(
+            out.flatten_all().unwrap().to_vec1::<f32>().unwrap(),
+            reference.flatten_all().unwrap().to_vec1::<f32>().unwrap()
+        );
     }
 
     #[cfg(all(feature = "metal", target_os = "macos"))]

--- a/crates/izwi-core/src/kernels/metal.rs
+++ b/crates/izwi-core/src/kernels/metal.rs
@@ -455,6 +455,29 @@ kernel void izwi_decode_gqa_attention_f16(
         output[out_base + dim] = half(acc);
     }
 }
+
+kernel void izwi_lfm_shortconv_decode3_f32(
+    device const float* cache [[buffer(0)]],
+    device const float* bx [[buffer(1)]],
+    device const float* conv [[buffer(2)]],
+    device float* output [[buffer(3)]],
+    constant uint& hidden_size [[buffer(4)]],
+    constant uint& elem_count [[buffer(5)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= elem_count) {
+        return;
+    }
+
+    const uint h = gid % hidden_size;
+    const uint b = gid / hidden_size;
+    const uint cache_base = ((b * hidden_size) + h) * 3;
+    const uint conv_base = h * 3;
+    output[gid] =
+        cache[cache_base + 1] * conv[conv_base] +
+        cache[cache_base + 2] * conv[conv_base + 1] +
+        bx[gid] * conv[conv_base + 2];
+}
 "#;
 
 #[cfg(feature = "metal")]
@@ -1080,6 +1103,13 @@ struct DecodeGqaAttentionOp {
 }
 
 #[cfg(feature = "metal")]
+#[derive(Debug, Clone, Copy)]
+struct LfmShortConvDecode3Op {
+    batch_size: usize,
+    hidden_size: usize,
+}
+
+#[cfg(feature = "metal")]
 impl CustomOp3 for DecodeGqaAttentionOp {
     fn name(&self) -> &'static str {
         "izwi-decode-gqa-attention-metal"
@@ -1241,6 +1271,139 @@ fn decode_gqa_attention_pipeline(
         .lock()
         .map_err(|err| candle_core::Error::Msg(err.to_string()))?
         .insert(key, pipeline.clone());
+
+    Ok(pipeline)
+}
+
+#[cfg(feature = "metal")]
+impl CustomOp3 for LfmShortConvDecode3Op {
+    fn name(&self) -> &'static str {
+        "izwi-lfm-shortconv-decode3-metal"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _s1: &CpuStorage,
+        _l1: &Layout,
+        _s2: &CpuStorage,
+        _l2: &Layout,
+        _s3: &CpuStorage,
+        _l3: &Layout,
+    ) -> CandleResult<(CpuStorage, Shape)> {
+        bail!("izwi-lfm-shortconv-decode3-metal requires Metal tensors")
+    }
+
+    fn metal_fwd(
+        &self,
+        cache_storage: &MetalStorage,
+        cache_layout: &Layout,
+        bx_storage: &MetalStorage,
+        bx_layout: &Layout,
+        conv_storage: &MetalStorage,
+        conv_layout: &Layout,
+    ) -> CandleResult<(MetalStorage, Shape)> {
+        if cache_storage.dtype() != DType::F32
+            || bx_storage.dtype() != DType::F32
+            || conv_storage.dtype() != DType::F32
+        {
+            bail!("izwi-lfm-shortconv-decode3-metal only supports F32 tensors")
+        }
+        if !cache_layout.is_contiguous()
+            || !bx_layout.is_contiguous()
+            || !conv_layout.is_contiguous()
+        {
+            bail!("izwi-lfm-shortconv-decode3-metal requires contiguous tensors")
+        }
+        if self.batch_size == 0 || self.hidden_size == 0 {
+            bail!("izwi-lfm-shortconv-decode3-metal requires non-empty dimensions")
+        }
+        let elem_count = self.batch_size.saturating_mul(self.hidden_size);
+        if cache_layout.shape().elem_count() != elem_count.saturating_mul(3)
+            || bx_layout.shape().elem_count() != elem_count
+            || conv_layout.shape().elem_count() != self.hidden_size.saturating_mul(3)
+        {
+            bail!("izwi-lfm-shortconv-decode3-metal input shape mismatch")
+        }
+        if elem_count > u32::MAX as usize || self.hidden_size > u32::MAX as usize {
+            bail!("izwi-lfm-shortconv-decode3-metal tensor is too large")
+        }
+
+        let device = cache_storage.device().clone();
+        let output = device.new_buffer(elem_count, DType::F32, "izwi-lfm-shortconv-decode3")?;
+        let encoder = device.command_encoder()?;
+        encoder.set_label("izwi-lfm-shortconv-decode3");
+        let pipeline = lfm_shortconv_decode3_pipeline(device.metal_device())?;
+        encoder.set_compute_pipeline_state(&pipeline);
+
+        encoder.set_buffer(
+            0,
+            Some(cache_storage.buffer()),
+            cache_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_buffer(
+            1,
+            Some(bx_storage.buffer()),
+            bx_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_buffer(
+            2,
+            Some(conv_storage.buffer()),
+            conv_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_buffer(3, Some(&output), 0);
+        encoder.set_bytes(4, &(self.hidden_size as u32));
+        encoder.set_bytes(5, &(elem_count as u32));
+
+        let threads_per_threadgroup = pipeline.max_total_threads_per_threadgroup().min(256).max(1);
+        encoder.dispatch_threads(
+            objc2_metal::MTLSize {
+                width: elem_count,
+                height: 1,
+                depth: 1,
+            },
+            objc2_metal::MTLSize {
+                width: threads_per_threadgroup,
+                height: 1,
+                depth: 1,
+            },
+        );
+
+        Ok((
+            MetalStorage::new(output, device, elem_count, DType::F32),
+            Shape::from((self.batch_size, self.hidden_size, 1)),
+        ))
+    }
+}
+
+#[cfg(feature = "metal")]
+fn lfm_shortconv_decode3_pipeline(device: &MetalDevice) -> CandleResult<ComputePipeline> {
+    static PIPELINES: OnceLock<Mutex<HashMap<u64, ComputePipeline>>> = OnceLock::new();
+    let registry_id = device.registry_id();
+    let pipelines = PIPELINES.get_or_init(|| Mutex::new(HashMap::new()));
+
+    if let Some(pipeline) = pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .get(&registry_id)
+        .cloned()
+    {
+        return Ok(pipeline);
+    }
+
+    let library = device
+        .new_library_with_source(IZWI_METAL_SOURCE, None)
+        .map_err(candle_core::Error::wrap)?;
+    let function = library
+        .get_function("izwi_lfm_shortconv_decode3_f32", None)
+        .map_err(candle_core::Error::wrap)?;
+    let pipeline = device
+        .new_compute_pipeline_state_with_function(&function)
+        .map_err(candle_core::Error::wrap)?;
+
+    pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .insert(registry_id, pipeline.clone());
 
     Ok(pipeline)
 }
@@ -1721,6 +1884,55 @@ pub fn try_fused_decode_gqa_attention_with_kv_len(
     None
 }
 
+pub fn try_lfm_shortconv_decode3(cache: &Tensor, bx: &Tensor, conv: &Tensor) -> Option<Tensor> {
+    #[cfg(not(feature = "metal"))]
+    let _ = (cache, bx, conv);
+
+    if !use_fused_kernels() {
+        return None;
+    }
+
+    #[cfg(feature = "metal")]
+    {
+        let (batch_size, hidden_size, cache_len) = cache.dims3().ok()?;
+        let (bx_batch, bx_hidden, bx_len) = bx.dims3().ok()?;
+        let (conv_hidden, conv_len) = conv.dims2().ok()?;
+        if cache_len != 3
+            || bx_len != 1
+            || conv_len != 3
+            || bx_batch != batch_size
+            || bx_hidden != hidden_size
+            || conv_hidden != hidden_size
+            || !cache.device().is_metal()
+            || !bx.device().is_metal()
+            || !conv.device().is_metal()
+            || !cache.device().same_device(bx.device())
+            || !cache.device().same_device(conv.device())
+            || cache.dtype() != DType::F32
+            || bx.dtype() != DType::F32
+            || conv.dtype() != DType::F32
+            || !cache.is_contiguous()
+            || !bx.is_contiguous()
+            || !conv.is_contiguous()
+        {
+            return None;
+        }
+        return cache
+            .apply_op3_no_bwd(
+                bx,
+                conv,
+                &LfmShortConvDecode3Op {
+                    batch_size,
+                    hidden_size,
+                },
+            )
+            .ok();
+    }
+
+    #[allow(unreachable_code)]
+    None
+}
+
 /// Try fused gated RMS normalization.
 ///
 /// Computes: rms_norm(x) * silu(gate)
@@ -2162,6 +2374,57 @@ mod tests {
         let v = Tensor::zeros((1, 1, 3, 4), DType::F32, &device).unwrap();
 
         assert!(try_fused_decode_gqa_attention(&q, &k, &v, 2, 1, 4, 0.5).is_none());
+    }
+
+    #[test]
+    fn lfm_shortconv_decode3_returns_none_on_cpu() {
+        let device = Device::Cpu;
+        let cache = Tensor::zeros((1, 2, 3), DType::F32, &device).unwrap();
+        let bx = Tensor::zeros((1, 2, 1), DType::F32, &device).unwrap();
+        let conv = Tensor::zeros((2, 3), DType::F32, &device).unwrap();
+
+        assert!(try_lfm_shortconv_decode3(&cache, &bx, &conv).is_none());
+    }
+
+    #[cfg(all(feature = "metal", target_os = "macos"))]
+    #[test]
+    fn metal_lfm_shortconv_decode3_matches_reference_if_available() {
+        let Ok(device) = Device::new_metal(0) else {
+            return;
+        };
+        let cache = Tensor::from_vec(
+            vec![
+                1.0f32, 2.0, 3.0, //
+                4.0, 5.0, 6.0,
+            ],
+            (1, 2, 3),
+            &device,
+        )
+        .unwrap();
+        let bx = Tensor::from_vec(vec![7.0f32, 8.0], (1, 2, 1), &device).unwrap();
+        let conv = Tensor::from_vec(
+            vec![
+                0.5f32, 1.5, 2.5, //
+                -1.0, 0.25, 0.75,
+            ],
+            (2, 3),
+            &device,
+        )
+        .unwrap();
+
+        let out = try_lfm_shortconv_decode3(&cache, &bx, &conv)
+            .expect("shortconv decode3 should run on Metal");
+        let actual = out.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let expected = vec![
+            2.0 * 0.5 + 3.0 * 1.5 + 7.0 * 2.5,
+            5.0 * -1.0 + 6.0 * 0.25 + 8.0 * 0.75,
+        ];
+        for (idx, (actual, expected)) in actual.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (actual - expected).abs() <= 1e-5,
+                "shortconv mismatch at {idx}: {actual} != {expected}"
+            );
+        }
     }
 
     #[cfg(all(feature = "metal", target_os = "macos"))]

--- a/crates/izwi-core/src/kernels/mod.rs
+++ b/crates/izwi-core/src/kernels/mod.rs
@@ -230,6 +230,18 @@ pub fn try_fused_decode_gqa_attention_with_kv_len(
     None
 }
 
+pub fn try_lfm_shortconv_decode3(cache: &Tensor, bx: &Tensor, conv: &Tensor) -> Option<Tensor> {
+    if !use_fused_kernels_for_device(cache.device()) {
+        return None;
+    }
+
+    if cache.device().is_metal() {
+        return metal::try_lfm_shortconv_decode3(cache, bx, conv);
+    }
+
+    None
+}
+
 pub fn try_fused_gated_rms_norm(
     hidden: &Tensor,
     gate: &Tensor,

--- a/crates/izwi-core/src/kernels/mod.rs
+++ b/crates/izwi-core/src/kernels/mod.rs
@@ -242,6 +242,18 @@ pub fn try_lfm_shortconv_decode3(cache: &Tensor, bx: &Tensor, conv: &Tensor) -> 
     None
 }
 
+pub fn try_lfm_shortconv_update3(cache: &Tensor, bx: &Tensor) -> Option<Tensor> {
+    if !use_fused_kernels_for_device(cache.device()) {
+        return None;
+    }
+
+    if cache.device().is_metal() {
+        return metal::try_lfm_shortconv_update3(cache, bx);
+    }
+
+    None
+}
+
 pub fn try_lfm_shortconv_sequence3(bx: &Tensor, conv: &Tensor) -> Option<Tensor> {
     if !use_fused_kernels_for_device(bx.device()) {
         return None;

--- a/crates/izwi-core/src/kernels/mod.rs
+++ b/crates/izwi-core/src/kernels/mod.rs
@@ -242,6 +242,18 @@ pub fn try_lfm_shortconv_decode3(cache: &Tensor, bx: &Tensor, conv: &Tensor) -> 
     None
 }
 
+pub fn try_lfm_shortconv_sequence3(bx: &Tensor, conv: &Tensor) -> Option<Tensor> {
+    if !use_fused_kernels_for_device(bx.device()) {
+        return None;
+    }
+
+    if bx.device().is_metal() {
+        return metal::try_lfm_shortconv_sequence3(bx, conv);
+    }
+
+    None
+}
+
 pub fn try_fused_gated_rms_norm(
     hidden: &Tensor,
     gate: &Tensor,

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/audio_output.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/audio_output.rs
@@ -33,6 +33,7 @@ const DEPTHFORMER_ROPE_BASE: f32 = 10_000.0;
 pub struct Lfm25AudioHead {
     frame_embedding: Embedding,
     codebook_offsets: Vec<u32>,
+    codebook_offsets_tensor: Tensor,
     depth_linear: QLinear,
     depthformer: Depthformer,
     depth_embeddings: Vec<CodebookEmbeddingHead>,
@@ -54,6 +55,32 @@ pub struct Lfm25AudioHeadProfile {
     pub materialize_pack_ms: f64,
     pub materialize_readback_ms: f64,
     pub codebook_steps: u64,
+}
+
+pub struct Lfm25SampledAudioFrame {
+    samples: Vec<CodebookSample>,
+    embedding: Tensor,
+}
+
+impl Lfm25SampledAudioFrame {
+    pub fn embedding(&self) -> &Tensor {
+        &self.embedding
+    }
+}
+
+#[derive(Debug)]
+pub struct Lfm25StackedAudioFrameTokens {
+    pub tokens: Tensor,
+    pub materialize_ms: f64,
+    pub pack_ms: f64,
+}
+
+#[derive(Debug)]
+pub struct Lfm25AudioFirstTokens {
+    pub tokens: Vec<u32>,
+    pub materialize_ms: f64,
+    pub pack_ms: f64,
+    pub readback_ms: f64,
 }
 
 impl Lfm25AudioHead {
@@ -93,6 +120,8 @@ impl Lfm25AudioHead {
                 })
             })
             .collect::<Result<Vec<_>>>()?;
+        let codebook_offsets_tensor =
+            Tensor::from_vec(codebook_offsets.clone(), (cfg.codebooks,), device)?;
 
         if hidden_size == 0 || cfg.depthformer_dim == 0 {
             return Err(Error::ModelLoadError(
@@ -103,6 +132,7 @@ impl Lfm25AudioHead {
         Ok(Self {
             frame_embedding,
             codebook_offsets,
+            codebook_offsets_tensor,
             depth_linear,
             depthformer,
             depth_embeddings,
@@ -152,6 +182,22 @@ impl Lfm25AudioHead {
         config: &Lfm25SamplingConfig,
         rng: &mut SimpleRng,
     ) -> Result<(Vec<u32>, Lfm25AudioHeadProfile)> {
+        let (frame, mut profile) =
+            self.sample_audio_frame_embedded_with_profile(hidden, config, rng)?;
+        let materialize_started = Instant::now();
+        let materialized = materialize_codebook_samples_with_profile(&frame.samples)?;
+        profile.materialize_ms = elapsed_ms(materialize_started);
+        profile.materialize_pack_ms = materialized.pack_ms;
+        profile.materialize_readback_ms = materialized.readback_ms;
+        Ok((materialized.samples, profile))
+    }
+
+    pub fn sample_audio_frame_embedded_with_profile(
+        &self,
+        hidden: &Tensor,
+        config: &Lfm25SamplingConfig,
+        rng: &mut SimpleRng,
+    ) -> Result<(Lfm25SampledAudioFrame, Lfm25AudioHeadProfile)> {
         let mut profile = Lfm25AudioHeadProfile::default();
         let hidden = ensure_rank3(hidden)?;
         let depth_linear_started = Instant::now();
@@ -193,12 +239,169 @@ impl Lfm25AudioHead {
             profile.codebook_steps = profile.codebook_steps.saturating_add(1);
         }
 
+        let embedding = self.embed_sampled_audio_frame(&samples, hidden.device())?;
+        Ok((Lfm25SampledAudioFrame { samples, embedding }, profile))
+    }
+
+    pub fn first_tokens_with_profile(
+        &self,
+        frames: &[Lfm25SampledAudioFrame],
+    ) -> Result<Lfm25AudioFirstTokens> {
         let materialize_started = Instant::now();
-        let materialized = materialize_codebook_samples_with_profile(&samples)?;
-        profile.materialize_ms = elapsed_ms(materialize_started);
-        profile.materialize_pack_ms = materialized.pack_ms;
-        profile.materialize_readback_ms = materialized.readback_ms;
-        Ok((materialized.samples, profile))
+        if frames.is_empty() {
+            return Ok(Lfm25AudioFirstTokens {
+                tokens: Vec::new(),
+                materialize_ms: elapsed_ms(materialize_started),
+                pack_ms: 0.0,
+                readback_ms: 0.0,
+            });
+        }
+
+        let device_tokens = frames
+            .iter()
+            .map(|frame| frame.samples.first())
+            .collect::<Option<Vec<_>>>();
+        if let Some(samples) = device_tokens {
+            if samples
+                .iter()
+                .all(|sample| matches!(sample, CodebookSample::DeviceGreedy(_)))
+            {
+                let tensors = samples
+                    .iter()
+                    .filter_map(|sample| match sample {
+                        CodebookSample::DeviceGreedy(token) => Some(token),
+                        CodebookSample::Host(_) => None,
+                    })
+                    .collect::<Vec<_>>();
+                let pack_started = Instant::now();
+                let packed = Tensor::cat(&tensors, 0)?;
+                let pack_ms = elapsed_ms(pack_started);
+                let readback_started = Instant::now();
+                let tokens = packed.to_vec1::<u32>().map_err(Error::from)?;
+                let readback_ms = elapsed_ms(readback_started);
+                return Ok(Lfm25AudioFirstTokens {
+                    tokens,
+                    materialize_ms: elapsed_ms(materialize_started),
+                    pack_ms,
+                    readback_ms,
+                });
+            }
+        }
+
+        let readback_started = Instant::now();
+        let tokens = frames
+            .iter()
+            .map(|frame| {
+                frame
+                    .samples
+                    .first()
+                    .ok_or_else(|| {
+                        Error::InferenceError("Empty LFM2.5 Audio sampled frame".to_string())
+                    })?
+                    .to_token()
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Lfm25AudioFirstTokens {
+            tokens,
+            materialize_ms: elapsed_ms(materialize_started),
+            pack_ms: 0.0,
+            readback_ms: elapsed_ms(readback_started),
+        })
+    }
+
+    pub fn stack_frame_tokens_with_profile(
+        &self,
+        frames: &[Lfm25SampledAudioFrame],
+        device: &Device,
+    ) -> Result<Lfm25StackedAudioFrameTokens> {
+        let materialize_started = Instant::now();
+        if frames.is_empty() {
+            return Ok(Lfm25StackedAudioFrameTokens {
+                tokens: Tensor::zeros((0, self.codebooks), DType::U32, device)?,
+                materialize_ms: elapsed_ms(materialize_started),
+                pack_ms: 0.0,
+            });
+        }
+
+        if frames
+            .iter()
+            .flat_map(|frame| frame.samples.iter())
+            .all(|sample| matches!(sample, CodebookSample::DeviceGreedy(_)))
+        {
+            let tensors = frames
+                .iter()
+                .flat_map(|frame| frame.samples.iter())
+                .filter_map(|sample| match sample {
+                    CodebookSample::DeviceGreedy(token) => Some(token),
+                    CodebookSample::Host(_) => None,
+                })
+                .collect::<Vec<_>>();
+            let pack_started = Instant::now();
+            let tokens = Tensor::cat(&tensors, 0)?
+                .reshape((frames.len(), self.codebooks))?
+                .contiguous()?;
+            let pack_ms = elapsed_ms(pack_started);
+            return Ok(Lfm25StackedAudioFrameTokens {
+                tokens,
+                materialize_ms: elapsed_ms(materialize_started),
+                pack_ms,
+            });
+        }
+
+        let pack_started = Instant::now();
+        let mut flat = Vec::with_capacity(frames.len() * self.codebooks);
+        for frame in frames {
+            for sample in &frame.samples {
+                flat.push(sample.to_token()?);
+            }
+        }
+        let tokens = Tensor::from_vec(flat, (frames.len(), self.codebooks), device)?;
+        let pack_ms = elapsed_ms(pack_started);
+        Ok(Lfm25StackedAudioFrameTokens {
+            tokens,
+            materialize_ms: elapsed_ms(materialize_started),
+            pack_ms,
+        })
+    }
+
+    fn embed_sampled_audio_frame(
+        &self,
+        samples: &[CodebookSample],
+        device: &Device,
+    ) -> Result<Tensor> {
+        if samples.len() != self.codebooks {
+            return Err(Error::InvalidInput(format!(
+                "Expected {} audio codebooks, received {}",
+                self.codebooks,
+                samples.len()
+            )));
+        }
+
+        if samples
+            .iter()
+            .all(|sample| matches!(sample, CodebookSample::DeviceGreedy(_)))
+        {
+            let tensors = samples
+                .iter()
+                .filter_map(|sample| match sample {
+                    CodebookSample::DeviceGreedy(token) => Some(token),
+                    CodebookSample::Host(_) => None,
+                })
+                .collect::<Vec<_>>();
+            let token_ids = Tensor::cat(&tensors, 0)?
+                .broadcast_add(&self.codebook_offsets_tensor)?
+                .reshape((1, self.codebooks))?
+                .contiguous()?;
+            let embeds = self.frame_embedding.forward(&token_ids)?;
+            let embeds = embeds.sum(1)?;
+            return embeds.unsqueeze(1).map_err(Error::from);
+        }
+
+        let tokens = samples
+            .iter()
+            .map(CodebookSample::to_token)
+            .collect::<Result<Vec<_>>>()?;
+        self.embed_audio_frame(&tokens, device)
     }
 }
 
@@ -606,6 +809,17 @@ struct CodebookEmbeddingHead {
 enum CodebookSample {
     Host(u32),
     DeviceGreedy(Tensor),
+}
+
+impl CodebookSample {
+    fn to_token(&self) -> Result<u32> {
+        match self {
+            CodebookSample::Host(token) => Ok(*token),
+            CodebookSample::DeviceGreedy(token) => {
+                token.squeeze(0)?.to_scalar::<u32>().map_err(Error::from)
+            }
+        }
+    }
 }
 
 impl CodebookEmbeddingHead {

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/audio_output.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/audio_output.rs
@@ -9,8 +9,8 @@ use candle_transformers::utils::repeat_kv as candle_repeat_kv;
 
 use crate::error::{Error, Result};
 use crate::kernels::{
-    try_fused_decode_gqa_attention_with_kv_len, try_fused_qk_rms_norm, try_fused_rope_pair_bshd,
-    try_fused_silu_mul_with_status,
+    try_fused_decode_gqa_attention_with_kv_len, try_fused_qk_rms_norm, try_fused_rms_norm,
+    try_fused_rope_pair_bshd, try_fused_silu_mul_with_status,
 };
 use crate::models::shared::telemetry::{
     record_decode_attention_path, record_fused_attention_attempt, record_fused_attention_fallback,
@@ -308,6 +308,16 @@ impl DepthRmsNorm {
     }
 
     fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        if input.device().is_metal() {
+            let input = if input.is_contiguous() {
+                input.clone()
+            } else {
+                input.contiguous()?
+            };
+            if let Some(output) = try_fused_rms_norm(&input, &self.weight, self.eps) {
+                return Ok(output);
+            }
+        }
         candle_nn::ops::rms_norm(input, &self.weight, self.eps as f32).map_err(Error::from)
     }
 

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/audio_output.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/audio_output.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Instant;
 
 use candle_core::{DType, Device, IndexOp, Tensor};
 use candle_nn::{Embedding, Module};
@@ -38,6 +39,19 @@ pub struct Lfm25AudioHead {
     codebooks: usize,
     depthformer_dim: usize,
     audio_end_token_id: u32,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Lfm25AudioHeadProfile {
+    pub depth_linear_ms: f64,
+    pub depth_reshape_ms: f64,
+    pub cache_setup_ms: f64,
+    pub codebook_input_ms: f64,
+    pub depthformer_ms: f64,
+    pub sample_ms: f64,
+    pub embed_ms: f64,
+    pub materialize_ms: f64,
+    pub codebook_steps: u64,
 }
 
 impl Lfm25AudioHead {
@@ -126,28 +140,61 @@ impl Lfm25AudioHead {
         config: &Lfm25SamplingConfig,
         rng: &mut SimpleRng,
     ) -> Result<Vec<u32>> {
+        self.sample_audio_frame_with_profile(hidden, config, rng)
+            .map(|(samples, _profile)| samples)
+    }
+
+    pub fn sample_audio_frame_with_profile(
+        &self,
+        hidden: &Tensor,
+        config: &Lfm25SamplingConfig,
+        rng: &mut SimpleRng,
+    ) -> Result<(Vec<u32>, Lfm25AudioHeadProfile)> {
+        let mut profile = Lfm25AudioHeadProfile::default();
         let hidden = ensure_rank3(hidden)?;
+        let depth_linear_started = Instant::now();
         let depth_input = self.depth_linear.forward(&hidden)?;
+        profile.depth_linear_ms = elapsed_ms(depth_linear_started);
+
+        let depth_reshape_started = Instant::now();
         let depth_input = depth_input
             .reshape((1, 1, self.codebooks, self.depthformer_dim))?
             .squeeze(0)?
             .squeeze(0)?; // [C, D]
+        profile.depth_reshape_ms = elapsed_ms(depth_reshape_started);
 
+        let cache_setup_started = Instant::now();
         let mut next_embed = Tensor::zeros(self.depthformer_dim, hidden.dtype(), hidden.device())?;
         let mut caches = self.depthformer.empty_cache();
         let mut samples = Vec::with_capacity(self.codebooks);
+        profile.cache_setup_ms = elapsed_ms(cache_setup_started);
 
         for codebook_idx in 0..self.codebooks {
+            let codebook_input_started = Instant::now();
             let cur = depth_input.i(codebook_idx)?.broadcast_add(&next_embed)?;
             let cur = cur.unsqueeze(0)?.unsqueeze(0)?;
+            profile.codebook_input_ms += elapsed_ms(codebook_input_started);
+
+            let depthformer_started = Instant::now();
             let out = self.depthformer.forward_cached(&cur, &mut caches)?;
+            profile.depthformer_ms += elapsed_ms(depthformer_started);
+
+            let sample_started = Instant::now();
             let sample = self.depth_embeddings[codebook_idx].sample(&out, config, rng)?;
+            profile.sample_ms += elapsed_ms(sample_started);
+
+            let embed_started = Instant::now();
             next_embed =
                 self.depth_embeddings[codebook_idx].embed_sample(&sample, hidden.device())?;
+            profile.embed_ms += elapsed_ms(embed_started);
             samples.push(sample);
+            profile.codebook_steps = profile.codebook_steps.saturating_add(1);
         }
 
-        materialize_codebook_samples(&samples)
+        let materialize_started = Instant::now();
+        let samples = materialize_codebook_samples(&samples)?;
+        profile.materialize_ms = elapsed_ms(materialize_started);
+        Ok((samples, profile))
     }
 }
 
@@ -670,6 +717,10 @@ impl QLinear {
             Ok(out)
         }
     }
+}
+
+fn elapsed_ms(started: Instant) -> f64 {
+    started.elapsed().as_secs_f64() * 1000.0
 }
 
 fn load_embedding_any(loader: &GgufLoader, device: &Device, names: &[String]) -> Result<Embedding> {

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/audio_output.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/audio_output.rs
@@ -51,6 +51,8 @@ pub struct Lfm25AudioHeadProfile {
     pub sample_ms: f64,
     pub embed_ms: f64,
     pub materialize_ms: f64,
+    pub materialize_pack_ms: f64,
+    pub materialize_readback_ms: f64,
     pub codebook_steps: u64,
 }
 
@@ -192,9 +194,11 @@ impl Lfm25AudioHead {
         }
 
         let materialize_started = Instant::now();
-        let samples = materialize_codebook_samples(&samples)?;
+        let materialized = materialize_codebook_samples_with_profile(&samples)?;
         profile.materialize_ms = elapsed_ms(materialize_started);
-        Ok((samples, profile))
+        profile.materialize_pack_ms = materialized.pack_ms;
+        profile.materialize_readback_ms = materialized.readback_ms;
+        Ok((materialized.samples, profile))
     }
 }
 
@@ -660,7 +664,15 @@ impl CodebookEmbeddingHead {
     }
 }
 
-fn materialize_codebook_samples(samples: &[CodebookSample]) -> Result<Vec<u32>> {
+struct MaterializedCodebookSamples {
+    samples: Vec<u32>,
+    pack_ms: f64,
+    readback_ms: f64,
+}
+
+fn materialize_codebook_samples_with_profile(
+    samples: &[CodebookSample],
+) -> Result<MaterializedCodebookSamples> {
     if samples
         .iter()
         .all(|sample| matches!(sample, CodebookSample::DeviceGreedy(_)))
@@ -673,13 +685,22 @@ fn materialize_codebook_samples(samples: &[CodebookSample]) -> Result<Vec<u32>> 
             })
             .collect::<Vec<_>>();
         if !tensors.is_empty() {
-            return Tensor::cat(&tensors, 0)?
-                .to_vec1::<u32>()
-                .map_err(Error::from);
+            let pack_started = Instant::now();
+            let packed = Tensor::cat(&tensors, 0)?;
+            let pack_ms = elapsed_ms(pack_started);
+            let readback_started = Instant::now();
+            let samples = packed.to_vec1::<u32>().map_err(Error::from)?;
+            let readback_ms = elapsed_ms(readback_started);
+            return Ok(MaterializedCodebookSamples {
+                samples,
+                pack_ms,
+                readback_ms,
+            });
         }
     }
 
-    samples
+    let readback_started = Instant::now();
+    let samples = samples
         .iter()
         .map(|sample| match sample {
             CodebookSample::Host(token) => Ok(*token),
@@ -687,7 +708,12 @@ fn materialize_codebook_samples(samples: &[CodebookSample]) -> Result<Vec<u32>> 
                 token.squeeze(0)?.to_scalar::<u32>().map_err(Error::from)
             }
         })
-        .collect()
+        .collect::<Result<Vec<_>>>()?;
+    Ok(MaterializedCodebookSamples {
+        samples,
+        pack_ms: 0.0,
+        readback_ms: elapsed_ms(readback_started),
+    })
 }
 
 #[derive(Debug)]

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/backbone.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/backbone.rs
@@ -11,6 +11,7 @@ use crate::error::{Error, Result};
 use crate::kernels::{
     try_fused_decode_gqa_attention_with_kv_len, try_fused_qk_rms_norm, try_fused_rope_pair_bshd,
     try_fused_silu_mul_with_status, try_lfm_shortconv_decode3, try_lfm_shortconv_sequence3,
+    try_lfm_shortconv_update3,
 };
 use crate::models::shared::attention::flash::{
     flash_attention_requested, try_fused_self_attention_with_options, CudaFlashAttentionOptions,
@@ -400,7 +401,15 @@ impl ShortConvLayer {
                 None
             };
 
-            if self.l_cache > 1 {
+            let fused_state = if self.l_cache == 3 {
+                try_lfm_shortconv_update3(&state, &bx)
+            } else {
+                None
+            };
+
+            if let Some(updated) = fused_state {
+                state = updated;
+            } else if self.l_cache > 1 {
                 let tail = state.narrow(2, 1, self.l_cache - 1)?;
                 state = Tensor::cat(&[&tail, &bx], 2)?;
             } else {

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/backbone.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/backbone.rs
@@ -382,18 +382,7 @@ impl ShortConvLayer {
         let x = projected.narrow(1, hidden_size * 2, hidden_size)?;
         let bx = (&b * &x)?.contiguous()?;
 
-        let mut conv_weight = self.conv.clone();
-        match conv_weight.rank() {
-            3 => conv_weight = conv_weight.squeeze(1)?,
-            2 => {
-                let (d0, d1) = conv_weight.dims2()?;
-                if d0 == self.l_cache && d1 == hidden_size {
-                    conv_weight = conv_weight.transpose(0, 1)?.contiguous()?;
-                }
-            }
-            _ => {}
-        }
-        let conv_weight = conv_weight.contiguous()?;
+        let conv_weight = &self.conv;
 
         let conv_out = if seq_len == 1 {
             let mut state = if let Some(cache) = &self.cache {
@@ -693,16 +682,20 @@ impl QuantizedLfm2Backbone {
                             format!("{legacy_prefix}.conv.out_proj.weight"),
                         ],
                     )?,
-                    conv: load_dense_any(
-                        loader,
-                        device,
-                        &[
-                            format!("{prefix}.shortconv.conv.weight"),
-                            format!("{prefix}.conv.conv.weight"),
-                            format!("{prefix}.shortconv.conv"),
-                            format!("{legacy_prefix}.conv.conv.weight"),
-                        ],
-                        Some(DType::F32),
+                    conv: normalize_shortconv_weight(
+                        load_dense_any(
+                            loader,
+                            device,
+                            &[
+                                format!("{prefix}.shortconv.conv.weight"),
+                                format!("{prefix}.conv.conv.weight"),
+                                format!("{prefix}.shortconv.conv"),
+                                format!("{legacy_prefix}.conv.conv.weight"),
+                            ],
+                            Some(DType::F32),
+                        )?,
+                        cfg.shortconv_l_cache,
+                        cfg.embedding_length,
                     )?,
                     l_cache: cfg.shortconv_l_cache,
                     cache: None,
@@ -859,6 +852,34 @@ fn lfm25_metal_prefill_sdpa_enabled() -> bool {
             )
         })
         .unwrap_or(true)
+}
+
+fn normalize_shortconv_weight(
+    mut conv_weight: Tensor,
+    l_cache: usize,
+    hidden_size: usize,
+) -> Result<Tensor> {
+    match conv_weight.rank() {
+        3 => conv_weight = conv_weight.squeeze(1)?,
+        2 => {}
+        rank => {
+            return Err(Error::ModelLoadError(format!(
+                "Unexpected LFM2 shortconv weight rank: {rank}"
+            )));
+        }
+    }
+
+    let (mut rows, mut cols) = conv_weight.dims2()?;
+    if rows == l_cache && cols == hidden_size {
+        conv_weight = conv_weight.transpose(0, 1)?;
+        (rows, cols) = conv_weight.dims2()?;
+    }
+    if rows != hidden_size || cols != l_cache {
+        return Err(Error::ModelLoadError(format!(
+            "Unexpected LFM2 shortconv weight shape: expected [{hidden_size}, {l_cache}], found [{rows}, {cols}]"
+        )));
+    }
+    conv_weight.contiguous().map_err(Error::from)
 }
 
 fn precompute_freqs(

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/backbone.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/backbone.rs
@@ -291,6 +291,29 @@ impl AttentionLayer {
             }
         }
 
+        if should_try_lfm25_metal_prefill_sdpa(
+            &query_states,
+            seq_len,
+            index_pos,
+            self.sliding_window,
+        ) {
+            if let Some(attn_output) = try_fused_self_attention_with_options(
+                &query_states,
+                &all_keys,
+                &all_values,
+                None,
+                self.head_dim,
+                true,
+                CudaFlashAttentionOptions::default(),
+            )? {
+                let attn_output =
+                    attn_output
+                        .transpose(1, 2)?
+                        .reshape((batch_size, seq_len, hidden_size))?;
+                return self.wo.forward(&attn_output).map_err(Error::from);
+            }
+        }
+
         if batch_size == 1 && seq_len == 1 && mask.is_none() && query_states.device().is_metal() {
             record_fused_attention_attempt();
             if let Some(attn_output) = try_fused_decode_gqa_attention_with_kv_len(
@@ -811,6 +834,31 @@ fn lfm25_cuda_flash_attention_options(
         window_size_left: if masked_prefill { sliding_window } else { None },
         ..CudaFlashAttentionOptions::default()
     }
+}
+
+fn should_try_lfm25_metal_prefill_sdpa(
+    query_states: &Tensor,
+    seq_len: usize,
+    index_pos: usize,
+    sliding_window: Option<usize>,
+) -> bool {
+    seq_len > 1
+        && index_pos == 0
+        && sliding_window.is_none()
+        && query_states.device().is_metal()
+        && lfm25_metal_prefill_sdpa_enabled()
+}
+
+fn lfm25_metal_prefill_sdpa_enabled() -> bool {
+    std::env::var("IZWI_LFM25_METAL_PREFILL_SDPA")
+        .ok()
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(true)
 }
 
 fn precompute_freqs(

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/backbone.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/backbone.rs
@@ -10,7 +10,7 @@ use candle_transformers::utils::repeat_kv as candle_repeat_kv;
 use crate::error::{Error, Result};
 use crate::kernels::{
     try_fused_decode_gqa_attention_with_kv_len, try_fused_qk_rms_norm, try_fused_rope_pair_bshd,
-    try_fused_silu_mul_with_status,
+    try_fused_silu_mul_with_status, try_lfm_shortconv_decode3,
 };
 use crate::models::shared::attention::flash::{
     flash_attention_requested, try_fused_self_attention_with_options, CudaFlashAttentionOptions,
@@ -394,6 +394,11 @@ impl ShortConvLayer {
                     bx.device(),
                 )?
             };
+            let fused_conv_out = if self.l_cache == 3 {
+                try_lfm_shortconv_decode3(&state, &bx, conv_weight)
+            } else {
+                None
+            };
 
             if self.l_cache > 1 {
                 let tail = state.narrow(2, 1, self.l_cache - 1)?;
@@ -403,9 +408,13 @@ impl ShortConvLayer {
             }
             self.cache = Some(state.clone());
 
-            (&state * &conv_weight.unsqueeze(0)?)?
-                .sum_keepdim(2)?
-                .contiguous()?
+            if let Some(conv_out) = fused_conv_out {
+                conv_out
+            } else {
+                (&state * &conv_weight.unsqueeze(0)?)?
+                    .sum_keepdim(2)?
+                    .contiguous()?
+            }
         } else {
             let conv = Conv1d::new(
                 conv_weight
@@ -434,7 +443,7 @@ impl ShortConvLayer {
                     )?;
                     cache = Tensor::cat(&[&zeros, &cache], 2)?;
                 }
-                self.cache = Some(cache);
+                self.cache = Some(cache.contiguous()?);
             }
 
             out

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/backbone.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/backbone.rs
@@ -10,7 +10,7 @@ use candle_transformers::utils::repeat_kv as candle_repeat_kv;
 use crate::error::{Error, Result};
 use crate::kernels::{
     try_fused_decode_gqa_attention_with_kv_len, try_fused_qk_rms_norm, try_fused_rope_pair_bshd,
-    try_fused_silu_mul_with_status, try_lfm_shortconv_decode3,
+    try_fused_silu_mul_with_status, try_lfm_shortconv_decode3, try_lfm_shortconv_sequence3,
 };
 use crate::models::shared::attention::flash::{
     flash_attention_requested, try_fused_self_attention_with_options, CudaFlashAttentionOptions,
@@ -416,19 +416,28 @@ impl ShortConvLayer {
                     .contiguous()?
             }
         } else {
-            let conv = Conv1d::new(
-                conv_weight
-                    .reshape((hidden_size, 1, self.l_cache))?
-                    .contiguous()?,
-                None,
-                Conv1dConfig {
-                    padding: self.l_cache.saturating_sub(1),
-                    groups: hidden_size,
-                    ..Default::default()
-                },
-            );
-            let mut out = conv.forward(&bx.contiguous()?)?;
-            out = out.narrow(2, 0, seq_len)?;
+            let bx = bx.contiguous()?;
+            let out = if self.l_cache == 3 {
+                try_lfm_shortconv_sequence3(&bx, conv_weight)
+            } else {
+                None
+            };
+            let out = if let Some(out) = out {
+                out
+            } else {
+                let conv = Conv1d::new(
+                    conv_weight
+                        .reshape((hidden_size, 1, self.l_cache))?
+                        .contiguous()?,
+                    None,
+                    Conv1dConfig {
+                        padding: self.l_cache.saturating_sub(1),
+                        groups: hidden_size,
+                        ..Default::default()
+                    },
+                );
+                conv.forward(&bx)?.narrow(2, 0, seq_len)?
+            };
 
             if self.l_cache > 0 {
                 let (_, _, cur_len) = bx.dims3()?;

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/backbone.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/backbone.rs
@@ -9,9 +9,9 @@ use candle_transformers::utils::repeat_kv as candle_repeat_kv;
 
 use crate::error::{Error, Result};
 use crate::kernels::{
-    try_fused_decode_gqa_attention_with_kv_len, try_fused_qk_rms_norm, try_fused_rope_pair_bshd,
-    try_fused_silu_mul_with_status, try_lfm_shortconv_decode3, try_lfm_shortconv_sequence3,
-    try_lfm_shortconv_update3,
+    try_fused_decode_gqa_attention_with_kv_len, try_fused_qk_rms_norm, try_fused_rms_norm,
+    try_fused_rope_pair_bshd, try_fused_silu_mul_with_status, try_lfm_shortconv_decode3,
+    try_lfm_shortconv_sequence3, try_lfm_shortconv_update3,
 };
 use crate::models::shared::attention::flash::{
     flash_attention_requested, try_fused_self_attention_with_options, CudaFlashAttentionOptions,
@@ -105,6 +105,16 @@ impl LfmRmsNorm {
     }
 
     fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        if input.device().is_metal() {
+            let input = if input.is_contiguous() {
+                input.clone()
+            } else {
+                input.contiguous()?
+            };
+            if let Some(output) = try_fused_rms_norm(&input, &self.weight, self.eps) {
+                return Ok(output);
+            }
+        }
         candle_nn::ops::rms_norm(input, &self.weight, self.eps as f32).map_err(Error::from)
     }
 

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/conformer.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/conformer.rs
@@ -421,6 +421,8 @@ struct ConformerConv {
     pointwise_conv1: Conv1d,
     depthwise_conv: Conv1d,
     affine_norm: AffineNorm1d,
+    folded_depthwise_weight: Tensor,
+    folded_depthwise_bias: Tensor,
     pointwise_conv2: Conv1d,
 }
 
@@ -496,11 +498,15 @@ impl ConformerConv {
                 format!("audio_encoder.layers.{idx}.conv.pointwise_conv2.bias"),
             ],
         )?;
+        let (folded_depthwise_weight, folded_depthwise_bias) =
+            fold_depthwise_conv_affine(&depthwise_conv, &affine_norm)?;
 
         Ok(Self {
             pointwise_conv1,
             depthwise_conv,
             affine_norm,
+            folded_depthwise_weight,
+            folded_depthwise_bias,
             pointwise_conv2,
         })
     }
@@ -514,13 +520,62 @@ impl ConformerConv {
         let x_b = x.i((.., hidden.., ..))?;
         x = x_a.broadcast_mul(&ops::sigmoid(&x_b)?)?;
 
-        x = forward_depthwise_conv1d(&self.depthwise_conv, &x)?;
-        x = self.affine_norm.forward(&x)?;
-        x = swish(&x)?;
+        x = if let Some(fused) = try_forward_depthwise_conv1d_affine_swish(
+            &self.depthwise_conv,
+            &self.folded_depthwise_weight,
+            &self.folded_depthwise_bias,
+            &x,
+        ) {
+            fused
+        } else {
+            let x = forward_depthwise_conv1d(&self.depthwise_conv, &x)?;
+            let x = self.affine_norm.forward(&x)?;
+            swish(&x)?
+        };
         x = self.pointwise_conv2.forward(&x)?;
 
         x.transpose(1, 2).map_err(Error::from)
     }
+}
+
+fn fold_depthwise_conv_affine(
+    conv: &Conv1d,
+    affine_norm: &AffineNorm1d,
+) -> Result<(Tensor, Tensor)> {
+    let weight = conv.weight();
+    let channels = affine_norm.weight.dim(0)?;
+    let scale = affine_norm.weight.reshape((channels, 1, 1))?;
+    let folded_weight = weight.broadcast_mul(&scale)?.contiguous()?;
+    let conv_bias = match conv.bias() {
+        Some(bias) => bias.clone(),
+        None => Tensor::zeros(
+            channels,
+            affine_norm.weight.dtype(),
+            affine_norm.weight.device(),
+        )?,
+    };
+    let folded_bias = conv_bias
+        .broadcast_mul(&affine_norm.weight)?
+        .broadcast_add(&affine_norm.bias)?
+        .contiguous()?;
+    Ok((folded_weight, folded_bias))
+}
+
+fn try_forward_depthwise_conv1d_affine_swish(
+    conv: &Conv1d,
+    folded_weight: &Tensor,
+    folded_bias: &Tensor,
+    x: &Tensor,
+) -> Option<Tensor> {
+    let cfg = conv.config();
+    parakeet_metal_kernels::try_depthwise_conv1d_bias_swish(
+        x,
+        folded_weight,
+        folded_bias,
+        cfg.padding,
+        cfg.stride,
+        cfg.dilation,
+    )
 }
 
 fn forward_depthwise_conv1d(conv: &Conv1d, x: &Tensor) -> Result<Tensor> {
@@ -1239,12 +1294,12 @@ mod tests {
     use candle_core::quantized::gguf_file::{write as write_gguf, Value as GgufValue};
     use candle_core::quantized::{GgmlDType, QTensor};
     use candle_core::{Device, Module, Tensor};
-    use candle_nn::Linear;
+    use candle_nn::{Conv1d, Conv1dConfig, Linear};
     use uuid::Uuid;
 
     use super::{
-        build_rel_positional_embedding, load_linear_any, rel_shift, subsampled_len_3x,
-        Lfm25AudioEncoder, RelPosSelfAttention,
+        build_rel_positional_embedding, fold_depthwise_conv_affine, load_linear_any, rel_shift,
+        subsampled_len_3x, AffineNorm1d, Lfm25AudioEncoder, RelPosSelfAttention,
     };
     use crate::models::architectures::lfm25_audio::config::parse_audio_encoder_config;
     use crate::models::shared::weights::gguf::GgufLoader;
@@ -1302,6 +1357,57 @@ mod tests {
         let device = Device::Cpu;
         let emb = build_rel_positional_embedding(5, 8, &device).expect("build embedding");
         assert_eq!(emb.dims3().unwrap(), (1, 9, 8));
+    }
+
+    #[test]
+    fn folded_depthwise_conv_affine_matches_explicit_path() {
+        let device = Device::Cpu;
+        let cfg = Conv1dConfig {
+            padding: 1,
+            groups: 2,
+            ..Default::default()
+        };
+        let weight = Tensor::from_vec(
+            vec![
+                1.0f32, 2.0, 3.0, //
+                -1.0, 0.5, 0.25,
+            ],
+            (2, 1, 3),
+            &device,
+        )
+        .expect("conv weight");
+        let bias = Tensor::from_vec(vec![0.5f32, -0.25], 2, &device).expect("conv bias");
+        let conv = Conv1d::new(weight, Some(bias), cfg);
+        let affine_norm = AffineNorm1d {
+            weight: Tensor::from_vec(vec![2.0f32, -3.0], 2, &device).expect("affine weight"),
+            bias: Tensor::from_vec(vec![0.1f32, 0.2], 2, &device).expect("affine bias"),
+        };
+        let input = Tensor::from_vec(
+            vec![
+                0.1f32, 0.2, 0.3, 0.4, //
+                -0.5, -0.4, -0.3, -0.2,
+            ],
+            (1, 2, 4),
+            &device,
+        )
+        .expect("input");
+
+        let (folded_weight, folded_bias) =
+            fold_depthwise_conv_affine(&conv, &affine_norm).expect("fold affine");
+        let folded_conv = Conv1d::new(folded_weight, Some(folded_bias), cfg);
+        let expected = affine_norm
+            .forward(&conv.forward(&input).expect("conv forward"))
+            .expect("affine forward");
+        let actual = folded_conv.forward(&input).expect("folded conv forward");
+
+        let expected = expected.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let actual = actual.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        for (idx, (actual, expected)) in actual.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (actual - expected).abs() <= 1e-5,
+                "folded conv mismatch at {idx}: {actual} != {expected}"
+            );
+        }
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/conformer.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/conformer.rs
@@ -532,6 +532,7 @@ struct RelPosSelfAttention {
     pos_bias_v: Tensor,
     n_heads: usize,
     head_dim: usize,
+    projected_pos_cache: Mutex<HashMap<usize, Tensor>>,
 }
 
 impl RelPosSelfAttention {
@@ -651,6 +652,7 @@ impl RelPosSelfAttention {
             pos_bias_v,
             n_heads: cfg.attention_head_count,
             head_dim: cfg.embedding_length / cfg.attention_head_count,
+            projected_pos_cache: Mutex::new(HashMap::new()),
         })
     }
 
@@ -675,12 +677,7 @@ impl RelPosSelfAttention {
             .reshape((batch, seq_len, self.n_heads, self.head_dim))?
             .transpose(1, 2)?
             .contiguous()?;
-        let p = self
-            .pos_proj
-            .forward(pos_emb)?
-            .reshape((1, 2 * seq_len - 1, self.n_heads, self.head_dim))?
-            .transpose(1, 2)?
-            .contiguous()?;
+        let p = self.projected_pos_embedding(pos_emb, seq_len)?;
 
         let pos_bias_u = self
             .pos_bias_u
@@ -707,6 +704,34 @@ impl RelPosSelfAttention {
         ))?;
 
         self.out_proj.forward(&out).map_err(Error::from)
+    }
+
+    fn projected_pos_embedding(&self, pos_emb: &Tensor, seq_len: usize) -> Result<Tensor> {
+        {
+            let cache = self.projected_pos_cache.lock().map_err(|_| {
+                Error::InferenceError(
+                    "LFM2.5 Audio encoder projected position cache mutex poisoned".to_string(),
+                )
+            })?;
+            if let Some(projected) = cache.get(&seq_len) {
+                return Ok(projected.clone());
+            }
+        }
+
+        let projected = self
+            .pos_proj
+            .forward(pos_emb)?
+            .reshape((1, 2 * seq_len - 1, self.n_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+
+        let mut cache = self.projected_pos_cache.lock().map_err(|_| {
+            Error::InferenceError(
+                "LFM2.5 Audio encoder projected position cache mutex poisoned".to_string(),
+            )
+        })?;
+        cache.insert(seq_len, projected.clone());
+        Ok(projected)
     }
 }
 
@@ -1165,17 +1190,20 @@ pub fn subsampled_len_3x(mut len: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::fs::{self, File};
     use std::path::{Path, PathBuf};
+    use std::sync::Mutex;
 
     use candle_core::quantized::gguf_file::{write as write_gguf, Value as GgufValue};
     use candle_core::quantized::{GgmlDType, QTensor};
     use candle_core::{Device, Module, Tensor};
+    use candle_nn::Linear;
     use uuid::Uuid;
 
     use super::{
         build_rel_positional_embedding, load_linear_any, rel_shift, subsampled_len_3x,
-        Lfm25AudioEncoder,
+        Lfm25AudioEncoder, RelPosSelfAttention,
     };
     use crate::models::architectures::lfm25_audio::config::parse_audio_encoder_config;
     use crate::models::shared::weights::gguf::GgufLoader;
@@ -1246,6 +1274,39 @@ mod tests {
             .unwrap();
         let shifted = rel_shift(&x).expect("rel shift");
         assert_eq!(shifted.dims4().unwrap(), (1, 1, 3, 5));
+    }
+
+    #[test]
+    fn projected_relative_position_embedding_is_cached_by_length() {
+        let device = Device::Cpu;
+        let identity = Tensor::eye(4, candle_core::DType::F32, &device).expect("identity");
+        let zero_bias = Tensor::zeros(4, candle_core::DType::F32, &device).expect("bias");
+        let linear = || Linear::new(identity.clone(), Some(zero_bias.clone()));
+        let attn = RelPosSelfAttention {
+            q_proj: linear(),
+            k_proj: linear(),
+            v_proj: linear(),
+            out_proj: linear(),
+            pos_proj: linear(),
+            pos_bias_u: Tensor::zeros((2, 2), candle_core::DType::F32, &device).expect("bias u"),
+            pos_bias_v: Tensor::zeros((2, 2), candle_core::DType::F32, &device).expect("bias v"),
+            n_heads: 2,
+            head_dim: 2,
+            projected_pos_cache: Mutex::new(HashMap::new()),
+        };
+        let pos_emb =
+            build_rel_positional_embedding(5, 4, &device).expect("relative position embedding");
+
+        let first = attn
+            .projected_pos_embedding(&pos_emb, 5)
+            .expect("first projection");
+        let second = attn
+            .projected_pos_embedding(&pos_emb, 5)
+            .expect("cached projection");
+
+        assert_eq!(first.dims4().unwrap(), (1, 2, 9, 2));
+        assert_eq!(second.dims4().unwrap(), (1, 2, 9, 2));
+        assert_eq!(attn.projected_pos_cache.lock().unwrap().len(), 1);
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/conformer.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/conformer.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
 use candle_core::{DType, Device, IndexOp, Tensor};
 use candle_nn::ops;
 use candle_nn::{Conv1d, Conv1dConfig, Conv2d, Conv2dConfig, LayerNorm, Linear, Module};
@@ -12,6 +15,7 @@ pub struct Lfm25AudioEncoder {
     layers: Vec<ConformerLayer>,
     adapter: AudioAdapter,
     cfg: Lfm25AudioEncoderConfig,
+    pos_emb_cache: Mutex<HashMap<usize, Tensor>>,
 }
 
 impl Lfm25AudioEncoder {
@@ -34,6 +38,7 @@ impl Lfm25AudioEncoder {
             layers,
             adapter,
             cfg,
+            pos_emb_cache: Mutex::new(HashMap::new()),
         })
     }
 
@@ -41,13 +46,26 @@ impl Lfm25AudioEncoder {
         let (mut x, encoded_len) = self.pre_encode.forward(features, feature_frames)?;
         x = x.narrow(1, 0, encoded_len)?;
 
-        let pos_emb =
-            build_rel_positional_embedding(encoded_len, self.cfg.embedding_length, x.device())?;
+        let pos_emb = self.rel_positional_embedding(encoded_len, x.device())?;
         for layer in &self.layers {
             x = layer.forward(&x, &pos_emb)?;
         }
 
         self.adapter.forward(&x)
+    }
+
+    fn rel_positional_embedding(&self, encoded_len: usize, device: &Device) -> Result<Tensor> {
+        let mut cache = self.pos_emb_cache.lock().map_err(|_| {
+            Error::InferenceError("LFM2.5 Audio encoder position cache mutex poisoned".to_string())
+        })?;
+        if let Some(pos_emb) = cache.get(&encoded_len) {
+            return Ok(pos_emb.clone());
+        }
+
+        let pos_emb =
+            build_rel_positional_embedding(encoded_len, self.cfg.embedding_length, device)?;
+        cache.insert(encoded_len, pos_emb.clone());
+        Ok(pos_emb)
     }
 }
 

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/conformer.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/conformer.rs
@@ -6,6 +6,7 @@ use candle_nn::ops;
 use candle_nn::{Conv1d, Conv1dConfig, Conv2d, Conv2dConfig, LayerNorm, Linear, Module};
 
 use crate::error::{Error, Result};
+use crate::models::architectures::parakeet::asr::metal_kernels as parakeet_metal_kernels;
 use crate::models::shared::weights::gguf::GgufLoader;
 
 use super::config::Lfm25AudioEncoderConfig;
@@ -206,11 +207,11 @@ impl ConvSubsamplingDw {
         x = self.conv0.forward(&x)?;
         x = x.relu()?;
 
-        x = self.conv2.forward(&x)?;
+        x = forward_depthwise_conv2d(&self.conv2, &x)?;
         x = self.conv3.forward(&x)?;
         x = x.relu()?;
 
-        x = self.conv5.forward(&x)?;
+        x = forward_depthwise_conv2d(&self.conv5, &x)?;
         x = self.conv6.forward(&x)?;
         x = x.relu()?;
 
@@ -513,13 +514,53 @@ impl ConformerConv {
         let x_b = x.i((.., hidden.., ..))?;
         x = x_a.broadcast_mul(&ops::sigmoid(&x_b)?)?;
 
-        x = self.depthwise_conv.forward(&x)?;
+        x = forward_depthwise_conv1d(&self.depthwise_conv, &x)?;
         x = self.affine_norm.forward(&x)?;
         x = swish(&x)?;
         x = self.pointwise_conv2.forward(&x)?;
 
         x.transpose(1, 2).map_err(Error::from)
     }
+}
+
+fn forward_depthwise_conv1d(conv: &Conv1d, x: &Tensor) -> Result<Tensor> {
+    let cfg = conv.config();
+    let Some(mut y) = parakeet_metal_kernels::try_depthwise_conv1d(
+        x,
+        conv.weight(),
+        cfg.padding,
+        cfg.stride,
+        cfg.dilation,
+    ) else {
+        return conv.forward(x).map_err(Error::from);
+    };
+
+    if let Some(bias) = conv.bias() {
+        let channels = bias.dims1()?;
+        y = y.broadcast_add(&bias.reshape((1, channels, 1))?)?;
+    }
+
+    Ok(y)
+}
+
+fn forward_depthwise_conv2d(conv: &Conv2d, x: &Tensor) -> Result<Tensor> {
+    let cfg = conv.config();
+    let Some(mut y) = parakeet_metal_kernels::try_depthwise_conv2d(
+        x,
+        conv.weight(),
+        cfg.padding,
+        cfg.stride,
+        cfg.dilation,
+    ) else {
+        return conv.forward(x).map_err(Error::from);
+    };
+
+    if let Some(bias) = conv.bias() {
+        let channels = bias.dims1()?;
+        y = y.broadcast_add(&bias.reshape((1, channels, 1, 1))?)?;
+    }
+
+    Ok(y)
 }
 
 struct RelPosSelfAttention {

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/detokenizer.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/detokenizer.rs
@@ -1,4 +1,5 @@
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use candle_core::{DType, Device, IndexOp, Tensor};
 use candle_nn::{Embedding, Module};
@@ -22,6 +23,17 @@ pub struct Lfm25AudioDetokenizer {
     hop_length: usize,
     codebooks: usize,
     codebook_offsets: Vec<u32>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Lfm25DetokenizerProfile {
+    pub embedding_ms: f64,
+    pub upsample_ms: f64,
+    pub backbone_forward_ms: f64,
+    pub projection_ms: f64,
+    pub waveform_prepare_ms: f64,
+    pub readback_ms: f64,
+    pub istft_ms: f64,
 }
 
 impl Lfm25AudioDetokenizer {
@@ -73,6 +85,16 @@ impl Lfm25AudioDetokenizer {
     }
 
     pub fn decode(&self, audio_codes: &[Vec<u32>], device: &Device) -> Result<Vec<f32>> {
+        self.decode_with_profile(audio_codes, device)
+            .map(|(samples, _profile)| samples)
+    }
+
+    pub fn decode_with_profile(
+        &self,
+        audio_codes: &[Vec<u32>],
+        device: &Device,
+    ) -> Result<(Vec<f32>, Lfm25DetokenizerProfile)> {
+        let mut profile = Lfm25DetokenizerProfile::default();
         if audio_codes.len() != self.codebooks {
             return Err(Error::InvalidInput(format!(
                 "Expected {} audio codebooks, received {}",
@@ -83,7 +105,7 @@ impl Lfm25AudioDetokenizer {
 
         let frames = audio_codes.first().map(Vec::len).unwrap_or(0);
         if frames == 0 {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), profile));
         }
         if audio_codes.iter().any(|codes| codes.len() != frames) {
             return Err(Error::InvalidInput(
@@ -100,19 +122,33 @@ impl Lfm25AudioDetokenizer {
             ));
         }
 
+        let embedding_started = Instant::now();
         let embeds = self.fused_embeddings(audio_codes, device)?;
+        profile.embedding_ms = elapsed_ms(embedding_started);
+
+        let upsample_started = Instant::now();
         let upsampled = self.upsample_nearest(&embeds)?;
+        profile.upsample_ms = elapsed_ms(upsample_started);
 
         let projected = {
             let mut guard = self.backbone.lock().map_err(|_| {
                 Error::InferenceError("LFM2.5 Audio detokenizer mutex poisoned".to_string())
             })?;
             guard.reset_state();
+            let backbone_started = Instant::now();
             let hidden = guard.forward_embeds(&upsampled, 0)?;
-            guard.project_hidden(&hidden)?
+            profile.backbone_forward_ms = elapsed_ms(backbone_started);
+            let projection_started = Instant::now();
+            let projected = guard.project_hidden(&hidden)?;
+            profile.projection_ms = elapsed_ms(projection_started);
+            projected
         };
 
-        self.projected_to_waveform(&projected)
+        let (samples, waveform_profile) = self.projected_to_waveform_with_profile(&projected)?;
+        profile.waveform_prepare_ms = waveform_profile.waveform_prepare_ms;
+        profile.readback_ms = waveform_profile.readback_ms;
+        profile.istft_ms = waveform_profile.istft_ms;
+        Ok((samples, profile))
     }
 
     fn fused_embeddings(&self, audio_codes: &[Vec<u32>], device: &Device) -> Result<Tensor> {
@@ -140,6 +176,16 @@ impl Lfm25AudioDetokenizer {
     }
 
     fn projected_to_waveform(&self, projected: &Tensor) -> Result<Vec<f32>> {
+        self.projected_to_waveform_with_profile(projected)
+            .map(|(samples, _profile)| samples)
+    }
+
+    fn projected_to_waveform_with_profile(
+        &self,
+        projected: &Tensor,
+    ) -> Result<(Vec<f32>, Lfm25DetokenizerProfile)> {
+        let mut profile = Lfm25DetokenizerProfile::default();
+        let waveform_prepare_started = Instant::now();
         let projected = projected.i(0)?.to_dtype(DType::F32)?;
         let (_frames, width) = projected.dims2()?;
         let freq_bins = self.n_fft / 2 + 1;
@@ -149,9 +195,16 @@ impl Lfm25AudioDetokenizer {
                 freq_bins * 2
             )));
         }
+        profile.waveform_prepare_ms = elapsed_ms(waveform_prepare_started);
 
+        let readback_started = Instant::now();
         let projected = projected.to_vec2::<f32>()?;
-        self.istft_same(&projected, freq_bins)
+        profile.readback_ms = elapsed_ms(readback_started);
+
+        let istft_started = Instant::now();
+        let samples = self.istft_same(&projected, freq_bins)?;
+        profile.istft_ms = elapsed_ms(istft_started);
+        Ok((samples, profile))
     }
 
     fn istft_same(&self, projected: &[Vec<f32>], freq_bins: usize) -> Result<Vec<f32>> {
@@ -201,6 +254,10 @@ impl Lfm25AudioDetokenizer {
 
         Ok(cropped)
     }
+}
+
+fn elapsed_ms(started: Instant) -> f64 {
+    started.elapsed().as_secs_f64() * 1000.0
 }
 
 fn load_embedding_any(loader: &GgufLoader, device: &Device, names: &[String]) -> Result<Embedding> {

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/detokenizer.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/detokenizer.rs
@@ -23,6 +23,7 @@ pub struct Lfm25AudioDetokenizer {
     hop_length: usize,
     codebooks: usize,
     codebook_offsets: Vec<u32>,
+    codebook_offsets_tensor: Tensor,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -69,6 +70,11 @@ impl Lfm25AudioDetokenizer {
                 })
             })
             .collect::<Result<Vec<_>>>()?;
+        let codebook_offsets_tensor = Tensor::from_vec(
+            codebook_offsets.clone(),
+            (decoder_config.codebooks,),
+            device,
+        )?;
 
         Ok(Self {
             fused_embedding,
@@ -81,6 +87,7 @@ impl Lfm25AudioDetokenizer {
             hop_length: decoder_config.output_hop_length,
             codebooks: decoder_config.codebooks,
             codebook_offsets,
+            codebook_offsets_tensor,
         })
     }
 
@@ -151,6 +158,51 @@ impl Lfm25AudioDetokenizer {
         Ok((samples, profile))
     }
 
+    pub fn decode_token_ids_with_profile(
+        &self,
+        audio_codes: &Tensor,
+    ) -> Result<(Vec<f32>, Lfm25DetokenizerProfile)> {
+        let mut profile = Lfm25DetokenizerProfile::default();
+        let (frames, codebooks) = audio_codes.dims2()?;
+        if codebooks != self.codebooks {
+            return Err(Error::InvalidInput(format!(
+                "Expected {} audio codebooks, received {codebooks}",
+                self.codebooks
+            )));
+        }
+        if frames == 0 {
+            return Ok((Vec::new(), profile));
+        }
+
+        let embedding_started = Instant::now();
+        let embeds = self.fused_embeddings_from_token_ids(audio_codes)?;
+        profile.embedding_ms = elapsed_ms(embedding_started);
+
+        let upsample_started = Instant::now();
+        let upsampled = self.upsample_nearest(&embeds)?;
+        profile.upsample_ms = elapsed_ms(upsample_started);
+
+        let projected = {
+            let mut guard = self.backbone.lock().map_err(|_| {
+                Error::InferenceError("LFM2.5 Audio detokenizer mutex poisoned".to_string())
+            })?;
+            guard.reset_state();
+            let backbone_started = Instant::now();
+            let hidden = guard.forward_embeds(&upsampled, 0)?;
+            profile.backbone_forward_ms = elapsed_ms(backbone_started);
+            let projection_started = Instant::now();
+            let projected = guard.project_hidden(&hidden)?;
+            profile.projection_ms = elapsed_ms(projection_started);
+            projected
+        };
+
+        let (samples, waveform_profile) = self.projected_to_waveform_with_profile(&projected)?;
+        profile.waveform_prepare_ms = waveform_profile.waveform_prepare_ms;
+        profile.readback_ms = waveform_profile.readback_ms;
+        profile.istft_ms = waveform_profile.istft_ms;
+        Ok((samples, profile))
+    }
+
     fn fused_embeddings(&self, audio_codes: &[Vec<u32>], device: &Device) -> Result<Tensor> {
         let frames = audio_codes[0].len();
         let mut flat = Vec::with_capacity(frames * self.codebooks);
@@ -161,6 +213,15 @@ impl Lfm25AudioDetokenizer {
         }
 
         let ids = Tensor::from_vec(flat, (frames, self.codebooks), device)?;
+        let embeds = self.fused_embedding.forward(&ids)?; // [T, C, D]
+        let embeds = embeds.sum(1)?.affine(1.0 / self.codebooks as f64, 0.0)?;
+        embeds.unsqueeze(0).map_err(Error::from)
+    }
+
+    fn fused_embeddings_from_token_ids(&self, audio_codes: &Tensor) -> Result<Tensor> {
+        let ids = audio_codes
+            .broadcast_add(&self.codebook_offsets_tensor)?
+            .contiguous()?;
         let embeds = self.fused_embedding.forward(&ids)?; // [T, C, D]
         let embeds = embeds.sum(1)?.affine(1.0 / self.codebooks as f64, 0.0)?;
         embeds.unsqueeze(0).map_err(Error::from)

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
@@ -22,14 +22,16 @@ use super::conformer::Lfm25AudioEncoder;
 use super::detokenizer::Lfm25AudioDetokenizer;
 use super::preprocessor::Lfm25AudioPreprocessor;
 use super::sampling::{
-    greedy_from_logits, sample_from_logits, Lfm25AudioGenerationConfig, SimpleRng,
+    greedy_from_logits, greedy_token_tensor_from_logits, sample_from_logits,
+    Lfm25AudioGenerationConfig, SimpleRng,
 };
-use super::tokenizer::Lfm25TextTokenizer;
+use super::tokenizer::{Lfm25SpecialTokenIds, Lfm25TextTokenizer};
 use super::LFM25_AUDIO_DEFAULT_INTERLEAVED_SYSTEM_PROMPT;
 
 const DEFAULT_MAX_NEW_TOKENS: usize = 1024;
 const DEFAULT_AUDIO_STREAM_DECODE_STRIDE_FRAMES: usize = 6;
 const DEFAULT_AUDIO_STREAM_HOLDBACK_FRAMES: usize = 2;
+const DEFAULT_ASR_STOP_CHECK_INTERVAL: usize = 8;
 
 #[derive(Debug, Clone)]
 pub struct Lfm25AudioTextOutput {
@@ -87,10 +89,14 @@ struct Lfm25AsrProfile {
     main_prefill_ms: f64,
     decode_loop_ms: f64,
     decode_argmax_ms: f64,
+    decode_host_read_ms: f64,
     decode_token_tensor_ms: f64,
     decode_forward_ms: f64,
     tokenizer_decode_ms: f64,
     token_select_reads: u64,
+    host_token_reads: u64,
+    host_read_chunks: u64,
+    device_token_steps: u64,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -305,46 +311,105 @@ impl Lfm25AudioModel {
             let mut generated_ids = Vec::new();
             let mut assembled = String::new();
             let max_new_tokens = max_new_tokens.max(1);
+            let stop_check_interval = lfm25_asr_stop_check_interval();
+            let use_deferred_device_decode = (self.device.device.is_metal()
+                || self.device.device.is_cuda())
+                && stop_check_interval > 1;
 
             let decode_started = Instant::now();
-            while generated_ids.len() < max_new_tokens {
-                let argmax_started = Instant::now();
-                let next = greedy_from_logits(&logits, vocab_limit)?;
-                profile.decode_argmax_ms += elapsed_ms(argmax_started);
-                profile.token_select_reads = profile.token_select_reads.saturating_add(1);
-                if next == specials.im_end
-                    || next == specials.eos
-                    || specials.eos_alt == Some(next)
-                    || next == specials.text_end
-                    || next == specials.audio_start
-                {
-                    break;
-                }
+            if use_deferred_device_decode {
+                while generated_ids.len() < max_new_tokens {
+                    let remaining = max_new_tokens.saturating_sub(generated_ids.len());
+                    let chunk_len = remaining.min(stop_check_interval);
+                    let mut chunk_tokens = Vec::with_capacity(chunk_len);
 
-                generated_ids.push(next);
-                let tokenizer_started = Instant::now();
-                let decoded = self.tokenizer.decode_text(&generated_ids)?;
-                profile.tokenizer_decode_ms += elapsed_ms(tokenizer_started);
-                let delta = text_delta(&assembled, &decoded);
-                if !delta.is_empty() {
-                    for ch in delta.chars() {
-                        let mut buf = [0u8; 4];
-                        on_delta(ch.encode_utf8(&mut buf));
+                    for _ in 0..chunk_len {
+                        let argmax_started = Instant::now();
+                        let next_token = greedy_token_tensor_from_logits(&logits, vocab_limit)?
+                            .ok_or_else(|| {
+                                Error::InferenceError(
+                                    "Device ASR argmax returned no token tensor".to_string(),
+                                )
+                            })?;
+                        profile.decode_argmax_ms += elapsed_ms(argmax_started);
+                        profile.token_select_reads = profile.token_select_reads.saturating_add(1);
+                        profile.device_token_steps = profile.device_token_steps.saturating_add(1);
+
+                        let token_tensor_started = Instant::now();
+                        let next_tensor = next_token.reshape((1, 1))?;
+                        profile.decode_token_tensor_ms += elapsed_ms(token_tensor_started);
+
+                        let decode_forward_started = Instant::now();
+                        logits = main_backbone.forward_tokens(&next_tensor, position)?;
+                        profile.decode_forward_ms += elapsed_ms(decode_forward_started);
+                        position += 1;
+                        chunk_tokens.push(next_token);
+                    }
+
+                    let read_started = Instant::now();
+                    let token_refs = chunk_tokens.iter().collect::<Vec<_>>();
+                    let host_tokens = Tensor::cat(&token_refs, 0)?
+                        .to_vec1::<u32>()
+                        .map_err(Error::from)?;
+                    profile.decode_host_read_ms += elapsed_ms(read_started);
+                    profile.host_read_chunks = profile.host_read_chunks.saturating_add(1);
+                    profile.host_token_reads = profile
+                        .host_token_reads
+                        .saturating_add(u64::try_from(host_tokens.len()).unwrap_or(u64::MAX));
+
+                    let mut should_stop = false;
+                    for next in host_tokens {
+                        if is_asr_stop_token(next, &specials) {
+                            should_stop = true;
+                            break;
+                        }
+
+                        if append_asr_text_token(
+                            &self.tokenizer,
+                            &mut generated_ids,
+                            &mut assembled,
+                            next,
+                            &mut profile,
+                            on_delta,
+                        )? {
+                            should_stop = true;
+                            break;
+                        }
+                    }
+                    if should_stop {
+                        break;
                     }
                 }
-                assembled = decoded;
+            } else {
+                while generated_ids.len() < max_new_tokens {
+                    let argmax_started = Instant::now();
+                    let next = greedy_from_logits(&logits, vocab_limit)?;
+                    profile.decode_argmax_ms += elapsed_ms(argmax_started);
+                    profile.token_select_reads = profile.token_select_reads.saturating_add(1);
+                    profile.host_token_reads = profile.host_token_reads.saturating_add(1);
+                    if is_asr_stop_token(next, &specials) {
+                        break;
+                    }
 
-                if has_token_repetition_loop(&generated_ids) {
-                    break;
+                    if append_asr_text_token(
+                        &self.tokenizer,
+                        &mut generated_ids,
+                        &mut assembled,
+                        next,
+                        &mut profile,
+                        on_delta,
+                    )? {
+                        break;
+                    }
+
+                    let token_tensor_started = Instant::now();
+                    let next_tensor = Tensor::from_vec(vec![next], (1, 1), &self.device.device)?;
+                    profile.decode_token_tensor_ms += elapsed_ms(token_tensor_started);
+                    let decode_forward_started = Instant::now();
+                    logits = main_backbone.forward_tokens(&next_tensor, position)?;
+                    profile.decode_forward_ms += elapsed_ms(decode_forward_started);
+                    position += 1;
                 }
-
-                let token_tensor_started = Instant::now();
-                let next_tensor = Tensor::from_vec(vec![next], (1, 1), &self.device.device)?;
-                profile.decode_token_tensor_ms += elapsed_ms(token_tensor_started);
-                let decode_forward_started = Instant::now();
-                logits = main_backbone.forward_tokens(&next_tensor, position)?;
-                profile.decode_forward_ms += elapsed_ms(decode_forward_started);
-                position += 1;
             }
             profile.decode_loop_ms = elapsed_ms(decode_started);
 
@@ -360,15 +425,14 @@ impl Lfm25AudioModel {
         })?;
         let main_backbone_ms = elapsed_ms(main_started);
         let model_total_ms = elapsed_ms(total_started);
-        let device_token_select_reads =
-            if self.device.device.is_metal() || self.device.device.is_cuda() {
-                profile.token_select_reads
-            } else {
-                0
-            };
-        let host_argmax_reads = profile
-            .token_select_reads
-            .saturating_sub(device_token_select_reads);
+        let device_token_select_reads = profile.device_token_steps;
+        let host_argmax_reads = if device_token_select_reads > 0 {
+            0
+        } else {
+            profile.host_token_reads
+        };
+        let stop_check_interval = lfm25_asr_stop_check_interval();
+        let deferred_stop_check = device_token_select_reads > 0 && stop_check_interval > 1;
         output.diagnostics = Some(serde_json::json!({
             "model": "lfm25_audio",
             "task": "asr",
@@ -385,6 +449,7 @@ impl Lfm25AudioModel {
                 "main_prefill": profile.main_prefill_ms,
                 "decode": profile.decode_loop_ms,
                 "decode_argmax": profile.decode_argmax_ms,
+                "decode_host_read": profile.decode_host_read_ms,
                 "decode_token_tensor": profile.decode_token_tensor_ms,
                 "decode_forward": profile.decode_forward_ms,
                 "tokenizer_decode": profile.tokenizer_decode_ms,
@@ -409,14 +474,25 @@ impl Lfm25AudioModel {
                 "token_select_reads": profile.token_select_reads,
                 "device_argmax_reads": device_token_select_reads,
                 "host_argmax_reads": host_argmax_reads,
+                "host_read_chunks": profile.host_read_chunks,
+                "host_token_reads": profile.host_token_reads,
+                "device_token_steps": profile.device_token_steps,
                 "profile": {
                     "enabled": true,
-                    "sampling_ms": profile.decode_argmax_ms,
+                    "sampling_ms": profile.decode_argmax_ms + profile.decode_host_read_ms,
+                    "argmax_ms": profile.decode_argmax_ms,
+                    "host_read_ms": profile.decode_host_read_ms,
+                    "host_read_chunks": profile.host_read_chunks,
                     "token_tensor_ms": profile.decode_token_tensor_ms,
                     "decoder_forward_ms": profile.decode_forward_ms,
                     "tokenizer_decode_ms": profile.tokenizer_decode_ms,
                     "step_total_ms": profile.decode_loop_ms
                 }
+            },
+            "execution": {
+                "deferred_stop_check": deferred_stop_check,
+                "chunked_stop_check": deferred_stop_check,
+                "stop_check_interval": stop_check_interval
             }
         }));
         Ok(output)
@@ -1116,6 +1192,45 @@ fn text_delta(previous: &str, current: &str) -> String {
         .take_while(|(left, right)| left == right)
         .count();
     current.chars().skip(common).collect()
+}
+
+fn append_asr_text_token(
+    tokenizer: &Lfm25TextTokenizer,
+    generated_ids: &mut Vec<u32>,
+    assembled: &mut String,
+    next: u32,
+    profile: &mut Lfm25AsrProfile,
+    on_delta: &mut dyn FnMut(&str),
+) -> Result<bool> {
+    generated_ids.push(next);
+    let tokenizer_started = Instant::now();
+    let decoded = tokenizer.decode_text(generated_ids)?;
+    profile.tokenizer_decode_ms += elapsed_ms(tokenizer_started);
+    let delta = text_delta(assembled, &decoded);
+    if !delta.is_empty() {
+        for ch in delta.chars() {
+            let mut buf = [0u8; 4];
+            on_delta(ch.encode_utf8(&mut buf));
+        }
+    }
+    *assembled = decoded;
+    Ok(has_token_repetition_loop(generated_ids))
+}
+
+fn is_asr_stop_token(next: u32, specials: &Lfm25SpecialTokenIds) -> bool {
+    next == specials.im_end
+        || next == specials.eos
+        || specials.eos_alt == Some(next)
+        || next == specials.text_end
+        || next == specials.audio_start
+}
+
+fn lfm25_asr_stop_check_interval() -> usize {
+    std::env::var("IZWI_LFM25_ASR_STOP_CHECK_INTERVAL")
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_ASR_STOP_CHECK_INTERVAL)
+        .clamp(1, 64)
 }
 
 fn next_audio_delta_stable(

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
@@ -115,6 +115,8 @@ struct Lfm25TtsProfile {
     audio_head_sample_ms: f64,
     audio_head_embed_step_ms: f64,
     audio_head_materialize_ms: f64,
+    audio_head_materialize_pack_ms: f64,
+    audio_head_materialize_readback_ms: f64,
     audio_embed_ms: f64,
     audio_forward_ms: f64,
     detokenizer_embedding_ms: f64,
@@ -628,6 +630,10 @@ impl Lfm25AudioModel {
                         profile.audio_head_sample_ms += audio_head_profile.sample_ms;
                         profile.audio_head_embed_step_ms += audio_head_profile.embed_ms;
                         profile.audio_head_materialize_ms += audio_head_profile.materialize_ms;
+                        profile.audio_head_materialize_pack_ms +=
+                            audio_head_profile.materialize_pack_ms;
+                        profile.audio_head_materialize_readback_ms +=
+                            audio_head_profile.materialize_readback_ms;
                         profile.audio_head_calls = profile.audio_head_calls.saturating_add(1);
                         profile.audio_head_codebook_steps = profile
                             .audio_head_codebook_steps
@@ -711,6 +717,8 @@ impl Lfm25AudioModel {
                     "audio_head_sample": profile.audio_head_sample_ms,
                     "audio_head_embed_step": profile.audio_head_embed_step_ms,
                     "audio_head_materialize": profile.audio_head_materialize_ms,
+                    "audio_head_materialize_pack": profile.audio_head_materialize_pack_ms,
+                    "audio_head_materialize_readback": profile.audio_head_materialize_readback_ms,
                     "audio_embed": profile.audio_embed_ms,
                     "audio_forward": profile.audio_forward_ms,
                     "main_backbone": main_backbone_ms,

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
@@ -10,7 +10,7 @@ use crate::error::{Error, Result};
 use crate::model::ModelVariant;
 use crate::models::shared::chat::{ChatMessage, ChatRole};
 
-use super::audio_output::Lfm25AudioHead;
+use super::audio_output::{Lfm25AudioHead, Lfm25SampledAudioFrame};
 use super::backbone::QuantizedLfm2Backbone;
 use super::bundle::{Lfm25AudioBundle, Lfm25AudioBundleInfo};
 use super::config::{
@@ -32,6 +32,7 @@ const DEFAULT_MAX_NEW_TOKENS: usize = 1024;
 const DEFAULT_AUDIO_STREAM_DECODE_STRIDE_FRAMES: usize = 6;
 const DEFAULT_AUDIO_STREAM_HOLDBACK_FRAMES: usize = 2;
 const DEFAULT_ASR_STOP_CHECK_INTERVAL: usize = 92;
+const DEFAULT_TTS_AUDIO_STOP_CHECK_INTERVAL: usize = 20;
 
 #[derive(Debug, Clone)]
 pub struct Lfm25AudioTextOutput {
@@ -537,148 +538,261 @@ impl Lfm25AudioModel {
         let vocab_limit = self.tokenizer.vocab_size();
         let specials = self.tokenizer.specials().clone();
         let codebooks = self.decoder_config.codebooks;
+        let audio_stop_check_interval = lfm25_tts_audio_stop_check_interval();
+        let chunked_audio_stop_check =
+            generation_config.audio.temperature <= 1e-5 && audio_stop_check_interval > 1;
 
         let main_started = Instant::now();
-        let (text, prompt_tokens, tokens_generated, audio_codes, mut profile) = self
-            .with_main_backbone(|main_backbone| {
-                let mut profile = Lfm25TtsProfile::default();
-                let mut rng = SimpleRng::new(generation_config.seed);
-                main_backbone.reset_state();
+        let (
+            text,
+            prompt_tokens,
+            tokens_generated,
+            audio_codes,
+            device_audio_codes,
+            audio_frames_generated,
+            mut profile,
+        ) = self.with_main_backbone(|main_backbone| {
+            let mut profile = Lfm25TtsProfile::default();
+            let mut rng = SimpleRng::new(generation_config.seed);
+            main_backbone.reset_state();
 
-                let prompt_embed_started = Instant::now();
-                let prompt_embeds =
-                    embed_token_ids(main_backbone, &self.device.device, &prompt_ids)?;
-                profile.prompt_embed_ms = elapsed_ms(prompt_embed_started);
-                let prompt_tokens = prompt_embeds.dim(1)?;
-                let prefill_started = Instant::now();
-                let prompt_hidden = main_backbone.forward_embeds(&prompt_embeds, 0)?;
-                let mut last_hidden = last_hidden_state(&prompt_hidden)?;
-                let mut logits = main_backbone.project_last_hidden(&prompt_hidden)?;
-                profile.main_prefill_ms = elapsed_ms(prefill_started);
-                let mut position = prompt_tokens;
-                let mut visible_text_ids = Vec::new();
-                let mut visible_text = String::new();
-                let mut audio_codes = vec![Vec::new(); codebooks];
-                let mut tokens_generated = 0usize;
-                let mut in_audio = false;
-                let max_new_tokens = max_new_tokens.max(1);
+            let prompt_embed_started = Instant::now();
+            let prompt_embeds = embed_token_ids(main_backbone, &self.device.device, &prompt_ids)?;
+            profile.prompt_embed_ms = elapsed_ms(prompt_embed_started);
+            let prompt_tokens = prompt_embeds.dim(1)?;
+            let prefill_started = Instant::now();
+            let prompt_hidden = main_backbone.forward_embeds(&prompt_embeds, 0)?;
+            let mut last_hidden = last_hidden_state(&prompt_hidden)?;
+            let mut logits = main_backbone.project_last_hidden(&prompt_hidden)?;
+            profile.main_prefill_ms = elapsed_ms(prefill_started);
+            let mut position = prompt_tokens;
+            let mut visible_text_ids = Vec::new();
+            let mut visible_text = String::new();
+            let mut audio_codes = vec![Vec::new(); codebooks];
+            let mut tokens_generated = 0usize;
+            let mut in_audio = false;
+            let mut generation_done = false;
+            let mut sampled_audio_frames: Vec<Lfm25SampledAudioFrame> = Vec::new();
+            let mut audio_stop_check_chunk: Vec<Lfm25SampledAudioFrame> = Vec::new();
+            let max_new_tokens = max_new_tokens.max(1);
 
-                while tokens_generated < max_new_tokens {
-                    if !in_audio {
-                        let sampling_started = Instant::now();
-                        let next = sample_from_logits(
-                            &logits,
-                            vocab_limit,
-                            &generation_config.text,
+            while tokens_generated < max_new_tokens && !generation_done {
+                if !in_audio {
+                    let sampling_started = Instant::now();
+                    let next = sample_from_logits(
+                        &logits,
+                        vocab_limit,
+                        &generation_config.text,
+                        &mut rng,
+                    )?;
+                    profile.text_sampling_ms += elapsed_ms(sampling_started);
+                    profile.text_sample_calls = profile.text_sample_calls.saturating_add(1);
+                    tokens_generated += 1;
+
+                    if next == specials.im_end
+                        || next == specials.eos
+                        || specials.eos_alt == Some(next)
+                    {
+                        break;
+                    }
+
+                    if next == specials.audio_start {
+                        in_audio = true;
+                    } else if next != specials.text_end {
+                        visible_text_ids.push(next);
+                        let tokenizer_started = Instant::now();
+                        let decoded = self.tokenizer.decode_text(&visible_text_ids)?;
+                        profile.tokenizer_decode_ms += elapsed_ms(tokenizer_started);
+                        let delta = text_delta(&visible_text, &decoded);
+                        if !delta.is_empty() {
+                            for ch in delta.chars() {
+                                let mut buf = [0u8; 4];
+                                on_text_delta(ch.encode_utf8(&mut buf));
+                            }
+                        }
+                        visible_text = decoded;
+                    }
+
+                    let text_forward_started = Instant::now();
+                    let next_embed = embed_token_ids(main_backbone, &self.device.device, &[next])?;
+                    let step_hidden = main_backbone.forward_embeds(&next_embed, position)?;
+                    position += 1;
+                    last_hidden = last_hidden_state(&step_hidden)?;
+                    logits = main_backbone.project_last_hidden(&step_hidden)?;
+                    profile.text_forward_ms += elapsed_ms(text_forward_started);
+
+                    if has_token_repetition_loop(&visible_text_ids) {
+                        break;
+                    }
+                } else if chunked_audio_stop_check {
+                    let audio_head_started = Instant::now();
+                    let (frame, audio_head_profile) =
+                        self.audio_head.sample_audio_frame_embedded_with_profile(
+                            &last_hidden,
+                            &generation_config.audio,
                             &mut rng,
                         )?;
-                        profile.text_sampling_ms += elapsed_ms(sampling_started);
-                        profile.text_sample_calls = profile.text_sample_calls.saturating_add(1);
-                        tokens_generated += 1;
+                    profile.audio_head_ms += elapsed_ms(audio_head_started);
+                    profile.audio_head_depth_linear_ms += audio_head_profile.depth_linear_ms;
+                    profile.audio_head_depth_reshape_ms += audio_head_profile.depth_reshape_ms;
+                    profile.audio_head_cache_setup_ms += audio_head_profile.cache_setup_ms;
+                    profile.audio_head_codebook_input_ms += audio_head_profile.codebook_input_ms;
+                    profile.audio_head_depthformer_ms += audio_head_profile.depthformer_ms;
+                    profile.audio_head_sample_ms += audio_head_profile.sample_ms;
+                    profile.audio_head_embed_step_ms += audio_head_profile.embed_ms;
+                    profile.audio_head_materialize_ms += audio_head_profile.materialize_ms;
+                    profile.audio_head_materialize_pack_ms +=
+                        audio_head_profile.materialize_pack_ms;
+                    profile.audio_head_materialize_readback_ms +=
+                        audio_head_profile.materialize_readback_ms;
+                    profile.audio_head_calls = profile.audio_head_calls.saturating_add(1);
+                    profile.audio_head_codebook_steps = profile
+                        .audio_head_codebook_steps
+                        .saturating_add(audio_head_profile.codebook_steps);
+                    tokens_generated += 1;
 
-                        if next == specials.im_end
-                            || next == specials.eos
-                            || specials.eos_alt == Some(next)
-                        {
-                            break;
-                        }
+                    let audio_embed_started = Instant::now();
+                    let audio_embed = frame.embedding().clone();
+                    profile.audio_embed_ms += elapsed_ms(audio_embed_started);
+                    let audio_forward_started = Instant::now();
+                    let step_hidden = main_backbone.forward_embeds(&audio_embed, position)?;
+                    position += 1;
+                    last_hidden = last_hidden_state(&step_hidden)?;
+                    profile.audio_forward_ms += elapsed_ms(audio_forward_started);
 
-                        if next == specials.audio_start {
-                            in_audio = true;
-                        } else if next != specials.text_end {
-                            visible_text_ids.push(next);
-                            let tokenizer_started = Instant::now();
-                            let decoded = self.tokenizer.decode_text(&visible_text_ids)?;
-                            profile.tokenizer_decode_ms += elapsed_ms(tokenizer_started);
-                            let delta = text_delta(&visible_text, &decoded);
-                            if !delta.is_empty() {
-                                for ch in delta.chars() {
-                                    let mut buf = [0u8; 4];
-                                    on_text_delta(ch.encode_utf8(&mut buf));
-                                }
-                            }
-                            visible_text = decoded;
-                        }
-
-                        let text_forward_started = Instant::now();
-                        let next_embed =
-                            embed_token_ids(main_backbone, &self.device.device, &[next])?;
-                        let step_hidden = main_backbone.forward_embeds(&next_embed, position)?;
-                        position += 1;
-                        last_hidden = last_hidden_state(&step_hidden)?;
-                        logits = main_backbone.project_last_hidden(&step_hidden)?;
-                        profile.text_forward_ms += elapsed_ms(text_forward_started);
-
-                        if has_token_repetition_loop(&visible_text_ids) {
-                            break;
-                        }
-                    } else {
-                        let audio_head_started = Instant::now();
-                        let (frame, audio_head_profile) =
-                            self.audio_head.sample_audio_frame_with_profile(
-                                &last_hidden,
-                                &generation_config.audio,
-                                &mut rng,
-                            )?;
-                        profile.audio_head_ms += elapsed_ms(audio_head_started);
-                        profile.audio_head_depth_linear_ms += audio_head_profile.depth_linear_ms;
-                        profile.audio_head_depth_reshape_ms += audio_head_profile.depth_reshape_ms;
-                        profile.audio_head_cache_setup_ms += audio_head_profile.cache_setup_ms;
-                        profile.audio_head_codebook_input_ms +=
-                            audio_head_profile.codebook_input_ms;
-                        profile.audio_head_depthformer_ms += audio_head_profile.depthformer_ms;
-                        profile.audio_head_sample_ms += audio_head_profile.sample_ms;
-                        profile.audio_head_embed_step_ms += audio_head_profile.embed_ms;
-                        profile.audio_head_materialize_ms += audio_head_profile.materialize_ms;
-                        profile.audio_head_materialize_pack_ms +=
-                            audio_head_profile.materialize_pack_ms;
-                        profile.audio_head_materialize_readback_ms +=
-                            audio_head_profile.materialize_readback_ms;
-                        profile.audio_head_calls = profile.audio_head_calls.saturating_add(1);
-                        profile.audio_head_codebook_steps = profile
-                            .audio_head_codebook_steps
-                            .saturating_add(audio_head_profile.codebook_steps);
-                        tokens_generated += 1;
-                        let is_end =
-                            frame.first().copied() == Some(self.audio_head.audio_end_token_id());
-                        if !is_end {
-                            for (codebook_idx, token) in frame.iter().copied().enumerate() {
-                                audio_codes[codebook_idx].push(token);
-                            }
-                        }
-
-                        let audio_embed_started = Instant::now();
-                        let audio_embed = self
+                    audio_stop_check_chunk.push(frame);
+                    let should_check_audio_stop = audio_stop_check_chunk.len()
+                        >= audio_stop_check_interval
+                        || tokens_generated >= max_new_tokens;
+                    if should_check_audio_stop {
+                        let first_tokens = self
                             .audio_head
-                            .embed_audio_frame(&frame, &self.device.device)?;
-                        profile.audio_embed_ms += elapsed_ms(audio_embed_started);
-                        let audio_forward_started = Instant::now();
-                        let step_hidden = main_backbone.forward_embeds(&audio_embed, position)?;
-                        position += 1;
-                        last_hidden = last_hidden_state(&step_hidden)?;
-                        profile.audio_forward_ms += elapsed_ms(audio_forward_started);
+                            .first_tokens_with_profile(&audio_stop_check_chunk)?;
+                        profile.audio_head_ms += first_tokens.materialize_ms;
+                        profile.audio_head_materialize_ms += first_tokens.materialize_ms;
+                        profile.audio_head_materialize_pack_ms += first_tokens.pack_ms;
+                        profile.audio_head_materialize_readback_ms += first_tokens.readback_ms;
 
-                        if is_end {
+                        if let Some(end_idx) = first_tokens
+                            .tokens
+                            .iter()
+                            .position(|token| *token == self.audio_head.audio_end_token_id())
+                        {
+                            let speculative_after_end =
+                                audio_stop_check_chunk.len().saturating_sub(end_idx + 1);
+                            tokens_generated =
+                                tokens_generated.saturating_sub(speculative_after_end);
+                            sampled_audio_frames.extend(audio_stop_check_chunk.drain(..end_idx));
+                            audio_stop_check_chunk.clear();
                             in_audio = false;
-                            logits = main_backbone.project_last_hidden(&step_hidden)?;
+                            generation_done = true;
+                        } else {
+                            sampled_audio_frames.append(&mut audio_stop_check_chunk);
                         }
+                    }
+                } else {
+                    let audio_head_started = Instant::now();
+                    let (frame, audio_head_profile) =
+                        self.audio_head.sample_audio_frame_with_profile(
+                            &last_hidden,
+                            &generation_config.audio,
+                            &mut rng,
+                        )?;
+                    profile.audio_head_ms += elapsed_ms(audio_head_started);
+                    profile.audio_head_depth_linear_ms += audio_head_profile.depth_linear_ms;
+                    profile.audio_head_depth_reshape_ms += audio_head_profile.depth_reshape_ms;
+                    profile.audio_head_cache_setup_ms += audio_head_profile.cache_setup_ms;
+                    profile.audio_head_codebook_input_ms += audio_head_profile.codebook_input_ms;
+                    profile.audio_head_depthformer_ms += audio_head_profile.depthformer_ms;
+                    profile.audio_head_sample_ms += audio_head_profile.sample_ms;
+                    profile.audio_head_embed_step_ms += audio_head_profile.embed_ms;
+                    profile.audio_head_materialize_ms += audio_head_profile.materialize_ms;
+                    profile.audio_head_materialize_pack_ms +=
+                        audio_head_profile.materialize_pack_ms;
+                    profile.audio_head_materialize_readback_ms +=
+                        audio_head_profile.materialize_readback_ms;
+                    profile.audio_head_calls = profile.audio_head_calls.saturating_add(1);
+                    profile.audio_head_codebook_steps = profile
+                        .audio_head_codebook_steps
+                        .saturating_add(audio_head_profile.codebook_steps);
+                    tokens_generated += 1;
+                    let is_end =
+                        frame.first().copied() == Some(self.audio_head.audio_end_token_id());
+                    if !is_end {
+                        for (codebook_idx, token) in frame.iter().copied().enumerate() {
+                            audio_codes[codebook_idx].push(token);
+                        }
+                    }
+
+                    let audio_embed_started = Instant::now();
+                    let audio_embed = self
+                        .audio_head
+                        .embed_audio_frame(&frame, &self.device.device)?;
+                    profile.audio_embed_ms += elapsed_ms(audio_embed_started);
+                    let audio_forward_started = Instant::now();
+                    let step_hidden = main_backbone.forward_embeds(&audio_embed, position)?;
+                    position += 1;
+                    last_hidden = last_hidden_state(&step_hidden)?;
+                    profile.audio_forward_ms += elapsed_ms(audio_forward_started);
+
+                    if is_end {
+                        in_audio = false;
+                        logits = main_backbone.project_last_hidden(&step_hidden)?;
+                    }
+                }
+            }
+
+            let (device_audio_codes, audio_frames_generated) = if chunked_audio_stop_check {
+                if !audio_stop_check_chunk.is_empty() {
+                    let first_tokens = self
+                        .audio_head
+                        .first_tokens_with_profile(&audio_stop_check_chunk)?;
+                    profile.audio_head_ms += first_tokens.materialize_ms;
+                    profile.audio_head_materialize_ms += first_tokens.materialize_ms;
+                    profile.audio_head_materialize_pack_ms += first_tokens.pack_ms;
+                    profile.audio_head_materialize_readback_ms += first_tokens.readback_ms;
+                    if let Some(end_idx) = first_tokens
+                        .tokens
+                        .iter()
+                        .position(|token| *token == self.audio_head.audio_end_token_id())
+                    {
+                        sampled_audio_frames.extend(audio_stop_check_chunk.drain(..end_idx));
+                    } else {
+                        sampled_audio_frames.append(&mut audio_stop_check_chunk);
                     }
                 }
 
-                Ok((
-                    visible_text.trim().to_string(),
-                    prompt_tokens,
-                    tokens_generated,
-                    audio_codes,
-                    profile,
-                ))
-            })?;
+                let stacked = self
+                    .audio_head
+                    .stack_frame_tokens_with_profile(&sampled_audio_frames, &self.device.device)?;
+                profile.audio_head_ms += stacked.materialize_ms;
+                profile.audio_head_materialize_ms += stacked.materialize_ms;
+                profile.audio_head_materialize_pack_ms += stacked.pack_ms;
+                (Some(stacked.tokens), sampled_audio_frames.len())
+            } else {
+                (None, audio_codes.first().map(Vec::len).unwrap_or(0))
+            };
+
+            Ok((
+                visible_text.trim().to_string(),
+                prompt_tokens,
+                tokens_generated,
+                audio_codes,
+                device_audio_codes,
+                audio_frames_generated,
+                profile,
+            ))
+        })?;
         let main_backbone_ms = elapsed_ms(main_started);
 
         let detokenizer_started = Instant::now();
-        let (samples, detokenizer_profile) = self
-            .detokenizer
-            .decode_with_profile(&audio_codes, &self.device.device)?;
+        let (samples, detokenizer_profile) = if let Some(device_audio_codes) = device_audio_codes {
+            self.detokenizer
+                .decode_token_ids_with_profile(&device_audio_codes)?
+        } else {
+            self.detokenizer
+                .decode_with_profile(&audio_codes, &self.device.device)?
+        };
         let detokenizer_ms = elapsed_ms(detokenizer_started);
         profile.detokenizer_embedding_ms = detokenizer_profile.embedding_ms;
         profile.detokenizer_upsample_ms = detokenizer_profile.upsample_ms;
@@ -688,7 +802,6 @@ impl Lfm25AudioModel {
         profile.detokenizer_readback_ms = detokenizer_profile.readback_ms;
         profile.detokenizer_istft_ms = detokenizer_profile.istft_ms;
         let model_total_ms = elapsed_ms(total_started);
-        let audio_frames_generated = audio_codes.first().map(Vec::len).unwrap_or(0);
         let samples_len = samples.len();
         Ok(Lfm25AudioGenerationOutput {
             text,
@@ -740,7 +853,9 @@ impl Lfm25AudioModel {
                     "max_new_tokens": max_new_tokens,
                     "text_sample_calls": profile.text_sample_calls,
                     "audio_head_calls": profile.audio_head_calls,
-                    "audio_head_codebook_steps": profile.audio_head_codebook_steps
+                    "audio_head_codebook_steps": profile.audio_head_codebook_steps,
+                    "chunked_audio_stop_check": chunked_audio_stop_check,
+                    "audio_stop_check_interval": audio_stop_check_interval
                 },
                 "audio": {
                     "audio_frames": audio_frames_generated,
@@ -1244,6 +1359,19 @@ fn lfm25_asr_stop_check_interval_from_env(value: Option<String>) -> usize {
         .clamp(1, 128)
 }
 
+fn lfm25_tts_audio_stop_check_interval() -> usize {
+    lfm25_tts_audio_stop_check_interval_from_env(
+        std::env::var("IZWI_LFM25_TTS_AUDIO_STOP_CHECK_INTERVAL").ok(),
+    )
+}
+
+fn lfm25_tts_audio_stop_check_interval_from_env(value: Option<String>) -> usize {
+    value
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_TTS_AUDIO_STOP_CHECK_INTERVAL)
+        .clamp(1, 32)
+}
+
 fn next_audio_delta_stable(
     all_samples: &[f32],
     emitted_samples: &mut usize,
@@ -1378,6 +1506,35 @@ mod tests {
         assert_eq!(
             lfm25_asr_stop_check_interval_from_env(Some("96".to_string())),
             96
+        );
+    }
+
+    #[test]
+    fn tts_audio_stop_check_interval_defaults_to_twenty() {
+        assert_eq!(lfm25_tts_audio_stop_check_interval_from_env(None), 20);
+        assert_eq!(
+            lfm25_tts_audio_stop_check_interval_from_env(Some("bad".to_string())),
+            20
+        );
+    }
+
+    #[test]
+    fn tts_audio_stop_check_interval_clamps_override() {
+        assert_eq!(
+            lfm25_tts_audio_stop_check_interval_from_env(Some("0".to_string())),
+            1
+        );
+        assert_eq!(
+            lfm25_tts_audio_stop_check_interval_from_env(Some("32".to_string())),
+            32
+        );
+        assert_eq!(
+            lfm25_tts_audio_stop_check_interval_from_env(Some("64".to_string())),
+            32
+        );
+        assert_eq!(
+            lfm25_tts_audio_stop_check_interval_from_env(Some("4".to_string())),
+            4
         );
     }
 

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
@@ -98,6 +98,9 @@ struct Lfm25AsrProfile {
     host_token_reads: u64,
     host_read_chunks: u64,
     device_token_steps: u64,
+    token_repetition_loop: bool,
+    text_repetition_loop: bool,
+    stop_reason: Option<&'static str>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -314,6 +317,7 @@ impl Lfm25AudioModel {
             let mut generated_ids = Vec::new();
             let mut assembled = String::new();
             let max_new_tokens = max_new_tokens.max(1);
+            let mut stop_reason = "max_tokens";
             let stop_check_interval = lfm25_asr_stop_check_interval();
             let use_deferred_device_decode = (self.device.device.is_metal()
                 || self.device.device.is_cuda())
@@ -363,18 +367,27 @@ impl Lfm25AudioModel {
                     let mut should_stop = false;
                     for next in host_tokens {
                         if is_asr_stop_token(next, &specials) {
+                            stop_reason = "stop_token";
                             should_stop = true;
                             break;
                         }
 
-                        if append_asr_text_token(
+                        let append_status = append_asr_text_token(
                             &self.tokenizer,
                             &mut generated_ids,
                             &mut assembled,
                             next,
                             &mut profile,
                             on_delta,
-                        )? {
+                        )?;
+                        if append_status.should_stop() {
+                            profile.token_repetition_loop |= append_status.token_repetition_loop;
+                            profile.text_repetition_loop |= append_status.text_repetition_loop;
+                            stop_reason = if append_status.text_repetition_loop {
+                                "text_repetition_loop"
+                            } else {
+                                "token_repetition_loop"
+                            };
                             should_stop = true;
                             break;
                         }
@@ -391,17 +404,26 @@ impl Lfm25AudioModel {
                     profile.token_select_reads = profile.token_select_reads.saturating_add(1);
                     profile.host_token_reads = profile.host_token_reads.saturating_add(1);
                     if is_asr_stop_token(next, &specials) {
+                        stop_reason = "stop_token";
                         break;
                     }
 
-                    if append_asr_text_token(
+                    let append_status = append_asr_text_token(
                         &self.tokenizer,
                         &mut generated_ids,
                         &mut assembled,
                         next,
                         &mut profile,
                         on_delta,
-                    )? {
+                    )?;
+                    if append_status.should_stop() {
+                        profile.token_repetition_loop |= append_status.token_repetition_loop;
+                        profile.text_repetition_loop |= append_status.text_repetition_loop;
+                        stop_reason = if append_status.text_repetition_loop {
+                            "text_repetition_loop"
+                        } else {
+                            "token_repetition_loop"
+                        };
                         break;
                     }
 
@@ -415,6 +437,7 @@ impl Lfm25AudioModel {
                 }
             }
             profile.decode_loop_ms = elapsed_ms(decode_started);
+            profile.stop_reason = Some(stop_reason);
 
             Ok((
                 Lfm25AudioTextOutput {
@@ -474,6 +497,10 @@ impl Lfm25AudioModel {
             "decode": {
                 "generated_tokens": output.tokens_generated,
                 "max_new_tokens": max_new_tokens,
+                "stop_reason": profile.stop_reason.unwrap_or("unknown"),
+                "repetition_loop": profile.token_repetition_loop || profile.text_repetition_loop,
+                "token_repetition_loop": profile.token_repetition_loop,
+                "text_repetition_loop": profile.text_repetition_loop,
                 "token_select_reads": profile.token_select_reads,
                 "device_argmax_reads": device_token_select_reads,
                 "host_argmax_reads": host_argmax_reads,
@@ -1317,6 +1344,18 @@ fn text_delta(previous: &str, current: &str) -> String {
     current.chars().skip(common).collect()
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+struct Lfm25AsrAppendStatus {
+    token_repetition_loop: bool,
+    text_repetition_loop: bool,
+}
+
+impl Lfm25AsrAppendStatus {
+    fn should_stop(self) -> bool {
+        self.token_repetition_loop || self.text_repetition_loop
+    }
+}
+
 fn append_asr_text_token(
     tokenizer: &Lfm25TextTokenizer,
     generated_ids: &mut Vec<u32>,
@@ -1324,11 +1363,18 @@ fn append_asr_text_token(
     next: u32,
     profile: &mut Lfm25AsrProfile,
     on_delta: &mut dyn FnMut(&str),
-) -> Result<bool> {
+) -> Result<Lfm25AsrAppendStatus> {
     generated_ids.push(next);
     let tokenizer_started = Instant::now();
-    let decoded = tokenizer.decode_text(generated_ids)?;
+    let mut decoded = tokenizer.decode_text(generated_ids)?;
     profile.tokenizer_decode_ms += elapsed_ms(tokenizer_started);
+    let token_repetition_loop = has_token_repetition_loop(generated_ids);
+    let text_repetition_loop = if let Some(trimmed) = trim_repeated_phrase_tail(&decoded) {
+        decoded = trimmed;
+        true
+    } else {
+        false
+    };
     let delta = text_delta(assembled, &decoded);
     if !delta.is_empty() {
         for ch in delta.chars() {
@@ -1337,7 +1383,10 @@ fn append_asr_text_token(
         }
     }
     *assembled = decoded;
-    Ok(has_token_repetition_loop(generated_ids))
+    Ok(Lfm25AsrAppendStatus {
+        token_repetition_loop,
+        text_repetition_loop,
+    })
 }
 
 fn is_asr_stop_token(next: u32, specials: &Lfm25SpecialTokenIds) -> bool {
@@ -1419,6 +1468,83 @@ fn has_token_repetition_loop(ids: &[u32]) -> bool {
         .any(|(span, repeats)| has_suffix_repeat(ids, *span, *repeats))
 }
 
+#[derive(Debug, Clone)]
+struct NormalizedTextWord {
+    normalized: String,
+    end: usize,
+}
+
+fn trim_repeated_phrase_tail(input: &str) -> Option<String> {
+    let words = normalized_text_words(input);
+    const MIN_REPEAT_COUNT: usize = 4;
+    const MIN_PHRASE_WORDS: usize = 2;
+    const MAX_PHRASE_WORDS: usize = 8;
+    let max_phrase_words = MAX_PHRASE_WORDS.min(words.len() / MIN_REPEAT_COUNT);
+    for phrase_words in MIN_PHRASE_WORDS..=max_phrase_words {
+        let mut repeat_count = 1usize;
+        while words.len() >= phrase_words.saturating_mul(repeat_count + 1) {
+            let right_start = words.len() - phrase_words * repeat_count;
+            let left_start = right_start.saturating_sub(phrase_words);
+            if !normalized_word_ranges_equal(&words, left_start, right_start, phrase_words) {
+                break;
+            }
+            repeat_count += 1;
+        }
+
+        if repeat_count >= MIN_REPEAT_COUNT {
+            let keep_words = words.len() - phrase_words * (repeat_count - 1);
+            let end = words[keep_words - 1].end;
+            return Some(input[..end].trim_end().to_string());
+        }
+    }
+    None
+}
+
+fn normalized_word_ranges_equal(
+    words: &[NormalizedTextWord],
+    left_start: usize,
+    right_start: usize,
+    len: usize,
+) -> bool {
+    (0..len).all(|offset| {
+        words[left_start + offset].normalized == words[right_start + offset].normalized
+    })
+}
+
+fn normalized_text_words(input: &str) -> Vec<NormalizedTextWord> {
+    let mut words = Vec::new();
+    let mut start = None;
+    for (idx, ch) in input.char_indices() {
+        if ch.is_whitespace() {
+            if let Some(word_start) = start.take() {
+                push_normalized_text_word(input, word_start, idx, &mut words);
+            }
+        } else if start.is_none() {
+            start = Some(idx);
+        }
+    }
+    if let Some(word_start) = start {
+        push_normalized_text_word(input, word_start, input.len(), &mut words);
+    }
+    words
+}
+
+fn push_normalized_text_word(
+    input: &str,
+    start: usize,
+    end: usize,
+    words: &mut Vec<NormalizedTextWord>,
+) {
+    let raw = &input[start..end];
+    let normalized = raw
+        .trim_matches(|ch: char| !ch.is_alphanumeric())
+        .to_ascii_lowercase();
+    if normalized.is_empty() {
+        return;
+    }
+    words.push(NormalizedTextWord { normalized, end });
+}
+
 fn resample_linear(audio: &[f32], src_rate: u32, dst_rate: u32) -> Vec<f32> {
     if src_rate == dst_rate || audio.len() < 2 {
         return audio.to_vec();
@@ -1478,6 +1604,26 @@ mod tests {
             strip_past_assistant_thinking("<think>plan</think>final answer"),
             "final answer"
         );
+    }
+
+    #[test]
+    fn repeated_phrase_tail_trim_keeps_one_tail_occurrence() {
+        let text = "So, human spaceflight is very expensive, and it's very expensive. It's very expensive. It's very expensive. It's very expensive.";
+        let trimmed = trim_repeated_phrase_tail(text).expect("repeated phrase tail");
+
+        assert_eq!(
+            trimmed,
+            "So, human spaceflight is very expensive, and it's very expensive."
+        );
+    }
+
+    #[test]
+    fn repeated_phrase_tail_trim_ignores_short_repeats() {
+        assert!(trim_repeated_phrase_tail(
+            "This is very expensive. It is very expensive, but it may be worth it."
+        )
+        .is_none());
+        assert!(trim_repeated_phrase_tail("yes yes yes yes yes yes").is_none());
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
@@ -31,7 +31,7 @@ use super::LFM25_AUDIO_DEFAULT_INTERLEAVED_SYSTEM_PROMPT;
 const DEFAULT_MAX_NEW_TOKENS: usize = 1024;
 const DEFAULT_AUDIO_STREAM_DECODE_STRIDE_FRAMES: usize = 6;
 const DEFAULT_AUDIO_STREAM_HOLDBACK_FRAMES: usize = 2;
-const DEFAULT_ASR_STOP_CHECK_INTERVAL: usize = 8;
+const DEFAULT_ASR_STOP_CHECK_INTERVAL: usize = 16;
 
 #[derive(Debug, Clone)]
 pub struct Lfm25AudioTextOutput {
@@ -1226,8 +1226,11 @@ fn is_asr_stop_token(next: u32, specials: &Lfm25SpecialTokenIds) -> bool {
 }
 
 fn lfm25_asr_stop_check_interval() -> usize {
-    std::env::var("IZWI_LFM25_ASR_STOP_CHECK_INTERVAL")
-        .ok()
+    lfm25_asr_stop_check_interval_from_env(std::env::var("IZWI_LFM25_ASR_STOP_CHECK_INTERVAL").ok())
+}
+
+fn lfm25_asr_stop_check_interval_from_env(value: Option<String>) -> usize {
+    value
         .and_then(|value| value.trim().parse::<usize>().ok())
         .unwrap_or(DEFAULT_ASR_STOP_CHECK_INTERVAL)
         .clamp(1, 64)
@@ -1338,6 +1341,31 @@ mod tests {
         assert_eq!(
             strip_past_assistant_thinking("<think>plan</think>final answer"),
             "final answer"
+        );
+    }
+
+    #[test]
+    fn asr_stop_check_interval_defaults_to_sixteen() {
+        assert_eq!(lfm25_asr_stop_check_interval_from_env(None), 16);
+        assert_eq!(
+            lfm25_asr_stop_check_interval_from_env(Some("bad".to_string())),
+            16
+        );
+    }
+
+    #[test]
+    fn asr_stop_check_interval_clamps_override() {
+        assert_eq!(
+            lfm25_asr_stop_check_interval_from_env(Some("0".to_string())),
+            1
+        );
+        assert_eq!(
+            lfm25_asr_stop_check_interval_from_env(Some("128".to_string())),
+            64
+        );
+        assert_eq!(
+            lfm25_asr_stop_check_interval_from_env(Some("32".to_string())),
+            32
         );
     }
 

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
@@ -101,9 +101,25 @@ struct Lfm25TtsProfile {
     tokenizer_decode_ms: f64,
     text_forward_ms: f64,
     audio_head_ms: f64,
+    audio_head_depth_linear_ms: f64,
+    audio_head_depth_reshape_ms: f64,
+    audio_head_cache_setup_ms: f64,
+    audio_head_codebook_input_ms: f64,
+    audio_head_depthformer_ms: f64,
+    audio_head_sample_ms: f64,
+    audio_head_embed_step_ms: f64,
+    audio_head_materialize_ms: f64,
     audio_embed_ms: f64,
     audio_forward_ms: f64,
+    detokenizer_embedding_ms: f64,
+    detokenizer_upsample_ms: f64,
+    detokenizer_backbone_ms: f64,
+    detokenizer_projection_ms: f64,
+    detokenizer_waveform_prepare_ms: f64,
+    detokenizer_readback_ms: f64,
+    detokenizer_istft_ms: f64,
     audio_head_calls: u64,
+    audio_head_codebook_steps: u64,
     text_sample_calls: u64,
 }
 
@@ -445,7 +461,7 @@ impl Lfm25AudioModel {
         let codebooks = self.decoder_config.codebooks;
 
         let main_started = Instant::now();
-        let (text, prompt_tokens, tokens_generated, audio_codes, profile) = self
+        let (text, prompt_tokens, tokens_generated, audio_codes, mut profile) = self
             .with_main_backbone(|main_backbone| {
                 let mut profile = Lfm25TtsProfile::default();
                 let mut rng = SimpleRng::new(generation_config.seed);
@@ -520,13 +536,26 @@ impl Lfm25AudioModel {
                         }
                     } else {
                         let audio_head_started = Instant::now();
-                        let frame = self.audio_head.sample_audio_frame(
-                            &last_hidden,
-                            &generation_config.audio,
-                            &mut rng,
-                        )?;
+                        let (frame, audio_head_profile) =
+                            self.audio_head.sample_audio_frame_with_profile(
+                                &last_hidden,
+                                &generation_config.audio,
+                                &mut rng,
+                            )?;
                         profile.audio_head_ms += elapsed_ms(audio_head_started);
+                        profile.audio_head_depth_linear_ms += audio_head_profile.depth_linear_ms;
+                        profile.audio_head_depth_reshape_ms += audio_head_profile.depth_reshape_ms;
+                        profile.audio_head_cache_setup_ms += audio_head_profile.cache_setup_ms;
+                        profile.audio_head_codebook_input_ms +=
+                            audio_head_profile.codebook_input_ms;
+                        profile.audio_head_depthformer_ms += audio_head_profile.depthformer_ms;
+                        profile.audio_head_sample_ms += audio_head_profile.sample_ms;
+                        profile.audio_head_embed_step_ms += audio_head_profile.embed_ms;
+                        profile.audio_head_materialize_ms += audio_head_profile.materialize_ms;
                         profile.audio_head_calls = profile.audio_head_calls.saturating_add(1);
+                        profile.audio_head_codebook_steps = profile
+                            .audio_head_codebook_steps
+                            .saturating_add(audio_head_profile.codebook_steps);
                         tokens_generated += 1;
                         let is_end =
                             frame.first().copied() == Some(self.audio_head.audio_end_token_id());
@@ -565,8 +594,17 @@ impl Lfm25AudioModel {
         let main_backbone_ms = elapsed_ms(main_started);
 
         let detokenizer_started = Instant::now();
-        let samples = self.detokenizer.decode(&audio_codes, &self.device.device)?;
+        let (samples, detokenizer_profile) = self
+            .detokenizer
+            .decode_with_profile(&audio_codes, &self.device.device)?;
         let detokenizer_ms = elapsed_ms(detokenizer_started);
+        profile.detokenizer_embedding_ms = detokenizer_profile.embedding_ms;
+        profile.detokenizer_upsample_ms = detokenizer_profile.upsample_ms;
+        profile.detokenizer_backbone_ms = detokenizer_profile.backbone_forward_ms;
+        profile.detokenizer_projection_ms = detokenizer_profile.projection_ms;
+        profile.detokenizer_waveform_prepare_ms = detokenizer_profile.waveform_prepare_ms;
+        profile.detokenizer_readback_ms = detokenizer_profile.readback_ms;
+        profile.detokenizer_istft_ms = detokenizer_profile.istft_ms;
         let model_total_ms = elapsed_ms(total_started);
         let audio_frames_generated = audio_codes.first().map(Vec::len).unwrap_or(0);
         let samples_len = samples.len();
@@ -589,10 +627,25 @@ impl Lfm25AudioModel {
                     "tokenizer_decode": profile.tokenizer_decode_ms,
                     "text_forward": profile.text_forward_ms,
                     "audio_head": profile.audio_head_ms,
+                    "audio_head_depth_linear": profile.audio_head_depth_linear_ms,
+                    "audio_head_depth_reshape": profile.audio_head_depth_reshape_ms,
+                    "audio_head_cache_setup": profile.audio_head_cache_setup_ms,
+                    "audio_head_codebook_input": profile.audio_head_codebook_input_ms,
+                    "audio_head_depthformer": profile.audio_head_depthformer_ms,
+                    "audio_head_sample": profile.audio_head_sample_ms,
+                    "audio_head_embed_step": profile.audio_head_embed_step_ms,
+                    "audio_head_materialize": profile.audio_head_materialize_ms,
                     "audio_embed": profile.audio_embed_ms,
                     "audio_forward": profile.audio_forward_ms,
                     "main_backbone": main_backbone_ms,
                     "detokenizer": detokenizer_ms,
+                    "detokenizer_embedding": profile.detokenizer_embedding_ms,
+                    "detokenizer_upsample": profile.detokenizer_upsample_ms,
+                    "detokenizer_backbone": profile.detokenizer_backbone_ms,
+                    "detokenizer_projection": profile.detokenizer_projection_ms,
+                    "detokenizer_waveform_prepare": profile.detokenizer_waveform_prepare_ms,
+                    "detokenizer_readback": profile.detokenizer_readback_ms,
+                    "detokenizer_istft": profile.detokenizer_istft_ms,
                     "model_total": model_total_ms
                 },
                 "prompt": {
@@ -602,7 +655,8 @@ impl Lfm25AudioModel {
                     "generated_tokens": tokens_generated,
                     "max_new_tokens": max_new_tokens,
                     "text_sample_calls": profile.text_sample_calls,
-                    "audio_head_calls": profile.audio_head_calls
+                    "audio_head_calls": profile.audio_head_calls,
+                    "audio_head_codebook_steps": profile.audio_head_codebook_steps
                 },
                 "audio": {
                     "audio_frames": audio_frames_generated,

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
@@ -31,7 +31,7 @@ use super::LFM25_AUDIO_DEFAULT_INTERLEAVED_SYSTEM_PROMPT;
 const DEFAULT_MAX_NEW_TOKENS: usize = 1024;
 const DEFAULT_AUDIO_STREAM_DECODE_STRIDE_FRAMES: usize = 6;
 const DEFAULT_AUDIO_STREAM_HOLDBACK_FRAMES: usize = 2;
-const DEFAULT_ASR_STOP_CHECK_INTERVAL: usize = 32;
+const DEFAULT_ASR_STOP_CHECK_INTERVAL: usize = 96;
 
 #[derive(Debug, Clone)]
 pub struct Lfm25AudioTextOutput {
@@ -1241,7 +1241,7 @@ fn lfm25_asr_stop_check_interval_from_env(value: Option<String>) -> usize {
     value
         .and_then(|value| value.trim().parse::<usize>().ok())
         .unwrap_or(DEFAULT_ASR_STOP_CHECK_INTERVAL)
-        .clamp(1, 64)
+        .clamp(1, 128)
 }
 
 fn next_audio_delta_stable(
@@ -1353,11 +1353,11 @@ mod tests {
     }
 
     #[test]
-    fn asr_stop_check_interval_defaults_to_thirty_two() {
-        assert_eq!(lfm25_asr_stop_check_interval_from_env(None), 32);
+    fn asr_stop_check_interval_defaults_to_ninety_six() {
+        assert_eq!(lfm25_asr_stop_check_interval_from_env(None), 96);
         assert_eq!(
             lfm25_asr_stop_check_interval_from_env(Some("bad".to_string())),
-            32
+            96
         );
     }
 
@@ -1369,11 +1369,15 @@ mod tests {
         );
         assert_eq!(
             lfm25_asr_stop_check_interval_from_env(Some("128".to_string())),
-            64
+            128
         );
         assert_eq!(
-            lfm25_asr_stop_check_interval_from_env(Some("32".to_string())),
-            32
+            lfm25_asr_stop_check_interval_from_env(Some("256".to_string())),
+            128
+        );
+        assert_eq!(
+            lfm25_asr_stop_check_interval_from_env(Some("96".to_string())),
+            96
         );
     }
 

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
@@ -31,7 +31,7 @@ use super::LFM25_AUDIO_DEFAULT_INTERLEAVED_SYSTEM_PROMPT;
 const DEFAULT_MAX_NEW_TOKENS: usize = 1024;
 const DEFAULT_AUDIO_STREAM_DECODE_STRIDE_FRAMES: usize = 6;
 const DEFAULT_AUDIO_STREAM_HOLDBACK_FRAMES: usize = 2;
-const DEFAULT_ASR_STOP_CHECK_INTERVAL: usize = 16;
+const DEFAULT_ASR_STOP_CHECK_INTERVAL: usize = 32;
 
 #[derive(Debug, Clone)]
 pub struct Lfm25AudioTextOutput {
@@ -1345,11 +1345,11 @@ mod tests {
     }
 
     #[test]
-    fn asr_stop_check_interval_defaults_to_sixteen() {
-        assert_eq!(lfm25_asr_stop_check_interval_from_env(None), 16);
+    fn asr_stop_check_interval_defaults_to_thirty_two() {
+        assert_eq!(lfm25_asr_stop_check_interval_from_env(None), 32);
         assert_eq!(
             lfm25_asr_stop_check_interval_from_env(Some("bad".to_string())),
-            16
+            32
         );
     }
 

--- a/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
+++ b/crates/izwi-core/src/models/architectures/lfm25_audio/model.rs
@@ -31,7 +31,7 @@ use super::LFM25_AUDIO_DEFAULT_INTERLEAVED_SYSTEM_PROMPT;
 const DEFAULT_MAX_NEW_TOKENS: usize = 1024;
 const DEFAULT_AUDIO_STREAM_DECODE_STRIDE_FRAMES: usize = 6;
 const DEFAULT_AUDIO_STREAM_HOLDBACK_FRAMES: usize = 2;
-const DEFAULT_ASR_STOP_CHECK_INTERVAL: usize = 96;
+const DEFAULT_ASR_STOP_CHECK_INTERVAL: usize = 92;
 
 #[derive(Debug, Clone)]
 pub struct Lfm25AudioTextOutput {
@@ -1353,11 +1353,11 @@ mod tests {
     }
 
     #[test]
-    fn asr_stop_check_interval_defaults_to_ninety_six() {
-        assert_eq!(lfm25_asr_stop_check_interval_from_env(None), 96);
+    fn asr_stop_check_interval_defaults_to_ninety_two() {
+        assert_eq!(lfm25_asr_stop_check_interval_from_env(None), 92);
         assert_eq!(
             lfm25_asr_stop_check_interval_from_env(Some("bad".to_string())),
-            96
+            92
         );
     }
 

--- a/crates/izwi-core/src/models/architectures/parakeet/asr/mod.rs
+++ b/crates/izwi-core/src/models/architectures/parakeet/asr/mod.rs
@@ -1,5 +1,5 @@
 mod decode;
-mod metal_kernels;
+pub(crate) mod metal_kernels;
 mod nemo;
 mod preprocessor;
 

--- a/crates/izwi-core/src/models/registry.rs
+++ b/crates/izwi-core/src/models/registry.rs
@@ -1,5 +1,6 @@
 //! Model registry to ensure models are loaded once and shared across the app.
 
+use izwi_asr_toolkit::{plan_audio_chunks, AsrLongFormConfig, TranscriptAssembler};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -59,6 +60,11 @@ type VoxtralTtsLoaderFn = fn(&Path, ModelVariant, DeviceProfile) -> Result<Voxtr
 type VibeVoiceTtsLoaderFn = fn(&Path, ModelVariant, DeviceProfile) -> Result<VibeVoiceTtsModel>;
 type QwenTtsLoaderFn = fn(&Path, ModelVariant, DeviceProfile, usize, &str) -> Result<Qwen3TtsModel>;
 type KokoroLoaderFn = fn(&Path, ModelVariant, DeviceProfile) -> Result<KokoroTtsModel>;
+
+const LFM25_AUDIO_ASR_DEFAULT_MAX_NEW_TOKENS: usize = 1024;
+const LFM25_AUDIO_ASR_MIN_CHUNK_NEW_TOKENS: usize = 128;
+const LFM25_AUDIO_ASR_MAX_CHUNK_NEW_TOKENS: usize = 256;
+const LFM25_AUDIO_ASR_TOKENS_PER_SECOND: f32 = 8.0;
 
 struct AsrLoaderRegistration {
     name: &'static str,
@@ -1122,6 +1128,93 @@ impl NativeAsrModel {
     }
 }
 
+fn lfm25_audio_asr_long_form_config() -> AsrLongFormConfig {
+    let mut cfg = AsrLongFormConfig::default();
+    if let Some(value) = env_positive_f32("IZWI_ASR_CHUNK_TARGET_SECS") {
+        cfg.target_chunk_secs = value;
+    }
+    if let Some(value) = env_positive_f32("IZWI_ASR_CHUNK_MAX_SECS") {
+        cfg.hard_max_chunk_secs = value;
+    }
+    if let Some(value) = env_positive_f32("IZWI_ASR_CHUNK_OVERLAP_SECS") {
+        cfg.overlap_secs = value;
+    }
+    if let Some(value) = env_positive_f32("IZWI_LFM25_ASR_CHUNK_TARGET_SECS") {
+        cfg.target_chunk_secs = value;
+    }
+    if let Some(value) = env_positive_f32("IZWI_LFM25_ASR_CHUNK_MAX_SECS") {
+        cfg.hard_max_chunk_secs = value;
+    }
+    if let Some(value) = env_positive_f32("IZWI_LFM25_ASR_CHUNK_OVERLAP_SECS") {
+        cfg.overlap_secs = value;
+    }
+    if cfg.hard_max_chunk_secs < cfg.min_chunk_secs {
+        cfg.hard_max_chunk_secs = cfg.min_chunk_secs;
+    }
+    cfg.target_chunk_secs = cfg
+        .target_chunk_secs
+        .max(cfg.min_chunk_secs.max(1.0))
+        .min(cfg.hard_max_chunk_secs);
+    cfg.overlap_secs = cfg.overlap_secs.clamp(0.0, cfg.target_chunk_secs * 0.45);
+    cfg
+}
+
+fn lfm25_audio_asr_single_pass_max_new_tokens(max_tokens: Option<usize>) -> usize {
+    max_tokens
+        .or_else(|| env_positive_usize("IZWI_LFM25_ASR_MAX_NEW_TOKENS"))
+        .unwrap_or(LFM25_AUDIO_ASR_DEFAULT_MAX_NEW_TOKENS)
+        .max(1)
+}
+
+fn lfm25_audio_asr_chunk_max_new_tokens(duration_secs: f32, max_tokens: Option<usize>) -> usize {
+    if let Some(max_tokens) = max_tokens {
+        return max_tokens.max(1);
+    }
+    if let Some(max_tokens) = env_positive_usize("IZWI_LFM25_ASR_CHUNK_MAX_NEW_TOKENS") {
+        return max_tokens;
+    }
+
+    let duration_budget = if duration_secs.is_finite() && duration_secs > 0.0 {
+        (duration_secs * LFM25_AUDIO_ASR_TOKENS_PER_SECOND).ceil() as usize
+    } else {
+        0
+    };
+    duration_budget.clamp(
+        LFM25_AUDIO_ASR_MIN_CHUNK_NEW_TOKENS,
+        LFM25_AUDIO_ASR_MAX_CHUNK_NEW_TOKENS,
+    )
+}
+
+fn audio_duration_secs(audio: &[f32], sample_rate: u32) -> f32 {
+    if sample_rate > 0 {
+        audio.len() as f32 / sample_rate as f32
+    } else {
+        0.0
+    }
+}
+
+fn samples_to_seconds_f64(samples: usize, sample_rate: u32) -> f64 {
+    if sample_rate > 0 {
+        samples as f64 / sample_rate as f64
+    } else {
+        0.0
+    }
+}
+
+fn env_positive_f32(key: &str) -> Option<f32> {
+    std::env::var(key)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<f32>().ok())
+        .filter(|value| value.is_finite() && *value > 0.0)
+}
+
+fn env_positive_usize(key: &str) -> Option<usize> {
+    std::env::var(key)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+}
+
 impl NativeAudioChatModel {
     pub fn generate_sequential(
         &self,
@@ -1197,7 +1290,7 @@ impl NativeAudioChatModel {
     }
 
     pub fn transcribe(&self, audio: &[f32], sample_rate: u32) -> Result<NativeAsrTranscription> {
-        self.transcribe_with_callback(audio, sample_rate, &mut |_delta| {})
+        self.transcribe_long_form_with_callback(audio, sample_rate, None, &mut |_delta| {})
     }
 
     pub fn transcribe_with_callback(
@@ -1206,10 +1299,34 @@ impl NativeAudioChatModel {
         sample_rate: u32,
         on_delta: &mut dyn FnMut(&str),
     ) -> Result<NativeAsrTranscription> {
+        self.transcribe_long_form_with_callback(audio, sample_rate, None, on_delta)
+    }
+
+    pub fn transcribe_with_callback_and_max_tokens(
+        &self,
+        audio: &[f32],
+        sample_rate: u32,
+        max_tokens: Option<usize>,
+        on_delta: &mut dyn FnMut(&str),
+    ) -> Result<NativeAsrTranscription> {
+        self.transcribe_long_form_with_callback(audio, sample_rate, max_tokens, on_delta)
+    }
+
+    pub fn transcribe_single_pass_with_callback_and_options(
+        &self,
+        audio: &[f32],
+        sample_rate: u32,
+        options: NativeAsrGenerationOptions,
+        on_delta: &mut dyn FnMut(&str),
+    ) -> Result<NativeAsrTranscription> {
         match self {
             Self::Lfm25Audio(model) => {
-                let output =
-                    model.transcribe_to_output_with_callback(audio, sample_rate, 1024, on_delta)?;
+                let output = model.transcribe_to_output_with_callback(
+                    audio,
+                    sample_rate,
+                    options.max_new_tokens.max(1),
+                    on_delta,
+                )?;
                 Ok(NativeAsrTranscription {
                     text: output.text,
                     language: None,
@@ -1217,6 +1334,107 @@ impl NativeAudioChatModel {
                 })
             }
         }
+    }
+
+    pub fn transcribe_long_form_with_callback(
+        &self,
+        audio: &[f32],
+        sample_rate: u32,
+        max_tokens: Option<usize>,
+        on_delta: &mut dyn FnMut(&str),
+    ) -> Result<NativeAsrTranscription> {
+        let duration_secs = audio_duration_secs(audio, sample_rate);
+        let chunk_cfg = lfm25_audio_asr_long_form_config();
+        let chunks = plan_audio_chunks(audio, sample_rate, &chunk_cfg, None);
+        if chunks.len() <= 1 {
+            return self.transcribe_single_pass_with_callback_and_options(
+                audio,
+                sample_rate,
+                NativeAsrGenerationOptions {
+                    max_new_tokens: lfm25_audio_asr_single_pass_max_new_tokens(max_tokens),
+                    ..NativeAsrGenerationOptions::default()
+                },
+                on_delta,
+            );
+        }
+
+        let mut assembler = TranscriptAssembler::new(chunk_cfg.clone());
+        let mut chunk_diagnostics = Vec::with_capacity(chunks.len());
+        for (idx, chunk) in chunks.iter().enumerate() {
+            if chunk.end_sample <= chunk.start_sample || chunk.end_sample > audio.len() {
+                chunk_diagnostics.push(serde_json::json!({
+                    "index": idx,
+                    "skipped": true,
+                    "skip_reason": "invalid_bounds",
+                    "start_sample": chunk.start_sample,
+                    "end_sample": chunk.end_sample
+                }));
+                continue;
+            }
+
+            let chunk_audio = &audio[chunk.start_sample..chunk.end_sample];
+            let chunk_duration_secs = audio_duration_secs(chunk_audio, sample_rate);
+            let chunk_max_tokens =
+                lfm25_audio_asr_chunk_max_new_tokens(chunk_duration_secs, max_tokens);
+            let output = self.transcribe_single_pass_with_callback_and_options(
+                chunk_audio,
+                sample_rate,
+                NativeAsrGenerationOptions {
+                    max_new_tokens: chunk_max_tokens,
+                    ..NativeAsrGenerationOptions::default()
+                },
+                &mut |_delta| {},
+            )?;
+            let delta = assembler.push_chunk_text(&output.text);
+            if !delta.is_empty() {
+                on_delta(&delta);
+            }
+
+            chunk_diagnostics.push(serde_json::json!({
+                "index": idx,
+                "start_sample": chunk.start_sample,
+                "end_sample": chunk.end_sample,
+                "start_seconds": samples_to_seconds_f64(chunk.start_sample, sample_rate),
+                "end_seconds": samples_to_seconds_f64(chunk.end_sample, sample_rate),
+                "duration_seconds": chunk_duration_secs,
+                "max_new_tokens": chunk_max_tokens,
+                "text_chars": output.text.len(),
+                "model_diagnostics": output.diagnostics
+            }));
+        }
+
+        Ok(NativeAsrTranscription {
+            text: assembler.text().to_string(),
+            language: None,
+            diagnostics: Some(serde_json::json!({
+                "model": "lfm25_audio",
+                "task": "asr",
+                "chunking": {
+                    "enabled": true,
+                    "planner": "duration",
+                    "input_samples": audio.len(),
+                    "input_sample_rate": sample_rate,
+                    "duration_seconds": duration_secs,
+                    "target_chunk_seconds": chunk_cfg.target_chunk_secs,
+                    "hard_max_chunk_seconds": chunk_cfg.hard_max_chunk_secs,
+                    "overlap_seconds": chunk_cfg.overlap_secs,
+                    "chunks": chunks.iter().map(|chunk| serde_json::json!({
+                        "start_sample": chunk.start_sample,
+                        "end_sample": chunk.end_sample,
+                        "start_seconds": samples_to_seconds_f64(chunk.start_sample, sample_rate),
+                        "end_seconds": samples_to_seconds_f64(chunk.end_sample, sample_rate),
+                    })).collect::<Vec<_>>(),
+                    "chunk_transcriptions": chunk_diagnostics
+                },
+                "decode": {
+                    "requested_max_tokens": max_tokens,
+                    "default_single_pass_max_tokens": LFM25_AUDIO_ASR_DEFAULT_MAX_NEW_TOKENS,
+                    "chunk_tokens_per_second": LFM25_AUDIO_ASR_TOKENS_PER_SECOND,
+                    "chunk_min_new_tokens": LFM25_AUDIO_ASR_MIN_CHUNK_NEW_TOKENS,
+                    "chunk_max_new_tokens": LFM25_AUDIO_ASR_MAX_CHUNK_NEW_TOKENS
+                }
+            })),
+        })
     }
 }
 
@@ -1998,6 +2216,12 @@ impl ModelRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     #[test]
     fn resolves_vibevoice_asr_loader_registration() {
@@ -2038,5 +2262,44 @@ mod tests {
 
         assert_eq!(registration.name, "vibevoice_tts");
         assert_eq!(registration.family, ModelFamily::VibeVoiceTts);
+    }
+
+    #[test]
+    fn lfm_audio_asr_chunk_budget_scales_and_caps() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        let previous = std::env::var("IZWI_LFM25_ASR_CHUNK_MAX_NEW_TOKENS").ok();
+        std::env::remove_var("IZWI_LFM25_ASR_CHUNK_MAX_NEW_TOKENS");
+
+        assert_eq!(
+            lfm25_audio_asr_chunk_max_new_tokens(0.0, None),
+            LFM25_AUDIO_ASR_MIN_CHUNK_NEW_TOKENS
+        );
+        assert_eq!(lfm25_audio_asr_chunk_max_new_tokens(24.0, None), 192);
+        assert_eq!(
+            lfm25_audio_asr_chunk_max_new_tokens(60.0, None),
+            LFM25_AUDIO_ASR_MAX_CHUNK_NEW_TOKENS
+        );
+        assert_eq!(lfm25_audio_asr_chunk_max_new_tokens(24.0, Some(42)), 42);
+
+        if let Some(previous) = previous {
+            std::env::set_var("IZWI_LFM25_ASR_CHUNK_MAX_NEW_TOKENS", previous);
+        }
+    }
+
+    #[test]
+    fn lfm_audio_asr_single_pass_preserves_legacy_default_cap() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        let previous = std::env::var("IZWI_LFM25_ASR_MAX_NEW_TOKENS").ok();
+        std::env::remove_var("IZWI_LFM25_ASR_MAX_NEW_TOKENS");
+
+        assert_eq!(
+            lfm25_audio_asr_single_pass_max_new_tokens(None),
+            LFM25_AUDIO_ASR_DEFAULT_MAX_NEW_TOKENS
+        );
+        assert_eq!(lfm25_audio_asr_single_pass_max_new_tokens(Some(64)), 64);
+
+        if let Some(previous) = previous {
+            std::env::set_var("IZWI_LFM25_ASR_MAX_NEW_TOKENS", previous);
+        }
     }
 }

--- a/crates/izwi-core/src/runtime/asr.rs
+++ b/crates/izwi-core/src/runtime/asr.rs
@@ -207,6 +207,7 @@ impl RuntimeService {
         variant: ModelVariant,
         samples: Vec<f32>,
         sample_rate: u32,
+        max_tokens: Option<usize>,
         mut on_delta: F,
     ) -> Result<AsrTranscription>
     where
@@ -227,7 +228,12 @@ impl RuntimeService {
                 on_delta(delta.to_string());
             }
         };
-        let output = model.transcribe_with_callback(&samples, sample_rate, &mut delta_sink)?;
+        let output = model.transcribe_with_callback_and_max_tokens(
+            &samples,
+            sample_rate,
+            max_tokens,
+            &mut delta_sink,
+        )?;
 
         Ok(AsrTranscription {
             text: output.text,
@@ -245,6 +251,7 @@ impl RuntimeService {
         &self,
         variant: ModelVariant,
         audio_base64: &str,
+        max_tokens: Option<usize>,
         on_delta: F,
     ) -> Result<AsrTranscription>
     where
@@ -252,7 +259,7 @@ impl RuntimeService {
     {
         let audio_bytes = base64_decode(audio_base64)?;
         let (samples, sample_rate) = decode_audio_bytes(&audio_bytes)?;
-        self.asr_transcribe_audio_chat_samples(variant, samples, sample_rate, on_delta)
+        self.asr_transcribe_audio_chat_samples(variant, samples, sample_rate, max_tokens, on_delta)
             .await
     }
 
@@ -260,13 +267,14 @@ impl RuntimeService {
         &self,
         variant: ModelVariant,
         audio_bytes: &[u8],
+        max_tokens: Option<usize>,
         on_delta: F,
     ) -> Result<AsrTranscription>
     where
         F: FnMut(String),
     {
         let (samples, sample_rate) = decode_audio_bytes(audio_bytes)?;
-        self.asr_transcribe_audio_chat_samples(variant, samples, sample_rate, on_delta)
+        self.asr_transcribe_audio_chat_samples(variant, samples, sample_rate, max_tokens, on_delta)
             .await
     }
 
@@ -354,7 +362,7 @@ impl RuntimeService {
         if variant.is_audio_chat() {
             self.observe_broker_capability_request(CapabilityKind::Asr, Some(variant), false)?;
             return self
-                .asr_transcribe_audio_chat_base64(variant, audio_base64, |_delta| {})
+                .asr_transcribe_audio_chat_base64(variant, audio_base64, max_tokens, |_delta| {})
                 .await;
         }
 
@@ -441,7 +449,7 @@ impl RuntimeService {
         if variant.is_audio_chat() {
             self.observe_broker_capability_request(CapabilityKind::Asr, Some(variant), true)?;
             return self
-                .asr_transcribe_audio_chat_base64(variant, audio_base64, on_delta)
+                .asr_transcribe_audio_chat_base64(variant, audio_base64, max_tokens, on_delta)
                 .await;
         }
 
@@ -525,7 +533,7 @@ impl RuntimeService {
         if variant.is_audio_chat() {
             self.observe_broker_capability_request(CapabilityKind::Asr, Some(variant), false)?;
             return self
-                .asr_transcribe_audio_chat_bytes(variant, audio_bytes, |_delta| {})
+                .asr_transcribe_audio_chat_bytes(variant, audio_bytes, max_tokens, |_delta| {})
                 .await;
         }
 
@@ -644,7 +652,7 @@ impl RuntimeService {
         if variant.is_audio_chat() {
             self.observe_broker_capability_request(CapabilityKind::Asr, Some(variant), true)?;
             return self
-                .asr_transcribe_audio_chat_bytes(variant, audio_bytes, on_delta)
+                .asr_transcribe_audio_chat_bytes(variant, audio_bytes, max_tokens, on_delta)
                 .await;
         }
 


### PR DESCRIPTION
Adds LFM2.5 Audio telemetry, benchmark reporting, Metal/Candle kernel and cache/readback optimizations for ASR/TTS/V2V, plus long-form ASR chunking and repetition-loop recovery for faster, safer transcription.