### PR TITLE
Fix Qwen3.5 multi-turn chat correctness, performance, and state reuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3710,6 +3710,7 @@ dependencies = [
  "candle-metal-kernels",
  "candle-nn",
  "candle-transformers",
+ "cudaforge",
  "dirs 5.0.1",
  "flate2",
  "futures",

--- a/crates/izwi-core/Cargo.toml
+++ b/crates/izwi-core/Cargo.toml
@@ -95,3 +95,6 @@ accelerate = [
 
 [dev-dependencies]
 tokio-test = "0.4"
+
+[build-dependencies]
+cudaforge = "0.1.5"

--- a/crates/izwi-core/build.rs
+++ b/crates/izwi-core/build.rs
@@ -1,0 +1,20 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=src/kernels/cuda/qwen35.cu");
+
+    if env::var_os("CARGO_FEATURE_CUDA").is_none() {
+        return Ok(());
+    }
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR")?);
+    let bindings = cudaforge::KernelBuilder::new()
+        .source_files(vec!["src/kernels/cuda/qwen35.cu"])
+        .arg("-std=c++17")
+        .arg("-O3")
+        .build_ptx()?;
+    bindings.write(out_dir.join("qwen35_ptx.rs"))?;
+    Ok(())
+}

--- a/crates/izwi-core/src/engine/core.rs
+++ b/crates/izwi-core/src/engine/core.rs
@@ -19,7 +19,9 @@ use super::execution::{
 };
 #[cfg(test)]
 use super::executor::REQUEST_DEADLINE_EXCEEDED;
-use super::executor::{ExecutorOutput, ExecutorStepResult, UnifiedExecutor, WorkerConfig};
+use super::executor::{
+    CacheReleaseReport, ExecutorOutput, ExecutorStepResult, UnifiedExecutor, WorkerConfig,
+};
 use super::kv_cache::{KVCacheConfig, KVCacheManager, KVCacheStats};
 use super::metal_kv_cache::{MetalKVCacheConfig, MetalKVCacheManager};
 use super::metrics::record_engine_batch_dispatch;
@@ -1553,6 +1555,11 @@ impl EngineCore {
             }
         }
         aborted
+    }
+
+    /// Purge reusable executor cache state owned by one model variant.
+    pub async fn purge_model_cache(&mut self, variant: ModelVariant) -> CacheReleaseReport {
+        self.executor.purge_model_cache(variant).await
     }
 
     /// Abort every request tracked by the core and release executor state.

--- a/crates/izwi-core/src/engine/core.rs
+++ b/crates/izwi-core/src/engine/core.rs
@@ -947,9 +947,12 @@ impl EngineCore {
 
     fn terminal_release_cause(disposition: &ExecutionDisposition) -> Option<TerminalReleaseCause> {
         match disposition {
-            ExecutionDisposition::Finished(ExecutionFinishReason::Completed) => {
-                Some(TerminalReleaseCause::Completed)
-            }
+            ExecutionDisposition::Finished(
+                ExecutionFinishReason::Completed
+                | ExecutionFinishReason::MaxTokens
+                | ExecutionFinishReason::StopToken
+                | ExecutionFinishReason::StopSequence,
+            ) => Some(TerminalReleaseCause::Completed),
             ExecutionDisposition::Finished(ExecutionFinishReason::Cancelled) => {
                 Some(TerminalReleaseCause::Cancelled)
             }

--- a/crates/izwi-core/src/engine/execution.rs
+++ b/crates/izwi-core/src/engine/execution.rs
@@ -311,6 +311,9 @@ pub enum YieldReason {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FinishReason {
     Completed,
+    MaxTokens,
+    StopToken,
+    StopSequence,
     Cancelled,
     TimedOut,
     Rejected,
@@ -319,7 +322,9 @@ pub enum FinishReason {
 impl FinishReason {
     fn terminal_outcome(self) -> TerminalOutcome {
         match self {
-            Self::Completed => TerminalOutcome::Completed,
+            Self::Completed | Self::MaxTokens | Self::StopToken | Self::StopSequence => {
+                TerminalOutcome::Completed
+            }
             Self::Cancelled => TerminalOutcome::Cancelled,
             Self::TimedOut => TerminalOutcome::TimedOut,
             Self::Rejected => TerminalOutcome::Rejected,

--- a/crates/izwi-core/src/engine/executor.rs
+++ b/crates/izwi-core/src/engine/executor.rs
@@ -368,6 +368,15 @@ impl ModelSessionResult {
         }
     }
 
+    pub fn finished(mut output: ExecutorOutput, reason: FinishReason) -> Self {
+        output.finished = true;
+        Self {
+            output,
+            disposition: ExecutionDisposition::Finished(reason),
+            safe_point: true,
+        }
+    }
+
     pub fn cancelled(mut output: ExecutorOutput) -> Self {
         output.finished = true;
         Self {

--- a/crates/izwi-core/src/engine/executor.rs
+++ b/crates/izwi-core/src/engine/executor.rs
@@ -522,6 +522,11 @@ pub trait ModelExecutor: Send + Sync {
     fn cleanup_session(&self, session: &SessionKey) -> CacheReleaseReport {
         self.cleanup_request(&session.request_id)
     }
+
+    /// Purge model-owned reusable cache state before one model is unloaded.
+    fn purge_model_cache(&self, _variant: ModelVariant) -> CacheReleaseReport {
+        CacheReleaseReport::unconfirmed()
+    }
 }
 
 /// Proof returned after an executor cache cleanup request. Preemption may only
@@ -1247,6 +1252,10 @@ impl ModelExecutor for NativeExecutor {
             .saturating_add(usize::from(reservations.remove(session).is_some()));
         CacheReleaseReport::confirmed(released)
     }
+
+    fn purge_model_cache(&self, variant: ModelVariant) -> CacheReleaseReport {
+        CacheReleaseReport::confirmed(self.qwen35_prefix_cache.purge_variant(variant))
+    }
 }
 
 /// Unified executor that wraps a model executor implementation.
@@ -1331,6 +1340,11 @@ impl UnifiedExecutor {
     pub async fn cleanup_session(&self, session: &SessionKey) -> CacheReleaseReport {
         let executor = self.inner.read().await;
         executor.cleanup_session(session)
+    }
+
+    pub async fn purge_model_cache(&self, variant: ModelVariant) -> CacheReleaseReport {
+        let executor = self.inner.read().await;
+        executor.purge_model_cache(variant)
     }
 }
 

--- a/crates/izwi-core/src/engine/executor.rs
+++ b/crates/izwi-core/src/engine/executor.rs
@@ -18,6 +18,8 @@ mod handler_audio_chat;
 mod handler_chat;
 #[path = "executor/handler_tts.rs"]
 mod handler_tts;
+#[path = "executor/prefix_cache.rs"]
+mod prefix_cache;
 #[path = "executor/state.rs"]
 mod state;
 #[path = "executor/streaming.rs"]
@@ -44,8 +46,10 @@ use crate::backends::{
 use crate::error::{Error, Result};
 use crate::model::ModelVariant;
 use crate::models::architectures::qwen3::tts::{Qwen3TtsModel, TtsSessionCacheRequest};
+use crate::models::architectures::qwen35::chat::Qwen35PrefixSnapshot;
 use crate::models::registry::{AsrModelLease, NativeAsrModel, NativeChatModel, QwenTtsModelLease};
 use crate::models::ModelRegistry;
+use prefix_cache::{configured_qwen35_prefix_cache_bytes, ExactPrefixCache};
 use state::{ActiveAsrDecode, ActiveChatDecode, ActiveQwenTtsDecode};
 
 fn panic_payload_to_string(payload: &(dyn std::any::Any + Send)) -> String {
@@ -557,6 +561,7 @@ pub struct NativeExecutor {
     initialized: bool,
     loaded_tts_model: Option<Arc<Qwen3TtsModel>>,
     chat_decode_states: Mutex<HashMap<SessionKey, ActiveChatDecode>>,
+    qwen35_prefix_cache: ExactPrefixCache<NativeChatModel, Qwen35PrefixSnapshot>,
     asr_decode_states: Mutex<HashMap<SessionKey, ActiveAsrDecode>>,
     qwen_tts_decode_states: Mutex<HashMap<SessionKey, ActiveQwenTtsDecode>>,
     cache_resource_leases: Mutex<HashMap<SessionKey, CacheResourceReservation>>,
@@ -565,11 +570,13 @@ pub struct NativeExecutor {
 impl NativeExecutor {
     /// Create a new native executor.
     pub fn new(config: WorkerConfig) -> Self {
+        let qwen35_prefix_cache = ExactPrefixCache::new(configured_qwen35_prefix_cache_bytes());
         Self {
             config,
             initialized: false,
             loaded_tts_model: None,
             chat_decode_states: Mutex::new(HashMap::new()),
+            qwen35_prefix_cache,
             asr_decode_states: Mutex::new(HashMap::new()),
             qwen_tts_decode_states: Mutex::new(HashMap::new()),
             cache_resource_leases: Mutex::new(HashMap::new()),
@@ -1172,6 +1179,7 @@ impl ModelExecutor for NativeExecutor {
             lease.prepare_materialized_release(zero)?;
         }
         chat.clear();
+        self.qwen35_prefix_cache.clear();
         asr.clear();
         tts.clear();
         reservations.clear();

--- a/crates/izwi-core/src/engine/executor.rs
+++ b/crates/izwi-core/src/engine/executor.rs
@@ -865,6 +865,12 @@ impl NativeExecutor {
             Error::InferenceError("cache allocation has no physical resource lease".to_string())
         })?;
         if observed_bytes > 0 {
+            if observed_bytes > reservation.reserved_bytes {
+                return Err(Error::InferenceError(format!(
+                    "materialized session cache uses {observed_bytes} bytes, exceeding its {}-byte authorization for request {} epoch {}",
+                    reservation.reserved_bytes, session.request_id, session.epoch
+                )));
+            }
             lease.record_materialized_usage(cache_resource_vector(
                 self.config.backend,
                 observed_bytes,

--- a/crates/izwi-core/src/engine/executor/handler_chat.rs
+++ b/crates/izwi-core/src/engine/executor/handler_chat.rs
@@ -1,12 +1,19 @@
+use std::sync::Arc;
 use std::time::Instant;
 
+use tracing::debug;
+
+use crate::engine::resources::{ReservationClass, ReservationOwner};
 use crate::error::{Error, Result};
+use crate::models::architectures::qwen35::chat::{Qwen35PrefixSnapshot, Qwen35PreparedPrompt};
+use crate::models::registry::NativeChatModel;
 use crate::models::shared::chat::ChatGenerationConfig;
 use crate::models::shared::chat::ChatMessage;
 
 use super::super::request::EngineCoreRequest;
 use super::super::scheduler::ScheduledRequest;
 use super::super::types::AudioOutput;
+use super::prefix_cache::{ExactPrefixHandle, ExactPrefixScope};
 use super::state::ActiveChatDecode;
 use super::{ExecutorOutput, ExecutorPhaseTiming, ModelSessionResult, NativeExecutor};
 
@@ -84,6 +91,14 @@ impl NativeExecutor {
         let generation_config = Self::chat_generation_config(request);
         let session = scheduled.session_key();
         let model = request.prepared_chat_model_for_executor()?;
+        let prefix_scope = ExactPrefixScope {
+            variant,
+            backend: self.config.backend,
+            activation_dtype: self.config.dtype.clone(),
+            kv_cache_dtype: self.config.kv_cache_dtype.clone(),
+        };
+        let prefix_cache_enabled =
+            self.qwen35_prefix_cache_enabled(prepared_qwen35_prompt, model.as_ref());
 
         // Fallback path for chat backends that do not expose incremental decode state.
         if !model.supports_incremental_decode() {
@@ -210,19 +225,48 @@ impl NativeExecutor {
                     request.id.clone(),
                 )));
             }
-            let decode_state = Self::run_blocking(|| {
-                model.start_decode_state_with_prepared(
+            let cached_prefix = prefix_cache_enabled
+                .then(|| {
+                    let prepared = prepared_qwen35_prompt
+                        .expect("enabled Qwen3.5 prefix cache requires prepared prompt");
+                    self.qwen35_prefix_cache.lookup(
+                        &model,
+                        &prefix_scope,
+                        prepared.prompt_ids(),
+                        prepared.prompt_positions(),
+                    )
+                })
+                .flatten();
+            let mut decode_state = Self::run_blocking(|| {
+                model.start_decode_state_with_prefix(
                     messages,
                     max_new_tokens,
                     &generation_config,
                     prepared_qwen35_prompt,
+                    cached_prefix.as_ref().map(|cached| cached.snapshot()),
+                    prefix_cache_enabled.then_some(self.qwen35_prefix_cache.max_retained_bytes()),
                 )
             })?;
+            let reused_prefix_tokens = decode_state.reused_qwen35_prefix_tokens();
+            if reused_prefix_tokens > 0 {
+                debug!(
+                    model = %variant,
+                    reused_prefix_tokens,
+                    prompt_tokens = request.num_prompt_tokens(),
+                    "Qwen3.5 exact-prefix cache hit"
+                );
+            }
+            let pending_prefix_snapshot = decode_state
+                .take_pending_qwen35_prefix_snapshot()
+                .and_then(|snapshot| {
+                    self.authorize_qwen35_prefix_snapshot(&prefix_scope, snapshot)
+                });
             ActiveChatDecode {
                 variant,
                 state: decode_state,
                 last_tokens_generated: 0,
                 stream_sequence: 0,
+                pending_prefix_snapshot,
             }
         };
 
@@ -278,6 +322,11 @@ impl NativeExecutor {
             }
 
             if step.finished {
+                if let Some(snapshot) = active_state.pending_prefix_snapshot.take() {
+                    let _ = self
+                        .qwen35_prefix_cache
+                        .insert(&model, prefix_scope.clone(), snapshot);
+                }
                 finished = true;
                 break;
             }
@@ -307,6 +356,43 @@ impl NativeExecutor {
             asr_diagnostics: None,
             error: None,
         }))
+    }
+
+    fn qwen35_prefix_cache_enabled(
+        &self,
+        prepared: Option<&Qwen35PreparedPrompt>,
+        model: &NativeChatModel,
+    ) -> bool {
+        self.config.resource_authority.is_some()
+            && self.qwen35_prefix_cache.max_retained_bytes() > 0
+            && matches!(model, NativeChatModel::Qwen35(_))
+            && prepared.is_some_and(Qwen35PreparedPrompt::supports_exact_prefix_reuse)
+    }
+
+    fn authorize_qwen35_prefix_snapshot(
+        &self,
+        scope: &ExactPrefixScope,
+        snapshot: Qwen35PrefixSnapshot,
+    ) -> Option<Arc<ExactPrefixHandle<Qwen35PrefixSnapshot>>> {
+        let Some(bytes) = snapshot.retained_bytes() else {
+            return None;
+        };
+        if bytes == 0 || bytes > self.qwen35_prefix_cache.max_retained_bytes() {
+            return None;
+        }
+        let Some(authority) = self.config.resource_authority.as_ref() else {
+            return None;
+        };
+        let resources = super::cache_resource_vector(scope.backend, bytes);
+        let owner = ReservationOwner::new(
+            ReservationClass::Cache,
+            format!("qwen35-prefix-pending:{}", scope.variant),
+        );
+        let Ok(lease) = authority.reserve_with_initial_materialized(owner, resources, resources)
+        else {
+            return None;
+        };
+        Some(ExactPrefixHandle::new(scope.backend, snapshot, Some(lease)))
     }
 }
 

--- a/crates/izwi-core/src/engine/executor/handler_chat.rs
+++ b/crates/izwi-core/src/engine/executor/handler_chat.rs
@@ -4,12 +4,12 @@ use std::time::Instant;
 
 use tracing::debug;
 
+use crate::engine::execution::FinishReason as ExecutionFinishReason;
 use crate::engine::resources::{ReservationClass, ReservationOwner, ResourceLease};
 use crate::error::{Error, Result};
 use crate::models::architectures::qwen35::chat::{Qwen35PrefixSnapshot, Qwen35PreparedPrompt};
 use crate::models::registry::NativeChatModel;
-use crate::models::shared::chat::ChatGenerationConfig;
-use crate::models::shared::chat::ChatMessage;
+use crate::models::shared::chat::{ChatGenerationConfig, ChatGenerationFinishReason, ChatMessage};
 
 use super::super::request::EngineCoreRequest;
 use super::super::scheduler::ScheduledRequest;
@@ -302,6 +302,7 @@ impl NativeExecutor {
         let mut decode_steps_ran = 0usize;
         let mut final_text = String::new();
         let mut finished = false;
+        let mut finish_reason = None;
 
         for _ in 0..decode_iterations {
             if request.is_cancelled() {
@@ -345,6 +346,7 @@ impl NativeExecutor {
             }
 
             if step.finished {
+                finish_reason = step.finish_reason;
                 if let Some(snapshot) = active_state.pending_prefix_snapshot.take() {
                     let _ = self
                         .qwen35_prefix_cache
@@ -367,7 +369,7 @@ impl NativeExecutor {
             guard.insert(session, active_state);
         }
 
-        Ok(ModelSessionResult::sequence(ExecutorOutput {
+        let output = ExecutorOutput {
             request_id: request.id.clone(),
             audio: Some(AudioOutput::empty(24_000)),
             text: Some(final_text),
@@ -378,7 +380,15 @@ impl NativeExecutor {
             phase_timing_override: None,
             asr_diagnostics: None,
             error: None,
-        }))
+        };
+        if finished {
+            Ok(ModelSessionResult::finished(
+                output,
+                Self::chat_execution_finish_reason(finish_reason),
+            ))
+        } else {
+            Ok(ModelSessionResult::sequence(output))
+        }
     }
 
     fn qwen35_prefix_cache_enabled(
@@ -390,6 +400,17 @@ impl NativeExecutor {
             && self.qwen35_prefix_cache.max_retained_bytes() > 0
             && matches!(model, NativeChatModel::Qwen35(_))
             && prepared.is_some_and(Qwen35PreparedPrompt::supports_exact_prefix_reuse)
+    }
+
+    fn chat_execution_finish_reason(
+        reason: Option<ChatGenerationFinishReason>,
+    ) -> ExecutionFinishReason {
+        match reason {
+            Some(ChatGenerationFinishReason::MaxTokens) => ExecutionFinishReason::MaxTokens,
+            Some(ChatGenerationFinishReason::StopToken) => ExecutionFinishReason::StopToken,
+            Some(ChatGenerationFinishReason::StopSequence) => ExecutionFinishReason::StopSequence,
+            None => ExecutionFinishReason::Completed,
+        }
     }
 
     fn preauthorize_qwen35_prefix_snapshot(

--- a/crates/izwi-core/src/engine/executor/handler_chat.rs
+++ b/crates/izwi-core/src/engine/executor/handler_chat.rs
@@ -1,9 +1,10 @@
+use std::mem::size_of;
 use std::sync::Arc;
 use std::time::Instant;
 
 use tracing::debug;
 
-use crate::engine::resources::{ReservationClass, ReservationOwner};
+use crate::engine::resources::{ReservationClass, ReservationOwner, ResourceLease};
 use crate::error::{Error, Result};
 use crate::models::architectures::qwen35::chat::{Qwen35PrefixSnapshot, Qwen35PreparedPrompt};
 use crate::models::registry::NativeChatModel;
@@ -19,6 +20,11 @@ use super::{ExecutorOutput, ExecutorPhaseTiming, ModelSessionResult, NativeExecu
 
 const FALLBACK_CHAT_STREAM_BATCH_PIECES: usize = 4;
 const FALLBACK_CHAT_STREAM_BATCH_BYTES: usize = 32;
+
+struct PendingPrefixAuthorization {
+    max_bytes: u64,
+    lease: ResourceLease,
+}
 
 #[derive(Debug, Default)]
 struct StreamDeltaBatch {
@@ -237,6 +243,19 @@ impl NativeExecutor {
                     )
                 })
                 .flatten();
+            let pending_prefix_authorization = prefix_cache_enabled
+                .then(|| {
+                    self.preauthorize_qwen35_prefix_snapshot(
+                        request,
+                        &prefix_scope,
+                        prepared_qwen35_prompt
+                            .expect("enabled Qwen3.5 prefix cache requires prepared prompt"),
+                    )
+                })
+                .flatten();
+            let capture_prefix_max_bytes = pending_prefix_authorization
+                .as_ref()
+                .map(|authorization| authorization.max_bytes);
             let mut decode_state = Self::run_blocking(|| {
                 model.start_decode_state_with_prefix(
                     messages,
@@ -244,7 +263,7 @@ impl NativeExecutor {
                     &generation_config,
                     prepared_qwen35_prompt,
                     cached_prefix.as_ref().map(|cached| cached.snapshot()),
-                    prefix_cache_enabled.then_some(self.qwen35_prefix_cache.max_retained_bytes()),
+                    capture_prefix_max_bytes,
                 )
             })?;
             let reused_prefix_tokens = decode_state.reused_qwen35_prefix_tokens();
@@ -256,11 +275,15 @@ impl NativeExecutor {
                     "Qwen3.5 exact-prefix cache hit"
                 );
             }
-            let pending_prefix_snapshot = decode_state
-                .take_pending_qwen35_prefix_snapshot()
-                .and_then(|snapshot| {
-                    self.authorize_qwen35_prefix_snapshot(&prefix_scope, snapshot)
-                });
+            let pending_prefix_snapshot = match (
+                decode_state.take_pending_qwen35_prefix_snapshot(),
+                pending_prefix_authorization,
+            ) {
+                (Some(snapshot), Some(authorization)) => {
+                    self.materialize_qwen35_prefix_snapshot(&prefix_scope, snapshot, authorization)
+                }
+                _ => None,
+            };
             ActiveChatDecode {
                 variant,
                 state: decode_state,
@@ -369,30 +392,54 @@ impl NativeExecutor {
             && prepared.is_some_and(Qwen35PreparedPrompt::supports_exact_prefix_reuse)
     }
 
-    fn authorize_qwen35_prefix_snapshot(
+    fn preauthorize_qwen35_prefix_snapshot(
         &self,
+        request: &EngineCoreRequest,
         scope: &ExactPrefixScope,
-        snapshot: Qwen35PrefixSnapshot,
-    ) -> Option<Arc<ExactPrefixHandle<Qwen35PrefixSnapshot>>> {
-        let Some(bytes) = snapshot.retained_bytes() else {
-            return None;
-        };
-        if bytes == 0 || bytes > self.qwen35_prefix_cache.max_retained_bytes() {
+        prepared: &Qwen35PreparedPrompt,
+    ) -> Option<PendingPrefixAuthorization> {
+        let state_bytes = self.authorized_session_cache_bytes(request).ok()?;
+        let metadata_per_token = size_of::<u32>().checked_add(size_of::<[usize; 3]>())?;
+        let metadata_bytes = prepared
+            .prompt_ids()
+            .len()
+            .checked_mul(metadata_per_token)?
+            .checked_add(size_of::<Qwen35PrefixSnapshot>())?;
+        let max_bytes = state_bytes.checked_add(u64::try_from(metadata_bytes).ok()?)?;
+        if max_bytes == 0 || max_bytes > self.qwen35_prefix_cache.max_retained_bytes() {
             return None;
         }
         let Some(authority) = self.config.resource_authority.as_ref() else {
             return None;
         };
-        let resources = super::cache_resource_vector(scope.backend, bytes);
+        let resources = super::cache_resource_vector(scope.backend, max_bytes);
         let owner = ReservationOwner::new(
             ReservationClass::Cache,
             format!("qwen35-prefix-pending:{}", scope.variant),
         );
-        let Ok(lease) = authority.reserve_with_initial_materialized(owner, resources, resources)
-        else {
+        let lease = authority.reserve(owner, resources).ok()?;
+        Some(PendingPrefixAuthorization { max_bytes, lease })
+    }
+
+    fn materialize_qwen35_prefix_snapshot(
+        &self,
+        scope: &ExactPrefixScope,
+        snapshot: Qwen35PrefixSnapshot,
+        authorization: PendingPrefixAuthorization,
+    ) -> Option<Arc<ExactPrefixHandle<Qwen35PrefixSnapshot>>> {
+        let bytes = snapshot.retained_bytes()?;
+        if bytes == 0 || bytes > authorization.max_bytes {
             return None;
-        };
-        Some(ExactPrefixHandle::new(scope.backend, snapshot, Some(lease)))
+        }
+        authorization
+            .lease
+            .record_materialized_usage(super::cache_resource_vector(scope.backend, bytes))
+            .ok()?;
+        Some(ExactPrefixHandle::new(
+            scope.backend,
+            snapshot,
+            Some(authorization.lease),
+        ))
     }
 }
 

--- a/crates/izwi-core/src/engine/executor/prefix_cache.rs
+++ b/crates/izwi-core/src/engine/executor/prefix_cache.rs
@@ -142,31 +142,45 @@ where
         }
 
         let requested_owner = Arc::downgrade(owner);
-        let mut state = self
-            .state
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        remove_stale_entries(&mut state);
+        let (cached, stale) = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            let stale = detach_stale_entries(&mut state);
 
-        let best = state
-            .entries
-            .iter()
-            .enumerate()
-            .filter(|(_, entry)| {
-                entry.scope == *scope
-                    && Weak::ptr_eq(&entry.owner, &requested_owner)
-                    && exact_prefix_matches(entry.cached.snapshot(), prompt_ids, prompt_positions)
-            })
-            .max_by_key(|(_, entry)| entry.cached.snapshot().token_ids().len())
-            .map(|(index, _)| index)?;
+            let best = state
+                .entries
+                .iter()
+                .enumerate()
+                .filter(|(_, entry)| {
+                    entry.scope == *scope
+                        && Weak::ptr_eq(&entry.owner, &requested_owner)
+                        && exact_prefix_matches(
+                            entry.cached.snapshot(),
+                            prompt_ids,
+                            prompt_positions,
+                        )
+                })
+                .max_by_key(|(_, entry)| entry.cached.snapshot().token_ids().len())
+                .map(|(index, _)| index);
 
-        let entry = state
-            .entries
-            .remove(best)
-            .expect("selected exact-prefix entry must still exist");
-        let cached = Arc::clone(&entry.cached);
-        state.entries.push_back(entry);
-        Some(cached)
+            let cached = best.map(|best| {
+                let entry = state
+                    .entries
+                    .remove(best)
+                    .expect("selected exact-prefix entry must still exist");
+                let cached = Arc::clone(&entry.cached);
+                state.entries.push_back(entry);
+                cached
+            });
+            (cached, stale)
+        };
+        // Resource leases and Candle/Metal storage must be released outside
+        // the cache mutex to avoid lock inversion and long device frees while
+        // other requests access the LRU.
+        drop(stale);
+        cached
     }
 
     /// Insert one immutable snapshot. Oversized or unaccountable snapshots are
@@ -185,49 +199,81 @@ where
         }
 
         let owner = Arc::downgrade(owner);
-        let mut state = self
-            .state
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        remove_stale_entries(&mut state);
+        let (inserted, detached) = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            let mut detached = detach_stale_entries(&mut state);
+            let mut remove = vec![false; state.entries.len()];
+            let replacement = cached.snapshot();
 
-        if let Some(index) = state.entries.iter().position(|entry| {
-            entry.scope == scope
-                && Weak::ptr_eq(&entry.owner, &owner)
-                && entry.cached.snapshot().token_ids() == cached.snapshot().token_ids()
-                && entry.cached.snapshot().positions() == cached.snapshot().positions()
-        }) {
-            if Arc::strong_count(&state.entries[index].cached) > 1 {
-                return false;
+            // Plan replacement and ancestor compaction before mutating the
+            // LRU. A failed fit must leave every useful entry intact.
+            for (index, entry) in state.entries.iter().enumerate() {
+                if entry.scope != scope || !Weak::ptr_eq(&entry.owner, &owner) {
+                    continue;
+                }
+                let candidate = entry.cached.snapshot();
+                let exact = candidate.token_ids() == replacement.token_ids()
+                    && candidate.positions() == replacement.positions();
+                if exact && Arc::strong_count(&entry.cached) > 1 {
+                    drop(state);
+                    drop(detached);
+                    return false;
+                }
+                let ancestor = candidate.token_ids().len() < replacement.token_ids().len()
+                    && replacement.token_ids().starts_with(candidate.token_ids())
+                    && replacement.positions().starts_with(candidate.positions());
+                if exact || (ancestor && Arc::strong_count(&entry.cached) == 1) {
+                    remove[index] = true;
+                }
             }
-            if let Some(replaced) = state.entries.remove(index) {
-                state.retained_bytes = state.retained_bytes.saturating_sub(replaced.retained_bytes);
+
+            let mut projected = state.retained_bytes;
+            for (index, entry) in state.entries.iter().enumerate() {
+                if remove[index] {
+                    projected = projected.saturating_sub(entry.retained_bytes);
+                }
             }
-        }
 
-        while state.retained_bytes.saturating_add(retained_bytes) > self.max_retained_bytes {
-            let Some(index) = state
-                .entries
-                .iter()
-                .position(|entry| Arc::strong_count(&entry.cached) == 1)
-            else {
-                return false;
-            };
-            let evicted = state
-                .entries
-                .remove(index)
-                .expect("selected evictable prefix entry must exist");
-            state.retained_bytes = state.retained_bytes.saturating_sub(evicted.retained_bytes);
-        }
+            while projected.saturating_add(retained_bytes) > self.max_retained_bytes {
+                let Some((index, entry)) =
+                    state.entries.iter().enumerate().find(|(index, entry)| {
+                        !remove[*index] && Arc::strong_count(&entry.cached) == 1
+                    })
+                else {
+                    drop(state);
+                    drop(detached);
+                    return false;
+                };
+                remove[index] = true;
+                projected = projected.saturating_sub(entry.retained_bytes);
+            }
 
-        state.retained_bytes = state.retained_bytes.saturating_add(retained_bytes);
-        state.entries.push_back(ExactPrefixEntry {
-            scope,
-            owner,
-            cached,
-            retained_bytes,
-        });
-        true
+            for index in (0..remove.len()).rev() {
+                if !remove[index] {
+                    continue;
+                }
+                let entry = state
+                    .entries
+                    .remove(index)
+                    .expect("planned exact-prefix removal must still exist");
+                state.retained_bytes = state.retained_bytes.saturating_sub(entry.retained_bytes);
+                detached.push(entry);
+            }
+
+            state.retained_bytes = state.retained_bytes.saturating_add(retained_bytes);
+            state.entries.push_back(ExactPrefixEntry {
+                scope,
+                owner,
+                cached,
+                retained_bytes,
+            });
+            (true, detached)
+        };
+        drop(detached);
+        inserted
     }
 
     pub(super) fn retained_bytes(&self) -> u64 {
@@ -237,13 +283,34 @@ where
             .retained_bytes
     }
 
+    /// Purge all checkpoints owned by one model variant.
+    ///
+    /// Model unload calls this after active requests have been aborted and
+    /// before the model residency lease is released. Any external lookup
+    /// handle remains valid and keeps its own resource lease until it drops.
+    pub(super) fn purge_variant(&self, variant: ModelVariant) -> usize {
+        let detached = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            detach_matching_entries(&mut state, |entry| entry.scope.variant == variant)
+        };
+        let removed = detached.len();
+        drop(detached);
+        removed
+    }
+
     pub(super) fn clear(&self) {
-        let mut state = self
-            .state
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        state.entries.clear();
-        state.retained_bytes = 0;
+        let detached = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            state.retained_bytes = 0;
+            std::mem::take(&mut state.entries)
+        };
+        drop(detached);
     }
 }
 
@@ -260,18 +327,33 @@ fn exact_prefix_matches<S: ExactPrefixSnapshot + ?Sized>(
         && prompt_positions.starts_with(cached_positions)
 }
 
-fn remove_stale_entries<O, S>(state: &mut ExactPrefixCacheState<O, S>) {
-    let mut retained_bytes = state.retained_bytes;
-    state.entries.retain(|entry| {
-        // A lookup handle owns the snapshot and its lease independently of the
-        // LRU entry, so a dead model owner can always be pruned immediately.
-        let retain = entry.owner.strong_count() > 0;
-        if !retain {
-            retained_bytes = retained_bytes.saturating_sub(entry.retained_bytes);
+fn detach_stale_entries<O, S>(
+    state: &mut ExactPrefixCacheState<O, S>,
+) -> Vec<ExactPrefixEntry<O, S>> {
+    // A lookup handle owns the snapshot and its lease independently of the LRU
+    // entry, so a dead model owner can always be detached immediately.
+    detach_matching_entries(state, |entry| entry.owner.strong_count() == 0)
+}
+
+fn detach_matching_entries<O, S>(
+    state: &mut ExactPrefixCacheState<O, S>,
+    mut should_detach: impl FnMut(&ExactPrefixEntry<O, S>) -> bool,
+) -> Vec<ExactPrefixEntry<O, S>> {
+    let mut detached = Vec::new();
+    let mut index = 0usize;
+    while index < state.entries.len() {
+        if should_detach(&state.entries[index]) {
+            let entry = state
+                .entries
+                .remove(index)
+                .expect("selected exact-prefix entry must still exist");
+            state.retained_bytes = state.retained_bytes.saturating_sub(entry.retained_bytes);
+            detached.push(entry);
+        } else {
+            index += 1;
         }
-        retain
-    });
-    state.retained_bytes = retained_bytes;
+    }
+    detached
 }
 
 #[cfg(test)]
@@ -315,13 +397,17 @@ mod tests {
         }
     }
 
-    fn scope() -> ExactPrefixScope {
+    fn scope_for(variant: ModelVariant) -> ExactPrefixScope {
         ExactPrefixScope {
-            variant: ModelVariant::Qwen354BGguf,
+            variant,
             backend: BackendKind::Cpu,
             activation_dtype: "float32".to_string(),
             kv_cache_dtype: "float16".to_string(),
         }
+    }
+
+    fn scope() -> ExactPrefixScope {
+        scope_for(ModelVariant::Qwen354BGguf)
     }
 
     fn snapshot(
@@ -404,6 +490,59 @@ mod tests {
             .lookup(&owner, &scope(), &[3, 9], &positions(2))
             .is_some());
         assert_eq!(cache.retained_bytes(), 10);
+    }
+
+    #[test]
+    fn monotonic_lineage_supersedes_unpinned_ancestors_but_preserves_branches() {
+        let cache = ExactPrefixCache::<(), TestSnapshot>::new(128);
+        let owner = Arc::new(());
+        assert!(cache.insert(&owner, scope(), snapshot(&[1], 4, "root")));
+        assert!(cache.insert(&owner, scope(), snapshot(&[1, 2], 5, "middle")));
+        assert!(cache.insert(&owner, scope(), snapshot(&[9, 8], 6, "branch")));
+        assert!(cache.insert(&owner, scope(), snapshot(&[1, 2, 3], 7, "tip")));
+
+        assert!(cache
+            .lookup(&owner, &scope(), &[1, 2, 9], &positions(3))
+            .is_none());
+        assert_eq!(
+            cache
+                .lookup(&owner, &scope(), &[1, 2, 3, 4], &positions(4))
+                .unwrap()
+                .snapshot()
+                .label,
+            "tip"
+        );
+        assert_eq!(
+            cache
+                .lookup(&owner, &scope(), &[9, 8, 7], &positions(3))
+                .unwrap()
+                .snapshot()
+                .label,
+            "branch"
+        );
+        assert_eq!(cache.retained_bytes(), 13);
+    }
+
+    #[test]
+    fn failed_insert_does_not_destroy_existing_ancestors() {
+        let cache = ExactPrefixCache::<(), TestSnapshot>::new(8);
+        let owner = Arc::new(());
+        assert!(cache.insert(&owner, scope(), snapshot(&[1], 8, "root")));
+        let pinned = cache
+            .lookup(&owner, &scope(), &[1, 2], &positions(2))
+            .unwrap();
+
+        assert!(!cache.insert(&owner, scope(), snapshot(&[1, 2], 8, "tip")));
+        assert_eq!(cache.retained_bytes(), 8);
+        assert_eq!(
+            cache
+                .lookup(&owner, &scope(), &[1, 3], &positions(2))
+                .unwrap()
+                .snapshot()
+                .label,
+            "root"
+        );
+        drop(pinned);
     }
 
     #[test]
@@ -494,5 +633,68 @@ mod tests {
         assert_eq!(authority.snapshot().reservations, 1);
         drop(pending);
         assert_eq!(authority.snapshot().reservations, 0);
+    }
+
+    #[test]
+    fn variant_purge_releases_only_matching_unpinned_leases() {
+        let capacity = super::super::cache_resource_vector(BackendKind::Cpu, 64);
+        let authority = Arc::new(ResourceAuthority::new(Arc::new(TestCapacityProvider {
+            snapshot: PhysicalCapacitySnapshot {
+                capacity,
+                available: capacity,
+                source: crate::engine::resources::CapacitySource::Test,
+            },
+        })));
+        let cache = ExactPrefixCache::<(), TestSnapshot>::new(64);
+        let owner = Arc::new(());
+
+        for (variant, id, label) in [
+            (ModelVariant::Qwen354BGguf, 1, "four"),
+            (ModelVariant::Qwen352BGguf, 2, "two"),
+        ] {
+            let resources = super::super::cache_resource_vector(BackendKind::Cpu, 4);
+            let lease = authority
+                .reserve_with_initial_materialized(
+                    ReservationOwner::new(ReservationClass::Cache, label),
+                    resources,
+                    resources,
+                )
+                .unwrap();
+            assert!(cache.insert(
+                &owner,
+                scope_for(variant),
+                ExactPrefixHandle::new(
+                    BackendKind::Cpu,
+                    TestSnapshot {
+                        ids: vec![id],
+                        positions: vec![[0; 3]],
+                        bytes: 4,
+                        label,
+                    },
+                    Some(lease),
+                ),
+            ));
+        }
+        assert_eq!(authority.snapshot().reservations, 2);
+
+        assert_eq!(cache.purge_variant(ModelVariant::Qwen354BGguf), 1);
+        assert_eq!(cache.retained_bytes(), 4);
+        assert_eq!(authority.snapshot().reservations, 1);
+        assert!(cache
+            .lookup(
+                &owner,
+                &scope_for(ModelVariant::Qwen354BGguf),
+                &[1, 3],
+                &positions(2),
+            )
+            .is_none());
+        assert!(cache
+            .lookup(
+                &owner,
+                &scope_for(ModelVariant::Qwen352BGguf),
+                &[2, 3],
+                &positions(2),
+            )
+            .is_some());
     }
 }

--- a/crates/izwi-core/src/engine/executor/prefix_cache.rs
+++ b/crates/izwi-core/src/engine/executor/prefix_cache.rs
@@ -1,0 +1,498 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex, Weak};
+
+use crate::backends::BackendKind;
+use crate::engine::resources::ResourceLease;
+use crate::model::ModelVariant;
+use crate::models::architectures::qwen35::chat::Qwen35PrefixSnapshot;
+
+const DEFAULT_QWEN35_PREFIX_CACHE_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_QWEN35_PREFIX_CACHE_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+
+pub(super) fn configured_qwen35_prefix_cache_bytes() -> u64 {
+    std::env::var("IZWI_QWEN35_PREFIX_CACHE_BYTES")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_QWEN35_PREFIX_CACHE_BYTES)
+        .min(MAX_QWEN35_PREFIX_CACHE_BYTES)
+}
+
+pub(super) trait ExactPrefixSnapshot: Send + Sync + 'static {
+    fn token_ids(&self) -> &[u32];
+
+    fn positions(&self) -> &[[usize; 3]];
+
+    /// All storage retained exclusively by this cache entry, including tensor
+    /// backing allocations and owned token/position metadata.
+    fn retained_bytes(&self) -> Option<u64>;
+}
+
+impl ExactPrefixSnapshot for Qwen35PrefixSnapshot {
+    fn token_ids(&self) -> &[u32] {
+        self.token_ids()
+    }
+
+    fn positions(&self) -> &[[usize; 3]] {
+        self.positions()
+    }
+
+    fn retained_bytes(&self) -> Option<u64> {
+        self.retained_bytes()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ExactPrefixScope {
+    pub(super) variant: ModelVariant,
+    pub(super) backend: BackendKind,
+    pub(super) activation_dtype: String,
+    pub(super) kv_cache_dtype: String,
+}
+
+pub(super) struct ExactPrefixHandle<S> {
+    backend: BackendKind,
+    // Snapshot precedes its lease so storage is dropped before authorization.
+    snapshot: S,
+    lease: Option<ResourceLease>,
+}
+
+impl<S> ExactPrefixHandle<S> {
+    pub(super) fn new(
+        backend: BackendKind,
+        snapshot: S,
+        lease: Option<ResourceLease>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            backend,
+            snapshot,
+            lease,
+        })
+    }
+
+    pub(super) fn snapshot(&self) -> &S {
+        &self.snapshot
+    }
+}
+
+impl<S> Drop for ExactPrefixHandle<S> {
+    fn drop(&mut self) {
+        if let Some(lease) = self.lease.as_ref() {
+            let _ =
+                lease.prepare_materialized_release(super::cache_resource_vector(self.backend, 0));
+        }
+    }
+}
+
+struct ExactPrefixEntry<O, S> {
+    scope: ExactPrefixScope,
+    owner: Weak<O>,
+    cached: Arc<ExactPrefixHandle<S>>,
+    retained_bytes: u64,
+}
+
+struct ExactPrefixCacheState<O, S> {
+    entries: VecDeque<ExactPrefixEntry<O, S>>,
+    retained_bytes: u64,
+}
+
+impl<O, S> Default for ExactPrefixCacheState<O, S> {
+    fn default() -> Self {
+        Self {
+            entries: VecDeque::new(),
+            retained_bytes: 0,
+        }
+    }
+}
+
+/// Bounded LRU of immutable exact-prefix snapshots.
+///
+/// The owner is weakly referenced so an unloaded model cannot keep cache state
+/// discoverable. Lookups clone only an `Arc` while holding the mutex; fallible
+/// Candle storage copies happen after the cache lock is released.
+pub(super) struct ExactPrefixCache<O, S> {
+    max_retained_bytes: u64,
+    state: Mutex<ExactPrefixCacheState<O, S>>,
+}
+
+impl<O, S> ExactPrefixCache<O, S>
+where
+    O: Send + Sync + 'static,
+    S: ExactPrefixSnapshot,
+{
+    pub(super) fn new(max_retained_bytes: u64) -> Self {
+        Self {
+            max_retained_bytes,
+            state: Mutex::new(ExactPrefixCacheState::default()),
+        }
+    }
+
+    pub(super) fn max_retained_bytes(&self) -> u64 {
+        self.max_retained_bytes
+    }
+
+    pub(super) fn lookup(
+        &self,
+        owner: &Arc<O>,
+        scope: &ExactPrefixScope,
+        prompt_ids: &[u32],
+        prompt_positions: &[[usize; 3]],
+    ) -> Option<Arc<ExactPrefixHandle<S>>> {
+        if self.max_retained_bytes == 0 || prompt_ids.len() != prompt_positions.len() {
+            return None;
+        }
+
+        let requested_owner = Arc::downgrade(owner);
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        remove_stale_entries(&mut state);
+
+        let best = state
+            .entries
+            .iter()
+            .enumerate()
+            .filter(|(_, entry)| {
+                entry.scope == *scope
+                    && Weak::ptr_eq(&entry.owner, &requested_owner)
+                    && exact_prefix_matches(entry.cached.snapshot(), prompt_ids, prompt_positions)
+            })
+            .max_by_key(|(_, entry)| entry.cached.snapshot().token_ids().len())
+            .map(|(index, _)| index)?;
+
+        let entry = state
+            .entries
+            .remove(best)
+            .expect("selected exact-prefix entry must still exist");
+        let cached = Arc::clone(&entry.cached);
+        state.entries.push_back(entry);
+        Some(cached)
+    }
+
+    /// Insert one immutable snapshot. Oversized or unaccountable snapshots are
+    /// skipped instead of weakening the byte bound or failing inference.
+    pub(super) fn insert(
+        &self,
+        owner: &Arc<O>,
+        scope: ExactPrefixScope,
+        cached: Arc<ExactPrefixHandle<S>>,
+    ) -> bool {
+        let Some(retained_bytes) = cached.snapshot().retained_bytes() else {
+            return false;
+        };
+        if self.max_retained_bytes == 0 || retained_bytes > self.max_retained_bytes {
+            return false;
+        }
+
+        let owner = Arc::downgrade(owner);
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        remove_stale_entries(&mut state);
+
+        if let Some(index) = state.entries.iter().position(|entry| {
+            entry.scope == scope
+                && Weak::ptr_eq(&entry.owner, &owner)
+                && entry.cached.snapshot().token_ids() == cached.snapshot().token_ids()
+                && entry.cached.snapshot().positions() == cached.snapshot().positions()
+        }) {
+            if Arc::strong_count(&state.entries[index].cached) > 1 {
+                return false;
+            }
+            if let Some(replaced) = state.entries.remove(index) {
+                state.retained_bytes = state.retained_bytes.saturating_sub(replaced.retained_bytes);
+            }
+        }
+
+        while state.retained_bytes.saturating_add(retained_bytes) > self.max_retained_bytes {
+            let Some(index) = state
+                .entries
+                .iter()
+                .position(|entry| Arc::strong_count(&entry.cached) == 1)
+            else {
+                return false;
+            };
+            let evicted = state
+                .entries
+                .remove(index)
+                .expect("selected evictable prefix entry must exist");
+            state.retained_bytes = state.retained_bytes.saturating_sub(evicted.retained_bytes);
+        }
+
+        state.retained_bytes = state.retained_bytes.saturating_add(retained_bytes);
+        state.entries.push_back(ExactPrefixEntry {
+            scope,
+            owner,
+            cached,
+            retained_bytes,
+        });
+        true
+    }
+
+    pub(super) fn retained_bytes(&self) -> u64 {
+        self.state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .retained_bytes
+    }
+
+    pub(super) fn clear(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        state.entries.clear();
+        state.retained_bytes = 0;
+    }
+}
+
+fn exact_prefix_matches<S: ExactPrefixSnapshot + ?Sized>(
+    snapshot: &S,
+    prompt_ids: &[u32],
+    prompt_positions: &[[usize; 3]],
+) -> bool {
+    let cached_ids = snapshot.token_ids();
+    let cached_positions = snapshot.positions();
+    !cached_ids.is_empty()
+        && cached_ids.len() == cached_positions.len()
+        && prompt_ids.starts_with(cached_ids)
+        && prompt_positions.starts_with(cached_positions)
+}
+
+fn remove_stale_entries<O, S>(state: &mut ExactPrefixCacheState<O, S>) {
+    let mut retained_bytes = state.retained_bytes;
+    state.entries.retain(|entry| {
+        // A lookup handle owns the snapshot and its lease independently of the
+        // LRU entry, so a dead model owner can always be pruned immediately.
+        let retain = entry.owner.strong_count() > 0;
+        if !retain {
+            retained_bytes = retained_bytes.saturating_sub(entry.retained_bytes);
+        }
+        retain
+    });
+    state.retained_bytes = retained_bytes;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::resources::{
+        PhysicalCapacityProvider, PhysicalCapacitySnapshot, ReservationClass, ReservationOwner,
+        ResourceAuthority,
+    };
+
+    #[derive(Debug)]
+    struct TestSnapshot {
+        ids: Vec<u32>,
+        positions: Vec<[usize; 3]>,
+        bytes: u64,
+        label: &'static str,
+    }
+
+    #[derive(Debug)]
+    struct TestCapacityProvider {
+        snapshot: PhysicalCapacitySnapshot,
+    }
+
+    impl PhysicalCapacityProvider for TestCapacityProvider {
+        fn snapshot(&self) -> PhysicalCapacitySnapshot {
+            self.snapshot
+        }
+    }
+
+    impl ExactPrefixSnapshot for TestSnapshot {
+        fn token_ids(&self) -> &[u32] {
+            &self.ids
+        }
+
+        fn positions(&self) -> &[[usize; 3]] {
+            &self.positions
+        }
+
+        fn retained_bytes(&self) -> Option<u64> {
+            Some(self.bytes)
+        }
+    }
+
+    fn scope() -> ExactPrefixScope {
+        ExactPrefixScope {
+            variant: ModelVariant::Qwen354BGguf,
+            backend: BackendKind::Cpu,
+            activation_dtype: "float32".to_string(),
+            kv_cache_dtype: "float16".to_string(),
+        }
+    }
+
+    fn snapshot(
+        ids: &[u32],
+        bytes: u64,
+        label: &'static str,
+    ) -> Arc<ExactPrefixHandle<TestSnapshot>> {
+        ExactPrefixHandle::new(
+            BackendKind::Cpu,
+            TestSnapshot {
+                ids: ids.to_vec(),
+                positions: (0..ids.len()).map(|index| [index; 3]).collect(),
+                bytes,
+                label,
+            },
+            None,
+        )
+    }
+
+    fn positions(len: usize) -> Vec<[usize; 3]> {
+        (0..len).map(|index| [index; 3]).collect()
+    }
+
+    #[test]
+    fn lookup_returns_the_longest_exact_token_and_position_prefix() {
+        let cache = ExactPrefixCache::<(), TestSnapshot>::new(128);
+        let owner = Arc::new(());
+        assert!(cache.insert(&owner, scope(), snapshot(&[1, 2], 10, "short")));
+        assert!(cache.insert(&owner, scope(), snapshot(&[1, 2, 3], 10, "long"),));
+
+        let hit = cache
+            .lookup(&owner, &scope(), &[1, 2, 3, 4], &positions(4))
+            .expect("longest exact prefix");
+        assert_eq!(hit.snapshot().label, "long");
+    }
+
+    #[test]
+    fn lookup_rejects_token_position_scope_and_model_mismatches() {
+        let cache = ExactPrefixCache::<(), TestSnapshot>::new(128);
+        let owner = Arc::new(());
+        assert!(cache.insert(&owner, scope(), snapshot(&[1, 2, 3], 10, "entry"),));
+
+        assert!(cache
+            .lookup(&owner, &scope(), &[1, 9, 3, 4], &positions(4))
+            .is_none());
+        let mut wrong_positions = positions(4);
+        wrong_positions[2] = [99; 3];
+        assert!(cache
+            .lookup(&owner, &scope(), &[1, 2, 3, 4], &wrong_positions)
+            .is_none());
+
+        let mut wrong_scope = scope();
+        wrong_scope.backend = BackendKind::Metal;
+        assert!(cache
+            .lookup(&owner, &wrong_scope, &[1, 2, 3, 4], &positions(4))
+            .is_none());
+        assert!(cache
+            .lookup(&Arc::new(()), &scope(), &[1, 2, 3, 4], &positions(4),)
+            .is_none());
+    }
+
+    #[test]
+    fn byte_bound_evicts_the_least_recently_used_entry() {
+        let cache = ExactPrefixCache::<(), TestSnapshot>::new(12);
+        let owner = Arc::new(());
+        assert!(cache.insert(&owner, scope(), snapshot(&[1], 4, "first")));
+        assert!(cache.insert(&owner, scope(), snapshot(&[2], 4, "second")));
+        assert!(cache
+            .lookup(&owner, &scope(), &[1, 9], &positions(2))
+            .is_some());
+        assert!(cache.insert(&owner, scope(), snapshot(&[3], 6, "third")));
+
+        assert!(cache
+            .lookup(&owner, &scope(), &[2, 9], &positions(2))
+            .is_none());
+        assert!(cache
+            .lookup(&owner, &scope(), &[1, 9], &positions(2))
+            .is_some());
+        assert!(cache
+            .lookup(&owner, &scope(), &[3, 9], &positions(2))
+            .is_some());
+        assert_eq!(cache.retained_bytes(), 10);
+    }
+
+    #[test]
+    fn stale_model_owner_is_pruned_and_oversized_entries_are_skipped() {
+        let cache = ExactPrefixCache::<(), TestSnapshot>::new(8);
+        let owner = Arc::new(());
+        assert!(cache.insert(&owner, scope(), snapshot(&[1], 8, "stale")));
+        drop(owner);
+
+        let replacement_owner = Arc::new(());
+        assert!(cache
+            .lookup(&replacement_owner, &scope(), &[1, 2], &positions(2),)
+            .is_none());
+        assert_eq!(cache.retained_bytes(), 0);
+        assert!(!cache.insert(&replacement_owner, scope(), snapshot(&[2], 9, "oversized"),));
+    }
+
+    #[test]
+    fn lookup_handle_keeps_exact_resource_lease_after_cache_clear() {
+        let capacity = super::super::cache_resource_vector(BackendKind::Cpu, 64);
+        let authority = Arc::new(ResourceAuthority::new(Arc::new(TestCapacityProvider {
+            snapshot: PhysicalCapacitySnapshot {
+                capacity,
+                available: capacity,
+                source: crate::engine::resources::CapacitySource::Test,
+            },
+        })));
+        let resources = super::super::cache_resource_vector(BackendKind::Cpu, 4);
+        let lease = authority
+            .reserve_with_initial_materialized(
+                ReservationOwner::new(ReservationClass::Cache, "prefix"),
+                resources,
+                resources,
+            )
+            .unwrap();
+        let cache = ExactPrefixCache::<(), TestSnapshot>::new(8);
+        let owner = Arc::new(());
+        let cached = ExactPrefixHandle::new(
+            BackendKind::Cpu,
+            TestSnapshot {
+                ids: vec![1],
+                positions: vec![[0; 3]],
+                bytes: 4,
+                label: "leased",
+            },
+            Some(lease),
+        );
+        assert!(cache.insert(&owner, scope(), cached));
+        let hit = cache
+            .lookup(&owner, &scope(), &[1, 2], &positions(2))
+            .unwrap();
+
+        cache.clear();
+        assert_eq!(authority.snapshot().reservations, 1);
+        assert_eq!(hit.snapshot().label, "leased");
+        drop(hit);
+        assert_eq!(authority.snapshot().reservations, 0);
+    }
+
+    #[test]
+    fn dropping_unpublished_pending_handle_releases_exact_authorization() {
+        let capacity = super::super::cache_resource_vector(BackendKind::Cpu, 64);
+        let authority = Arc::new(ResourceAuthority::new(Arc::new(TestCapacityProvider {
+            snapshot: PhysicalCapacitySnapshot {
+                capacity,
+                available: capacity,
+                source: crate::engine::resources::CapacitySource::Test,
+            },
+        })));
+        let resources = super::super::cache_resource_vector(BackendKind::Cpu, 4);
+        let lease = authority
+            .reserve_with_initial_materialized(
+                ReservationOwner::new(ReservationClass::Cache, "pending-prefix"),
+                resources,
+                resources,
+            )
+            .unwrap();
+        let pending = ExactPrefixHandle::new(
+            BackendKind::Cpu,
+            TestSnapshot {
+                ids: vec![1],
+                positions: vec![[0; 3]],
+                bytes: 4,
+                label: "pending",
+            },
+            Some(lease),
+        );
+        assert_eq!(authority.snapshot().reservations, 1);
+        drop(pending);
+        assert_eq!(authority.snapshot().reservations, 0);
+    }
+}

--- a/crates/izwi-core/src/engine/executor/state.rs
+++ b/crates/izwi-core/src/engine/executor/state.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+use super::prefix_cache::ExactPrefixHandle;
 use crate::model::ModelVariant;
 use crate::models::architectures::qwen3::tts::Qwen3TtsModel;
 use crate::models::architectures::qwen3::tts::TtsDecodeState as QwenTtsDecodeState;
+use crate::models::architectures::qwen35::chat::Qwen35PrefixSnapshot;
 use crate::models::registry::{
     AsrModelLease, NativeAsrDecodeState, NativeAsrModel, NativeChatDecodeState, QwenTtsModelLease,
 };
@@ -13,6 +15,7 @@ pub(super) struct ActiveChatDecode {
     pub(super) state: NativeChatDecodeState,
     pub(super) last_tokens_generated: usize,
     pub(super) stream_sequence: usize,
+    pub(super) pending_prefix_snapshot: Option<Arc<ExactPrefixHandle<Qwen35PrefixSnapshot>>>,
 }
 
 pub(super) struct ActiveAsrDecode {

--- a/crates/izwi-core/src/engine/mod.rs
+++ b/crates/izwi-core/src/engine/mod.rs
@@ -50,8 +50,8 @@ pub use execution::{
     WorkUnit, YieldReason,
 };
 pub use executor::{
-    ExecutorOutput, ExecutorStepResult, ModelExecutor, ModelSessionResult, WorkerConfig,
-    REQUEST_DEADLINE_EXCEEDED,
+    CacheReleaseReport, ExecutorOutput, ExecutorStepResult, ModelExecutor, ModelSessionResult,
+    WorkerConfig, REQUEST_DEADLINE_EXCEEDED,
 };
 pub use kv_cache::{
     BlockAllocator, CacheResidency, KVCacheConfig as KVConfig, KVCacheManager, KVCacheStats,
@@ -1105,6 +1105,11 @@ impl Engine {
             self.wake_notify.notify_one();
         }
         aborted
+    }
+
+    /// Purge reusable executor cache state owned by one model variant.
+    pub async fn purge_model_cache(&self, variant: ModelVariant) -> CacheReleaseReport {
+        self.core.write().await.purge_model_cache(variant).await
     }
 
     /// Abort every request currently tracked by the engine.

--- a/crates/izwi-core/src/engine/output/mod.rs
+++ b/crates/izwi-core/src/engine/output/mod.rs
@@ -201,6 +201,21 @@ impl OutputProcessor {
                 executor_output.error = None;
                 Some(FinishReason::StopToken)
             }
+            ExecutionDisposition::Finished(ExecutionFinishReason::MaxTokens) => {
+                executor_output.finished = true;
+                executor_output.error = None;
+                Some(FinishReason::MaxTokens)
+            }
+            ExecutionDisposition::Finished(ExecutionFinishReason::StopToken) => {
+                executor_output.finished = true;
+                executor_output.error = None;
+                Some(FinishReason::StopToken)
+            }
+            ExecutionDisposition::Finished(ExecutionFinishReason::StopSequence) => {
+                executor_output.finished = true;
+                executor_output.error = None;
+                Some(FinishReason::StopSequence)
+            }
             ExecutionDisposition::Finished(ExecutionFinishReason::Cancelled) => {
                 executor_output.finished = true;
                 executor_output.error = Some("request cancelled".to_string());
@@ -488,6 +503,27 @@ mod tests {
         assert_eq!(output.finish_reason, Some(FinishReason::Aborted));
         assert_eq!(output.error.as_deref(), Some("request cancelled"));
         assert_eq!(output.num_tokens, 0);
+    }
+
+    #[test]
+    fn successful_chat_finish_reasons_remain_exact() {
+        for (execution, expected) in [
+            (ExecutionFinishReason::MaxTokens, FinishReason::MaxTokens),
+            (ExecutionFinishReason::StopToken, FinishReason::StopToken),
+            (
+                ExecutionFinishReason::StopSequence,
+                FinishReason::StopSequence,
+            ),
+        ] {
+            let mut processor = OutputProcessor::new(24_000);
+            let output = processor.process_execution(
+                ExecutorOutput::terminal("chat".to_string()),
+                &ExecutionDisposition::Finished(execution),
+                10,
+                Duration::from_millis(1),
+            );
+            assert_eq!(output.finish_reason, Some(expected));
+        }
     }
 
     #[test]

--- a/crates/izwi-core/src/engine/request.rs
+++ b/crates/izwi-core/src/engine/request.rs
@@ -1477,6 +1477,7 @@ impl EngineCoreRequest {
             top_k: self.params.top_k,
             repetition_penalty: self.params.repetition_penalty.max(1.0),
             presence_penalty: self.params.presence_penalty.clamp(-2.0, 2.0),
+            stop_sequences: self.params.stop_sequences.clone(),
             stop_token_ids: self.params.stop_token_ids.clone(),
             seed: Self::chat_request_seed(&self.id),
             request: self.chat_config.clone(),

--- a/crates/izwi-core/src/kernels/cuda.rs
+++ b/crates/izwi-core/src/kernels/cuda.rs
@@ -5,7 +5,7 @@
 //! by `Device::is_cuda()` and fall back to the caller's existing implementation
 //! when a shape, dtype, or build does not support the operation.
 
-use candle_core::{DType, Tensor, D};
+use candle_core::{CpuStorage, CustomOp3, DType, Layout, Shape, Tensor, D};
 
 use crate::kernels::FusedSiluMulResult;
 
@@ -99,6 +99,62 @@ pub fn try_fused_gated_rms_norm(
     normalized.broadcast_mul(&silu_gate).ok()
 }
 
+pub fn try_qwen35_causal_conv_sequence(
+    input: &Tensor,
+    weight: &Tensor,
+    history: &Tensor,
+) -> Option<(Tensor, Tensor)> {
+    if !cuda_tensor_pair_supported(input, weight)
+        || !cuda_tensor_pair_supported(input, history)
+        || input.dtype() != DType::F32
+    {
+        return None;
+    }
+    let (batch, sequence, conv_dim) = input.dims3().ok()?;
+    let (weight_channels, kernel_size) = weight.dims2().ok()?;
+    let (history_channels, history_len) = history.dims2().ok()?;
+    if batch != 1
+        || sequence == 0
+        || conv_dim == 0
+        || kernel_size < 2
+        || weight_channels != conv_dim
+        || history_channels != conv_dim
+        || history_len != kernel_size - 1
+    {
+        return None;
+    }
+
+    let input = input.contiguous().ok()?;
+    let weight = weight.contiguous().ok()?;
+    let history = history.contiguous().ok()?;
+    let output_elements = sequence.checked_mul(conv_dim)?;
+    let state_elements = history_len.checked_mul(conv_dim)?;
+    let packed = input
+        .apply_op3_no_bwd(
+            &weight,
+            &history,
+            &CudaCausalConvSequenceOp {
+                conv_dim,
+                sequence,
+                kernel_size,
+            },
+        )
+        .ok()?;
+    let output = packed
+        .narrow(0, 0, output_elements)
+        .ok()?
+        .reshape((1, sequence, conv_dim))
+        .ok()?;
+    let final_history = packed
+        .narrow(0, output_elements, state_elements)
+        .ok()?
+        .reshape((conv_dim, history_len))
+        .ok()?
+        .force_contiguous()
+        .ok()?;
+    Some((output, final_history))
+}
+
 pub fn try_fused_gated_delta_recurrent(
     query: &Tensor,
     key: &Tensor,
@@ -117,7 +173,14 @@ pub fn try_fused_gated_delta_recurrent(
         return None;
     }
 
-    fused_gated_delta_candle(query, key, value, g, beta, state)
+    let queries = query.unsqueeze(1).ok()?;
+    let keys = key.unsqueeze(1).ok()?;
+    let values = value.unsqueeze(1).ok()?;
+    let gates = g.unsqueeze(1).ok()?;
+    let betas = beta.unsqueeze(1).ok()?;
+    let (outputs, next_state) =
+        cuda_gated_delta_sequence(&queries, &keys, &values, &gates, &betas, state)?;
+    Some((outputs.squeeze(1).ok()?, next_state))
 }
 
 pub fn try_tiled_deltanet_recurrence(
@@ -127,7 +190,7 @@ pub fn try_tiled_deltanet_recurrence(
     g: &Tensor,
     beta: &Tensor,
     initial_state: &Tensor,
-    tile_size: usize,
+    _tile_size: usize,
 ) -> Option<(Tensor, Tensor)> {
     if !cuda_tensor_pair_supported(queries, keys)
         || !cuda_tensor_pair_supported(queries, values)
@@ -141,10 +204,10 @@ pub fn try_tiled_deltanet_recurrence(
 
     let (batch, seq_len, num_heads, head_k_dim) = queries.dims4().ok()?;
     let (k_batch, k_seq_len, k_num_heads, k_head_k_dim) = keys.dims4().ok()?;
-    let (v_batch, v_seq_len, v_num_heads, _v_head_dim) = values.dims4().ok()?;
+    let (v_batch, v_seq_len, v_num_heads, v_head_dim) = values.dims4().ok()?;
     let (g_batch, g_seq_len, g_heads) = g.dims3().ok()?;
     let (b_batch, b_seq_len, b_heads) = beta.dims3().ok()?;
-    let (s_batch, s_heads, s_head_k_dim, _s_head_v_dim) = initial_state.dims4().ok()?;
+    let (s_batch, s_heads, s_head_k_dim, s_head_v_dim) = initial_state.dims4().ok()?;
 
     if batch != 1
         || k_batch != batch
@@ -165,33 +228,11 @@ pub fn try_tiled_deltanet_recurrence(
     if b_heads != num_heads || k_head_k_dim != head_k_dim || s_heads != num_heads {
         return None;
     }
-    if s_head_k_dim != head_k_dim {
+    if s_head_k_dim != head_k_dim || s_head_v_dim != v_head_dim {
         return None;
     }
 
-    let tile_size = tile_size.max(1).min(seq_len.max(1));
-    let mut outputs = Vec::with_capacity(seq_len);
-    let mut state = initial_state.clone();
-
-    for tile_start in (0..seq_len).step_by(tile_size) {
-        let tile_end = (tile_start + tile_size).min(seq_len);
-        for token_idx in tile_start..tile_end {
-            let query = queries.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-            let key = keys.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-            let value = values.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-            let g_t = g.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-            let beta_t = beta.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-
-            let (output, next_state) =
-                fused_gated_delta_candle(&query, &key, &value, &g_t, &beta_t, &state)?;
-            outputs.push(output.unsqueeze(1).ok()?);
-            state = next_state;
-        }
-    }
-
-    let output_refs: Vec<&Tensor> = outputs.iter().collect();
-    let outputs = Tensor::cat(&output_refs, 1).ok()?;
-    Some((outputs, state))
+    cuda_gated_delta_sequence(queries, keys, values, g, beta, initial_state)
 }
 
 fn cuda_tensor_supported(tensor: &Tensor) -> bool {
@@ -202,45 +243,287 @@ fn cuda_tensor_pair_supported(lhs: &Tensor, rhs: &Tensor) -> bool {
     cuda_tensor_supported(lhs) && rhs.device().is_cuda() && lhs.dtype() == rhs.dtype()
 }
 
-fn fused_gated_delta_candle(
-    query: &Tensor,
-    key: &Tensor,
-    value: &Tensor,
+fn cuda_gated_delta_sequence(
+    queries: &Tensor,
+    keys: &Tensor,
+    values: &Tensor,
     g: &Tensor,
     beta: &Tensor,
-    state: &Tensor,
+    initial_state: &Tensor,
 ) -> Option<(Tensor, Tensor)> {
-    let dim = query.dim(D::Minus1).ok()?;
-    let scale = 1.0f64 / (dim as f64).sqrt();
-    let scaled_query = (query * scale).ok()?;
-    let g = g.exp().ok()?.reshape((1, g.dim(1).ok()?, 1, 1)).ok()?;
-    let beta = beta.reshape((1, beta.dim(1).ok()?, 1)).ok()?;
+    let (batch, sequence, heads, key_dim) = queries.dims4().ok()?;
+    let (key_batch, key_sequence, key_heads, key_width) = keys.dims4().ok()?;
+    let (value_batch, value_sequence, value_heads, value_dim) = values.dims4().ok()?;
+    let (g_batch, g_sequence, g_heads) = g.dims3().ok()?;
+    let (beta_batch, beta_sequence, beta_heads) = beta.dims3().ok()?;
+    let (state_batch, state_heads, state_key_dim, state_value_dim) = initial_state.dims4().ok()?;
+    if sequence == 0 || heads == 0 || key_dim == 0 || value_dim == 0 {
+        return None;
+    }
+    if (key_batch, key_sequence, key_heads, key_width) != (batch, sequence, heads, key_dim)
+        || (value_batch, value_sequence, value_heads) != (batch, sequence, heads)
+        || (g_batch, g_sequence, g_heads) != (batch, sequence, heads)
+        || (beta_batch, beta_sequence, beta_heads) != (batch, sequence, heads)
+        || (state_batch, state_heads, state_key_dim, state_value_dim)
+            != (batch, heads, key_dim, value_dim)
+    {
+        return None;
+    }
 
-    let gated_state = state.broadcast_mul(&g).ok()?;
-    let kv_mem = key
-        .unsqueeze(2)
+    let qkv = Tensor::cat(&[queries, keys, values], D::Minus1)
         .ok()?
-        .matmul(&gated_state)
-        .ok()?
-        .squeeze(2)
+        .contiguous()
         .ok()?;
-    let delta = (value - kv_mem).ok()?.broadcast_mul(&beta).ok()?;
-    let new_state = (&gated_state
-        + &key
-            .unsqueeze(3)
-            .ok()?
-            .matmul(&delta.unsqueeze(2).ok()?)
-            .ok()?)
-        .ok()?;
-    let output = scaled_query
-        .unsqueeze(2)
-        .ok()?
-        .matmul(&new_state)
-        .ok()?
-        .squeeze(2)
+    let gates = Tensor::cat(
+        &[
+            &g.unsqueeze(D::Minus1).ok()?,
+            &beta.unsqueeze(D::Minus1).ok()?,
+        ],
+        D::Minus1,
+    )
+    .ok()?
+    .contiguous()
+    .ok()?;
+    let initial_state = initial_state.contiguous().ok()?;
+    let packed = qkv
+        .apply_op3_no_bwd(
+            &gates,
+            &initial_state,
+            &CudaGatedDeltaSequenceOp {
+                batch,
+                sequence,
+                heads,
+                key_dim,
+                value_dim,
+            },
+        )
         .ok()?;
 
-    Some((output, new_state))
+    let output_elements = batch * sequence * heads * value_dim;
+    let state_elements = batch * heads * key_dim * value_dim;
+    let outputs = packed
+        .narrow(0, 0, output_elements)
+        .ok()?
+        .reshape((batch, sequence, heads, value_dim))
+        .ok()?;
+    let next_state = packed
+        .narrow(0, output_elements, state_elements)
+        .ok()?
+        .reshape((batch, heads, key_dim, value_dim))
+        .ok()?
+        // The packed custom-op result also contains sequence outputs. Detach
+        // the persistent state so it retains only its exact live allocation.
+        .force_contiguous()
+        .ok()?;
+    Some((outputs, next_state))
+}
+
+struct CudaCausalConvSequenceOp {
+    conv_dim: usize,
+    sequence: usize,
+    kernel_size: usize,
+}
+
+impl CustomOp3 for CudaCausalConvSequenceOp {
+    fn name(&self) -> &'static str {
+        "qwen35-causal-conv-sequence"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _input: &CpuStorage,
+        _input_layout: &Layout,
+        _weight: &CpuStorage,
+        _weight_layout: &Layout,
+        _history: &CpuStorage,
+        _history_layout: &Layout,
+    ) -> candle_core::Result<(CpuStorage, Shape)> {
+        candle_core::bail!("Qwen3.5 CUDA causal convolution has no CPU implementation")
+    }
+
+    #[cfg(feature = "cuda")]
+    fn cuda_fwd(
+        &self,
+        input: &candle_core::CudaStorage,
+        input_layout: &Layout,
+        weight: &candle_core::CudaStorage,
+        weight_layout: &Layout,
+        history: &candle_core::CudaStorage,
+        history_layout: &Layout,
+    ) -> candle_core::Result<(candle_core::CudaStorage, Shape)> {
+        use candle_core::backend::BackendStorage;
+        use candle_core::cuda_backend::cudarc::driver::{LaunchConfig, PushKernelArg};
+        use candle_core::cuda_backend::{CudaStorageSlice, WrapErr};
+
+        fn contiguous_slice<'a>(
+            storage: &'a CudaStorageSlice,
+            layout: &Layout,
+            name: &str,
+        ) -> candle_core::Result<candle_core::cuda_backend::cudarc::driver::CudaView<'a, f32>>
+        {
+            let CudaStorageSlice::F32(slice) = storage else {
+                candle_core::bail!("{name} must use F32 storage")
+            };
+            let Some((start, end)) = layout.contiguous_offsets() else {
+                candle_core::bail!("{name} must be contiguous")
+            };
+            Ok(slice.slice(start..end))
+        }
+
+        let input_slice = contiguous_slice(&input.slice, input_layout, "input")?;
+        let weight_slice = contiguous_slice(&weight.slice, weight_layout, "weight")?;
+        let history_slice = contiguous_slice(&history.slice, history_layout, "history")?;
+        let output_elements = self.sequence.checked_mul(self.conv_dim).ok_or_else(|| {
+            candle_core::Error::Msg("Qwen3.5 CUDA convolution output overflow".to_string())
+        })?;
+        let state_elements = (self.kernel_size - 1)
+            .checked_mul(self.conv_dim)
+            .ok_or_else(|| {
+                candle_core::Error::Msg("Qwen3.5 CUDA convolution state overflow".to_string())
+            })?;
+        let total_elements = output_elements.checked_add(state_elements).ok_or_else(|| {
+            candle_core::Error::Msg("Qwen3.5 CUDA convolution allocation overflow".to_string())
+        })?;
+        if total_elements > i32::MAX as usize {
+            candle_core::bail!("Qwen3.5 CUDA convolution tensor is too large")
+        }
+        let device = input.device();
+        // SAFETY: the custom kernel writes every element before the storage is observed.
+        let output = unsafe { device.alloc::<f32>(total_elements)? };
+        let function = device.get_or_load_custom_func(
+            "qwen35_causal_conv_sequence_f32",
+            "izwi_qwen35_causal_conv_sequence",
+            qwen35_cuda_ptx::QWEN35,
+        )?;
+        let config = LaunchConfig::for_num_elems(total_elements as u32);
+        let mut builder = function.builder();
+        builder.arg(&input_slice);
+        builder.arg(&weight_slice);
+        builder.arg(&history_slice);
+        builder.arg(&output);
+        candle_core::builder_arg!(
+            builder,
+            self.conv_dim as i32,
+            self.sequence as i32,
+            self.kernel_size as i32,
+            output_elements as i32,
+            total_elements as i32
+        );
+        // SAFETY: argument types and element bounds match the CUDA kernel signature.
+        unsafe { builder.launch(config) }.w()?;
+
+        Ok((
+            candle_core::CudaStorage {
+                slice: CudaStorageSlice::F32(output),
+                device: device.clone(),
+            },
+            Shape::from_dims(&[total_elements]),
+        ))
+    }
+}
+
+struct CudaGatedDeltaSequenceOp {
+    batch: usize,
+    sequence: usize,
+    heads: usize,
+    key_dim: usize,
+    value_dim: usize,
+}
+
+impl CustomOp3 for CudaGatedDeltaSequenceOp {
+    fn name(&self) -> &'static str {
+        "qwen35-gated-delta-sequence"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _qkv: &CpuStorage,
+        _qkv_layout: &Layout,
+        _gates: &CpuStorage,
+        _gates_layout: &Layout,
+        _state: &CpuStorage,
+        _state_layout: &Layout,
+    ) -> candle_core::Result<(CpuStorage, Shape)> {
+        candle_core::bail!("Qwen3.5 CUDA recurrence has no CPU implementation")
+    }
+
+    #[cfg(feature = "cuda")]
+    fn cuda_fwd(
+        &self,
+        qkv: &candle_core::CudaStorage,
+        qkv_layout: &Layout,
+        gates: &candle_core::CudaStorage,
+        gates_layout: &Layout,
+        state: &candle_core::CudaStorage,
+        state_layout: &Layout,
+    ) -> candle_core::Result<(candle_core::CudaStorage, Shape)> {
+        use candle_core::backend::BackendStorage;
+        use candle_core::cuda_backend::cudarc::driver::{LaunchConfig, PushKernelArg};
+        use candle_core::cuda_backend::{CudaStorageSlice, WrapErr};
+
+        fn contiguous_slice<'a>(
+            storage: &'a CudaStorageSlice,
+            layout: &Layout,
+            name: &str,
+        ) -> candle_core::Result<candle_core::cuda_backend::cudarc::driver::CudaView<'a, f32>>
+        {
+            let CudaStorageSlice::F32(slice) = storage else {
+                candle_core::bail!("{name} must use F32 storage")
+            };
+            let Some((start, end)) = layout.contiguous_offsets() else {
+                candle_core::bail!("{name} must be contiguous")
+            };
+            Ok(slice.slice(start..end))
+        }
+
+        let qkv_slice = contiguous_slice(&qkv.slice, qkv_layout, "qkv")?;
+        let gates_slice = contiguous_slice(&gates.slice, gates_layout, "gates")?;
+        let state_slice = contiguous_slice(&state.slice, state_layout, "initial_state")?;
+        let device = qkv.device();
+        let output_elements = self.batch * self.sequence * self.heads * self.value_dim;
+        let state_elements = self.batch * self.heads * self.key_dim * self.value_dim;
+        // SAFETY: the custom kernel writes every element before the storage is observed.
+        let output = unsafe { device.alloc::<f32>(output_elements + state_elements)? };
+        let function = device.get_or_load_custom_func(
+            "qwen35_gated_delta_sequence_f32",
+            "izwi_qwen35_gated_delta_sequence",
+            qwen35_cuda_ptx::QWEN35,
+        )?;
+        let block_size = self.value_dim.next_power_of_two().clamp(32, 256) as u32;
+        let config = LaunchConfig {
+            grid_dim: ((self.batch * self.heads) as u32, 1, 1),
+            block_dim: (block_size, 1, 1),
+            shared_mem_bytes: 0,
+        };
+        let mut builder = function.builder();
+        builder.arg(&qkv_slice);
+        builder.arg(&gates_slice);
+        builder.arg(&state_slice);
+        builder.arg(&output);
+        candle_core::builder_arg!(
+            builder,
+            self.batch as i32,
+            self.sequence as i32,
+            self.heads as i32,
+            self.key_dim as i32,
+            self.value_dim as i32
+        );
+        // SAFETY: argument types and launch dimensions match the CUDA kernel signature.
+        unsafe { builder.launch(config) }.w()?;
+
+        Ok((
+            candle_core::CudaStorage {
+                slice: CudaStorageSlice::F32(output),
+                device: device.clone(),
+            },
+            Shape::from_dims(&[output_elements + state_elements]),
+        ))
+    }
+}
+
+#[cfg(feature = "cuda")]
+mod qwen35_cuda_ptx {
+    include!(concat!(env!("OUT_DIR"), "/qwen35_ptx.rs"));
 }
 
 #[cfg(test)]

--- a/crates/izwi-core/src/kernels/cuda/qwen35.cu
+++ b/crates/izwi-core/src/kernels/cuda/qwen35.cu
@@ -1,0 +1,103 @@
+#include <math.h>
+
+extern "C" __global__ void qwen35_causal_conv_sequence_f32(
+    const float* __restrict__ input,
+    const float* __restrict__ weight,
+    const float* __restrict__ history,
+    float* __restrict__ packed_output,
+    int conv_dim,
+    int sequence,
+    int kernel_size,
+    int output_elements,
+    int total_elements) {
+  const int gid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (gid >= total_elements) return;
+
+  const int history_len = kernel_size - 1;
+  if (gid < output_elements) {
+    const int token_idx = gid / conv_dim;
+    const int channel_idx = gid - token_idx * conv_dim;
+    float value = 0.0f;
+    for (int tap = 0; tap < kernel_size; ++tap) {
+      const int source_idx = token_idx + tap;
+      const float source = source_idx < history_len
+          ? history[channel_idx * history_len + source_idx]
+          : input[(source_idx - history_len) * conv_dim + channel_idx];
+      value += source * weight[channel_idx * kernel_size + tap];
+    }
+    packed_output[gid] = value / (1.0f + expf(-value));
+    return;
+  }
+
+  const int state_idx = gid - output_elements;
+  const int channel_idx = state_idx / history_len;
+  const int history_idx = state_idx - channel_idx * history_len;
+  const int source_idx = sequence + history_idx;
+  packed_output[gid] = source_idx < history_len
+      ? history[channel_idx * history_len + source_idx]
+      : input[(source_idx - history_len) * conv_dim + channel_idx];
+}
+
+// Qwen3.5 Gated DeltaNet sequence recurrence for F32 tensors.
+//
+// One CUDA block owns one (batch, head) pair. Each lane owns one or more
+// value columns, so the complete recurrent state remains on-device for the
+// whole sequence and no synchronization is needed between value columns.
+extern "C" __global__ void qwen35_gated_delta_sequence_f32(
+    const float* __restrict__ qkv,
+    const float* __restrict__ gates,
+    const float* __restrict__ initial_state,
+    float* __restrict__ packed_output,
+    int batch,
+    int sequence,
+    int heads,
+    int key_dim,
+    int value_dim) {
+  const int batch_head = blockIdx.x;
+  if (batch_head >= batch * heads) {
+    return;
+  }
+  const int batch_idx = batch_head / heads;
+  const int head_idx = batch_head - batch_idx * heads;
+  const int output_elements = batch * sequence * heads * value_dim;
+  float* state = packed_output + output_elements;
+  const int state_base = batch_head * key_dim * value_dim;
+
+  for (int index = threadIdx.x; index < key_dim * value_dim;
+       index += blockDim.x) {
+    state[state_base + index] = initial_state[state_base + index];
+  }
+  __syncthreads();
+
+  const float query_scale = rsqrtf((float)key_dim);
+  const int qkv_width = key_dim * 2 + value_dim;
+  for (int value_idx = threadIdx.x; value_idx < value_dim;
+       value_idx += blockDim.x) {
+    for (int token_idx = 0; token_idx < sequence; ++token_idx) {
+      const int token_head = (batch_idx * sequence + token_idx) * heads + head_idx;
+      const int qkv_base = token_head * qkv_width;
+      const int gate_base = token_head * 2;
+      const float decay = expf(gates[gate_base]);
+      const float beta = gates[gate_base + 1];
+
+      float recalled_value = 0.0f;
+      for (int key_idx = 0; key_idx < key_dim; ++key_idx) {
+        const int state_idx = state_base + key_idx * value_dim + value_idx;
+        recalled_value += qkv[qkv_base + key_dim + key_idx]
+                            * (decay * state[state_idx]);
+      }
+      const float delta =
+          (qkv[qkv_base + key_dim * 2 + value_idx] - recalled_value) * beta;
+
+      float result = 0.0f;
+      for (int key_idx = 0; key_idx < key_dim; ++key_idx) {
+        const int state_idx = state_base + key_idx * value_dim + value_idx;
+        const float next_state = decay * state[state_idx]
+                                 + qkv[qkv_base + key_dim + key_idx] * delta;
+        state[state_idx] = next_state;
+        result += qkv[qkv_base + key_idx] * query_scale * next_state;
+      }
+      packed_output[token_head * value_dim + value_idx] = result;
+    }
+  }
+}

--- a/crates/izwi-core/src/kernels/metal.rs
+++ b/crates/izwi-core/src/kernels/metal.rs
@@ -458,6 +458,133 @@ kernel void izwi_decode_gqa_attention_f16(
     }
 }
 
+kernel void izwi_qwen35_causal_conv_sequence_f32(
+    device const float* input [[buffer(0)]],
+    device const float* weight [[buffer(1)]],
+    device const float* history [[buffer(2)]],
+    device float* output [[buffer(3)]],
+    constant uint& conv_dim [[buffer(4)]],
+    constant uint& seq_len [[buffer(5)]],
+    constant uint& kernel_size [[buffer(6)]],
+    constant uint& output_elem_count [[buffer(7)]],
+    constant uint& total_elem_count [[buffer(8)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= total_elem_count) {
+        return;
+    }
+
+    const uint history_len = kernel_size - 1;
+    if (gid < output_elem_count) {
+        const uint token = gid / conv_dim;
+        const uint channel = gid - token * conv_dim;
+        const uint weight_base = channel * kernel_size;
+        float value = 0.0f;
+        for (uint tap = 0; tap < kernel_size; tap++) {
+            const uint source_pos = token + tap;
+            const float source = source_pos < history_len
+                ? history[channel * history_len + source_pos]
+                : input[(source_pos - history_len) * conv_dim + channel];
+            value += source * weight[weight_base + tap];
+        }
+        output[gid] = value / (1.0f + exp(-value));
+        return;
+    }
+
+    // Persist the last `kernel_size - 1` raw inputs in oldest-to-newest order.
+    // This also handles chunks shorter than the history window by retaining the
+    // still-live suffix of the incoming history.
+    const uint state_idx = gid - output_elem_count;
+    const uint channel = state_idx / history_len;
+    const uint history_pos = state_idx - channel * history_len;
+    const uint source_pos = seq_len + history_pos;
+    output[gid] = source_pos < history_len
+        ? history[channel * history_len + source_pos]
+        : input[(source_pos - history_len) * conv_dim + channel];
+}
+
+kernel void izwi_qwen35_gated_delta_sequence_f32(
+    device const float* qkv [[buffer(0)]],
+    device const float* gates [[buffer(1)]],
+    device const float* initial_state [[buffer(2)]],
+    device float* output [[buffer(3)]],
+    constant uint& seq_len [[buffer(4)]],
+    constant uint& num_k_heads [[buffer(5)]],
+    constant uint& num_v_heads [[buffer(6)]],
+    constant uint& head_k_dim [[buffer(7)]],
+    constant uint& head_v_dim [[buffer(8)]],
+    constant uint& qkv_width [[buffer(9)]],
+    constant uint& output_elem_count [[buffer(10)]],
+    constant float& query_scale [[buffer(11)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint head [[threadgroup_position_in_grid]],
+    uint threads_per_threadgroup [[threads_per_threadgroup]]
+) {
+    threadgroup float delta[256];
+
+    if (head >= num_v_heads) {
+        return;
+    }
+
+    const uint state_head_size = head_k_dim * head_v_dim;
+    const uint state_base = output_elem_count + head * state_head_size;
+    const uint initial_state_base = head * state_head_size;
+    for (uint idx = tid; idx < state_head_size; idx += threads_per_threadgroup) {
+        output[state_base + idx] = initial_state[initial_state_base + idx];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // GGUF conversion stores V heads in tiled order, so the matching K head is
+    // `v_head % num_k_heads` for both 16K/16V and 16K/32V layouts.
+    const uint key_head = head % num_k_heads;
+    const uint key_width = num_k_heads * head_k_dim;
+    const uint value_offset = key_width * 2;
+
+    for (uint token = 0; token < seq_len; token++) {
+        const uint qkv_base = token * qkv_width;
+        const uint query_base = qkv_base + key_head * head_k_dim;
+        const uint key_base = qkv_base + key_width + key_head * head_k_dim;
+        const uint value_base = qkv_base + value_offset + head * head_v_dim;
+        const uint gate_base = token * num_v_heads * 2;
+        const float decay = exp(gates[gate_base + head]);
+        const float beta = gates[gate_base + num_v_heads + head];
+
+        for (uint idx = tid; idx < state_head_size; idx += threads_per_threadgroup) {
+            output[state_base + idx] *= decay;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (uint value_dim = tid; value_dim < head_v_dim; value_dim += threads_per_threadgroup) {
+            float memory = 0.0f;
+            for (uint key_dim = 0; key_dim < head_k_dim; key_dim++) {
+                memory += output[state_base + key_dim * head_v_dim + value_dim]
+                    * qkv[key_base + key_dim];
+            }
+            delta[value_dim] = (qkv[value_base + value_dim] - memory) * beta;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (uint idx = tid; idx < state_head_size; idx += threads_per_threadgroup) {
+            const uint key_dim = idx / head_v_dim;
+            const uint value_dim = idx - key_dim * head_v_dim;
+            output[state_base + idx] += qkv[key_base + key_dim] * delta[value_dim];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (uint value_dim = tid; value_dim < head_v_dim; value_dim += threads_per_threadgroup) {
+            float recurrent_value = 0.0f;
+            for (uint key_dim = 0; key_dim < head_k_dim; key_dim++) {
+                recurrent_value += output[state_base + key_dim * head_v_dim + value_dim]
+                    * (qkv[query_base + key_dim] * query_scale);
+            }
+            output[(token * num_v_heads + head) * head_v_dim + value_dim] = recurrent_value;
+        }
+        // No thread may begin decaying the next state until every output read
+        // for the current token has completed.
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+}
+
 kernel void izwi_lfm_shortconv_decode3_f32(
     device const float* cache [[buffer(0)]],
     device const float* bx [[buffer(1)]],
@@ -1734,6 +1861,391 @@ fn lfm_shortconv_sequence3_pipeline(device: &MetalDevice) -> CandleResult<Comput
     Ok(pipeline)
 }
 
+#[cfg(feature = "metal")]
+#[derive(Debug, Clone, Copy)]
+struct Qwen35CausalConvSequenceOp {
+    conv_dim: usize,
+    seq_len: usize,
+    kernel_size: usize,
+}
+
+#[cfg(feature = "metal")]
+impl CustomOp3 for Qwen35CausalConvSequenceOp {
+    fn name(&self) -> &'static str {
+        "izwi-qwen35-causal-conv-sequence-metal"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _s1: &CpuStorage,
+        _l1: &Layout,
+        _s2: &CpuStorage,
+        _l2: &Layout,
+        _s3: &CpuStorage,
+        _l3: &Layout,
+    ) -> CandleResult<(CpuStorage, Shape)> {
+        bail!("izwi-qwen35-causal-conv-sequence-metal requires Metal tensors")
+    }
+
+    fn metal_fwd(
+        &self,
+        input_storage: &MetalStorage,
+        input_layout: &Layout,
+        weight_storage: &MetalStorage,
+        weight_layout: &Layout,
+        history_storage: &MetalStorage,
+        history_layout: &Layout,
+    ) -> CandleResult<(MetalStorage, Shape)> {
+        if input_storage.dtype() != DType::F32
+            || weight_storage.dtype() != DType::F32
+            || history_storage.dtype() != DType::F32
+        {
+            bail!("izwi-qwen35-causal-conv-sequence-metal only supports F32 tensors")
+        }
+        if !input_layout.is_contiguous()
+            || !weight_layout.is_contiguous()
+            || !history_layout.is_contiguous()
+        {
+            bail!("izwi-qwen35-causal-conv-sequence-metal requires contiguous tensors")
+        }
+        if self.conv_dim == 0 || self.seq_len == 0 || self.kernel_size < 2 {
+            bail!(
+                "izwi-qwen35-causal-conv-sequence-metal requires non-empty dimensions and kernel_size >= 2"
+            )
+        }
+        let history_len = self.kernel_size - 1;
+        let Some(output_elem_count) = self.seq_len.checked_mul(self.conv_dim) else {
+            bail!("izwi-qwen35-causal-conv-sequence-metal output size overflow")
+        };
+        let Some(state_elem_count) = history_len.checked_mul(self.conv_dim) else {
+            bail!("izwi-qwen35-causal-conv-sequence-metal state size overflow")
+        };
+        let Some(weight_elem_count) = self.kernel_size.checked_mul(self.conv_dim) else {
+            bail!("izwi-qwen35-causal-conv-sequence-metal weight size overflow")
+        };
+        let Some(total_elem_count) = output_elem_count.checked_add(state_elem_count) else {
+            bail!("izwi-qwen35-causal-conv-sequence-metal packed output size overflow")
+        };
+        if input_layout.shape().elem_count() != output_elem_count
+            || weight_layout.shape().elem_count() != weight_elem_count
+            || history_layout.shape().elem_count() != state_elem_count
+        {
+            bail!("izwi-qwen35-causal-conv-sequence-metal input shape mismatch")
+        }
+        if total_elem_count > u32::MAX as usize
+            || output_elem_count > u32::MAX as usize
+            || self.conv_dim > u32::MAX as usize
+            || self.seq_len > u32::MAX as usize
+            || self.kernel_size > u32::MAX as usize
+        {
+            bail!("izwi-qwen35-causal-conv-sequence-metal tensor is too large")
+        }
+
+        let device = input_storage.device().clone();
+        let output = device.new_buffer(
+            total_elem_count,
+            DType::F32,
+            "izwi-qwen35-causal-conv-sequence",
+        )?;
+        let encoder = device.command_encoder()?;
+        encoder.set_label("izwi-qwen35-causal-conv-sequence");
+        let pipeline = qwen35_causal_conv_sequence_pipeline(device.metal_device())?;
+        encoder.set_compute_pipeline_state(&pipeline);
+
+        encoder.set_input_buffer(
+            0,
+            Some(input_storage.buffer()),
+            input_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_input_buffer(
+            1,
+            Some(weight_storage.buffer()),
+            weight_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_input_buffer(
+            2,
+            Some(history_storage.buffer()),
+            history_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_output_buffer(3, Some(&output), 0);
+        encoder.set_bytes(4, &(self.conv_dim as u32));
+        encoder.set_bytes(5, &(self.seq_len as u32));
+        encoder.set_bytes(6, &(self.kernel_size as u32));
+        encoder.set_bytes(7, &(output_elem_count as u32));
+        encoder.set_bytes(8, &(total_elem_count as u32));
+
+        let threads_per_threadgroup = pipeline.max_total_threads_per_threadgroup().min(256).max(1);
+        encoder.dispatch_threads(
+            objc2_metal::MTLSize {
+                width: total_elem_count,
+                height: 1,
+                depth: 1,
+            },
+            objc2_metal::MTLSize {
+                width: threads_per_threadgroup,
+                height: 1,
+                depth: 1,
+            },
+        );
+        drop(encoder);
+
+        Ok((
+            MetalStorage::new(output, device, total_elem_count, DType::F32),
+            Shape::from(total_elem_count),
+        ))
+    }
+}
+
+#[cfg(feature = "metal")]
+fn qwen35_causal_conv_sequence_pipeline(device: &MetalDevice) -> CandleResult<ComputePipeline> {
+    static PIPELINES: OnceLock<Mutex<HashMap<u64, ComputePipeline>>> = OnceLock::new();
+    let registry_id = device.registry_id();
+    let pipelines = PIPELINES.get_or_init(|| Mutex::new(HashMap::new()));
+
+    if let Some(pipeline) = pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .get(&registry_id)
+        .cloned()
+    {
+        return Ok(pipeline);
+    }
+
+    let library = device
+        .new_library_with_source(IZWI_METAL_SOURCE, None)
+        .map_err(candle_core::Error::wrap)?;
+    let function = library
+        .get_function("izwi_qwen35_causal_conv_sequence_f32", None)
+        .map_err(candle_core::Error::wrap)?;
+    let pipeline = device
+        .new_compute_pipeline_state_with_function(&function)
+        .map_err(candle_core::Error::wrap)?;
+
+    pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .insert(registry_id, pipeline.clone());
+    Ok(pipeline)
+}
+
+#[cfg(feature = "metal")]
+#[derive(Debug, Clone, Copy)]
+struct Qwen35GatedDeltaSequenceOp {
+    seq_len: usize,
+    num_k_heads: usize,
+    num_v_heads: usize,
+    head_k_dim: usize,
+    head_v_dim: usize,
+    qkv_width: usize,
+    query_scale: f32,
+}
+
+#[cfg(feature = "metal")]
+impl CustomOp3 for Qwen35GatedDeltaSequenceOp {
+    fn name(&self) -> &'static str {
+        "izwi-qwen35-gated-delta-sequence-metal"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _s1: &CpuStorage,
+        _l1: &Layout,
+        _s2: &CpuStorage,
+        _l2: &Layout,
+        _s3: &CpuStorage,
+        _l3: &Layout,
+    ) -> CandleResult<(CpuStorage, Shape)> {
+        bail!("izwi-qwen35-gated-delta-sequence-metal requires Metal tensors")
+    }
+
+    fn metal_fwd(
+        &self,
+        qkv_storage: &MetalStorage,
+        qkv_layout: &Layout,
+        gates_storage: &MetalStorage,
+        gates_layout: &Layout,
+        state_storage: &MetalStorage,
+        state_layout: &Layout,
+    ) -> CandleResult<(MetalStorage, Shape)> {
+        if qkv_storage.dtype() != DType::F32
+            || gates_storage.dtype() != DType::F32
+            || state_storage.dtype() != DType::F32
+        {
+            bail!("izwi-qwen35-gated-delta-sequence-metal only supports F32 tensors")
+        }
+        if !qkv_layout.is_contiguous()
+            || !gates_layout.is_contiguous()
+            || !state_layout.is_contiguous()
+        {
+            bail!("izwi-qwen35-gated-delta-sequence-metal requires contiguous tensors")
+        }
+        if self.seq_len == 0
+            || self.num_k_heads != 16
+            || !matches!(self.num_v_heads, 16 | 32)
+            || self.num_v_heads % self.num_k_heads != 0
+            || self.head_k_dim == 0
+            || self.head_v_dim == 0
+            || self.head_v_dim > 256
+        {
+            bail!(
+                "izwi-qwen35-gated-delta-sequence-metal requires Qwen3.5 16K/16V or 16K/32V non-empty heads with head_v_dim <= 256"
+            )
+        }
+        let Some(key_width) = self.num_k_heads.checked_mul(self.head_k_dim) else {
+            bail!("izwi-qwen35-gated-delta-sequence-metal key width overflow")
+        };
+        let Some(value_width) = self.num_v_heads.checked_mul(self.head_v_dim) else {
+            bail!("izwi-qwen35-gated-delta-sequence-metal value width overflow")
+        };
+        let Some(expected_qkv_width) = key_width
+            .checked_mul(2)
+            .and_then(|width| width.checked_add(value_width))
+        else {
+            bail!("izwi-qwen35-gated-delta-sequence-metal qkv width overflow")
+        };
+        if self.qkv_width != expected_qkv_width {
+            bail!("izwi-qwen35-gated-delta-sequence-metal qkv width mismatch")
+        }
+        let Some(qkv_elem_count) = self.seq_len.checked_mul(self.qkv_width) else {
+            bail!("izwi-qwen35-gated-delta-sequence-metal qkv size overflow")
+        };
+        let Some(gate_elem_count) = self
+            .seq_len
+            .checked_mul(self.num_v_heads)
+            .and_then(|count| count.checked_mul(2))
+        else {
+            bail!("izwi-qwen35-gated-delta-sequence-metal gate size overflow")
+        };
+        let Some(output_elem_count) = self
+            .seq_len
+            .checked_mul(self.num_v_heads)
+            .and_then(|count| count.checked_mul(self.head_v_dim))
+        else {
+            bail!("izwi-qwen35-gated-delta-sequence-metal output size overflow")
+        };
+        let Some(state_elem_count) = self
+            .num_v_heads
+            .checked_mul(self.head_k_dim)
+            .and_then(|count| count.checked_mul(self.head_v_dim))
+        else {
+            bail!("izwi-qwen35-gated-delta-sequence-metal state size overflow")
+        };
+        let Some(total_elem_count) = output_elem_count.checked_add(state_elem_count) else {
+            bail!("izwi-qwen35-gated-delta-sequence-metal packed output size overflow")
+        };
+        if qkv_layout.shape().elem_count() != qkv_elem_count
+            || gates_layout.shape().elem_count() != gate_elem_count
+            || state_layout.shape().elem_count() != state_elem_count
+        {
+            bail!("izwi-qwen35-gated-delta-sequence-metal input shape mismatch")
+        }
+        if total_elem_count > u32::MAX as usize
+            || output_elem_count > u32::MAX as usize
+            || self.seq_len > u32::MAX as usize
+            || self.num_k_heads > u32::MAX as usize
+            || self.num_v_heads > u32::MAX as usize
+            || self.head_k_dim > u32::MAX as usize
+            || self.head_v_dim > u32::MAX as usize
+            || self.qkv_width > u32::MAX as usize
+        {
+            bail!("izwi-qwen35-gated-delta-sequence-metal tensor is too large")
+        }
+
+        let device = qkv_storage.device().clone();
+        let output = device.new_buffer(
+            total_elem_count,
+            DType::F32,
+            "izwi-qwen35-gated-delta-sequence",
+        )?;
+        let encoder = device.command_encoder()?;
+        encoder.set_label("izwi-qwen35-gated-delta-sequence");
+        let pipeline = qwen35_gated_delta_sequence_pipeline(device.metal_device())?;
+        encoder.set_compute_pipeline_state(&pipeline);
+
+        encoder.set_input_buffer(
+            0,
+            Some(qkv_storage.buffer()),
+            qkv_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_input_buffer(
+            1,
+            Some(gates_storage.buffer()),
+            gates_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_input_buffer(
+            2,
+            Some(state_storage.buffer()),
+            state_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_output_buffer(3, Some(&output), 0);
+        encoder.set_bytes(4, &(self.seq_len as u32));
+        encoder.set_bytes(5, &(self.num_k_heads as u32));
+        encoder.set_bytes(6, &(self.num_v_heads as u32));
+        encoder.set_bytes(7, &(self.head_k_dim as u32));
+        encoder.set_bytes(8, &(self.head_v_dim as u32));
+        encoder.set_bytes(9, &(self.qkv_width as u32));
+        encoder.set_bytes(10, &(output_elem_count as u32));
+        encoder.set_bytes(11, &self.query_scale);
+
+        let threads_per_threadgroup = self
+            .head_v_dim
+            .next_power_of_two()
+            .min(pipeline.max_total_threads_per_threadgroup())
+            .min(256)
+            .max(1);
+        encoder.dispatch_thread_groups(
+            objc2_metal::MTLSize {
+                width: self.num_v_heads,
+                height: 1,
+                depth: 1,
+            },
+            objc2_metal::MTLSize {
+                width: threads_per_threadgroup,
+                height: 1,
+                depth: 1,
+            },
+        );
+        drop(encoder);
+
+        Ok((
+            MetalStorage::new(output, device, total_elem_count, DType::F32),
+            Shape::from(total_elem_count),
+        ))
+    }
+}
+
+#[cfg(feature = "metal")]
+fn qwen35_gated_delta_sequence_pipeline(device: &MetalDevice) -> CandleResult<ComputePipeline> {
+    static PIPELINES: OnceLock<Mutex<HashMap<u64, ComputePipeline>>> = OnceLock::new();
+    let registry_id = device.registry_id();
+    let pipelines = PIPELINES.get_or_init(|| Mutex::new(HashMap::new()));
+
+    if let Some(pipeline) = pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .get(&registry_id)
+        .cloned()
+    {
+        return Ok(pipeline);
+    }
+
+    let library = device
+        .new_library_with_source(IZWI_METAL_SOURCE, None)
+        .map_err(candle_core::Error::wrap)?;
+    let function = library
+        .get_function("izwi_qwen35_gated_delta_sequence_f32", None)
+        .map_err(candle_core::Error::wrap)?;
+    let pipeline = device
+        .new_compute_pipeline_state_with_function(&function)
+        .map_err(candle_core::Error::wrap)?;
+
+    pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .insert(registry_id, pipeline.clone());
+    Ok(pipeline)
+}
+
 /// Try fused gated delta recurrent computation.
 ///
 /// This fuses multiple operations:
@@ -2341,6 +2853,78 @@ pub fn try_lfm_shortconv_sequence3(bx: &Tensor, conv: &Tensor) -> Option<Tensor>
     None
 }
 
+/// Run Qwen3.5's stateful causal depthwise-convolution sequence path in one
+/// Metal dispatch. Inputs use token-major `[1, sequence, channels]` layout;
+/// history is `[channels, kernel_size - 1]` in oldest-to-newest order.
+pub fn try_qwen35_causal_conv_sequence(
+    input: &Tensor,
+    weight: &Tensor,
+    history: &Tensor,
+) -> Option<(Tensor, Tensor)> {
+    #[cfg(not(feature = "metal"))]
+    let _ = (input, weight, history);
+
+    if !use_fused_kernels() {
+        return None;
+    }
+
+    #[cfg(feature = "metal")]
+    {
+        let (batch, seq_len, conv_dim) = input.dims3().ok()?;
+        let (weight_channels, kernel_size) = weight.dims2().ok()?;
+        let (history_channels, history_len) = history.dims2().ok()?;
+        if batch != 1
+            || seq_len == 0
+            || conv_dim == 0
+            || kernel_size < 2
+            || weight_channels != conv_dim
+            || history_channels != conv_dim
+            || history_len != kernel_size - 1
+            || !input.device().is_metal()
+            || !weight.device().is_metal()
+            || !history.device().is_metal()
+            || !input.device().same_device(weight.device())
+            || !input.device().same_device(history.device())
+            || input.dtype() != DType::F32
+            || weight.dtype() != DType::F32
+            || history.dtype() != DType::F32
+            || !input.is_contiguous()
+            || !weight.is_contiguous()
+            || !history.is_contiguous()
+        {
+            return None;
+        }
+
+        let output_elem_count = seq_len.checked_mul(conv_dim)?;
+        let state_elem_count = history_len.checked_mul(conv_dim)?;
+        let packed = input
+            .apply_op3_no_bwd(
+                weight,
+                history,
+                &Qwen35CausalConvSequenceOp {
+                    conv_dim,
+                    seq_len,
+                    kernel_size,
+                },
+            )
+            .ok()?;
+        let output = packed
+            .narrow(0, 0, output_elem_count)
+            .ok()?
+            .reshape((1, seq_len, conv_dim))
+            .ok()?;
+        let final_history = packed
+            .narrow(0, output_elem_count, state_elem_count)
+            .ok()?
+            .reshape((conv_dim, history_len))
+            .ok()?;
+        return Some((output, final_history));
+    }
+
+    #[allow(unreachable_code)]
+    None
+}
+
 /// Try fused gated RMS normalization.
 ///
 /// Computes: rms_norm(x) * silu(gate)
@@ -2359,27 +2943,22 @@ pub fn try_fused_gated_rms_norm(
     rms_out.broadcast_mul(&silu_gate).ok()
 }
 
-/// Try tiled DeltaNet recurrence using Metal tile memory.
+/// Try the reference Qwen3.5 Gated DeltaNet recurrence in one Metal dispatch.
 ///
-/// This processes multiple tokens (tile_size, typically 32 or 64) while keeping
-/// the hidden state in fast tile memory instead of VRAM. This eliminates
-/// memory round-trips for the recurrence h_t = A * h_{t-1} + B.
-///
-/// The tile memory is high-speed memory local to the GPU shader. By loading
-/// the hidden state into tile memory, we can process an entire sequence of
-/// tokens without writing the state back to main VRAM.
-///
-/// This is the primary optimization that enables llama.cpp to achieve 3x
-/// higher TPS than naive implementations.
+/// The shader keeps token causality inside each value-head threadgroup and
+/// evaluates state decay, delta correction, state update, and output reduction
+/// in F32. Q/K retain the converted GGUF's 16-head tiled layout while V may
+/// contain either 16 or 32 heads.
 ///
 /// # Arguments
-/// * `queries` - Query tensors [batch, seq, num_heads, head_dim]
-/// * `keys` - Key tensors [batch, seq, num_heads, head_dim]
+/// * `queries` - Query tensors [1, seq, 16, head_k_dim]
+/// * `keys` - Key tensors [1, seq, 16, head_k_dim]
 /// * `values` - Value tensors [batch, seq, num_v_heads, head_v_dim]
 /// * `g` - Pre-computed gate values [batch, seq, num_v_heads]
 /// * `beta` - Beta values [batch, seq, num_v_heads]
 /// * `initial_state` - Initial recurrent state [batch, num_v_heads, head_k_dim, head_v_dim]
-/// * `tile_size` - Number of tokens to process per tile (32 or 64 recommended)
+/// * `tile_size` - Retained for the backend-neutral API; the Metal dispatch
+///   processes the full supplied sequence.
 ///
 /// # Returns
 /// (outputs, final_state) where outputs is [batch, seq, num_v_heads, head_v_dim]
@@ -2392,72 +2971,116 @@ pub fn try_tiled_deltanet_recurrence(
     initial_state: &Tensor,
     tile_size: usize,
 ) -> Option<(Tensor, Tensor)> {
+    #[cfg(not(feature = "metal"))]
+    let _ = (queries, keys, values, g, beta, initial_state, tile_size);
+
     if !use_fused_kernels() {
         return None;
     }
 
-    // Only supported for F32 on Metal devices
-    if queries.dtype() != DType::F32 {
-        return None;
-    }
-
-    if !queries.device().is_metal() {
-        return None;
-    }
-
-    let (batch, seq_len, num_heads, head_k_dim) = queries.dims4().ok()?;
-    let (k_batch, k_seq_len, k_num_heads, k_head_k_dim) = keys.dims4().ok()?;
-    let (v_batch, v_seq_len, v_num_heads, _v_head_dim) = values.dims4().ok()?;
-    let (g_batch, g_seq_len, g_heads) = g.dims3().ok()?;
-    let (b_batch, b_seq_len, b_heads) = beta.dims3().ok()?;
-    let (s_batch, s_heads, s_head_k_dim, _s_head_v_dim) = initial_state.dims4().ok()?;
-
-    if batch != 1
-        || k_batch != batch
-        || v_batch != batch
-        || g_batch != batch
-        || b_batch != batch
-        || s_batch != batch
+    #[cfg(feature = "metal")]
     {
-        return None;
-    }
-    if k_seq_len != seq_len || v_seq_len != seq_len || g_seq_len != seq_len || b_seq_len != seq_len
-    {
-        return None;
-    }
-    if k_num_heads != num_heads || g_heads != num_heads || b_heads != num_heads {
-        return None;
-    }
-    if k_head_k_dim != head_k_dim || s_heads != num_heads || s_head_k_dim != head_k_dim {
-        return None;
-    }
-    if v_num_heads != num_heads {
-        return None;
-    }
+        let _ = tile_size;
+        let (batch, seq_len, num_k_heads, head_k_dim) = queries.dims4().ok()?;
+        let (k_batch, k_seq_len, k_num_heads, k_head_k_dim) = keys.dims4().ok()?;
+        let (v_batch, v_seq_len, num_v_heads, head_v_dim) = values.dims4().ok()?;
+        let (g_batch, g_seq_len, g_heads) = g.dims3().ok()?;
+        let (b_batch, b_seq_len, b_heads) = beta.dims3().ok()?;
+        let (s_batch, s_heads, s_head_k_dim, s_head_v_dim) = initial_state.dims4().ok()?;
 
-    let tile_size = tile_size.max(1).min(seq_len.max(1));
-    let mut outputs = Vec::with_capacity(seq_len);
-    let mut state = initial_state.clone();
-
-    for tile_start in (0..seq_len).step_by(tile_size) {
-        let tile_end = (tile_start + tile_size).min(seq_len);
-        for token_idx in tile_start..tile_end {
-            let query = queries.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-            let key = keys.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-            let value = values.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-            let g_t = g.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-            let beta_t = beta.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-
-            let (output, next_state) =
-                fused_gated_delta_sequential(&query, &key, &value, &g_t, &beta_t, &state).ok()?;
-            outputs.push(output.unsqueeze(1).ok()?);
-            state = next_state;
+        if batch != 1
+            || seq_len == 0
+            || k_batch != batch
+            || v_batch != batch
+            || g_batch != batch
+            || b_batch != batch
+            || s_batch != batch
+            || k_seq_len != seq_len
+            || v_seq_len != seq_len
+            || g_seq_len != seq_len
+            || b_seq_len != seq_len
+            || num_k_heads != 16
+            || k_num_heads != num_k_heads
+            || !matches!(num_v_heads, 16 | 32)
+            || num_v_heads % num_k_heads != 0
+            || g_heads != num_v_heads
+            || b_heads != num_v_heads
+            || s_heads != num_v_heads
+            || k_head_k_dim != head_k_dim
+            || s_head_k_dim != head_k_dim
+            || s_head_v_dim != head_v_dim
+            || head_k_dim == 0
+            || head_v_dim == 0
+            || head_v_dim > 256
+            || !queries.device().is_metal()
+            || !keys.device().is_metal()
+            || !values.device().is_metal()
+            || !g.device().is_metal()
+            || !beta.device().is_metal()
+            || !initial_state.device().is_metal()
+            || !queries.device().same_device(keys.device())
+            || !queries.device().same_device(values.device())
+            || !queries.device().same_device(g.device())
+            || !queries.device().same_device(beta.device())
+            || !queries.device().same_device(initial_state.device())
+            || queries.dtype() != DType::F32
+            || keys.dtype() != DType::F32
+            || values.dtype() != DType::F32
+            || g.dtype() != DType::F32
+            || beta.dtype() != DType::F32
+            || initial_state.dtype() != DType::F32
+            || !queries.is_contiguous()
+            || !keys.is_contiguous()
+            || !values.is_contiguous()
+            || !g.is_contiguous()
+            || !beta.is_contiguous()
+            || !initial_state.is_contiguous()
+        {
+            return None;
         }
+
+        let key_width = num_k_heads.checked_mul(head_k_dim)?;
+        let value_width = num_v_heads.checked_mul(head_v_dim)?;
+        let qkv_width = key_width.checked_mul(2)?.checked_add(value_width)?;
+        let query_flat = queries.reshape((1, seq_len, key_width)).ok()?;
+        let key_flat = keys.reshape((1, seq_len, key_width)).ok()?;
+        let value_flat = values.reshape((1, seq_len, value_width)).ok()?;
+        let qkv = Tensor::cat(&[&query_flat, &key_flat, &value_flat], 2).ok()?;
+        let gates = Tensor::cat(&[g, beta], 2).ok()?;
+        let output_elem_count = seq_len.checked_mul(num_v_heads)?.checked_mul(head_v_dim)?;
+        let state_elem_count = num_v_heads
+            .checked_mul(head_k_dim)?
+            .checked_mul(head_v_dim)?;
+        let packed = qkv
+            .apply_op3_no_bwd(
+                &gates,
+                initial_state,
+                &Qwen35GatedDeltaSequenceOp {
+                    seq_len,
+                    num_k_heads,
+                    num_v_heads,
+                    head_k_dim,
+                    head_v_dim,
+                    qkv_width,
+                    query_scale: 1.0 / (head_k_dim as f32).sqrt(),
+                },
+            )
+            .ok()?;
+        let output = packed
+            .narrow(0, 0, output_elem_count)
+            .ok()?
+            .reshape((1, seq_len, num_v_heads, head_v_dim))
+            .ok()?;
+        let final_state = packed
+            .narrow(0, output_elem_count, state_elem_count)
+            .ok()?
+            .reshape((1, num_v_heads, head_k_dim, head_v_dim))
+            .ok()?;
+        return Some((output, final_state));
     }
 
-    let output_refs: Vec<&Tensor> = outputs.iter().collect();
-    let outputs = Tensor::cat(&output_refs, 1).ok()?;
-    Some((outputs, state))
+    #[allow(unreachable_code)]
+    None
 }
 
 /// Try SIMD-group softmax for attention.
@@ -2656,6 +3279,117 @@ mod tests {
     #[cfg(all(feature = "metal", target_os = "macos"))]
     use candle_nn::Module;
 
+    fn qwen35_causal_conv_reference(
+        input: &[f32],
+        weight: &[f32],
+        history: &[f32],
+        seq_len: usize,
+        conv_dim: usize,
+        kernel_size: usize,
+    ) -> (Vec<f32>, Vec<f32>) {
+        let history_len = kernel_size - 1;
+        let mut output = vec![0f32; seq_len * conv_dim];
+        for token in 0..seq_len {
+            for channel in 0..conv_dim {
+                let mut value = 0f32;
+                for tap in 0..kernel_size {
+                    let source_pos = token + tap;
+                    let source = if source_pos < history_len {
+                        history[channel * history_len + source_pos]
+                    } else {
+                        input[(source_pos - history_len) * conv_dim + channel]
+                    };
+                    value += source * weight[channel * kernel_size + tap];
+                }
+                output[token * conv_dim + channel] = value / (1.0 + (-value).exp());
+            }
+        }
+
+        let mut final_history = vec![0f32; conv_dim * history_len];
+        for channel in 0..conv_dim {
+            for history_pos in 0..history_len {
+                let source_pos = seq_len + history_pos;
+                final_history[channel * history_len + history_pos] = if source_pos < history_len {
+                    history[channel * history_len + source_pos]
+                } else {
+                    input[(source_pos - history_len) * conv_dim + channel]
+                };
+            }
+        }
+        (output, final_history)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn qwen35_gated_delta_reference(
+        query: &[f32],
+        key: &[f32],
+        value: &[f32],
+        g: &[f32],
+        beta: &[f32],
+        initial_state: &[f32],
+        seq_len: usize,
+        num_k_heads: usize,
+        num_v_heads: usize,
+        head_k_dim: usize,
+        head_v_dim: usize,
+    ) -> (Vec<f32>, Vec<f32>) {
+        let mut state = initial_state.to_vec();
+        let mut output = vec![0f32; seq_len * num_v_heads * head_v_dim];
+        let query_scale = 1.0f32 / (head_k_dim as f32).sqrt();
+        let state_head_size = head_k_dim * head_v_dim;
+        for token in 0..seq_len {
+            for value_head in 0..num_v_heads {
+                let key_head = value_head % num_k_heads;
+                let state_base = value_head * state_head_size;
+                let key_base = (token * num_k_heads + key_head) * head_k_dim;
+                let value_base = (token * num_v_heads + value_head) * head_v_dim;
+                let decay = g[token * num_v_heads + value_head].exp();
+                for state_value in &mut state[state_base..state_base + state_head_size] {
+                    *state_value *= decay;
+                }
+
+                let mut delta = vec![0f32; head_v_dim];
+                for value_dim in 0..head_v_dim {
+                    let mut memory = 0f32;
+                    for key_dim in 0..head_k_dim {
+                        memory += state[state_base + key_dim * head_v_dim + value_dim]
+                            * key[key_base + key_dim];
+                    }
+                    delta[value_dim] = (value[value_base + value_dim] - memory)
+                        * beta[token * num_v_heads + value_head];
+                }
+
+                for key_dim in 0..head_k_dim {
+                    for value_dim in 0..head_v_dim {
+                        state[state_base + key_dim * head_v_dim + value_dim] +=
+                            key[key_base + key_dim] * delta[value_dim];
+                    }
+                }
+
+                for value_dim in 0..head_v_dim {
+                    let mut recurrent_value = 0f32;
+                    for key_dim in 0..head_k_dim {
+                        recurrent_value += state[state_base + key_dim * head_v_dim + value_dim]
+                            * (query[key_base + key_dim] * query_scale);
+                    }
+                    output[value_base + value_dim] = recurrent_value;
+                }
+            }
+        }
+        (output, state)
+    }
+
+    fn assert_f32_close(actual: &[f32], expected: &[f32], tolerance: f32, context: &str) {
+        assert_eq!(actual.len(), expected.len(), "{context} length mismatch");
+        for (idx, (&actual, &expected)) in actual.iter().zip(expected.iter()).enumerate() {
+            let bound = tolerance * (1.0 + expected.abs());
+            assert!(
+                actual.is_finite() && (actual - expected).abs() <= bound,
+                "{context} mismatch at {idx}: {actual} != {expected} (bound {bound})"
+            );
+        }
+    }
+
     #[test]
     fn test_l2_norm_matches_reference() {
         let device = Device::Cpu;
@@ -2812,6 +3546,194 @@ mod tests {
         let bx = Tensor::zeros((1, 2, 1), DType::F32, &device).unwrap();
 
         assert!(try_lfm_shortconv_update3(&cache, &bx).is_none());
+    }
+
+    #[test]
+    fn qwen35_sequence_kernels_reject_cpu_tensors() {
+        let device = Device::Cpu;
+        let conv_input = Tensor::zeros((1, 2, 8), DType::F32, &device).unwrap();
+        let conv_weight = Tensor::zeros((8, 4), DType::F32, &device).unwrap();
+        let conv_history = Tensor::zeros((8, 3), DType::F32, &device).unwrap();
+        assert!(
+            try_qwen35_causal_conv_sequence(&conv_input, &conv_weight, &conv_history).is_none()
+        );
+
+        let query = Tensor::zeros((1, 2, 16, 2), DType::F32, &device).unwrap();
+        let key = Tensor::zeros((1, 2, 16, 2), DType::F32, &device).unwrap();
+        let value = Tensor::zeros((1, 2, 16, 3), DType::F32, &device).unwrap();
+        let g = Tensor::zeros((1, 2, 16), DType::F32, &device).unwrap();
+        let beta = Tensor::zeros((1, 2, 16), DType::F32, &device).unwrap();
+        let state = Tensor::zeros((1, 16, 2, 3), DType::F32, &device).unwrap();
+        assert!(
+            try_tiled_deltanet_recurrence(&query, &key, &value, &g, &beta, &state, 64).is_none()
+        );
+    }
+
+    #[cfg(all(feature = "metal", target_os = "macos"))]
+    #[test]
+    fn metal_qwen35_causal_conv_sequence_matches_cpu_reference_if_available() {
+        let Ok(Ok(device)) = std::panic::catch_unwind(|| Device::new_metal(0)) else {
+            return;
+        };
+        let seq_len = 2;
+        let conv_dim = 5;
+        let kernel_size = 4;
+        let input: Vec<f32> = (0..seq_len * conv_dim)
+            .map(|idx| ((idx % 9) as f32 - 4.0) * 0.13)
+            .collect();
+        let weight: Vec<f32> = (0..conv_dim * kernel_size)
+            .map(|idx| ((idx % 7) as f32 - 3.0) * 0.09)
+            .collect();
+        let history: Vec<f32> = (0..conv_dim * (kernel_size - 1))
+            .map(|idx| ((idx % 11) as f32 - 5.0) * 0.07)
+            .collect();
+        let (expected_output, expected_history) =
+            qwen35_causal_conv_reference(&input, &weight, &history, seq_len, conv_dim, kernel_size);
+
+        let input_tensor = Tensor::from_vec(input, (1, seq_len, conv_dim), &device).expect("input");
+        let weight_tensor =
+            Tensor::from_vec(weight, (conv_dim, kernel_size), &device).expect("weight");
+        let history_tensor =
+            Tensor::from_vec(history, (conv_dim, kernel_size - 1), &device).expect("history");
+        let (output, final_history) =
+            try_qwen35_causal_conv_sequence(&input_tensor, &weight_tensor, &history_tensor)
+                .expect("Qwen3.5 causal conv custom Metal op should run");
+        let output = output.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let final_history = final_history
+            .flatten_all()
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap();
+        assert_f32_close(&output, &expected_output, 2e-5, "causal conv output");
+        assert_f32_close(
+            &final_history,
+            &expected_history,
+            1e-6,
+            "causal conv history",
+        );
+    }
+
+    #[cfg(all(feature = "metal", target_os = "macos"))]
+    #[test]
+    fn metal_qwen35_gated_delta_matches_cpu_reference_for_both_layouts_if_available() {
+        let Ok(Ok(device)) = std::panic::catch_unwind(|| Device::new_metal(0)) else {
+            return;
+        };
+        let seq_len = 3;
+        let num_k_heads = 16;
+        let head_k_dim = 3;
+        let head_v_dim = 5;
+
+        for num_v_heads in [16usize, 32] {
+            let query: Vec<f32> = (0..seq_len * num_k_heads * head_k_dim)
+                .map(|idx| ((idx % 17) as f32 - 8.0) * 0.025)
+                .collect();
+            let key: Vec<f32> = (0..seq_len * num_k_heads * head_k_dim)
+                .map(|idx| ((idx % 13) as f32 - 6.0) * 0.021)
+                .collect();
+            let value: Vec<f32> = (0..seq_len * num_v_heads * head_v_dim)
+                .map(|idx| ((idx % 19) as f32 - 9.0) * 0.018)
+                .collect();
+            let g: Vec<f32> = (0..seq_len * num_v_heads)
+                .map(|idx| -0.015 * ((idx % 5) + 1) as f32)
+                .collect();
+            let beta: Vec<f32> = (0..seq_len * num_v_heads)
+                .map(|idx| 0.2 + 0.03 * (idx % 4) as f32)
+                .collect();
+            let initial_state: Vec<f32> = (0..num_v_heads * head_k_dim * head_v_dim)
+                .map(|idx| ((idx % 23) as f32 - 11.0) * 0.004)
+                .collect();
+            let (expected_output, expected_state) = qwen35_gated_delta_reference(
+                &query,
+                &key,
+                &value,
+                &g,
+                &beta,
+                &initial_state,
+                seq_len,
+                num_k_heads,
+                num_v_heads,
+                head_k_dim,
+                head_v_dim,
+            );
+
+            let query_tensor =
+                Tensor::from_vec(query, (1, seq_len, num_k_heads, head_k_dim), &device).unwrap();
+            let key_tensor =
+                Tensor::from_vec(key, (1, seq_len, num_k_heads, head_k_dim), &device).unwrap();
+            let value_tensor =
+                Tensor::from_vec(value, (1, seq_len, num_v_heads, head_v_dim), &device).unwrap();
+            let g_tensor = Tensor::from_vec(g, (1, seq_len, num_v_heads), &device).unwrap();
+            let beta_tensor = Tensor::from_vec(beta, (1, seq_len, num_v_heads), &device).unwrap();
+            let state_tensor = Tensor::from_vec(
+                initial_state,
+                (1, num_v_heads, head_k_dim, head_v_dim),
+                &device,
+            )
+            .unwrap();
+
+            let (output, final_state) = try_tiled_deltanet_recurrence(
+                &query_tensor,
+                &key_tensor,
+                &value_tensor,
+                &g_tensor,
+                &beta_tensor,
+                &state_tensor,
+                64,
+            )
+            .expect("Qwen3.5 Gated DeltaNet custom Metal op should run");
+            assert_eq!(output.dtype(), DType::F32);
+            assert_eq!(final_state.dtype(), DType::F32);
+            let output = output.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+            let final_state = final_state.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+            let layout = format!("16K/{num_v_heads}V");
+            assert_f32_close(&output, &expected_output, 2e-4, &format!("{layout} output"));
+            assert_f32_close(
+                &final_state,
+                &expected_state,
+                2e-4,
+                &format!("{layout} state"),
+            );
+        }
+    }
+
+    #[cfg(all(feature = "metal", target_os = "macos"))]
+    #[test]
+    fn metal_qwen35_gated_delta_rejects_invalid_dtype_and_head_layout_if_available() {
+        let Ok(Ok(device)) = std::panic::catch_unwind(|| Device::new_metal(0)) else {
+            return;
+        };
+        let query = Tensor::zeros((1, 2, 16, 2), DType::F32, &device).unwrap();
+        let key = Tensor::zeros((1, 2, 16, 2), DType::F32, &device).unwrap();
+        let value = Tensor::zeros((1, 2, 16, 3), DType::F32, &device).unwrap();
+        let g = Tensor::zeros((1, 2, 16), DType::F32, &device).unwrap();
+        let beta = Tensor::zeros((1, 2, 16), DType::F32, &device).unwrap();
+        let state = Tensor::zeros((1, 16, 2, 3), DType::F32, &device).unwrap();
+        assert!(try_tiled_deltanet_recurrence(
+            &query.to_dtype(DType::F16).unwrap(),
+            &key,
+            &value,
+            &g,
+            &beta,
+            &state,
+            64,
+        )
+        .is_none());
+
+        let invalid_value = Tensor::zeros((1, 2, 24, 3), DType::F32, &device).unwrap();
+        let invalid_g = Tensor::zeros((1, 2, 24), DType::F32, &device).unwrap();
+        let invalid_beta = Tensor::zeros((1, 2, 24), DType::F32, &device).unwrap();
+        let invalid_state = Tensor::zeros((1, 24, 2, 3), DType::F32, &device).unwrap();
+        assert!(try_tiled_deltanet_recurrence(
+            &query,
+            &key,
+            &invalid_value,
+            &invalid_g,
+            &invalid_beta,
+            &invalid_state,
+            64,
+        )
+        .is_none());
     }
 
     #[cfg(all(feature = "metal", target_os = "macos"))]

--- a/crates/izwi-core/src/kernels/mod.rs
+++ b/crates/izwi-core/src/kernels/mod.rs
@@ -268,6 +268,26 @@ pub fn try_lfm_shortconv_sequence3(bx: &Tensor, conv: &Tensor) -> Option<Tensor>
     None
 }
 
+pub fn try_qwen35_causal_conv_sequence(
+    input: &Tensor,
+    weight: &Tensor,
+    history: &Tensor,
+) -> Option<(Tensor, Tensor)> {
+    if !use_fused_kernels_for_device(input.device()) {
+        return None;
+    }
+
+    if input.device().is_cuda() {
+        return cuda::try_qwen35_causal_conv_sequence(input, weight, history);
+    }
+
+    if input.device().is_metal() {
+        return metal::try_qwen35_causal_conv_sequence(input, weight, history);
+    }
+
+    None
+}
+
 pub fn try_fused_gated_rms_norm(
     hidden: &Tensor,
     gate: &Tensor,

--- a/crates/izwi-core/src/lib.rs
+++ b/crates/izwi-core/src/lib.rs
@@ -105,7 +105,8 @@ pub use catalog::{
     ModelVariant, SpeechModelCapabilities,
 };
 pub use runtime_models::shared::chat::{
-    ChatMediaInput, ChatMediaKind, ChatMessage, ChatRequestConfig, ChatRole,
+    ChatGenerationFinishReason, ChatMediaInput, ChatMediaKind, ChatMessage, ChatRequestConfig,
+    ChatRole,
 };
 
 // Canonical native registry/device exports.

--- a/crates/izwi-core/src/models/architectures/qwen35/chat.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/chat.rs
@@ -69,6 +69,8 @@ pub struct ChatDecodeState {
     track_history: bool,
     decode_stream: TokenizerDecodeStreamState,
     assembled: String,
+    emitted_text_bytes: usize,
+    stop_sequences: Vec<String>,
     max_new_tokens: usize,
     finished: bool,
     next_text_position: usize,
@@ -514,6 +516,8 @@ impl Qwen35ChatModel {
             track_history,
             decode_stream: TokenizerDecodeStreamState::default(),
             assembled: String::new(),
+            emitted_text_bytes: 0,
+            stop_sequences: normalize_stop_sequences(&config.stop_sequences),
             max_new_tokens: max_new_tokens.max(1),
             finished: false,
             next_text_position: prepared_prompt.next_text_position,
@@ -525,8 +529,9 @@ impl Qwen35ChatModel {
     pub fn decode_step(&self, state: &mut ChatDecodeState) -> Result<ChatDecodeStep> {
         if state.finished || state.tokens_generated >= state.max_new_tokens {
             state.finished = true;
+            let delta = flush_stream_text(&state.assembled, &mut state.emitted_text_bytes)?;
             return Ok(ChatDecodeStep {
-                delta: String::new(),
+                delta,
                 text: state.assembled.trim().to_string(),
                 tokens_generated: state.tokens_generated,
                 finished: true,
@@ -547,31 +552,47 @@ impl Qwen35ChatModel {
         )?;
         if self.is_stop_token(next, &state.config) {
             state.finished = true;
+            let delta = flush_stream_text(&state.assembled, &mut state.emitted_text_bytes)?;
             return Ok(ChatDecodeStep {
-                delta: String::new(),
+                delta,
                 text: state.assembled.trim().to_string(),
                 tokens_generated: state.tokens_generated,
                 finished: true,
             });
         }
 
-        let delta = self
+        let decoded = self
             .tokenizer
             .decode_token_piece(&mut state.decode_stream, next)?;
         if state.track_history {
             state.history_ids.push(next);
         }
         state.tokens_generated = state.tokens_generated.saturating_add(1);
-        state.assembled.push_str(&delta);
-        state.logits = self.text_model.forward_token_id_at(
-            next,
-            [state.next_text_position; 3],
-            &mut state.text_state,
+        state.assembled.push_str(&decoded);
+        let stopped_on_sequence = truncate_at_stop_sequence(
+            &mut state.assembled,
+            state.emitted_text_bytes,
+            &state.stop_sequences,
         )?;
-        state.next_text_position += 1;
-        if state.tokens_generated >= state.max_new_tokens {
+        if stopped_on_sequence {
             state.finished = true;
+        } else {
+            state.logits = self.text_model.forward_token_id_at(
+                next,
+                [state.next_text_position; 3],
+                &mut state.text_state,
+            )?;
+            state.next_text_position += 1;
+            if state.tokens_generated >= state.max_new_tokens {
+                state.finished = true;
+            }
         }
+        let delta = take_stream_safe_text(
+            &state.assembled,
+            &mut state.emitted_text_bytes,
+            &state.stop_sequences,
+            state.finished,
+        )?;
         let final_text = if state.finished {
             state.assembled.trim().to_string()
         } else {
@@ -1301,6 +1322,87 @@ fn initial_penalty_history(
     history
 }
 
+fn normalize_stop_sequences(stop_sequences: &[String]) -> Vec<String> {
+    let mut normalized = Vec::with_capacity(stop_sequences.len());
+    for sequence in stop_sequences {
+        if sequence.is_empty() || normalized.iter().any(|existing| existing == sequence) {
+            continue;
+        }
+        normalized.push(sequence.clone());
+    }
+    normalized
+}
+
+fn truncate_at_stop_sequence(
+    text: &mut String,
+    emitted_text_bytes: usize,
+    stop_sequences: &[String],
+) -> Result<bool> {
+    let stop_index = stop_sequences
+        .iter()
+        .filter_map(|sequence| text.find(sequence))
+        .min();
+    let Some(stop_index) = stop_index else {
+        return Ok(false);
+    };
+    if stop_index < emitted_text_bytes {
+        return Err(Error::InferenceError(format!(
+            "Qwen3.5 stop-sequence streaming invariant failed: stop begins at byte {stop_index}, but {emitted_text_bytes} bytes were already emitted"
+        )));
+    }
+    text.truncate(stop_index);
+    Ok(true)
+}
+
+fn take_stream_safe_text(
+    text: &str,
+    emitted_text_bytes: &mut usize,
+    stop_sequences: &[String],
+    terminal: bool,
+) -> Result<String> {
+    let safe_end = if terminal {
+        text.len()
+    } else {
+        text.len()
+            .saturating_sub(longest_stop_prefix_suffix(text, stop_sequences))
+    };
+    if *emitted_text_bytes > safe_end || !text.is_char_boundary(*emitted_text_bytes) {
+        return Err(Error::InferenceError(format!(
+            "Qwen3.5 streamed text cursor is invalid: emitted={}, safe_end={}, text_len={}",
+            *emitted_text_bytes,
+            safe_end,
+            text.len()
+        )));
+    }
+    let delta = text[*emitted_text_bytes..safe_end].to_string();
+    *emitted_text_bytes = safe_end;
+    Ok(delta)
+}
+
+fn flush_stream_text(text: &str, emitted_text_bytes: &mut usize) -> Result<String> {
+    take_stream_safe_text(text, emitted_text_bytes, &[], true)
+}
+
+fn longest_stop_prefix_suffix(text: &str, stop_sequences: &[String]) -> usize {
+    let max_stop_bytes = stop_sequences.iter().map(String::len).max().unwrap_or(0);
+    if max_stop_bytes == 0 || text.is_empty() {
+        return 0;
+    }
+
+    let earliest_candidate = text.len().saturating_sub(max_stop_bytes);
+    text.char_indices()
+        .filter(|(index, _)| *index >= earliest_candidate)
+        .filter_map(|(index, _)| {
+            let suffix = &text[index..];
+            stop_sequences
+                .iter()
+                .any(|sequence| sequence.starts_with(suffix))
+                .then_some(suffix.len())
+        })
+        .max()
+        .unwrap_or(0)
+}
+
 fn sample_next_token(
     logits: &Tensor,
     vocab_size: usize,
@@ -1863,6 +1965,93 @@ mod tests {
     }
 
     #[test]
+    fn render_prompt_matches_qwen35_multiturn_golden() {
+        let config = ChatGenerationConfig {
+            request: ChatRequestConfig {
+                enable_thinking: Some(false),
+                tools: Vec::new(),
+                media_inputs: Vec::new(),
+            },
+            ..ChatGenerationConfig::default()
+        };
+        let prompt = render_prompt(
+            &[
+                ChatMessage {
+                    role: ChatRole::User,
+                    content: "First question".to_string(),
+                },
+                ChatMessage {
+                    role: ChatRole::Assistant,
+                    content: "reasoning first</think>\nFinal answer".to_string(),
+                },
+                ChatMessage {
+                    role: ChatRole::User,
+                    content: "Follow-up".to_string(),
+                },
+            ],
+            &config,
+            true,
+        )
+        .expect("prompt should render");
+
+        assert_eq!(
+            prompt,
+            "<|im_start|>user\nFirst question<|im_end|>\n\
+             <|im_start|>assistant\nFinal answer<|im_end|>\n\
+             <|im_start|>user\nFollow-up<|im_end|>\n\
+             <|im_start|>assistant\n<think>\n\n</think>\n\n"
+        );
+    }
+
+    #[test]
+    fn stop_sequence_streaming_holds_back_cross_token_prefixes() {
+        let stops =
+            normalize_stop_sequences(&["END".to_string(), String::new(), "END".to_string()]);
+        assert_eq!(stops, ["END"]);
+
+        let mut text = "hello E".to_string();
+        let mut emitted = 0usize;
+        assert_eq!(
+            take_stream_safe_text(&text, &mut emitted, &stops, false).unwrap(),
+            "hello "
+        );
+        text.push('N');
+        assert!(take_stream_safe_text(&text, &mut emitted, &stops, false)
+            .unwrap()
+            .is_empty());
+        text.push_str("D ignored");
+        assert!(truncate_at_stop_sequence(&mut text, emitted, &stops).unwrap());
+        assert_eq!(text, "hello ");
+        assert!(take_stream_safe_text(&text, &mut emitted, &stops, true)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn stop_sequence_streaming_releases_nonmatching_and_unicode_prefixes() {
+        let stops = vec!["終わり".to_string(), "END".to_string()];
+        let mut emitted = 0usize;
+        let mut text = "go E".to_string();
+        assert_eq!(
+            take_stream_safe_text(&text, &mut emitted, &stops, false).unwrap(),
+            "go "
+        );
+        text.push('x');
+        assert_eq!(
+            take_stream_safe_text(&text, &mut emitted, &stops, false).unwrap(),
+            "Ex"
+        );
+        text.push_str(" answer 終");
+        assert_eq!(
+            take_stream_safe_text(&text, &mut emitted, &stops, false).unwrap(),
+            " answer "
+        );
+        text.push_str("わり trailing");
+        assert!(truncate_at_stop_sequence(&mut text, emitted, &stops).unwrap());
+        assert_eq!(text, "go Ex answer ");
+    }
+
+    #[test]
     fn penalty_history_starts_with_the_complete_prompt() {
         let prompt = [11, 12, 13, 14];
         let history = initial_penalty_history(&prompt, 8, true);
@@ -1885,6 +2074,7 @@ mod tests {
             top_k: 0,
             repetition_penalty: 1.0,
             presence_penalty: 0.0,
+            stop_sequences: Vec::new(),
             stop_token_ids: Vec::new(),
             seed: 7,
             request: ChatRequestConfig::default(),
@@ -1904,6 +2094,7 @@ mod tests {
             top_k: 0,
             repetition_penalty: 1.0,
             presence_penalty: 0.0,
+            stop_sequences: Vec::new(),
             stop_token_ids: Vec::new(),
             seed: 7,
             request: ChatRequestConfig::default(),
@@ -2003,6 +2194,7 @@ mod tests {
             top_k: 0,
             repetition_penalty: 1.0,
             presence_penalty: 0.0,
+            stop_sequences: Vec::new(),
             stop_token_ids: Vec::new(),
             seed: 7,
             request: ChatRequestConfig::default(),
@@ -2036,6 +2228,7 @@ mod tests {
             top_k: 0,
             repetition_penalty: 1.0,
             presence_penalty: 0.0,
+            stop_sequences: Vec::new(),
             stop_token_ids: Vec::new(),
             seed: 7,
             request: ChatRequestConfig {
@@ -2088,6 +2281,7 @@ mod tests {
             top_k: 0,
             repetition_penalty: 1.0,
             presence_penalty: 0.0,
+            stop_sequences: Vec::new(),
             stop_token_ids: Vec::new(),
             seed: 7,
             request: ChatRequestConfig::default(),
@@ -2182,6 +2376,7 @@ mod tests {
             top_k: 0,
             repetition_penalty: 1.0,
             presence_penalty: 0.0,
+            stop_sequences: Vec::new(),
             stop_token_ids: Vec::new(),
             seed: 7,
             request: ChatRequestConfig {
@@ -2231,6 +2426,7 @@ mod tests {
             top_k: 0,
             repetition_penalty: 1.0,
             presence_penalty: 0.0,
+            stop_sequences: Vec::new(),
             stop_token_ids: Vec::new(),
             seed: 7,
             request: ChatRequestConfig {

--- a/crates/izwi-core/src/models/architectures/qwen35/chat.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/chat.rs
@@ -3,6 +3,7 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fs;
+use std::mem::size_of;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -44,12 +45,21 @@ pub struct Qwen35PreparedPrompt {
     prompt_ids: Vec<u32>,
     prompt_positions: Vec<[usize; 3]>,
     next_text_position: usize,
+    reusable_prefix_len: Option<usize>,
     vision_inputs: Option<PreparedVisionInputs>,
 }
 
 impl Qwen35PreparedPrompt {
     pub fn prompt_ids(&self) -> &[u32] {
         &self.prompt_ids
+    }
+
+    pub(crate) fn prompt_positions(&self) -> &[[usize; 3]] {
+        &self.prompt_positions
+    }
+
+    pub(crate) fn supports_exact_prefix_reuse(&self) -> bool {
+        self.vision_inputs.is_none() && self.reusable_prefix_len.is_some()
     }
 }
 
@@ -85,6 +95,8 @@ pub struct ChatDecodeState {
     max_new_tokens: usize,
     finished: bool,
     next_text_position: usize,
+    pending_prefix_snapshot: Option<Qwen35PrefixSnapshot>,
+    reused_prefix_tokens: usize,
     config: ChatGenerationConfig,
     rng: SimpleRng,
 }
@@ -102,6 +114,65 @@ impl ChatDecodeState {
     /// Complete per-session scheduler accounting.
     pub fn session_cache_bytes(&self) -> Option<u64> {
         self.allocated_session_bytes()
+    }
+
+    pub(crate) fn take_pending_prefix_snapshot(&mut self) -> Option<Qwen35PrefixSnapshot> {
+        self.pending_prefix_snapshot.take()
+    }
+
+    pub(crate) fn reused_prefix_tokens(&self) -> usize {
+        self.reused_prefix_tokens
+    }
+}
+
+/// Immutable checkpoint at an exact rendered-token boundary. Request-specific
+/// sampler, history, RNG, and stream state are rebuilt on every restore.
+pub struct Qwen35PrefixSnapshot {
+    text_state: Qwen35TextRuntimeState,
+    token_ids: Vec<u32>,
+    positions: Vec<[usize; 3]>,
+    next_text_position: usize,
+}
+
+impl Qwen35PrefixSnapshot {
+    pub(crate) fn token_ids(&self) -> &[u32] {
+        &self.token_ids
+    }
+
+    pub(crate) fn positions(&self) -> &[[usize; 3]] {
+        &self.positions
+    }
+
+    pub(crate) fn retained_bytes(&self) -> Option<u64> {
+        let mut accounting = TensorStorageAccounting::default();
+        self.text_state.account_storage(&mut accounting)?;
+        accounting.add_bytes(
+            u64::try_from(self.token_ids.capacity().checked_mul(size_of::<u32>())?).ok()?,
+        )?;
+        accounting.add_bytes(
+            u64::try_from(
+                self.positions
+                    .capacity()
+                    .checked_mul(size_of::<[usize; 3]>())?,
+            )
+            .ok()?,
+        )?;
+        accounting.add_bytes(u64::try_from(size_of::<Self>()).ok()?)?;
+        Some(accounting.bytes())
+    }
+
+    fn matches(&self, prepared: &Qwen35PreparedPrompt) -> bool {
+        let prefix_len = self.token_ids.len();
+        prepared.vision_inputs.is_none()
+            && prefix_len > 0
+            && prefix_len == self.positions.len()
+            && self.next_text_position == prefix_len
+            && prepared.prompt_ids.starts_with(&self.token_ids)
+            && prepared.prompt_positions.starts_with(&self.positions)
+            && prepared
+                .prompt_positions
+                .get(prefix_len)
+                .is_some_and(|position| *position == [self.next_text_position; 3])
     }
 }
 
@@ -495,9 +566,34 @@ impl Qwen35ChatModel {
         config: &ChatGenerationConfig,
         prepared: Option<&Qwen35PreparedPrompt>,
     ) -> Result<ChatDecodeState> {
+        self.start_decode_state_with_optional_prepared_and_prefix(
+            messages,
+            max_new_tokens,
+            config,
+            prepared,
+            None,
+            None,
+        )
+    }
+
+    pub(crate) fn start_decode_state_with_optional_prepared_and_prefix(
+        &self,
+        messages: &[ChatMessage],
+        max_new_tokens: usize,
+        config: &ChatGenerationConfig,
+        prepared: Option<&Qwen35PreparedPrompt>,
+        prefix: Option<&Qwen35PrefixSnapshot>,
+        capture_prefix_max_bytes: Option<u64>,
+    ) -> Result<ChatDecodeState> {
         let prepared_prompt =
             resolve_prepared_prompt(prepared, || self.prepare_prompt(messages, config))?;
-        self.start_decode_state_with_prepared(&prepared_prompt, max_new_tokens, config)
+        self.start_decode_state_with_prepared_and_prefix(
+            &prepared_prompt,
+            max_new_tokens,
+            config,
+            prefix,
+            capture_prefix_max_bytes,
+        )
     }
 
     pub fn start_decode_state_with_prepared(
@@ -506,15 +602,50 @@ impl Qwen35ChatModel {
         max_new_tokens: usize,
         config: &ChatGenerationConfig,
     ) -> Result<ChatDecodeState> {
+        self.start_decode_state_with_prepared_and_prefix(
+            prepared_prompt,
+            max_new_tokens,
+            config,
+            None,
+            None,
+        )
+    }
+
+    fn start_decode_state_with_prepared_and_prefix(
+        &self,
+        prepared_prompt: &Qwen35PreparedPrompt,
+        max_new_tokens: usize,
+        config: &ChatGenerationConfig,
+        prefix: Option<&Qwen35PrefixSnapshot>,
+        capture_prefix_max_bytes: Option<u64>,
+    ) -> Result<ChatDecodeState> {
         if prepared_prompt.prompt_ids.is_empty() {
             return Err(Error::InvalidInput(
                 "Chat request must include at least one tokenizable message".to_string(),
             ));
         }
 
-        let mut text_state = self.text_model.new_state();
-        let logits =
-            compact_tensor_storage(&self.prefill_prompt(prepared_prompt, &mut text_state)?)?;
+        let reusable_prefix = prefix.filter(|prefix| prefix.matches(prepared_prompt));
+        let (mut text_state, reused_prefix_tokens) = match reusable_prefix {
+            Some(prefix) => match prefix.text_state.fork_for_prefix() {
+                Ok(state) => (state, prefix.token_ids.len()),
+                Err(_) => (self.text_model.new_state(), 0),
+            },
+            None => (self.text_model.new_state(), 0),
+        };
+        let (logits, pending_prefix_snapshot) = if prepared_prompt.vision_inputs.is_none() {
+            self.prefill_text_prompt_with_prefix_checkpoint(
+                prepared_prompt,
+                &mut text_state,
+                reused_prefix_tokens,
+                capture_prefix_max_bytes,
+            )?
+        } else {
+            (
+                compact_tensor_storage(&self.prefill_prompt(prepared_prompt, &mut text_state)?)?,
+                None,
+            )
+        };
         let track_history =
             config.repetition_penalty > 1.0 || config.presence_penalty.abs() > f32::EPSILON;
         let history_ids =
@@ -533,6 +664,8 @@ impl Qwen35ChatModel {
             max_new_tokens: max_new_tokens.max(1),
             finished: false,
             next_text_position: prepared_prompt.next_text_position,
+            pending_prefix_snapshot,
+            reused_prefix_tokens,
             config: config.clone(),
             rng: SimpleRng::new(config.seed),
         })
@@ -624,6 +757,82 @@ impl Qwen35ChatModel {
             || token_id == self.tokenizer.specials.eos
             || self.tokenizer.specials.eos_alt == Some(token_id)
             || config.stop_token_ids.contains(&token_id)
+    }
+
+    fn prefill_text_prompt_with_prefix_checkpoint(
+        &self,
+        prepared: &Qwen35PreparedPrompt,
+        text_state: &mut Qwen35TextRuntimeState,
+        reused_prefix_tokens: usize,
+        capture_prefix_max_bytes: Option<u64>,
+    ) -> Result<(Tensor, Option<Qwen35PrefixSnapshot>)> {
+        let token_count = prepared.prompt_ids.len();
+        if reused_prefix_tokens >= token_count {
+            return Err(Error::InferenceError(
+                "Qwen3.5 cached prefix leaves no prompt suffix for logits".to_string(),
+            ));
+        }
+
+        let checkpoint = prepared
+            .reusable_prefix_len
+            .filter(|checkpoint| *checkpoint > reused_prefix_tokens && *checkpoint < token_count);
+        let mut cursor = reused_prefix_tokens;
+        if let Some(checkpoint) = checkpoint {
+            self.prefill_text_range(prepared, text_state, cursor, checkpoint, false)?;
+            cursor = checkpoint;
+        }
+
+        let pending = match (checkpoint, capture_prefix_max_bytes) {
+            (Some(checkpoint), Some(max_bytes)) if max_bytes > 0 => text_state
+                .fork_for_prefix()
+                .ok()
+                .map(|text_state| Qwen35PrefixSnapshot {
+                    text_state,
+                    token_ids: prepared.prompt_ids[..checkpoint].to_vec(),
+                    positions: prepared.prompt_positions[..checkpoint].to_vec(),
+                    next_text_position: checkpoint,
+                })
+                .filter(|snapshot| {
+                    snapshot
+                        .retained_bytes()
+                        .is_some_and(|bytes| bytes <= max_bytes)
+                }),
+            _ => None,
+        };
+
+        let logits = self
+            .prefill_text_range(prepared, text_state, cursor, token_count, true)?
+            .ok_or_else(|| {
+                Error::InferenceError("Qwen3.5 text suffix prefill produced no logits".to_string())
+            })?;
+        Ok((compact_tensor_storage(&logits)?, pending))
+    }
+
+    fn prefill_text_range(
+        &self,
+        prepared: &Qwen35PreparedPrompt,
+        text_state: &mut Qwen35TextRuntimeState,
+        start: usize,
+        end: usize,
+        compute_final_logits: bool,
+    ) -> Result<Option<Tensor>> {
+        let mut logits = None;
+        let mut chunk_start = start;
+        let chunk_size = qwen35_prefill_chunk_size();
+        while chunk_start < end {
+            let chunk_end = (chunk_start + chunk_size).min(end);
+            let compute_logits = compute_final_logits && chunk_end == end;
+            if let Some(chunk_logits) = self.text_model.prefill_token_ids(
+                &prepared.prompt_ids[chunk_start..chunk_end],
+                &prepared.prompt_positions[chunk_start..chunk_end],
+                text_state,
+                compute_logits,
+            )? {
+                logits = Some(chunk_logits);
+            }
+            chunk_start = chunk_end;
+        }
+        Ok(logits)
     }
 
     fn prefill_prompt(
@@ -745,11 +954,14 @@ impl Qwen35ChatModel {
                 ));
             }
             let prompt_ids = self.tokenizer.encode_text(&prompt)?;
+            let reusable_prefix_len =
+                reusable_prefix_token_len(&self.tokenizer, &prompt, &prompt_ids)?;
             let prompt_positions = build_text_positions(prompt_ids.len());
             return Ok(Qwen35PreparedPrompt {
                 next_text_position: prompt_positions.len(),
                 prompt_ids,
                 prompt_positions,
+                reusable_prefix_len,
                 vision_inputs: None,
             });
         };
@@ -780,6 +992,7 @@ impl Qwen35ChatModel {
             prompt_ids,
             prompt_positions,
             next_text_position,
+            reusable_prefix_len: None,
             vision_inputs: Some(vision_inputs),
         })
     }
@@ -861,6 +1074,26 @@ fn qwen35_session_cache_upper_bound_bytes(
 
 fn build_text_positions(token_count: usize) -> Vec<[usize; 3]> {
     (0..token_count).map(|idx| [idx; 3]).collect()
+}
+
+fn reusable_prefix_token_len(
+    tokenizer: &Qwen35Tokenizer,
+    rendered_prompt: &str,
+    full_ids: &[u32],
+) -> Result<Option<usize>> {
+    const ASSISTANT_HEADER: &str = "<|im_start|>assistant\n";
+    let Some(header_start) = rendered_prompt.rfind(ASSISTANT_HEADER) else {
+        return Ok(None);
+    };
+    let boundary_end = header_start + ASSISTANT_HEADER.len();
+    let boundary_ids = tokenizer.encode_text(&rendered_prompt[..boundary_end])?;
+    // Tokenizers may merge across an arbitrary string boundary. Reuse is only
+    // valid when the independently encoded boundary is literally the full
+    // prompt's token prefix.
+    Ok(
+        (!boundary_ids.is_empty() && full_ids.starts_with(&boundary_ids))
+            .then_some(boundary_ids.len()),
+    )
 }
 
 fn expand_image_placeholders(prompt: &str, token_counts: &[usize]) -> Result<String> {
@@ -1802,6 +2035,7 @@ mod tests {
             prompt_ids: vec![1, 2, 3],
             prompt_positions: build_text_positions(3),
             next_text_position: 3,
+            reusable_prefix_len: Some(2),
             vision_inputs: None,
         };
         let preparation_calls = AtomicUsize::new(0);

--- a/crates/izwi-core/src/models/architectures/qwen35/chat.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/chat.rs
@@ -25,6 +25,17 @@ use super::vision::{PreparedVisionInputs, Qwen35VisionModel};
 
 const IMAGE_PAD_PLACEHOLDER: &str = "<|image_pad|>";
 const VIDEO_PAD_PLACEHOLDER: &str = "<|video_pad|>";
+const DEFAULT_PREFILL_CHUNK_SIZE: usize = 256;
+const MAX_PREFILL_CHUNK_SIZE: usize = 2048;
+
+fn qwen35_prefill_chunk_size() -> usize {
+    std::env::var("IZWI_QWEN35_PREFILL_CHUNK_SIZE")
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_PREFILL_CHUNK_SIZE)
+        .min(MAX_PREFILL_CHUNK_SIZE)
+}
 
 /// Fully prepared Qwen3.5 prefill input. The runtime carries this exact
 /// artifact into the executor so media loading and vision encoding happen once.
@@ -503,7 +514,7 @@ impl Qwen35ChatModel {
 
         let mut text_state = self.text_model.new_state();
         let logits =
-            compact_tensor_storage(&self.prefill_prompt(&prepared_prompt, &mut text_state)?)?;
+            compact_tensor_storage(&self.prefill_prompt(prepared_prompt, &mut text_state)?)?;
         let track_history =
             config.repetition_penalty > 1.0 || config.presence_penalty.abs() > f32::EPSILON;
         let history_ids =
@@ -674,14 +685,20 @@ impl Qwen35ChatModel {
                     run_end += 1;
                 }
 
-                let compute_logits = run_end == prepared_prompt.prompt_ids.len();
-                if let Some(run_logits) = self.text_model.prefill_token_ids(
-                    &prepared_prompt.prompt_ids[idx..run_end],
-                    &prepared_prompt.prompt_positions[idx..run_end],
-                    text_state,
-                    compute_logits,
-                )? {
-                    logits = Some(run_logits);
+                let chunk_size = qwen35_prefill_chunk_size();
+                let mut chunk_start = idx;
+                while chunk_start < run_end {
+                    let chunk_end = (chunk_start + chunk_size).min(run_end);
+                    let compute_logits = chunk_end == prepared_prompt.prompt_ids.len();
+                    if let Some(run_logits) = self.text_model.prefill_token_ids(
+                        &prepared_prompt.prompt_ids[chunk_start..chunk_end],
+                        &prepared_prompt.prompt_positions[chunk_start..chunk_end],
+                        text_state,
+                        compute_logits,
+                    )? {
+                        logits = Some(run_logits);
+                    }
+                    chunk_start = chunk_end;
                 }
                 idx = run_end;
                 continue;
@@ -1798,6 +1815,25 @@ mod tests {
 
         assert_eq!(resolved.prompt_ids(), prepared.prompt_ids());
         assert_eq!(preparation_calls.load(AtomicOrdering::Relaxed), 0);
+    }
+
+    #[test]
+    fn prefill_chunk_size_is_bounded_and_rejects_zero() {
+        let _guard = crate::env_test_lock().lock().expect("env lock");
+
+        std::env::remove_var("IZWI_QWEN35_PREFILL_CHUNK_SIZE");
+        assert_eq!(qwen35_prefill_chunk_size(), DEFAULT_PREFILL_CHUNK_SIZE);
+
+        std::env::set_var("IZWI_QWEN35_PREFILL_CHUNK_SIZE", "0");
+        assert_eq!(qwen35_prefill_chunk_size(), DEFAULT_PREFILL_CHUNK_SIZE);
+
+        std::env::set_var("IZWI_QWEN35_PREFILL_CHUNK_SIZE", "64");
+        assert_eq!(qwen35_prefill_chunk_size(), 64);
+
+        std::env::set_var("IZWI_QWEN35_PREFILL_CHUNK_SIZE", "999999");
+        assert_eq!(qwen35_prefill_chunk_size(), MAX_PREFILL_CHUNK_SIZE);
+
+        std::env::remove_var("IZWI_QWEN35_PREFILL_CHUNK_SIZE");
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/qwen35/chat.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/chat.rs
@@ -15,7 +15,7 @@ use crate::backends::{BackendKind, DeviceProfile};
 use crate::error::{Error, Result};
 use crate::model::ModelVariant;
 use crate::models::shared::chat::{ChatGenerationConfig, ChatMessage, ChatRole};
-use crate::models::shared::memory::accounting::TensorStorageAccounting;
+use crate::models::shared::memory::accounting::{compact_tensor_storage, TensorStorageAccounting};
 use crate::models::shared::telemetry::record_prefill_token_mode_step;
 use crate::models::shared::weights::gguf::{GgufLoader, GgufModelInfo};
 use crate::tokenizer::{Tokenizer, TokenizerDecodeStreamState};
@@ -502,7 +502,8 @@ impl Qwen35ChatModel {
         }
 
         let mut text_state = self.text_model.new_state();
-        let logits = self.prefill_prompt(&prepared_prompt, &mut text_state)?;
+        let logits =
+            compact_tensor_storage(&self.prefill_prompt(&prepared_prompt, &mut text_state)?)?;
         let track_history =
             config.repetition_penalty > 1.0 || config.presence_penalty.abs() > f32::EPSILON;
         let history_ids =
@@ -577,11 +578,11 @@ impl Qwen35ChatModel {
         if stopped_on_sequence {
             state.finished = true;
         } else {
-            state.logits = self.text_model.forward_token_id_at(
+            state.logits = compact_tensor_storage(&self.text_model.forward_token_id_at(
                 next,
                 [state.next_text_position; 3],
                 &mut state.text_state,
-            )?;
+            )?)?;
             state.next_text_position += 1;
             if state.tokens_generated >= state.max_new_tokens {
                 state.finished = true;

--- a/crates/izwi-core/src/models/architectures/qwen35/chat.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/chat.rs
@@ -129,8 +129,8 @@ impl ChatDecodeState {
 /// sampler, history, RNG, and stream state are rebuilt on every restore.
 pub struct Qwen35PrefixSnapshot {
     text_state: Qwen35TextRuntimeState,
-    token_ids: Vec<u32>,
-    positions: Vec<[usize; 3]>,
+    token_ids: Box<[u32]>,
+    positions: Box<[[usize; 3]]>,
     next_text_position: usize,
 }
 
@@ -146,16 +146,10 @@ impl Qwen35PrefixSnapshot {
     pub(crate) fn retained_bytes(&self) -> Option<u64> {
         let mut accounting = TensorStorageAccounting::default();
         self.text_state.account_storage(&mut accounting)?;
+        accounting
+            .add_bytes(u64::try_from(self.token_ids.len().checked_mul(size_of::<u32>())?).ok()?)?;
         accounting.add_bytes(
-            u64::try_from(self.token_ids.capacity().checked_mul(size_of::<u32>())?).ok()?,
-        )?;
-        accounting.add_bytes(
-            u64::try_from(
-                self.positions
-                    .capacity()
-                    .checked_mul(size_of::<[usize; 3]>())?,
-            )
-            .ok()?,
+            u64::try_from(self.positions.len().checked_mul(size_of::<[usize; 3]>())?).ok()?,
         )?;
         accounting.add_bytes(u64::try_from(size_of::<Self>()).ok()?)?;
         Some(accounting.bytes())
@@ -788,8 +782,12 @@ impl Qwen35ChatModel {
                 .ok()
                 .map(|text_state| Qwen35PrefixSnapshot {
                     text_state,
-                    token_ids: prepared.prompt_ids[..checkpoint].to_vec(),
-                    positions: prepared.prompt_positions[..checkpoint].to_vec(),
+                    token_ids: prepared.prompt_ids[..checkpoint]
+                        .to_vec()
+                        .into_boxed_slice(),
+                    positions: prepared.prompt_positions[..checkpoint]
+                        .to_vec()
+                        .into_boxed_slice(),
                     next_text_position: checkpoint,
                 })
                 .filter(|snapshot| {

--- a/crates/izwi-core/src/models/architectures/qwen35/chat.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/chat.rs
@@ -4,7 +4,6 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use candle_core::quantized::gguf_file::Value as GgufValue;
@@ -19,7 +18,7 @@ use crate::models::shared::chat::{ChatGenerationConfig, ChatMessage, ChatRole};
 use crate::models::shared::memory::accounting::TensorStorageAccounting;
 use crate::models::shared::telemetry::record_prefill_token_mode_step;
 use crate::models::shared::weights::gguf::{GgufLoader, GgufModelInfo};
-use crate::tokenizer::Tokenizer;
+use crate::tokenizer::{Tokenizer, TokenizerDecodeStreamState};
 
 use super::text::{Qwen35TextModel, Qwen35TextRuntimeState};
 use super::vision::{PreparedVisionInputs, Qwen35VisionModel};
@@ -68,6 +67,7 @@ pub struct ChatDecodeState {
     history_ids: Vec<u32>,
     tokens_generated: usize,
     track_history: bool,
+    decode_stream: TokenizerDecodeStreamState,
     assembled: String,
     max_new_tokens: usize,
     finished: bool,
@@ -154,17 +154,16 @@ struct Qwen35Tokenizer {
     inner: Tokenizer,
     vocab_size: usize,
     specials: SpecialTokenIds,
-    literal_special_tokens: Vec<(String, u32)>,
     chat_template: String,
     default_enable_thinking: bool,
     bos_token: Option<String>,
-    decode_piece_cache: Mutex<HashMap<u32, String>>,
 }
 
 #[derive(Debug)]
 struct GgufTokenizerMetadata {
     tokens: Vec<String>,
     merges: Vec<String>,
+    token_types: Vec<usize>,
     pre_tokenizer: Option<String>,
     chat_template: String,
     eos_token_id: Option<u32>,
@@ -176,9 +175,10 @@ impl Qwen35Tokenizer {
         let config = load_tokenizer_config_file(model_dir)?;
         let inner = match Tokenizer::from_path(model_dir) {
             Ok(inner) => inner,
-            Err(_) => Tokenizer::from_gguf_bpe(
+            Err(_) => Tokenizer::from_gguf_bpe_with_token_types(
                 &gguf_meta.tokens,
                 &gguf_meta.merges,
+                &gguf_meta.token_types,
                 gguf_meta.pre_tokenizer.as_deref(),
                 false,
             )?,
@@ -226,16 +226,6 @@ impl Qwen35Tokenizer {
             .unwrap_or_else(|| gguf_meta.chat_template.clone());
         let default_enable_thinking = resolve_default_enable_thinking(&chat_template, variant);
 
-        let mut literal_special_tokens: Vec<(String, u32)> = token_to_id
-            .iter()
-            .filter_map(|(token, id)| {
-                (token.starts_with("<|") && token.ends_with("|>")).then_some((token.clone(), *id))
-            })
-            .collect();
-        literal_special_tokens.sort_by(|(left, _), (right, _)| {
-            right.len().cmp(&left.len()).then_with(|| left.cmp(right))
-        });
-
         Ok(Self {
             inner,
             vocab_size,
@@ -247,79 +237,28 @@ impl Qwen35Tokenizer {
                 eos,
                 eos_alt,
             },
-            literal_special_tokens,
             chat_template,
             default_enable_thinking,
             bos_token: config.and_then(|cfg| cfg.bos_token),
-            decode_piece_cache: Mutex::new(HashMap::new()),
         })
     }
 
     fn encode_text(&self, text: &str) -> Result<Vec<u32>> {
-        if self.literal_special_tokens.is_empty() {
-            return self.inner.encode(text);
-        }
-
-        let mut ids = Vec::new();
-        let mut offset = 0usize;
-        while offset < text.len() {
-            let tail = &text[offset..];
-            let mut next_match: Option<(usize, &str, u32)> = None;
-            for (token, token_id) in &self.literal_special_tokens {
-                if let Some(rel_idx) = tail.find(token) {
-                    let candidate = (rel_idx, token.as_str(), *token_id);
-                    match next_match {
-                        None => next_match = Some(candidate),
-                        Some((best_idx, best_token, _)) => {
-                            if rel_idx < best_idx
-                                || (rel_idx == best_idx && token.len() > best_token.len())
-                            {
-                                next_match = Some(candidate);
-                            }
-                        }
-                    }
-                }
-            }
-
-            let Some((rel_idx, matched_token, matched_id)) = next_match else {
-                ids.extend(self.inner.encode(tail)?);
-                break;
-            };
-
-            if rel_idx > 0 {
-                ids.extend(self.inner.encode(&tail[..rel_idx])?);
-            }
-            ids.push(matched_id);
-            offset += rel_idx + matched_token.len();
-        }
-
-        Ok(ids)
+        self.inner.encode(text)
     }
 
-    fn decode_text(&self, ids: &[u32]) -> Result<String> {
-        let filtered: Vec<u32> = ids
-            .iter()
-            .copied()
-            .filter(|id| (*id as usize) < self.vocab_size)
-            .collect();
-        self.inner.decode(&filtered)
-    }
-
-    fn decode_token_piece(&self, token_id: u32) -> Result<String> {
+    fn decode_token_piece(
+        &self,
+        state: &mut TokenizerDecodeStreamState,
+        token_id: u32,
+    ) -> Result<String> {
         if token_id as usize >= self.vocab_size {
             return Ok(String::new());
         }
-        if let Ok(cache) = self.decode_piece_cache.lock() {
-            if let Some(piece) = cache.get(&token_id) {
-                return Ok(piece.clone());
-            }
-        }
-
-        let piece = self.decode_text(&[token_id])?;
-        if let Ok(mut cache) = self.decode_piece_cache.lock() {
-            cache.insert(token_id, piece.clone());
-        }
-        Ok(piece)
+        Ok(self
+            .inner
+            .decode_stream_step(state, token_id, true)?
+            .unwrap_or_default())
     }
 }
 
@@ -564,17 +503,16 @@ impl Qwen35ChatModel {
         let logits = self.prefill_prompt(&prepared_prompt, &mut text_state)?;
         let track_history =
             config.repetition_penalty > 1.0 || config.presence_penalty.abs() > f32::EPSILON;
+        let history_ids =
+            initial_penalty_history(&prepared_prompt.prompt_ids, max_new_tokens, track_history);
 
         Ok(ChatDecodeState {
             text_state,
             logits,
-            history_ids: if track_history {
-                Vec::with_capacity(max_new_tokens.max(1))
-            } else {
-                Vec::new()
-            },
+            history_ids,
             tokens_generated: 0,
             track_history,
+            decode_stream: TokenizerDecodeStreamState::default(),
             assembled: String::new(),
             max_new_tokens: max_new_tokens.max(1),
             finished: false,
@@ -617,7 +555,9 @@ impl Qwen35ChatModel {
             });
         }
 
-        let delta = self.tokenizer.decode_token_piece(next)?;
+        let delta = self
+            .tokenizer
+            .decode_token_piece(&mut state.decode_stream, next)?;
         if state.track_history {
             state.history_ids.push(next);
         }
@@ -1194,6 +1134,7 @@ fn parse_gguf_tokenizer_metadata(loader: &GgufLoader) -> Result<GgufTokenizerMet
     Ok(GgufTokenizerMetadata {
         tokens: required_string_array(loader, "tokenizer.ggml.tokens")?,
         merges: required_string_array(loader, "tokenizer.ggml.merges")?,
+        token_types: required_usize_array(loader, "tokenizer.ggml.token_type")?,
         pre_tokenizer: loader.get_metadata_string("tokenizer.ggml.pre"),
         chat_template: loader
             .get_metadata_string("tokenizer.chat_template")
@@ -1346,6 +1287,20 @@ fn gguf_to_f64(value: &GgufValue) -> Option<f64> {
     }
 }
 
+fn initial_penalty_history(
+    prompt_ids: &[u32],
+    max_new_tokens: usize,
+    track_history: bool,
+) -> Vec<u32> {
+    if !track_history {
+        return Vec::new();
+    }
+
+    let mut history = Vec::with_capacity(prompt_ids.len().saturating_add(max_new_tokens.max(1)));
+    history.extend_from_slice(prompt_ids);
+    history
+}
+
 fn sample_next_token(
     logits: &Tensor,
     vocab_size: usize,
@@ -1366,6 +1321,12 @@ fn sample_next_token(
         && config.presence_penalty.abs() <= f32::EPSILON
         && config.top_k == 0
         && config.top_p >= 1.0;
+    let sampling_context = if deterministic_greedy {
+        "deterministic greedy sampling"
+    } else {
+        "configured sampling"
+    };
+    validate_finite_vocab_logits(logits, vocab_size, sampling_context)?;
     if deterministic_greedy {
         return argmax_clamped(logits, vocab_size);
     }
@@ -1523,6 +1484,66 @@ fn clamp_logits_to_vocab(values: &mut [f32], vocab_size: usize) {
     if vocab_size < values.len() {
         values[vocab_size..].fill(f32::NEG_INFINITY);
     }
+}
+
+fn validate_finite_vocab_logits(
+    logits: &Tensor,
+    vocab_size: usize,
+    sampling_context: &str,
+) -> Result<()> {
+    let logits = match logits.rank() {
+        1 => logits.clone(),
+        2 => {
+            let (rows, _cols) = logits.dims2()?;
+            if rows != 1 {
+                return Err(Error::InferenceError(format!(
+                    "Unexpected Qwen3.5 logits shape during {sampling_context}: {:?}",
+                    logits.shape().dims()
+                )));
+            }
+            logits.i(0)?
+        }
+        rank => {
+            return Err(Error::InferenceError(format!(
+                "Unexpected Qwen3.5 logits rank during {sampling_context}: {rank}"
+            )))
+        }
+    };
+
+    let logits_len = logits.dim(0)?;
+    let inspected_len = vocab_size.min(logits_len);
+    if inspected_len == 0 {
+        return Err(Error::InferenceError(format!(
+            "Qwen3.5 {sampling_context} has no in-vocabulary logits to validate \
+             (vocab_size={vocab_size}, logits_len={logits_len})"
+        )));
+    }
+
+    let in_vocab = logits.narrow(0, 0, inspected_len)?.to_dtype(DType::F32)?;
+    let nan_count = in_vocab
+        .ne(&in_vocab)?
+        .to_dtype(DType::F32)?
+        .sum_all()?
+        .to_scalar::<f32>()? as usize;
+    let infinite_count = in_vocab
+        .abs()?
+        .eq(f32::INFINITY)?
+        .to_dtype(DType::F32)?
+        .sum_all()?
+        .to_scalar::<f32>()? as usize;
+    let non_finite_count = nan_count.saturating_add(infinite_count);
+
+    if non_finite_count > 0 {
+        return Err(Error::InferenceError(format!(
+            "Qwen3.5 {sampling_context} received {non_finite_count} non-finite \
+             in-vocabulary raw logits ({nan_count} NaN, {infinite_count} infinite) \
+             across {inspected_len} inspected logits \
+             (vocab_size={vocab_size}, logits_len={logits_len}); refusing to sample \
+             corrupted model state"
+        )));
+    }
+
+    Ok(())
 }
 
 fn argmax_values(values: &[f32]) -> Result<u32> {
@@ -1842,9 +1863,18 @@ mod tests {
     }
 
     #[test]
+    fn penalty_history_starts_with_the_complete_prompt() {
+        let prompt = [11, 12, 13, 14];
+        let history = initial_penalty_history(&prompt, 8, true);
+        assert_eq!(history, prompt);
+        assert!(history.capacity() >= prompt.len() + 8);
+        assert!(initial_penalty_history(&prompt, 8, false).is_empty());
+    }
+
+    #[test]
     fn sample_next_token_masks_logits_above_vocab_limit() {
         let logits = Tensor::from_vec(
-            vec![0.1f32, 0.2, 0.3, 12.0, 9.0],
+            vec![0.1f32, 0.2, 0.3, f32::NAN, f32::INFINITY],
             (5,),
             &candle_core::Device::Cpu,
         )
@@ -1881,6 +1911,45 @@ mod tests {
         let mut rng = SimpleRng::new(7);
         let result = sample_next_token(&logits, 0, &config, &[], &mut rng);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn greedy_sampler_rejects_any_non_finite_raw_logits() {
+        let logits = Tensor::from_vec(
+            vec![f32::NAN, 1.25, f32::INFINITY, f32::NEG_INFINITY],
+            (4,),
+            &candle_core::Device::Cpu,
+        )
+        .expect("logits");
+        let mut rng = SimpleRng::new(7);
+        let error = sample_next_token(&logits, 4, &ChatGenerationConfig::default(), &[], &mut rng)
+            .expect_err("one non-finite in-vocabulary logit must fail greedy sampling");
+        let message = error.to_string();
+        assert!(message.contains("deterministic greedy sampling"));
+        assert!(message.contains("3 non-finite"));
+        assert!(message.contains("1 NaN, 2 infinite"));
+        assert!(message.contains("vocab_size=4, logits_len=4"));
+    }
+
+    #[test]
+    fn configured_sampler_rejects_any_non_finite_raw_logits() {
+        let logits = Tensor::from_vec(
+            vec![0.5f32, f32::NAN, 1.25],
+            (3,),
+            &candle_core::Device::Cpu,
+        )
+        .expect("logits");
+        let config = ChatGenerationConfig {
+            temperature: 0.8,
+            ..ChatGenerationConfig::default()
+        };
+        let mut rng = SimpleRng::new(7);
+        let error = sample_next_token(&logits, 3, &config, &[], &mut rng)
+            .expect_err("one non-finite in-vocabulary logit must fail configured sampling");
+        let message = error.to_string();
+        assert!(message.contains("configured sampling"));
+        assert!(message.contains("1 non-finite"));
+        assert!(message.contains("1 NaN, 0 infinite"));
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/qwen35/chat.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/chat.rs
@@ -15,7 +15,9 @@ use tracing::info;
 use crate::backends::{BackendKind, DeviceProfile};
 use crate::error::{Error, Result};
 use crate::model::ModelVariant;
-use crate::models::shared::chat::{ChatGenerationConfig, ChatMessage, ChatRole};
+use crate::models::shared::chat::{
+    ChatGenerationConfig, ChatGenerationFinishReason, ChatMessage, ChatRole,
+};
 use crate::models::shared::memory::accounting::{compact_tensor_storage, TensorStorageAccounting};
 use crate::models::shared::telemetry::record_prefill_token_mode_step;
 use crate::models::shared::weights::gguf::{GgufLoader, GgufModelInfo};
@@ -94,6 +96,7 @@ pub struct ChatDecodeState {
     stop_sequences: Vec<String>,
     max_new_tokens: usize,
     finished: bool,
+    finish_reason: Option<ChatGenerationFinishReason>,
     next_text_position: usize,
     pending_prefix_snapshot: Option<Qwen35PrefixSnapshot>,
     reused_prefix_tokens: usize,
@@ -176,6 +179,7 @@ pub struct ChatDecodeStep {
     pub text: String,
     pub tokens_generated: usize,
     pub finished: bool,
+    pub finish_reason: Option<ChatGenerationFinishReason>,
 }
 
 #[derive(Debug, Clone)]
@@ -657,6 +661,7 @@ impl Qwen35ChatModel {
             stop_sequences: normalize_stop_sequences(&config.stop_sequences),
             max_new_tokens: max_new_tokens.max(1),
             finished: false,
+            finish_reason: None,
             next_text_position: prepared_prompt.next_text_position,
             pending_prefix_snapshot,
             reused_prefix_tokens,
@@ -668,12 +673,16 @@ impl Qwen35ChatModel {
     pub fn decode_step(&self, state: &mut ChatDecodeState) -> Result<ChatDecodeStep> {
         if state.finished || state.tokens_generated >= state.max_new_tokens {
             state.finished = true;
+            state
+                .finish_reason
+                .get_or_insert(ChatGenerationFinishReason::MaxTokens);
             let delta = flush_stream_text(&state.assembled, &mut state.emitted_text_bytes)?;
             return Ok(ChatDecodeStep {
                 delta,
                 text: state.assembled.trim().to_string(),
                 tokens_generated: state.tokens_generated,
                 finished: true,
+                finish_reason: state.finish_reason,
             });
         }
 
@@ -691,12 +700,14 @@ impl Qwen35ChatModel {
         )?;
         if self.is_stop_token(next, &state.config) {
             state.finished = true;
+            state.finish_reason = Some(ChatGenerationFinishReason::StopToken);
             let delta = flush_stream_text(&state.assembled, &mut state.emitted_text_bytes)?;
             return Ok(ChatDecodeStep {
                 delta,
                 text: state.assembled.trim().to_string(),
                 tokens_generated: state.tokens_generated,
                 finished: true,
+                finish_reason: state.finish_reason,
             });
         }
 
@@ -713,8 +724,13 @@ impl Qwen35ChatModel {
             state.emitted_text_bytes,
             &state.stop_sequences,
         )?;
-        if stopped_on_sequence {
+        if let Some(reason) = generated_token_finish_reason(
+            stopped_on_sequence,
+            state.tokens_generated,
+            state.max_new_tokens,
+        ) {
             state.finished = true;
+            state.finish_reason = Some(reason);
         } else {
             state.logits = compact_tensor_storage(&self.text_model.forward_token_id_at(
                 next,
@@ -722,9 +738,6 @@ impl Qwen35ChatModel {
                 &mut state.text_state,
             )?)?;
             state.next_text_position += 1;
-            if state.tokens_generated >= state.max_new_tokens {
-                state.finished = true;
-            }
         }
         let delta = take_stream_safe_text(
             &state.assembled,
@@ -743,6 +756,7 @@ impl Qwen35ChatModel {
             text: final_text,
             tokens_generated: state.tokens_generated,
             finished: state.finished,
+            finish_reason: state.finish_reason,
         })
     }
 
@@ -993,6 +1007,20 @@ impl Qwen35ChatModel {
             reusable_prefix_len: None,
             vision_inputs: Some(vision_inputs),
         })
+    }
+}
+
+fn generated_token_finish_reason(
+    stopped_on_sequence: bool,
+    tokens_generated: usize,
+    max_new_tokens: usize,
+) -> Option<ChatGenerationFinishReason> {
+    if stopped_on_sequence {
+        Some(ChatGenerationFinishReason::StopSequence)
+    } else if tokens_generated >= max_new_tokens {
+        Some(ChatGenerationFinishReason::MaxTokens)
+    } else {
+        None
     }
 }
 
@@ -2047,6 +2075,19 @@ mod tests {
 
         assert_eq!(resolved.prompt_ids(), prepared.prompt_ids());
         assert_eq!(preparation_calls.load(AtomicOrdering::Relaxed), 0);
+    }
+
+    #[test]
+    fn stop_sequence_precedes_length_on_the_final_allowed_token() {
+        assert_eq!(
+            generated_token_finish_reason(true, 4, 4),
+            Some(ChatGenerationFinishReason::StopSequence)
+        );
+        assert_eq!(
+            generated_token_finish_reason(false, 4, 4),
+            Some(ChatGenerationFinishReason::MaxTokens)
+        );
+        assert_eq!(generated_token_finish_reason(false, 3, 4), None);
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/qwen35/text.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/text.rs
@@ -6,12 +6,10 @@ use candle_transformers::models::with_tracing::QMatMul;
 use candle_transformers::quantized_nn::RmsNorm;
 
 use crate::error::{Error, Result};
-use crate::kernels::buffer_pool::{
-    global_buffer_pool_for_device, maybe_init_global_buffer_pool, SharedBufferPool,
-};
 use crate::kernels::{
     try_fused_gated_delta_recurrent, try_fused_gated_rms_norm, try_fused_l2_norm,
-    try_fused_silu_mul, try_tiled_deltanet_recurrence, use_block_fusion_for_device,
+    try_fused_silu_mul, try_qwen35_causal_conv_sequence, try_tiled_deltanet_recurrence,
+    use_block_fusion_for_device,
 };
 use crate::models::architectures::qwen3::core::repeat_kv;
 use crate::models::shared::attention::flash::{
@@ -23,8 +21,8 @@ use crate::models::shared::attention::paged::{
 };
 use crate::models::shared::memory::accounting::{compact_tensor_storage, TensorStorageAccounting};
 use crate::models::shared::telemetry::{
-    record_decode_attention_path, record_prefill_sequence_span, record_prefill_token_mode_step,
-    record_rope_kernel, record_rope_manual, DecodeAttentionPath,
+    record_decode_attention_path, record_prefill_sequence_span, record_rope_kernel,
+    record_rope_manual, DecodeAttentionPath,
 };
 use crate::models::shared::weights::gguf::GgufLoader;
 
@@ -237,9 +235,6 @@ impl Qwen35TextModel {
                 cfg.ssm_inner_size, cfg.ssm_time_step_rank
             )));
         }
-
-        // Phase 5: initialize the shared scratch buffer pool once per process.
-        let _ = maybe_init_global_buffer_pool(device);
 
         let embedding_weights = loader
             .load_qtensor("token_embd.weight", device)?
@@ -486,8 +481,6 @@ impl Qwen35Layer {
         state: &mut Qwen35LayerRuntimeState,
         device: &Device,
     ) -> Result<()> {
-        let pool = global_buffer_pool_for_device(device);
-
         match (&self.mixer, state) {
             (
                 Qwen35Mixer::Linear(mixer),
@@ -508,8 +501,7 @@ impl Qwen35Layer {
                     *conv_state = Some(ConvRingState { slots, next_idx: 0 });
                 }
                 if recurrent_state.is_none() {
-                    *recurrent_state = Some(pooled_zero_tensor(
-                        pool.as_ref(),
+                    *recurrent_state = Some(owned_zero_tensor(
                         &[1, mixer.num_v_heads, mixer.head_k_dim, mixer.head_v_dim],
                         DType::F32,
                         device,
@@ -841,22 +833,6 @@ impl Qwen35FullAttention {
             )));
         }
 
-        let has_cached_prefix = full_attention_state_has_cached_prefix(state)?;
-
-        // Safe fallback: if the layer already has cached prefix pages (for example after
-        // multimodal placeholder spans), keep the token-step semantics to preserve
-        // attention offset correctness.
-        if has_cached_prefix {
-            let mut outputs = Vec::with_capacity(seq_len);
-            for (idx, &position_id) in position_ids.iter().enumerate() {
-                let token_hidden = hidden_states.narrow(1, idx, 1)?;
-                record_prefill_token_mode_step();
-                outputs.push(self.forward(&token_hidden, state, position_id)?);
-            }
-            let refs: Vec<&Tensor> = outputs.iter().collect();
-            return Tensor::cat(&refs, 1).map_err(Error::from);
-        }
-
         let (k_pages, v_pages, dense_k_cache_h, dense_v_cache_h, dense_kv_tokens) = match state {
             Qwen35LayerRuntimeState::Full {
                 k_pages,
@@ -911,20 +887,55 @@ impl Qwen35FullAttention {
         let query_states = query_states.transpose(1, 2)?.contiguous()?;
         let key_states_h = key_states_kv.transpose(1, 2)?.contiguous()?;
         let value_states_h = value_states_kv.transpose(1, 2)?.contiguous()?;
-        let attn_output = if let Some(out) = try_fused_self_attention_preserve_dtype(
-            &query_states,
-            &key_states_h,
-            &value_states_h,
-            None,
-            self.head_dim,
-            true,
-        )? {
-            out
+
+        // A bounded prefill chunk may follow an already cached prefix. Materialize
+        // that prefix once, concatenate the current KV, and use the rectangular
+        // causal mask in `unfused_causal_attention`. Fused self-attention kernels
+        // are only used for square, prefix-free spans until their rectangular-mask
+        // semantics are explicitly guaranteed.
+        let cached_key_states_h = cached_kv_head_major(k_pages, dense_k_cache_h)?;
+        let cached_value_states_h = cached_kv_head_major(v_pages, dense_v_cache_h)?;
+        if cached_key_states_h.is_some() != cached_value_states_h.is_some() {
+            return Err(Error::InferenceError(
+                "Qwen3.5 full-attention key/value prefix caches are inconsistent".to_string(),
+            ));
+        }
+        let has_cached_prefix = cached_key_states_h.is_some();
+        let attention_key_states_h = if let Some(cached) = cached_key_states_h.as_ref() {
+            Tensor::cat(&[cached, &key_states_h], 2)?
+        } else {
+            key_states_h.clone()
+        };
+        let attention_value_states_h = if let Some(cached) = cached_value_states_h.as_ref() {
+            Tensor::cat(&[cached, &value_states_h], 2)?
+        } else {
+            value_states_h.clone()
+        };
+        let attn_output = if !has_cached_prefix {
+            if let Some(out) = try_fused_self_attention_preserve_dtype(
+                &query_states,
+                &attention_key_states_h,
+                &attention_value_states_h,
+                None,
+                self.head_dim,
+                true,
+            )? {
+                out
+            } else {
+                unfused_causal_attention(
+                    &query_states,
+                    &attention_key_states_h,
+                    &attention_value_states_h,
+                    self.num_heads,
+                    self.num_kv_heads,
+                    self.head_dim,
+                )?
+            }
         } else {
             unfused_causal_attention(
                 &query_states,
-                &key_states_h,
-                &value_states_h,
+                &attention_key_states_h,
+                &attention_value_states_h,
                 self.num_heads,
                 self.num_kv_heads,
                 self.head_dim,
@@ -1167,6 +1178,21 @@ fn unfused_causal_attention(
         .map_err(Error::from)
 }
 
+fn cached_kv_head_major(
+    pages: &[KvPage],
+    dense_cache_h: &Option<Tensor>,
+) -> Result<Option<Tensor>> {
+    // Pages are authoritative whenever present. A dense tensor may be a
+    // transient materialization of an earlier page set and therefore stale
+    // after a later append.
+    if !pages.is_empty() {
+        return Ok(Some(
+            materialize_pages(pages)?.transpose(1, 2)?.contiguous()?,
+        ));
+    }
+    Ok(dense_cache_h.clone())
+}
+
 fn qwen35_causal_attention_mask(
     query_len: usize,
     key_len: usize,
@@ -1387,18 +1413,13 @@ impl Qwen35LinearAttention {
             self.head_v_dim,
         ))?;
 
-        let mut query = l2norm(&query, 1e-6)?;
-        let mut key = l2norm(&key, 1e-6)?;
-        if self.num_v_heads != self.num_k_heads {
-            if self.num_k_heads == 0 || !self.num_v_heads.is_multiple_of(self.num_k_heads) {
-                return Err(Error::InferenceError(format!(
-                    "Invalid linear-attention head layout: num_v_heads={}, num_k_heads={}",
-                    self.num_v_heads, self.num_k_heads
-                )));
-            }
-            let repeats = self.num_v_heads / self.num_k_heads;
-            query = repeat_head_states_seq(&query, repeats)?;
-            key = repeat_head_states_seq(&key, repeats)?;
+        let query = l2norm(&query, 1e-6)?;
+        let key = l2norm(&key, 1e-6)?;
+        if self.num_k_heads == 0 || !self.num_v_heads.is_multiple_of(self.num_k_heads) {
+            return Err(Error::InferenceError(format!(
+                "Invalid linear-attention head layout: num_v_heads={}, num_k_heads={}",
+                self.num_v_heads, self.num_k_heads
+            )));
         }
 
         let current_state = if let Some(state) = recurrent_state.take() {
@@ -1415,8 +1436,8 @@ impl Qwen35LinearAttention {
         let g = g.reshape((1, seq_len, self.num_v_heads))?;
         let tile_size =
             qwen35_tiled_recurrence_tile_size(seq_len, self.tiled_recurrence_tile_size_override);
-        let (output, next_state) = if self.tiled_recurrence_enabled {
-            if let Some((tiled_output, tiled_state)) = try_tiled_deltanet_recurrence(
+        let fused_sequence = if self.tiled_recurrence_enabled {
+            try_tiled_deltanet_recurrence(
                 &query,
                 &key,
                 &value,
@@ -1424,13 +1445,42 @@ impl Qwen35LinearAttention {
                 &beta,
                 &current_state,
                 tile_size,
-            ) {
-                (tiled_output, tiled_state)
+            )
+        } else {
+            None
+        };
+        let (output, next_state) = if let Some(fused_sequence) = fused_sequence {
+            fused_sequence
+        } else {
+            // CUDA's equal-head kernel and the portable Candle reference consume
+            // tiled Q/K heads. The Metal sequence op above consumes the compact
+            // converted-GGUF 16K layout directly for both 16V and 32V models.
+            let (query, key) = if self.num_v_heads == self.num_k_heads {
+                (query, key)
+            } else {
+                let repeats = self.num_v_heads / self.num_k_heads;
+                (
+                    repeat_head_states_seq(&query, repeats)?,
+                    repeat_head_states_seq(&key, repeats)?,
+                )
+            };
+            if self.tiled_recurrence_enabled {
+                if let Some(fused_sequence) = try_tiled_deltanet_recurrence(
+                    &query,
+                    &key,
+                    &value,
+                    &g,
+                    &beta,
+                    &current_state,
+                    tile_size,
+                ) {
+                    fused_sequence
+                } else {
+                    recurrent_gated_delta_sequence(&query, &key, &value, &g, &beta, current_state)?
+                }
             } else {
                 recurrent_gated_delta_sequence(&query, &key, &value, &g, &beta, current_state)?
             }
-        } else {
-            recurrent_gated_delta_sequence(&query, &key, &value, &g, &beta, current_state)?
         };
         *recurrent_state = Some(compact_tensor_storage(&next_state)?);
 
@@ -1449,6 +1499,34 @@ impl Qwen35LinearAttention {
         let seq_len = mixed_qkv.dim(1)?;
         if seq_len == 1 {
             return self.depthwise_conv_step(mixed_qkv, conv_state);
+        }
+
+        if self.kernel_size > 1 {
+            let history_len = self.kernel_size - 1;
+            let buffer = conv_state.as_mut().ok_or_else(|| {
+                Error::InferenceError("conv_state not initialized but kernel_size > 1".to_string())
+            })?;
+            if buffer.slots.len() != history_len || buffer.next_idx >= history_len {
+                return Err(Error::InferenceError(format!(
+                    "Invalid Qwen3.5 convolution history: slots={}, next_idx={}, expected_slots={history_len}",
+                    buffer.slots.len(),
+                    buffer.next_idx
+                )));
+            }
+            let logical_slots: Vec<&Tensor> = (0..history_len)
+                .map(|idx| &buffer.slots[(buffer.next_idx + idx) % history_len])
+                .collect();
+            let history = Tensor::cat(&logical_slots, 1)?;
+            if let Some((output, final_history)) =
+                try_qwen35_causal_conv_sequence(mixed_qkv, &self.conv_kernel, &history)
+            {
+                let final_history = compact_tensor_storage(&final_history)?;
+                buffer.slots = (0..history_len)
+                    .map(|idx| final_history.narrow(1, idx, 1))
+                    .collect::<candle_core::Result<Vec<_>>>()?;
+                buffer.next_idx = 0;
+                return Ok(output);
+            }
         }
 
         let mut outputs = Vec::with_capacity(seq_len);
@@ -1733,32 +1811,13 @@ fn build_rope_inv_freqs(rope_dim: usize, rope_theta: f64) -> Result<Vec<f32>> {
     Ok(inv_freqs)
 }
 
-fn pooled_zero_tensor(
-    pool: Option<&SharedBufferPool>,
-    shape: &[usize],
-    dtype: DType,
-    device: &Device,
-) -> Result<Tensor> {
-    if let Some(pool) = pool {
-        let num_elements = shape.iter().product::<usize>();
-        if let Some((size, idx, buf)) = pool.acquire(num_elements) {
-            let maybe_tensor = buf.view(shape).ok();
-            pool.release(size, idx);
-
-            if let Some(tensor) = maybe_tensor {
-                // Guard against accidental cross-device reuse from a mismatched global pool.
-                if format!("{:?}", tensor.device()) == format!("{device:?}") {
-                    if tensor.dtype() == dtype {
-                        return Ok(tensor);
-                    }
-                    if let Ok(casted) = tensor.to_dtype(dtype) {
-                        return Ok(casted);
-                    }
-                }
-            }
-        }
-    }
-
+/// Allocate persistent runtime state with independent backing storage.
+///
+/// Candle tensor views are cloneable and can outlive a scratch-pool checkout,
+/// so persistent state must never be returned from a pool slot whose lease has
+/// already ended. This invariant also makes future in-place state kernels safe
+/// across concurrent chat sessions.
+fn owned_zero_tensor(shape: &[usize], dtype: DType, device: &Device) -> Result<Tensor> {
     Tensor::zeros(shape.to_vec(), dtype, device).map_err(Error::from)
 }
 
@@ -2069,12 +2128,77 @@ fn recurrent_gated_delta(
 mod tests {
     use super::{
         append_dense_kv_cache_h, apply_rotary_emb, build_mrope,
-        full_attention_state_has_cached_prefix, qwen35_dense_decode_max_pages,
+        full_attention_state_has_cached_prefix, owned_zero_tensor, qwen35_dense_decode_max_pages,
         qwen35_page_count_for_tokens, repeat_head_states, repeat_head_states_seq, softplus,
         unfused_causal_attention, ConvRingState, Qwen35LayerRuntimeState, Qwen35TextRuntimeState,
     };
     use candle_core::{DType, Device, IndexOp, Tensor};
     use candle_nn::rotary_emb;
+    use std::collections::HashSet;
+    use std::sync::{Arc, Barrier};
+
+    fn tensor_storage_address(tensor: &Tensor) -> usize {
+        let (storage, _) = tensor.storage_and_layout();
+        std::ptr::from_ref(&*storage) as usize
+    }
+
+    #[test]
+    fn owned_recurrent_states_do_not_alias_across_concurrent_sessions() {
+        const SESSION_COUNT: usize = 8;
+        let barrier = Arc::new(Barrier::new(SESSION_COUNT));
+        let handles = (0..SESSION_COUNT)
+            .map(|_| {
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    owned_zero_tensor(&[1, 2, 4, 4], DType::F32, &Device::Cpu)
+                        .expect("persistent recurrent state should allocate")
+                })
+            })
+            .collect::<Vec<_>>();
+        let states = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("allocation thread should finish"))
+            .collect::<Vec<_>>();
+
+        let storage_addresses = states
+            .iter()
+            .map(tensor_storage_address)
+            .collect::<HashSet<_>>();
+        assert_eq!(storage_addresses.len(), SESSION_COUNT);
+        assert!(states.iter().all(|state| state.dims() == [1, 2, 4, 4]));
+        assert!(states.iter().all(|state| {
+            state
+                .flatten_all()
+                .and_then(|state| state.to_vec1::<f32>())
+                .is_ok_and(|values| values.iter().all(|value| *value == 0.0))
+        }));
+    }
+
+    #[cfg(feature = "metal")]
+    #[test]
+    fn owned_recurrent_states_do_not_alias_on_metal() {
+        let Ok(Ok(device)) = std::panic::catch_unwind(|| Device::new_metal(0)) else {
+            return;
+        };
+        let first = owned_zero_tensor(&[1, 2, 4, 4], DType::F32, &device)
+            .expect("first Metal recurrent state should allocate");
+        let second = owned_zero_tensor(&[1, 2, 4, 4], DType::F32, &device)
+            .expect("second Metal recurrent state should allocate");
+
+        assert_ne!(
+            tensor_storage_address(&first),
+            tensor_storage_address(&second)
+        );
+        assert_eq!(
+            first.flatten_all().unwrap().to_vec1::<f32>().unwrap(),
+            vec![0.0; 32]
+        );
+        assert_eq!(
+            second.flatten_all().unwrap().to_vec1::<f32>().unwrap(),
+            vec![0.0; 32]
+        );
+    }
 
     #[test]
     fn repeat_head_states_uses_tiled_order() {
@@ -2179,6 +2303,20 @@ mod tests {
 
         let prefill =
             unfused_causal_attention(&query, &key, &value, 2, 1, 2).expect("causal prefill");
+        let rectangular =
+            unfused_causal_attention(&query.narrow(2, 2, 2).unwrap(), &key, &value, 2, 1, 2)
+                .expect("rectangular prefix attention");
+        let expected_rectangular = prefill.narrow(2, 2, 2).unwrap();
+        let rectangular_values = rectangular.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let expected_values = expected_rectangular
+            .flatten_all()
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap();
+        for (actual, expected) in rectangular_values.iter().zip(expected_values.iter()) {
+            assert!((actual - expected).abs() < 1e-5);
+        }
+
         let mut steps = Vec::new();
         for token_idx in 0..4 {
             let q = query.narrow(2, token_idx, 1).unwrap();

--- a/crates/izwi-core/src/models/architectures/qwen35/text.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/text.rs
@@ -21,7 +21,7 @@ use crate::models::shared::attention::paged::{
     append_to_pages, default_kv_page_size, default_kv_quantization, materialize_pages,
     paged_decode_attention, KvCacheQuantization, KvPage,
 };
-use crate::models::shared::memory::accounting::TensorStorageAccounting;
+use crate::models::shared::memory::accounting::{compact_tensor_storage, TensorStorageAccounting};
 use crate::models::shared::telemetry::{
     record_decode_attention_path, record_prefill_sequence_span, record_prefill_token_mode_step,
     record_rope_kernel, record_rope_manual, DecodeAttentionPath,
@@ -114,7 +114,7 @@ impl ConvRingState {
             return Ok(());
         }
         let slot_refs: Vec<&Tensor> = self.slots.iter().collect();
-        let packed = Tensor::cat(&slot_refs, 1)?;
+        let packed = compact_tensor_storage(&Tensor::cat(&slot_refs, 1)?)?;
         let mut slots = Vec::with_capacity(self.slots.len());
         for idx in 0..self.slots.len() {
             slots.push(packed.narrow(1, idx, 1)?);
@@ -1327,7 +1327,7 @@ impl Qwen35LinearAttention {
         let g = g.reshape((1, self.num_v_heads))?;
         let (output, next_state) =
             recurrent_gated_delta(&query, &key, &value, &g, &beta, current_state)?;
-        *recurrent_state = Some(next_state);
+        *recurrent_state = Some(compact_tensor_storage(&next_state)?);
 
         let output = output.reshape((self.num_v_heads, self.head_v_dim))?;
         let z = z.reshape((self.num_v_heads, self.head_v_dim))?;
@@ -1432,7 +1432,7 @@ impl Qwen35LinearAttention {
         } else {
             recurrent_gated_delta_sequence(&query, &key, &value, &g, &beta, current_state)?
         };
-        *recurrent_state = Some(next_state);
+        *recurrent_state = Some(compact_tensor_storage(&next_state)?);
 
         let output = output.reshape((seq_len * self.num_v_heads, self.head_v_dim))?;
         let z = z.reshape((seq_len * self.num_v_heads, self.head_v_dim))?;
@@ -1900,15 +1900,14 @@ fn append_dense_kv_cache_h(cache: &mut Option<Tensor>, append: &Tensor) -> Resul
         return Ok(());
     }
     let append = append.contiguous()?;
-    match cache {
+    let next = match cache {
         Some(existing) => {
             let existing_ref: &Tensor = &*existing;
-            *cache = Some(Tensor::cat(&[existing_ref, &append], 2)?);
+            Tensor::cat(&[existing_ref, &append], 2)?
         }
-        None => {
-            *cache = Some(append);
-        }
-    }
+        None => append.clone(),
+    };
+    *cache = Some(compact_tensor_storage(&next)?);
     Ok(())
 }
 

--- a/crates/izwi-core/src/models/architectures/qwen35/text.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/text.rs
@@ -14,7 +14,9 @@ use crate::kernels::{
     try_fused_silu_mul, try_tiled_deltanet_recurrence, use_block_fusion_for_device,
 };
 use crate::models::architectures::qwen3::core::repeat_kv;
-use crate::models::shared::attention::flash::try_fused_self_attention;
+use crate::models::shared::attention::flash::{
+    try_fused_self_attention, try_fused_self_attention_preserve_dtype,
+};
 use crate::models::shared::attention::paged::{
     append_to_pages, default_kv_page_size, default_kv_quantization, materialize_pages,
     paged_decode_attention, KvCacheQuantization, KvPage,
@@ -100,6 +102,28 @@ struct ConvRingState {
     next_idx: usize,
 }
 
+impl ConvRingState {
+    /// Copy every logical history slot into one compact backing allocation.
+    ///
+    /// Token slices produced during sequence prefill are views into the entire
+    /// projected `[batch, sequence, conv_dim]` tensor. Retaining those views in
+    /// decode state would retain and account the full prefill allocation rather
+    /// than the fixed `kernel_size - 1` convolution history.
+    fn compact_owned(&mut self) -> Result<()> {
+        if self.slots.is_empty() {
+            return Ok(());
+        }
+        let slot_refs: Vec<&Tensor> = self.slots.iter().collect();
+        let packed = Tensor::cat(&slot_refs, 1)?;
+        let mut slots = Vec::with_capacity(self.slots.len());
+        for idx in 0..self.slots.len() {
+            slots.push(packed.narrow(1, idx, 1)?);
+        }
+        self.slots = slots;
+        Ok(())
+    }
+}
+
 enum Qwen35LayerRuntimeState {
     Linear {
         conv_state: Option<ConvRingState>,
@@ -112,6 +136,25 @@ enum Qwen35LayerRuntimeState {
         dense_v_cache_h: Option<Tensor>,
         dense_kv_tokens: usize,
     },
+}
+
+fn full_attention_state_has_cached_prefix(state: &Qwen35LayerRuntimeState) -> Result<bool> {
+    match state {
+        Qwen35LayerRuntimeState::Full {
+            k_pages,
+            v_pages,
+            dense_k_cache_h,
+            dense_v_cache_h,
+            dense_kv_tokens,
+        } => Ok(!k_pages.is_empty()
+            || !v_pages.is_empty()
+            || dense_k_cache_h.is_some()
+            || dense_v_cache_h.is_some()
+            || *dense_kv_tokens > 0),
+        _ => Err(Error::InferenceError(
+            "Qwen3.5 layer runtime state does not match full-attention layer".to_string(),
+        )),
+    }
 }
 
 struct Qwen35Layer {
@@ -454,16 +497,13 @@ impl Qwen35Layer {
                 },
             ) => {
                 if conv_state.is_none() && mixer.kernel_size > 1 {
-                    // Initialize the ring buffer with zeros
-                    let mut slots = Vec::with_capacity(mixer.kernel_size - 1);
-                    let zero = pooled_zero_tensor(
-                        pool.as_ref(),
-                        &[mixer.conv_dim, 1],
-                        DType::F32,
-                        device,
-                    )?;
-                    for _ in 0..(mixer.kernel_size - 1) {
-                        slots.push(zero.clone());
+                    // Keep the persistent history in one exact-size allocation;
+                    // scratch-pool capacity must not become retained state.
+                    let history_len = mixer.kernel_size - 1;
+                    let zero = Tensor::zeros((mixer.conv_dim, history_len), DType::F32, device)?;
+                    let mut slots = Vec::with_capacity(history_len);
+                    for idx in 0..history_len {
+                        slots.push(zero.narrow(1, idx, 1)?);
                     }
                     *conv_state = Some(ConvRingState { slots, next_idx: 0 });
                 }
@@ -761,18 +801,14 @@ impl Qwen35FullAttention {
             )? {
                 out
             } else {
-                // Unfused fallback path still expects explicit KV expansion.
-                let key_states = key_states_h.transpose(1, 2)?.contiguous()?;
-                let value_states = value_states_h.transpose(1, 2)?.contiguous()?;
-                let key_states = repeat_kv(&key_states, self.num_heads, self.num_kv_heads)?;
-                let value_states = repeat_kv(&value_states, self.num_heads, self.num_kv_heads)?;
-                let key_states = key_states.transpose(1, 2)?.contiguous()?;
-                let value_states = value_states.transpose(1, 2)?.contiguous()?;
-                let key_states_t = key_states.transpose(2, 3)?.contiguous()?;
-                let attn = query_states.matmul(&key_states_t)?;
-                let attn = (attn / (self.head_dim as f64).sqrt())?;
-                let attn = ops::softmax_last_dim(&attn)?;
-                attn.contiguous()?.matmul(&value_states)?
+                unfused_causal_attention(
+                    &query_states,
+                    &key_states_h,
+                    &value_states_h,
+                    self.num_heads,
+                    self.num_kv_heads,
+                    self.head_dim,
+                )?
             };
             attn_output
                 .transpose(1, 2)?
@@ -805,21 +841,12 @@ impl Qwen35FullAttention {
             )));
         }
 
-        let has_prefix_pages = match state {
-            Qwen35LayerRuntimeState::Full {
-                k_pages, v_pages, ..
-            } => !k_pages.is_empty() || !v_pages.is_empty(),
-            _ => {
-                return Err(Error::InferenceError(
-                    "Qwen3.5 layer runtime state does not match full-attention layer".to_string(),
-                ))
-            }
-        };
+        let has_cached_prefix = full_attention_state_has_cached_prefix(state)?;
 
         // Safe fallback: if the layer already has cached prefix pages (for example after
         // multimodal placeholder spans), keep the token-step semantics to preserve
         // attention offset correctness.
-        if has_prefix_pages {
+        if has_cached_prefix {
             let mut outputs = Vec::with_capacity(seq_len);
             for (idx, &position_id) in position_ids.iter().enumerate() {
                 let token_hidden = hidden_states.narrow(1, idx, 1)?;
@@ -884,7 +911,7 @@ impl Qwen35FullAttention {
         let query_states = query_states.transpose(1, 2)?.contiguous()?;
         let key_states_h = key_states_kv.transpose(1, 2)?.contiguous()?;
         let value_states_h = value_states_kv.transpose(1, 2)?.contiguous()?;
-        let attn_output = if let Some(out) = try_fused_self_attention(
+        let attn_output = if let Some(out) = try_fused_self_attention_preserve_dtype(
             &query_states,
             &key_states_h,
             &value_states_h,
@@ -894,16 +921,14 @@ impl Qwen35FullAttention {
         )? {
             out
         } else {
-            // Unfused fallback path still expects explicit KV expansion.
-            let key_states = repeat_kv(&key_states_kv, self.num_heads, self.num_kv_heads)?;
-            let value_states = repeat_kv(&value_states_kv, self.num_heads, self.num_kv_heads)?;
-            let key_states = key_states.transpose(1, 2)?.contiguous()?;
-            let value_states = value_states.transpose(1, 2)?.contiguous()?;
-            let key_states_t = key_states.transpose(2, 3)?.contiguous()?;
-            let attn = query_states.matmul(&key_states_t)?;
-            let attn = (attn / (self.head_dim as f64).sqrt())?;
-            let attn = ops::softmax_last_dim(&attn)?;
-            attn.contiguous()?.matmul(&value_states)?
+            unfused_causal_attention(
+                &query_states,
+                &key_states_h,
+                &value_states_h,
+                self.num_heads,
+                self.num_kv_heads,
+                self.head_dim,
+            )?
         };
         let attn_output =
             attn_output
@@ -1091,6 +1116,74 @@ impl Qwen35FullAttention {
         }
         matches!(dtype, DType::F16 | DType::BF16 | DType::F32)
     }
+}
+
+/// Reference attention path used whenever a backend cannot preserve the input
+/// dtype in its fused kernel. Q/K/V use head-major layout
+/// `[batch, heads, tokens, head_dim]`.
+fn unfused_causal_attention(
+    query_states: &Tensor,
+    key_states_h: &Tensor,
+    value_states_h: &Tensor,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+) -> Result<Tensor> {
+    let query_len = query_states.dim(2)?;
+    let key_len = key_states_h.dim(2)?;
+    if query_len == 0 || key_len == 0 || query_len > key_len {
+        return Err(Error::InvalidInput(format!(
+            "Invalid Qwen3.5 causal attention lengths: query={query_len}, key={key_len}"
+        )));
+    }
+
+    // `repeat_kv` consumes sequence-major KV and returns sequence-major GQA
+    // expansion. Convert back to head-major for the score/value matmuls.
+    let key_states = key_states_h.transpose(1, 2)?.contiguous()?;
+    let value_states = value_states_h.transpose(1, 2)?.contiguous()?;
+    let key_states = repeat_kv(&key_states, num_heads, num_kv_heads)?;
+    let value_states = repeat_kv(&value_states, num_heads, num_kv_heads)?;
+    let key_states = key_states.transpose(1, 2)?.contiguous()?;
+    let value_states = value_states.transpose(1, 2)?.contiguous()?;
+
+    let key_states_t = key_states.transpose(2, 3)?.contiguous()?;
+    let scores = query_states.matmul(&key_states_t)?;
+    let mut scores = (scores / (head_dim as f64).sqrt())?;
+    if query_len > 1 {
+        let query_start = key_len - query_len;
+        let mask = qwen35_causal_attention_mask(
+            query_len,
+            key_len,
+            query_start,
+            scores.device(),
+            scores.dtype(),
+        )?;
+        scores = scores.broadcast_add(&mask)?;
+    }
+    let probabilities = ops::softmax_last_dim(&scores)?;
+    probabilities
+        .contiguous()?
+        .matmul(&value_states)
+        .map_err(Error::from)
+}
+
+fn qwen35_causal_attention_mask(
+    query_len: usize,
+    key_len: usize,
+    query_start: usize,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    let mut values = vec![0f32; query_len * key_len];
+    for query_idx in 0..query_len {
+        let last_visible_key = query_start + query_idx;
+        for key_idx in (last_visible_key + 1)..key_len {
+            values[query_idx * key_len + key_idx] = f32::NEG_INFINITY;
+        }
+    }
+    Tensor::from_vec(values, (1, 1, query_len, key_len), device)?
+        .to_dtype(dtype)
+        .map_err(Error::from)
 }
 
 impl Qwen35LinearAttention {
@@ -1409,9 +1502,11 @@ impl Qwen35LinearAttention {
                 convolved = (&convolved + &(prev_token * k_slice)?)?;
             }
 
-            // Update the ring buffer in O(1): overwrite oldest and advance cursor.
+            // Overwrite the oldest logical slot, advance the cursor, then compact
+            // the history so state accounting retains only the live conv window.
             buffer.slots[buffer.next_idx] = current;
             buffer.next_idx = (buffer.next_idx + 1) % history_len;
+            buffer.compact_owned()?;
 
             convolved.squeeze(1)?
         };
@@ -1668,7 +1763,13 @@ fn pooled_zero_tensor(
 }
 
 fn softplus(x: &Tensor) -> Result<Tensor> {
-    (x.exp()? + 1.0)?.log().map_err(Error::from)
+    // Match the reference Gated DeltaNet path: discretization is evaluated in
+    // F32 and uses a stable softplus identity. `log(exp(x) + 1)` overflows for
+    // otherwise valid large positive activations.
+    let x = x.to_dtype(DType::F32)?;
+    let positive = x.relu()?;
+    let correction = (x.abs()?.neg()?.exp()? + 1.0)?.log()?;
+    (&positive + &correction).map_err(Error::from)
 }
 
 fn l2norm(x: &Tensor, eps: f64) -> Result<Tensor> {
@@ -1968,11 +2069,12 @@ fn recurrent_gated_delta(
 #[cfg(test)]
 mod tests {
     use super::{
-        append_dense_kv_cache_h, apply_rotary_emb, build_mrope, qwen35_dense_decode_max_pages,
-        qwen35_page_count_for_tokens, repeat_head_states, repeat_head_states_seq, ConvRingState,
-        Qwen35LayerRuntimeState, Qwen35TextRuntimeState,
+        append_dense_kv_cache_h, apply_rotary_emb, build_mrope,
+        full_attention_state_has_cached_prefix, qwen35_dense_decode_max_pages,
+        qwen35_page_count_for_tokens, repeat_head_states, repeat_head_states_seq, softplus,
+        unfused_causal_attention, ConvRingState, Qwen35LayerRuntimeState, Qwen35TextRuntimeState,
     };
-    use candle_core::{DType, Device, Tensor};
+    use candle_core::{DType, Device, IndexOp, Tensor};
     use candle_nn::rotary_emb;
 
     #[test]
@@ -2023,32 +2125,121 @@ mod tests {
     }
 
     #[test]
-    fn runtime_accounting_deduplicates_shared_conv_slots() {
-        let shared = Tensor::zeros((32, 1), DType::F32, &Device::Cpu).unwrap();
-        let single = Qwen35TextRuntimeState {
+    fn compact_conv_ring_drops_full_prefill_backing() {
+        let backing = Tensor::zeros((1, 40, 32), DType::F32, &Device::Cpu).unwrap();
+        let mut slots = Vec::new();
+        for token_idx in 37..40 {
+            slots.push(backing.i((0, token_idx)).unwrap().reshape((32, 1)).unwrap());
+        }
+        let mut state = Qwen35TextRuntimeState {
             layers: vec![Qwen35LayerRuntimeState::Linear {
-                conv_state: Some(ConvRingState {
-                    slots: vec![shared.clone()],
-                    next_idx: 0,
-                }),
-                recurrent_state: None,
-            }],
-        };
-        let repeated = Qwen35TextRuntimeState {
-            layers: vec![Qwen35LayerRuntimeState::Linear {
-                conv_state: Some(ConvRingState {
-                    slots: vec![shared.clone(), shared.clone(), shared],
-                    next_idx: 0,
-                }),
+                conv_state: Some(ConvRingState { slots, next_idx: 0 }),
                 recurrent_state: None,
             }],
         };
 
-        assert_eq!(
-            single.allocated_session_bytes(),
-            repeated.allocated_session_bytes()
-        );
-        assert!(single.allocated_session_bytes().unwrap() >= 32 * 4);
+        let retained_prefill_bytes = state.allocated_session_bytes().unwrap();
+        assert!(retained_prefill_bytes >= 40 * 32 * 4);
+
+        let Qwen35LayerRuntimeState::Linear { conv_state, .. } = &mut state.layers[0] else {
+            unreachable!("test state is linear")
+        };
+        conv_state
+            .as_mut()
+            .unwrap()
+            .compact_owned()
+            .expect("compaction should succeed");
+
+        assert_eq!(state.allocated_session_bytes(), Some(3 * 32 * 4));
+    }
+
+    #[test]
+    fn unfused_causal_prefill_matches_incremental_token_steps() {
+        let device = Device::Cpu;
+        let query = Tensor::from_vec(
+            vec![
+                0.2f32, 0.1, 0.3, -0.2, 0.4, 0.5, -0.1, 0.6, // head 0
+                -0.3, 0.2, 0.7, 0.1, 0.2, -0.4, 0.5, 0.3, // head 1
+            ],
+            (1, 2, 4, 2),
+            &device,
+        )
+        .unwrap();
+        let key = Tensor::from_vec(
+            vec![0.1f32, 0.3, 0.4, -0.2, 0.6, 0.5, -0.1, 0.7],
+            (1, 1, 4, 2),
+            &device,
+        )
+        .unwrap();
+        let value = Tensor::from_vec(
+            vec![1.0f32, 10.0, 2.0, 20.0, 4.0, 40.0, 8.0, 80.0],
+            (1, 1, 4, 2),
+            &device,
+        )
+        .unwrap();
+
+        let prefill =
+            unfused_causal_attention(&query, &key, &value, 2, 1, 2).expect("causal prefill");
+        let mut steps = Vec::new();
+        for token_idx in 0..4 {
+            let q = query.narrow(2, token_idx, 1).unwrap();
+            let k = key.narrow(2, 0, token_idx + 1).unwrap();
+            let v = value.narrow(2, 0, token_idx + 1).unwrap();
+            steps.push(
+                unfused_causal_attention(&q, &k, &v, 2, 1, 2).expect("incremental attention"),
+            );
+        }
+        let step_refs: Vec<&Tensor> = steps.iter().collect();
+        let incremental = Tensor::cat(&step_refs, 2).unwrap();
+
+        let prefill = prefill.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let incremental = incremental.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        for (prefill, incremental) in prefill.iter().zip(incremental.iter()) {
+            assert!((prefill - incremental).abs() < 1e-5);
+        }
+    }
+
+    #[test]
+    fn dense_full_attention_cache_counts_as_a_prefix() {
+        let dense = Tensor::zeros((1, 1, 2, 2), DType::F32, &Device::Cpu).unwrap();
+        let state = Qwen35LayerRuntimeState::Full {
+            k_pages: Vec::new(),
+            v_pages: Vec::new(),
+            dense_k_cache_h: Some(dense),
+            dense_v_cache_h: None,
+            dense_kv_tokens: 0,
+        };
+        assert!(full_attention_state_has_cached_prefix(&state).unwrap());
+
+        let tracked_only = Qwen35LayerRuntimeState::Full {
+            k_pages: Vec::new(),
+            v_pages: Vec::new(),
+            dense_k_cache_h: None,
+            dense_v_cache_h: None,
+            dense_kv_tokens: 2,
+        };
+        assert!(full_attention_state_has_cached_prefix(&tracked_only).unwrap());
+
+        let empty = Qwen35LayerRuntimeState::Full {
+            k_pages: Vec::new(),
+            v_pages: Vec::new(),
+            dense_k_cache_h: None,
+            dense_v_cache_h: None,
+            dense_kv_tokens: 0,
+        };
+        assert!(!full_attention_state_has_cached_prefix(&empty).unwrap());
+    }
+
+    #[test]
+    fn softplus_is_f32_and_stable_for_large_magnitudes() {
+        let input = Tensor::from_vec(vec![-1000f32, 0.0, 1000.0], 3, &Device::Cpu).unwrap();
+        let output = softplus(&input).expect("softplus");
+        assert_eq!(output.dtype(), DType::F32);
+        let values = output.to_vec1::<f32>().unwrap();
+        assert!(values.iter().all(|value| value.is_finite()));
+        assert!(values[0].abs() < 1e-6);
+        assert!((values[1] - std::f32::consts::LN_2).abs() < 1e-6);
+        assert!((values[2] - 1000.0).abs() < 1e-4);
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/qwen35/text.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/text.rs
@@ -19,7 +19,9 @@ use crate::models::shared::attention::paged::{
     append_to_pages, default_kv_page_size, default_kv_quantization, materialize_pages,
     paged_decode_attention, KvCacheQuantization, KvPage,
 };
-use crate::models::shared::memory::accounting::{compact_tensor_storage, TensorStorageAccounting};
+use crate::models::shared::memory::accounting::{
+    compact_tensor_storage, deep_copy_tensor_storage, TensorStorageAccounting,
+};
 use crate::models::shared::telemetry::{
     record_decode_attention_path, record_prefill_sequence_span, record_rope_kernel,
     record_rope_manual, DecodeAttentionPath,
@@ -45,6 +47,17 @@ pub struct Qwen35TextRuntimeState {
 }
 
 impl Qwen35TextRuntimeState {
+    /// Fork all persistent tensors into independent Candle backing storage.
+    pub(crate) fn fork_for_prefix(&self) -> Result<Self> {
+        Ok(Self {
+            layers: self
+                .layers
+                .iter()
+                .map(Qwen35LayerRuntimeState::fork_for_prefix)
+                .collect::<Result<Vec<_>>>()?,
+        })
+    }
+
     /// Backing allocations retained by the per-request text runtime state.
     ///
     /// This intentionally excludes model-global caches (notably full-attention
@@ -101,6 +114,17 @@ struct ConvRingState {
 }
 
 impl ConvRingState {
+    fn fork_for_prefix(&self) -> Result<Self> {
+        Ok(Self {
+            slots: self
+                .slots
+                .iter()
+                .map(deep_copy_tensor_storage)
+                .collect::<candle_core::Result<Vec<_>>>()?,
+            next_idx: self.next_idx,
+        })
+    }
+
     /// Copy every logical history slot into one compact backing allocation.
     ///
     /// Token slices produced during sequence prefill are views into the entire
@@ -134,6 +158,51 @@ enum Qwen35LayerRuntimeState {
         dense_v_cache_h: Option<Tensor>,
         dense_kv_tokens: usize,
     },
+}
+
+impl Qwen35LayerRuntimeState {
+    fn fork_for_prefix(&self) -> Result<Self> {
+        match self {
+            Self::Linear {
+                conv_state,
+                recurrent_state,
+            } => Ok(Self::Linear {
+                conv_state: conv_state
+                    .as_ref()
+                    .map(ConvRingState::fork_for_prefix)
+                    .transpose()?,
+                recurrent_state: recurrent_state
+                    .as_ref()
+                    .map(deep_copy_tensor_storage)
+                    .transpose()?,
+            }),
+            Self::Full {
+                k_pages,
+                v_pages,
+                dense_k_cache_h,
+                dense_v_cache_h,
+                dense_kv_tokens,
+            } => Ok(Self::Full {
+                k_pages: k_pages
+                    .iter()
+                    .map(KvPage::deep_copy)
+                    .collect::<Result<Vec<_>>>()?,
+                v_pages: v_pages
+                    .iter()
+                    .map(KvPage::deep_copy)
+                    .collect::<Result<Vec<_>>>()?,
+                dense_k_cache_h: dense_k_cache_h
+                    .as_ref()
+                    .map(deep_copy_tensor_storage)
+                    .transpose()?,
+                dense_v_cache_h: dense_v_cache_h
+                    .as_ref()
+                    .map(deep_copy_tensor_storage)
+                    .transpose()?,
+                dense_kv_tokens: *dense_kv_tokens,
+            }),
+        }
+    }
 }
 
 fn full_attention_state_has_cached_prefix(state: &Qwen35LayerRuntimeState) -> Result<bool> {
@@ -2130,7 +2199,8 @@ mod tests {
         append_dense_kv_cache_h, apply_rotary_emb, build_mrope,
         full_attention_state_has_cached_prefix, owned_zero_tensor, qwen35_dense_decode_max_pages,
         qwen35_page_count_for_tokens, repeat_head_states, repeat_head_states_seq, softplus,
-        unfused_causal_attention, ConvRingState, Qwen35LayerRuntimeState, Qwen35TextRuntimeState,
+        unfused_causal_attention, ConvRingState, KvPage, Qwen35LayerRuntimeState,
+        Qwen35TextRuntimeState,
     };
     use candle_core::{DType, Device, IndexOp, Tensor};
     use candle_nn::rotary_emb;
@@ -2173,6 +2243,116 @@ mod tests {
                 .and_then(|state| state.to_vec1::<f32>())
                 .is_ok_and(|values| values.iter().all(|value| *value == 0.0))
         }));
+    }
+
+    fn assert_prefix_forks_have_independent_hybrid_state_storage(device: &Device) {
+        let state = Qwen35TextRuntimeState {
+            layers: vec![
+                Qwen35LayerRuntimeState::Linear {
+                    conv_state: Some(ConvRingState {
+                        slots: vec![Tensor::ones((1, 1, 4), DType::F32, device).unwrap()],
+                        next_idx: 0,
+                    }),
+                    recurrent_state: Some(Tensor::ones((1, 1, 2, 2), DType::F32, device).unwrap()),
+                },
+                Qwen35LayerRuntimeState::Full {
+                    k_pages: vec![KvPage::Dense(
+                        Tensor::ones((1, 1, 1, 2), DType::F32, device).unwrap(),
+                    )],
+                    v_pages: vec![KvPage::Dense(
+                        Tensor::ones((1, 1, 1, 2), DType::F32, device).unwrap(),
+                    )],
+                    dense_k_cache_h: Some(Tensor::ones((1, 1, 1, 2), DType::F32, device).unwrap()),
+                    dense_v_cache_h: Some(Tensor::ones((1, 1, 1, 2), DType::F32, device).unwrap()),
+                    dense_kv_tokens: 1,
+                },
+            ],
+        };
+        let mut first = state.fork_for_prefix().unwrap();
+        let second = state.fork_for_prefix().unwrap();
+
+        let (
+            Qwen35LayerRuntimeState::Linear {
+                conv_state: Some(first_conv),
+                recurrent_state: Some(first_recurrent),
+            },
+            Qwen35LayerRuntimeState::Linear {
+                conv_state: Some(second_conv),
+                recurrent_state: Some(second_recurrent),
+            },
+        ) = (&mut first.layers[0], &second.layers[0])
+        else {
+            panic!("linear states")
+        };
+        assert_ne!(
+            tensor_storage_address(&first_conv.slots[0]),
+            tensor_storage_address(&second_conv.slots[0])
+        );
+        assert_ne!(
+            tensor_storage_address(first_recurrent),
+            tensor_storage_address(second_recurrent)
+        );
+        first_conv.slots[0] = Tensor::zeros((1, 1, 4), DType::F32, device).unwrap();
+        *first_recurrent = Tensor::zeros((1, 1, 2, 2), DType::F32, device).unwrap();
+        assert_eq!(
+            second_conv.slots[0]
+                .flatten_all()
+                .unwrap()
+                .to_vec1::<f32>()
+                .unwrap(),
+            vec![1.0; 4]
+        );
+        assert_eq!(
+            second_recurrent
+                .flatten_all()
+                .unwrap()
+                .to_vec1::<f32>()
+                .unwrap(),
+            vec![1.0; 4]
+        );
+
+        let (
+            Qwen35LayerRuntimeState::Full {
+                k_pages: first_pages,
+                dense_k_cache_h: Some(first_dense),
+                ..
+            },
+            Qwen35LayerRuntimeState::Full {
+                k_pages: second_pages,
+                dense_k_cache_h: Some(second_dense),
+                ..
+            },
+        ) = (&first.layers[1], &second.layers[1])
+        else {
+            panic!("full states")
+        };
+        let (KvPage::Dense(first_page), KvPage::Dense(second_page)) =
+            (&first_pages[0], &second_pages[0])
+        else {
+            panic!("dense pages")
+        };
+        assert_ne!(
+            tensor_storage_address(first_page),
+            tensor_storage_address(second_page)
+        );
+        assert_ne!(
+            tensor_storage_address(first_dense),
+            tensor_storage_address(second_dense)
+        );
+    }
+
+    #[test]
+    fn prefix_forks_have_independent_hybrid_state_storage() {
+        assert_prefix_forks_have_independent_hybrid_state_storage(&Device::Cpu);
+    }
+
+    #[cfg(feature = "metal")]
+    #[test]
+    fn prefix_forks_have_independent_hybrid_state_storage_on_metal() {
+        let Ok(Ok(device)) = std::panic::catch_unwind(|| Device::new_metal(0)) else {
+            return;
+        };
+        assert_prefix_forks_have_independent_hybrid_state_storage(&device);
     }
 
     #[cfg(feature = "metal")]

--- a/crates/izwi-core/src/models/registry.rs
+++ b/crates/izwi-core/src/models/registry.rs
@@ -42,7 +42,8 @@ use crate::models::architectures::qwen3::chat::{
 };
 use crate::models::architectures::qwen3::tts::Qwen3TtsModel;
 use crate::models::architectures::qwen35::chat::{
-    ChatDecodeState as Qwen35ChatDecodeState, Qwen35ChatModel, Qwen35PreparedPrompt,
+    ChatDecodeState as Qwen35ChatDecodeState, Qwen35ChatModel, Qwen35PrefixSnapshot,
+    Qwen35PreparedPrompt,
 };
 use crate::models::architectures::sortformer::diarization::{
     SortformerDiarizerModel, SortformerWorkspaceEstimate, SortformerWorkspaceEvent,
@@ -1819,6 +1820,20 @@ impl NativeChatDecodeState {
             Self::Qwen35(state) => state.session_cache_bytes(),
         }
     }
+
+    pub(crate) fn take_pending_qwen35_prefix_snapshot(&mut self) -> Option<Qwen35PrefixSnapshot> {
+        match self {
+            Self::Qwen35(state) => state.take_pending_prefix_snapshot(),
+            Self::Qwen3(_) => None,
+        }
+    }
+
+    pub(crate) fn reused_qwen35_prefix_tokens(&self) -> usize {
+        match self {
+            Self::Qwen35(state) => state.reused_prefix_tokens(),
+            Self::Qwen3(_) => 0,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -2004,9 +2019,28 @@ impl NativeChatModel {
         config: &ChatGenerationConfig,
         prepared_qwen35: Option<&Qwen35PreparedPrompt>,
     ) -> Result<NativeChatDecodeState> {
+        self.start_decode_state_with_prefix(
+            messages,
+            max_new_tokens,
+            config,
+            prepared_qwen35,
+            None,
+            None,
+        )
+    }
+
+    pub(crate) fn start_decode_state_with_prefix(
+        &self,
+        messages: &[ChatMessage],
+        max_new_tokens: usize,
+        config: &ChatGenerationConfig,
+        prepared_qwen35: Option<&Qwen35PreparedPrompt>,
+        prefix: Option<&Qwen35PrefixSnapshot>,
+        capture_prefix_max_bytes: Option<u64>,
+    ) -> Result<NativeChatDecodeState> {
         match self {
             Self::Qwen3(model) => {
-                if prepared_qwen35.is_some() {
+                if prepared_qwen35.is_some() || prefix.is_some() {
                     return Err(Error::InvalidInput(
                         "Qwen3.5 prepared prompt was routed to a Qwen3 model".to_string(),
                     ));
@@ -2016,11 +2050,13 @@ impl NativeChatModel {
                 ))
             }
             Self::Qwen35(model) => {
-                let state = model.start_decode_state_with_optional_prepared(
+                let state = model.start_decode_state_with_optional_prepared_and_prefix(
                     messages,
                     max_new_tokens,
                     config,
                     prepared_qwen35,
+                    prefix,
+                    capture_prefix_max_bytes,
                 )?;
                 Ok(NativeChatDecodeState::Qwen35(state))
             }

--- a/crates/izwi-core/src/models/registry.rs
+++ b/crates/izwi-core/src/models/registry.rs
@@ -57,7 +57,7 @@ use crate::models::architectures::voxtral::tts::VoxtralTtsModel;
 use crate::models::architectures::whisper::asr::{
     AsrTranscriptionOutput as WhisperAsrTranscriptionOutput, WhisperTurboAsrModel,
 };
-use crate::models::shared::chat::{ChatGenerationConfig, ChatMessage};
+use crate::models::shared::chat::{ChatGenerationConfig, ChatGenerationFinishReason, ChatMessage};
 use crate::runtime::{DiarizationConfig, DiarizationResult};
 
 type AsrLoaderFn = fn(&Path, ModelVariant, DeviceProfile) -> Result<NativeAsrModel>;
@@ -1842,6 +1842,7 @@ pub struct NativeChatDecodeStep {
     pub text: String,
     pub tokens_generated: usize,
     pub finished: bool,
+    pub finish_reason: Option<ChatGenerationFinishReason>,
 }
 
 impl NativeChatModel {
@@ -2078,6 +2079,7 @@ impl NativeChatModel {
                     text: step.text,
                     tokens_generated: step.tokens_generated,
                     finished: step.finished,
+                    finish_reason: None,
                 })
             }
             (Self::Qwen35(model), NativeChatDecodeState::Qwen35(state)) => {
@@ -2087,6 +2089,7 @@ impl NativeChatModel {
                     text: step.text,
                     tokens_generated: step.tokens_generated,
                     finished: step.finished,
+                    finish_reason: step.finish_reason,
                 })
             }
             _ => Err(Error::InvalidInput(

--- a/crates/izwi-core/src/models/shared/attention/flash.rs
+++ b/crates/izwi-core/src/models/shared/attention/flash.rs
@@ -157,6 +157,34 @@ pub fn try_fused_self_attention(
     try_fused_self_attention_scaled(q, k, v, mask, head_dim, causal, scale)
 }
 
+/// Try fused self-attention without lowering F32 inputs to F16.
+///
+/// Candle's Metal SDPA implementation cannot safely execute every long F32
+/// prefill shape. In that case this helper returns `None` so the caller can use
+/// a correctness-preserving F32 fallback instead of silently narrowing the
+/// model activations to F16.
+pub fn try_fused_self_attention_preserve_dtype(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    mask: Option<&Tensor>,
+    head_dim: usize,
+    causal: bool,
+) -> Result<Option<Tensor>> {
+    let scale = 1.0f32 / (head_dim as f32).sqrt();
+    try_fused_self_attention_with_options_and_scale(
+        q,
+        k,
+        v,
+        mask,
+        head_dim,
+        causal,
+        scale,
+        CudaFlashAttentionOptions::default(),
+        false,
+    )
+}
+
 /// Try a fused self-attention kernel with an explicit attention score scale.
 ///
 /// Input/output layout: `[batch, heads, seq, head_dim]`.
@@ -178,6 +206,7 @@ pub fn try_fused_self_attention_scaled(
         causal,
         scale,
         CudaFlashAttentionOptions::default(),
+        true,
     )
 }
 
@@ -205,6 +234,7 @@ pub fn try_fused_self_attention_with_options(
         causal,
         scale,
         cuda_options,
+        true,
     )
 }
 
@@ -217,6 +247,7 @@ fn try_fused_self_attention_with_options_and_scale(
     causal: bool,
     scale: f32,
     cuda_options: CudaFlashAttentionOptions<'_>,
+    allow_metal_f32_prefill_f16_cast: bool,
 ) -> Result<Option<Tensor>> {
     let masked = mask.is_some();
     record_fused_attention_attempt();
@@ -270,11 +301,12 @@ fn try_fused_self_attention_with_options_and_scale(
     }
 
     if q.device().is_metal() {
-        match should_try_metal_sdpa(q, k, v, mask)? {
+        match should_try_metal_sdpa(q, k, v, mask, allow_metal_f32_prefill_f16_cast)? {
             MetalSdpaDecision::Try => {
                 let q_seq = q.dim(2)?;
-                let use_f16_cast =
-                    mask.is_none() && should_use_metal_sdpa_f16_cast(q.dtype(), q_seq);
+                let use_f16_cast = allow_metal_f32_prefill_f16_cast
+                    && mask.is_none()
+                    && should_use_metal_sdpa_f16_cast(q.dtype(), q_seq);
                 let sdpa_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     if use_f16_cast {
                         run_metal_sdpa_with_f16_inputs(q, k, v, mask, causal, scale)
@@ -444,6 +476,7 @@ fn should_try_metal_sdpa(
     k: &Tensor,
     v: &Tensor,
     mask: Option<&Tensor>,
+    allow_f32_prefill_f16_cast: bool,
 ) -> Result<MetalSdpaDecision> {
     if let Some(mask) = mask {
         return should_try_metal_sdpa_masked(q, k, v, mask);
@@ -477,7 +510,10 @@ fn should_try_metal_sdpa(
 
     // F32 + full-SDPA prefill has triggered oversized threadgroup plans on some
     // Apple GPUs. We only enable this shape when the guarded F16-cast route is on.
-    if q_seq > 8 && q.dtype() == DType::F32 && !metal_sdpa_f32_prefill_cast_enabled() {
+    if q_seq > 8
+        && q.dtype() == DType::F32
+        && !(allow_f32_prefill_f16_cast && metal_sdpa_f32_prefill_cast_enabled())
+    {
         return Ok(MetalSdpaDecision::Skip(
             AttentionFallbackReason::UnsupportedBackend,
         ));
@@ -637,8 +673,8 @@ mod tests {
     use super::{
         cuda_flash_attention_capabilities, cuda_flash_attention_head_dim_supported,
         cuda_flash_attention_window, metal_sdpa_mask_shape_supported, metal_sdpa_shape_supported,
-        should_try_cuda_flash_attention, should_use_metal_sdpa_f16_cast,
-        CudaFlashAttentionDecision, CudaFlashAttentionOptions,
+        should_try_cuda_flash_attention, should_try_metal_sdpa, should_use_metal_sdpa_f16_cast,
+        CudaFlashAttentionDecision, CudaFlashAttentionOptions, MetalSdpaDecision,
         CUDA_FLASH_ATTENTION_HEAD_DIM_MULTIPLE, CUDA_FLASH_ATTENTION_MAX_HEAD_DIM,
     };
     use crate::models::shared::telemetry::AttentionFallbackReason;
@@ -672,6 +708,25 @@ mod tests {
         assert!(!should_use_metal_sdpa_f16_cast(DType::F32, 23));
 
         std::env::remove_var("IZWI_METAL_SDPA_F32_PREFILL_F16");
+    }
+
+    #[test]
+    fn preserve_dtype_policy_rejects_long_f32_metal_sdpa_shape() {
+        let _guard = crate::env_test_lock().lock().expect("env lock");
+        std::env::remove_var("IZWI_METAL_SDPA_F32_PREFILL_F16");
+
+        let q = Tensor::zeros((1, 4, 9, 256), DType::F32, &Device::Cpu).unwrap();
+        let k = Tensor::zeros((1, 1, 9, 256), DType::F32, &Device::Cpu).unwrap();
+        let v = Tensor::zeros((1, 1, 9, 256), DType::F32, &Device::Cpu).unwrap();
+
+        assert!(matches!(
+            should_try_metal_sdpa(&q, &k, &v, None, false).unwrap(),
+            MetalSdpaDecision::Skip(AttentionFallbackReason::UnsupportedBackend)
+        ));
+        assert!(matches!(
+            should_try_metal_sdpa(&q, &k, &v, None, true).unwrap(),
+            MetalSdpaDecision::Try
+        ));
     }
 
     #[test]

--- a/crates/izwi-core/src/models/shared/attention/paged.rs
+++ b/crates/izwi-core/src/models/shared/attention/paged.rs
@@ -3,7 +3,7 @@
 use candle_core::{DType, Tensor, D};
 
 use crate::error::{Error, Result};
-use crate::models::shared::memory::accounting::TensorStorageAccounting;
+use crate::models::shared::memory::accounting::{compact_tensor_storage, TensorStorageAccounting};
 use crate::models::shared::telemetry::{record_decode_attention_path, DecodeAttentionPath};
 
 const Q4_0_BLOCK_SIZE: usize = 32;
@@ -87,7 +87,7 @@ impl KvPage {
     fn from_dense(tensor: Tensor, quantization: KvCacheQuantization) -> Result<Self> {
         // A page must own compact storage. Retaining a narrow view can keep an
         // entire previous backing allocation alive and invalidate byte accounting.
-        let tensor = tensor.contiguous()?;
+        let tensor = compact_tensor_storage(&tensor)?;
         match quantization {
             KvCacheQuantization::None => Ok(Self::Dense(tensor)),
             KvCacheQuantization::Int8 => {

--- a/crates/izwi-core/src/models/shared/attention/paged.rs
+++ b/crates/izwi-core/src/models/shared/attention/paged.rs
@@ -3,7 +3,9 @@
 use candle_core::{DType, Tensor, D};
 
 use crate::error::{Error, Result};
-use crate::models::shared::memory::accounting::{compact_tensor_storage, TensorStorageAccounting};
+use crate::models::shared::memory::accounting::{
+    compact_tensor_storage, deep_copy_tensor_storage, TensorStorageAccounting,
+};
 use crate::models::shared::telemetry::{record_decode_attention_path, DecodeAttentionPath};
 
 const Q4_0_BLOCK_SIZE: usize = 32;
@@ -84,6 +86,41 @@ pub enum KvPage {
 }
 
 impl KvPage {
+    /// Fork this page with independent Candle backing storage.
+    ///
+    /// Prefix-cache snapshots may be restored into multiple mutable decode
+    /// sessions. `Tensor::clone` shares storage, so it is not a sufficient
+    /// boundary if a backend later introduces in-place KV updates.
+    pub(crate) fn deep_copy(&self) -> Result<Self> {
+        match self {
+            Self::Dense(tensor) => Ok(Self::Dense(deep_copy_tensor_storage(tensor)?)),
+            Self::Int8 {
+                values,
+                scale,
+                target_dtype,
+            } => Ok(Self::Int8 {
+                values: deep_copy_tensor_storage(values)?,
+                scale: *scale,
+                target_dtype: *target_dtype,
+            }),
+            Self::Q4_0 {
+                values,
+                scales,
+                shape,
+                seq_len,
+                num_elements,
+                target_dtype,
+            } => Ok(Self::Q4_0 {
+                values: deep_copy_tensor_storage(values)?,
+                scales: deep_copy_tensor_storage(scales)?,
+                shape: *shape,
+                seq_len: *seq_len,
+                num_elements: *num_elements,
+                target_dtype: *target_dtype,
+            }),
+        }
+    }
+
     fn from_dense(tensor: Tensor, quantization: KvCacheQuantization) -> Result<Self> {
         // A page must own compact storage. Retaining a narrow view can keep an
         // entire previous backing allocation alive and invalidate byte accounting.

--- a/crates/izwi-core/src/models/shared/chat.rs
+++ b/crates/izwi-core/src/models/shared/chat.rs
@@ -61,6 +61,7 @@ pub struct ChatGenerationConfig {
     pub top_k: usize,
     pub repetition_penalty: f32,
     pub presence_penalty: f32,
+    pub stop_sequences: Vec<String>,
     pub stop_token_ids: Vec<u32>,
     pub seed: u64,
     pub request: ChatRequestConfig,
@@ -74,6 +75,7 @@ impl Default for ChatGenerationConfig {
             top_k: 0,
             repetition_penalty: 1.0,
             presence_penalty: 0.0,
+            stop_sequences: Vec::new(),
             stop_token_ids: Vec::new(),
             seed: 0,
             request: ChatRequestConfig::default(),
@@ -93,6 +95,7 @@ mod tests {
         assert_eq!(config.top_k, 0);
         assert_eq!(config.repetition_penalty, 1.0);
         assert_eq!(config.presence_penalty, 0.0);
+        assert!(config.stop_sequences.is_empty());
         assert!(config.stop_token_ids.is_empty());
         assert_eq!(config.seed, 0);
         assert_eq!(config.request, ChatRequestConfig::default());

--- a/crates/izwi-core/src/models/shared/chat.rs
+++ b/crates/izwi-core/src/models/shared/chat.rs
@@ -27,6 +27,14 @@ pub struct ChatMessage {
     pub content: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChatGenerationFinishReason {
+    MaxTokens,
+    StopToken,
+    StopSequence,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ChatMediaKind {

--- a/crates/izwi-core/src/models/shared/memory/accounting.rs
+++ b/crates/izwi-core/src/models/shared/memory/accounting.rs
@@ -4,6 +4,59 @@ use std::collections::HashSet;
 
 use candle_core::{CpuStorage, Storage, Tensor};
 
+/// Copy a tensor into storage whose backing allocation matches its logical size.
+///
+/// Candle's Metal scratch allocator may satisfy a small operation from any larger
+/// available pooled buffer. That is desirable for intermediates, but a tensor
+/// retained as recurrent/KV state would pin the larger transient allocation and
+/// make model-owned cache accounting nondeterministic. Persistent Metal state
+/// uses Candle's non-pooled private-buffer API and an ordered device blit.
+pub(crate) fn compact_tensor_storage(tensor: &Tensor) -> candle_core::Result<Tensor> {
+    let tensor = tensor.contiguous()?;
+
+    #[cfg(feature = "metal")]
+    if let candle_core::Device::Metal(device) = tensor.device() {
+        use candle_core::{op::BackpropOp, MetalStorage};
+
+        let element_count = tensor.elem_count();
+        if element_count == 0 {
+            return Ok(tensor);
+        }
+        let dtype = tensor.dtype();
+        let byte_count = element_count
+            .checked_mul(dtype.size_in_bytes())
+            .ok_or_else(|| {
+                candle_core::Error::Msg("persistent Metal tensor byte size overflow".to_string())
+            })?;
+        let target = device.new_private_buffer(element_count, dtype, "persistent-state")?;
+        let (storage, layout) = tensor.storage_and_layout();
+        let Storage::Metal(source) = &*storage else {
+            return Err(candle_core::Error::Msg(
+                "Metal tensor exposed non-Metal storage".to_string(),
+            ));
+        };
+        let source_offset = layout
+            .start_offset()
+            .checked_mul(dtype.size_in_bytes())
+            .ok_or_else(|| {
+                candle_core::Error::Msg("persistent Metal tensor offset overflow".to_string())
+            })?;
+        {
+            let mut blit = device.blit_command_encoder()?;
+            blit.copy_from_buffer(source.buffer(), source_offset, &target, 0, byte_count);
+        }
+        let storage = MetalStorage::new(target, device.clone(), element_count, dtype);
+        return Ok(Tensor::from_storage(
+            Storage::Metal(storage),
+            tensor.shape().clone(),
+            BackpropOp::none(),
+            false,
+        ));
+    }
+
+    Ok(tensor)
+}
+
 /// Accumulates the backing allocations retained by a set of Candle tensors.
 ///
 /// Tensor views share a Candle storage allocation. Accounting logical tensor
@@ -110,6 +163,8 @@ fn metal_storage_bytes(_storage: &candle_core::MetalStorage) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "metal")]
+    use super::compact_tensor_storage;
     use super::TensorStorageAccounting;
     use candle_core::{Device, IndexOp, Tensor};
 
@@ -150,5 +205,20 @@ mod tests {
         let mut accounting = TensorStorageAccounting::default();
         accounting.add_bytes(u64::MAX).unwrap();
         assert!(accounting.add_bytes(1).is_none());
+    }
+
+    #[cfg(feature = "metal")]
+    #[test]
+    fn persistent_metal_copy_has_exact_backing_size() {
+        let Ok(Ok(device)) = std::panic::catch_unwind(|| Device::new_metal(0)) else {
+            return;
+        };
+        let pooled = Tensor::zeros((3,), candle_core::DType::F32, &device).unwrap();
+        let compact = compact_tensor_storage(&pooled).unwrap();
+        let mut accounting = TensorStorageAccounting::default();
+        accounting.add_tensor(&compact).unwrap();
+
+        assert_eq!(accounting.bytes(), 3 * std::mem::size_of::<f32>() as u64);
+        assert_eq!(compact.to_vec1::<f32>().unwrap(), vec![0.0; 3]);
     }
 }

--- a/crates/izwi-core/src/models/shared/memory/accounting.rs
+++ b/crates/izwi-core/src/models/shared/memory/accounting.rs
@@ -57,6 +57,16 @@ pub(crate) fn compact_tensor_storage(tensor: &Tensor) -> candle_core::Result<Ten
     Ok(tensor)
 }
 
+/// Deep-copy persistent state without routing Metal through Candle's pooled
+/// allocator, which may return an oversized backing allocation.
+pub(crate) fn deep_copy_tensor_storage(tensor: &Tensor) -> candle_core::Result<Tensor> {
+    if tensor.device().is_metal() {
+        compact_tensor_storage(tensor)
+    } else {
+        tensor.copy()
+    }
+}
+
 /// Accumulates the backing allocations retained by a set of Candle tensors.
 ///
 /// Tensor views share a Candle storage allocation. Accounting logical tensor

--- a/crates/izwi-core/src/runtime/chat.rs
+++ b/crates/izwi-core/src/runtime/chat.rs
@@ -1,17 +1,39 @@
 //! Chat runtime methods routed through the unified core engine.
 
 use crate::catalog::ModelFamily;
-use crate::engine::{GenerationParams, TaskType};
+use crate::engine::{GenerationParams, OutputFinishReason as EngineFinishReason, TaskType};
 use crate::error::{Error, Result};
 use crate::model::ModelVariant;
 use crate::models::architectures::qwen35::media_resource_estimate;
-use crate::models::shared::chat::{ChatGenerationConfig, ChatMessage, ChatRequestConfig};
+use crate::models::shared::chat::{
+    ChatGenerationConfig, ChatGenerationFinishReason, ChatMessage, ChatRequestConfig,
+};
 use crate::runtime::request::ChatRuntimeRequest;
 use crate::runtime::service::{
     media_preparation_resources, retained_chat_preparation_input_bytes, AdmittedEngineRequest,
     RuntimeService,
 };
 use crate::runtime::types::{ChatGeneration, RuntimeRequestContext};
+
+fn chat_generation_finish_reason(reason: Option<EngineFinishReason>) -> ChatGenerationFinishReason {
+    match reason {
+        Some(EngineFinishReason::MaxTokens) => ChatGenerationFinishReason::MaxTokens,
+        Some(EngineFinishReason::StopSequence) => ChatGenerationFinishReason::StopSequence,
+        Some(EngineFinishReason::StopToken) | None => ChatGenerationFinishReason::StopToken,
+        Some(EngineFinishReason::Aborted | EngineFinishReason::Error) => {
+            ChatGenerationFinishReason::StopToken
+        }
+    }
+}
+
+fn validate_chat_stop_support(variant: ModelVariant, params: &GenerationParams) -> Result<()> {
+    if !params.stop_sequences.is_empty() && !variant.is_qwen35_chat_gguf() {
+        return Err(Error::InvalidInput(format!(
+            "Chat stop sequences are supported only by Qwen3.5 chat models, not {variant}"
+        )));
+    }
+    Ok(())
+}
 
 impl RuntimeService {
     fn prompt_token_config(
@@ -46,6 +68,7 @@ impl RuntimeService {
                 "Chat request missing messages".to_string(),
             ));
         }
+        validate_chat_stop_support(variant, &params)?;
         if !chat_config.media_inputs.is_empty() && variant.family() != ModelFamily::Qwen35Chat {
             return Err(Error::InvalidInput(format!(
                 "Chat model {variant} does not support Qwen3.5 media inputs"
@@ -157,6 +180,7 @@ impl RuntimeService {
             prompt_tokens: output.token_stats.prompt_tokens,
             tokens_generated: output.num_tokens,
             generation_time_ms: output.generation_time.as_secs_f64() * 1000.0,
+            finish_reason: chat_generation_finish_reason(output.finish_reason),
         })
     }
 
@@ -232,6 +256,7 @@ impl RuntimeService {
             prompt_tokens: output.token_stats.prompt_tokens,
             tokens_generated: output.num_tokens,
             generation_time_ms: output.generation_time.as_secs_f64() * 1000.0,
+            finish_reason: chat_generation_finish_reason(output.finish_reason),
         })
     }
 
@@ -320,6 +345,7 @@ impl RuntimeService {
             prompt_tokens: output.token_stats.prompt_tokens,
             tokens_generated: output.num_tokens,
             generation_time_ms: output.generation_time.as_secs_f64() * 1000.0,
+            finish_reason: chat_generation_finish_reason(output.finish_reason),
         })
     }
 
@@ -428,6 +454,24 @@ impl RuntimeService {
             prompt_tokens: output.token_stats.prompt_tokens,
             tokens_generated: output.num_tokens,
             generation_time_ms: output.generation_time.as_secs_f64() * 1000.0,
+            finish_reason: chat_generation_finish_reason(output.finish_reason),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_rejects_stop_sequences_that_a_model_would_ignore() {
+        let mut params = GenerationParams::default();
+        params.stop_sequences = vec!["done".to_string()];
+
+        let error = validate_chat_stop_support(ModelVariant::Qwen34BGguf, &params)
+            .expect_err("Qwen3 would ignore text stop sequences");
+        assert!(error.to_string().contains("only by Qwen3.5"));
+        validate_chat_stop_support(ModelVariant::Qwen354BGguf, &params)
+            .expect("Qwen3.5 should accept text stop sequences");
     }
 }

--- a/crates/izwi-core/src/runtime/chat.rs
+++ b/crates/izwi-core/src/runtime/chat.rs
@@ -24,6 +24,7 @@ impl RuntimeService {
             top_k: params.top_k,
             repetition_penalty: params.repetition_penalty.max(1.0),
             presence_penalty: params.presence_penalty.clamp(-2.0, 2.0),
+            stop_sequences: params.stop_sequences.clone(),
             stop_token_ids: params.stop_token_ids.clone(),
             seed: 0,
             request: chat_config.clone(),

--- a/crates/izwi-core/src/runtime/lifecycle/unload.rs
+++ b/crates/izwi-core/src/runtime/lifecycle/unload.rs
@@ -85,8 +85,19 @@ impl ModelLifecycleController {
         }
     }
 
+    async fn purge_executor_model_cache(&self, variant: ModelVariant) -> Result<()> {
+        let release = self.core_engine.purge_model_cache(variant).await;
+        if variant.family() == ModelFamily::Qwen35Chat && !release.confirmed {
+            return Err(Error::InferenceError(format!(
+                "Qwen3.5 cache purge was not confirmed before unloading {variant}"
+            )));
+        }
+        Ok(())
+    }
+
     pub(super) async fn rollback_model_locked(&self, variant: ModelVariant) -> Result<()> {
         let _ = self.core_engine.abort_requests_for_variant(variant).await;
+        self.purge_executor_model_cache(variant).await?;
         self.model_manager.unload_model(variant).await?;
         self.remove_registry_and_auxiliary_state(variant).await;
         self.remove_resident_slot(variant);
@@ -121,6 +132,10 @@ impl ModelLifecycleController {
     pub(super) async fn unload_model_locked(&self, variant: ModelVariant) -> Result<()> {
         self.begin_unloading_slot(variant)?;
         let _ = self.core_engine.abort_requests_for_variant(variant).await;
+        if let Err(error) = self.purge_executor_model_cache(variant).await {
+            self.restore_ready_slot_after_failed_unload(variant);
+            return Err(error);
+        }
 
         // Clear externally visible Ready state before removing the physical
         // handle. The authoritative slot remains Unloading and retains its

--- a/crates/izwi-core/src/runtime/types.rs
+++ b/crates/izwi-core/src/runtime/types.rs
@@ -159,6 +159,7 @@ pub struct ChatGeneration {
     pub prompt_tokens: usize,
     pub tokens_generated: usize,
     pub generation_time_ms: f64,
+    pub finish_reason: crate::models::shared::chat::ChatGenerationFinishReason,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/izwi-core/src/tokenizer.rs
+++ b/crates/izwi-core/src/tokenizer.rs
@@ -1,4 +1,4 @@
-//! Text tokenization for Qwen3-TTS
+//! Shared text tokenization helpers.
 
 use std::collections::HashMap;
 use std::fs;
@@ -6,17 +6,18 @@ use std::path::Path;
 use uuid::Uuid;
 
 use serde::Deserialize;
-use tokenizers::AddedToken;
-use tokenizers::SplitDelimiterBehavior;
-use tokenizers::Tokenizer as HfTokenizer;
-use tokenizers::decoders::DecoderWrapper;
 use tokenizers::decoders::byte_fallback::ByteFallback;
 use tokenizers::decoders::sequence::Sequence as DecoderSequence;
+use tokenizers::decoders::DecoderWrapper;
 use tokenizers::models::bpe::BPE;
-use tokenizers::pre_tokenizers::PreTokenizerWrapper;
 use tokenizers::pre_tokenizers::byte_level::ByteLevel;
 use tokenizers::pre_tokenizers::sequence::Sequence as PreTokenizerSequence;
 use tokenizers::pre_tokenizers::split::{Split, SplitPattern};
+use tokenizers::pre_tokenizers::PreTokenizerWrapper;
+use tokenizers::tokenizer::step_decode_stream;
+use tokenizers::AddedToken;
+use tokenizers::SplitDelimiterBehavior;
+use tokenizers::Tokenizer as HfTokenizer;
 use tracing::{debug, info, warn};
 
 use crate::error::{Error, Result};
@@ -36,6 +37,15 @@ pub struct Tokenizer {
 }
 
 const QWEN2_PRETOKENIZER_REGEX: &str = "(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\\r\\n\\p{L}\\p{N}]?[\\p{L}\\p{M}]+|\\p{N}| ?[^\\s\\p{L}\\p{M}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+";
+const GGUF_TOKEN_TYPE_CONTROL: usize = 3;
+const GGUF_TOKEN_TYPE_USER_DEFINED: usize = 4;
+
+#[derive(Debug, Clone, Default)]
+pub struct TokenizerDecodeStreamState {
+    ids: Vec<u32>,
+    prefix: String,
+    prefix_index: usize,
+}
 
 impl Tokenizer {
     pub fn from_path(model_dir: &Path) -> Result<Self> {
@@ -188,10 +198,45 @@ impl Tokenizer {
         pre_tokenizer: Option<&str>,
         add_prefix_space: bool,
     ) -> Result<Self> {
+        Self::from_gguf_bpe_metadata(tokens, merges, None, pre_tokenizer, add_prefix_space)
+    }
+
+    pub fn from_gguf_bpe_with_token_types(
+        tokens: &[String],
+        merges: &[String],
+        token_types: &[usize],
+        pre_tokenizer: Option<&str>,
+        add_prefix_space: bool,
+    ) -> Result<Self> {
+        Self::from_gguf_bpe_metadata(
+            tokens,
+            merges,
+            Some(token_types),
+            pre_tokenizer,
+            add_prefix_space,
+        )
+    }
+
+    fn from_gguf_bpe_metadata(
+        tokens: &[String],
+        merges: &[String],
+        token_types: Option<&[usize]>,
+        pre_tokenizer: Option<&str>,
+        add_prefix_space: bool,
+    ) -> Result<Self> {
         if tokens.is_empty() {
             return Err(Error::TokenizationError(
                 "Cannot build tokenizer from empty GGUF token list".to_string(),
             ));
+        }
+        if let Some(token_types) = token_types {
+            if token_types.len() != tokens.len() {
+                return Err(Error::TokenizationError(format!(
+                    "GGUF tokenizer token/type length mismatch: {} tokens, {} types",
+                    tokens.len(),
+                    token_types.len()
+                )));
+            }
         }
 
         let mut vocab = HashMap::with_capacity(tokens.len());
@@ -234,8 +279,9 @@ impl Tokenizer {
             .to_str()
             .ok_or_else(|| Error::TokenizationError("Invalid temporary merges path".to_string()))?;
 
+        let is_qwen35 = matches!(pre_tokenizer, Some("qwen35"));
         let bpe = BPE::from_file(vocab_str, merges_str)
-            .byte_fallback(true)
+            .byte_fallback(!is_qwen35)
             .build()
             .map_err(|e| Error::TokenizationError(format!("BPE build failed: {e}")))?;
         let _ = fs::remove_file(&vocab_path);
@@ -243,13 +289,13 @@ impl Tokenizer {
         let _ = fs::remove_dir(&temp_dir);
         let mut inner = HfTokenizer::new(bpe);
 
-        let byte_level = if matches!(pre_tokenizer, Some("qwen2")) {
+        let byte_level = if matches!(pre_tokenizer, Some("qwen2" | "qwen35")) {
             let split = Split::new(
                 SplitPattern::Regex(QWEN2_PRETOKENIZER_REGEX.to_string()),
                 SplitDelimiterBehavior::Isolated,
                 false,
             )
-            .map_err(|e| Error::TokenizationError(format!("Invalid Qwen2 split regex: {e}")))?;
+            .map_err(|e| Error::TokenizationError(format!("Invalid Qwen split regex: {e}")))?;
             let byte_level = ByteLevel::new(add_prefix_space, false, false);
             let sequence = PreTokenizerSequence::new(vec![
                 PreTokenizerWrapper::Split(split),
@@ -263,11 +309,31 @@ impl Tokenizer {
             byte_level
         };
 
-        let decoder = DecoderWrapper::Sequence(DecoderSequence::new(vec![
-            DecoderWrapper::ByteFallback(ByteFallback::new()),
-            DecoderWrapper::ByteLevel(byte_level),
-        ]));
+        let decoder = if is_qwen35 {
+            DecoderWrapper::ByteLevel(byte_level)
+        } else {
+            DecoderWrapper::Sequence(DecoderSequence::new(vec![
+                DecoderWrapper::ByteFallback(ByteFallback::new()),
+                DecoderWrapper::ByteLevel(byte_level),
+            ]))
+        };
         inner.with_decoder(Some(decoder));
+
+        if let Some(token_types) = token_types {
+            for (token, &token_type) in tokens.iter().zip(token_types) {
+                let is_special = token_type == GGUF_TOKEN_TYPE_CONTROL;
+                if !is_special && token_type != GGUF_TOKEN_TYPE_USER_DEFINED {
+                    continue;
+                }
+
+                let token = AddedToken::from(token.clone(), is_special).normalized(false);
+                if is_special {
+                    inner.add_special_tokens(&[token]);
+                } else {
+                    inner.add_tokens(&[token]);
+                }
+            }
+        }
 
         debug!("Loaded BPE tokenizer from GGUF metadata");
         Self::new_with_tokenizer(inner)
@@ -300,6 +366,23 @@ impl Tokenizer {
         self.inner
             .decode(ids, false)
             .map_err(|e| Error::TokenizationError(e.to_string()))
+    }
+
+    pub fn decode_stream_step(
+        &self,
+        state: &mut TokenizerDecodeStreamState,
+        token_id: u32,
+        skip_special_tokens: bool,
+    ) -> Result<Option<String>> {
+        step_decode_stream(
+            &self.inner,
+            vec![token_id],
+            skip_special_tokens,
+            &mut state.ids,
+            &mut state.prefix,
+            &mut state.prefix_index,
+        )
+        .map_err(|e| Error::TokenizationError(e.to_string()))
     }
 
     pub fn vocab_size(&self) -> usize {
@@ -365,4 +448,108 @@ fn load_tokenizer_config(model_dir: &Path) -> Result<Option<TokenizerConfigFile>
     let config_str = fs::read_to_string(config_path)?;
     let config: TokenizerConfigFile = serde_json::from_str(&config_str)?;
     Ok(Some(config))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Tokenizer, TokenizerDecodeStreamState};
+
+    fn qwen35_fixture() -> Tokenizer {
+        let tokens = [
+            "a",
+            "l",
+            "p",
+            "h",
+            "b",
+            "e",
+            "t",
+            "Ċ",
+            "al",
+            "alp",
+            "alph",
+            "alpha",
+            "be",
+            "bet",
+            "beta",
+            "ĊĊ",
+            "<think>",
+            "</think>",
+            "<tool_call>",
+            "</tool_call>",
+            "<tool_response>",
+            "</tool_response>",
+            "<|im_start|>",
+            "Ã",
+            "©",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+        let merges = [
+            "a l", "al p", "alp h", "alph a", "b e", "be t", "bet a", "Ċ Ċ",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+        let mut token_types = vec![1usize; tokens.len()];
+        token_types[16..22].fill(4);
+        token_types[22] = 3;
+
+        Tokenizer::from_gguf_bpe_with_token_types(
+            &tokens,
+            &merges,
+            &token_types,
+            Some("qwen35"),
+            false,
+        )
+        .expect("Qwen3.5 tokenizer fixture")
+    }
+
+    #[test]
+    fn qwen35_gguf_pretokenizer_matches_newline_golden() {
+        let tokenizer = qwen35_fixture();
+        assert_eq!(tokenizer.encode("alpha\n\nbeta").unwrap(), vec![11, 15, 14]);
+    }
+
+    #[test]
+    fn qwen35_gguf_token_types_keep_chat_tokens_atomic() {
+        let tokenizer = qwen35_fixture();
+        let ids = tokenizer
+            .encode("<|im_start|><think>\n\n</think><tool_call><tool_response>")
+            .unwrap();
+        assert_eq!(ids, vec![22, 16, 15, 17, 18, 20]);
+    }
+
+    #[test]
+    fn decode_stream_waits_for_complete_utf8() {
+        let tokenizer = qwen35_fixture();
+        let ids = tokenizer.encode("é").unwrap();
+        assert_eq!(ids, vec![23, 24]);
+
+        let mut state = TokenizerDecodeStreamState::default();
+        assert_eq!(
+            tokenizer
+                .decode_stream_step(&mut state, ids[0], true)
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            tokenizer
+                .decode_stream_step(&mut state, ids[1], true)
+                .unwrap(),
+            Some("é".to_string())
+        );
+    }
+
+    #[test]
+    fn gguf_token_types_must_align_with_vocab() {
+        let result = Tokenizer::from_gguf_bpe_with_token_types(
+            &["a".to_string()],
+            &[],
+            &[],
+            Some("qwen35"),
+            false,
+        );
+        assert!(result.is_err());
+    }
 }

--- a/crates/izwi-server/src/api/agent/handlers.rs
+++ b/crates/izwi-server/src/api/agent/handlers.rs
@@ -93,7 +93,11 @@ pub async fn create_session(
 
     let thread = state
         .chat_store
-        .create_thread(req.title, Some(model_id.clone()))
+        .create_thread_with_system_prompt(
+            req.title,
+            Some(model_id.clone()),
+            Some(system_prompt.clone()),
+        )
         .await
         .map_err(map_store_error)?;
 
@@ -140,6 +144,10 @@ pub async fn create_turn(
             .cloned()
             .ok_or_else(|| ApiError::not_found("Agent session not found"))?
     };
+    let _turn_guard = state
+        .chat_store
+        .acquire_turn(&session_record.thread_id)
+        .await;
 
     let requested_model_id = match req.model_id.as_deref() {
         Some(model_id) => Some(resolve_chat_model_id(Some(model_id))?),

--- a/crates/izwi-server/src/api/chat/handlers.rs
+++ b/crates/izwi-server/src/api/chat/handlers.rs
@@ -9,17 +9,23 @@ use axum::{
 };
 use futures::Stream;
 use serde::{Deserialize, Serialize};
+use tokio::sync::{oneshot, OwnedMutexGuard};
 
 use crate::api::request_context::RequestContext;
 use crate::app::chat::{
-    generate_chat, parse_chat_model, spawn_chat_stream, ChatExecutionRequest, ChatStreamEvent,
+    generate_chat, parse_chat_model, parse_stop_sequences, spawn_chat_stream_with_completion,
+    validate_chat_stop_support, ChatExecutionRequest, ChatStreamEvent,
 };
 use crate::app::chat_content::{
     flatten_thread_content, validate_media_inputs_for_variant, FlattenedMultimodalContent,
 };
-use crate::chat_store::{ChatStore, ChatThreadMessage, ChatThreadSummary};
+use crate::chat_store::{
+    ChatStore, ChatThreadMessage, ChatThreadSummary, ChatThreadSystemPromptUpdate,
+};
 use crate::error::ApiError;
 use crate::state::AppState;
+#[cfg(test)]
+use izwi_core::ChatGenerationFinishReason;
 use izwi_core::{ChatGeneration, ChatMediaInput, ChatMessage, ChatRequestConfig, ChatRole};
 
 #[derive(Debug, Serialize)]
@@ -33,6 +39,8 @@ pub struct CreateChatThreadRequest {
     pub title: Option<String>,
     #[serde(default)]
     pub model_id: Option<String>,
+    #[serde(default)]
+    pub system_prompt: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -73,12 +81,15 @@ pub struct CreateThreadMessageRequest {
     pub top_p: Option<f32>,
     #[serde(default)]
     pub enable_thinking: Option<bool>,
+    #[serde(default)]
+    pub stop: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ChatGenerationStats {
     pub tokens_generated: usize,
     pub generation_time_ms: f64,
+    pub finish_reason: izwi_core::ChatGenerationFinishReason,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -137,7 +148,13 @@ pub async fn create_thread(
 ) -> Result<Json<ChatThreadSummary>, ApiError> {
     let thread = state
         .chat_store
-        .create_thread(req.title, req.model_id)
+        .create_thread_with_system_prompt(
+            req.title,
+            req.model_id,
+            req.system_prompt
+                .as_deref()
+                .and_then(normalize_system_prompt),
+        )
         .await
         .map_err(map_store_error)?;
 
@@ -176,6 +193,7 @@ pub async fn delete_thread(
     State(state): State<AppState>,
     Path(thread_id): Path<String>,
 ) -> Result<Json<DeleteChatThreadResponse>, ApiError> {
+    let _turn_guard = state.chat_store.acquire_turn(&thread_id).await;
     let deleted = state
         .chat_store
         .delete_thread(thread_id.clone())
@@ -201,6 +219,7 @@ pub async fn update_thread(
         return Err(ApiError::bad_request("Thread title cannot be empty"));
     }
 
+    let _turn_guard = state.chat_store.acquire_turn(&thread_id).await;
     let updated = state
         .chat_store
         .update_thread_title(thread_id, req.title)
@@ -228,17 +247,25 @@ pub async fn create_thread_message(
         return Err(ApiError::bad_request("Message content cannot be empty"));
     }
 
-    get_thread_or_not_found(&state, &thread_id).await?;
+    let stop_sequences = parse_stop_sequences(req.stop.as_ref())?;
+    validate_chat_stop_support(model_variant, &stop_sequences)?;
+
+    let turn_guard = state.chat_store.acquire_turn(&thread_id).await;
+    let thread = get_thread_or_not_found(&state, &thread_id).await?;
     let existing_messages = state
         .chat_store
         .list_messages(thread_id.clone())
         .await
         .map_err(map_store_error)?;
 
+    let (system_prompt_update, effective_system_prompt) = resolve_thread_system_prompt(
+        thread.system_prompt.as_deref(),
+        req.system_prompt.as_deref(),
+    );
     let (runtime_messages, media_inputs) = build_runtime_messages(
         &existing_messages,
         &flattened_content,
-        req.system_prompt.as_deref(),
+        effective_system_prompt.as_deref(),
     )?;
     validate_media_inputs_for_variant(model_variant, &media_inputs)
         .map_err(ApiError::bad_request)?;
@@ -247,6 +274,7 @@ pub async fn create_thread_message(
         thread_id.clone(),
         flattened_content.display_text.clone(),
         prepared_content_parts.clone(),
+        thread.updated_at,
     );
 
     let execution_request = ChatExecutionRequest {
@@ -257,7 +285,7 @@ pub async fn create_thread_message(
         temperature: req.temperature,
         top_p: req.top_p,
         presence_penalty: None,
-        stop_sequences: Vec::new(),
+        stop_sequences,
         chat_config: ChatRequestConfig {
             enable_thinking: req.enable_thinking,
             tools: Vec::new(),
@@ -273,14 +301,21 @@ pub async fn create_thread_message(
             thread_id,
             user_message,
             execution_request,
+            system_prompt_update,
+            turn_guard,
         )
         .await;
     }
 
     let generation = generate_chat(&state, execution_request).await;
-    let (generation, user_message, assistant_message) =
-        persist_generated_thread_turn(&state.chat_store, user_message, &model_id, generation)
-            .await?;
+    let (generation, user_message, assistant_message) = persist_generated_thread_turn(
+        &state.chat_store,
+        user_message,
+        &model_id,
+        generation,
+        system_prompt_update,
+    )
+    .await?;
 
     let response = CreateThreadMessageResponse {
         thread_id,
@@ -290,6 +325,7 @@ pub async fn create_thread_message(
         stats: ChatGenerationStats {
             tokens_generated: generation.tokens_generated,
             generation_time_ms: generation.generation_time_ms,
+            finish_reason: generation.finish_reason,
         },
     };
 
@@ -301,15 +337,17 @@ async fn persist_generated_thread_turn(
     user_message: ChatThreadMessage,
     model_id: &str,
     generation: Result<ChatGeneration, ApiError>,
+    system_prompt_update: ChatThreadSystemPromptUpdate,
 ) -> Result<(ChatGeneration, ChatThreadMessage, ChatThreadMessage), ApiError> {
     let generation = generation?;
     let (user_message, assistant_message) = chat_store
-        .append_turn(
+        .append_turn_with_system_prompt_update(
             user_message,
             generation.text.clone(),
             Some(model_id.to_string()),
             generation.tokens_generated,
             generation.generation_time_ms,
+            system_prompt_update,
         )
         .await
         .map_err(map_store_or_not_found)?;
@@ -322,18 +360,23 @@ async fn create_streaming_thread_message(
     thread_id: String,
     user_message: ChatThreadMessage,
     execution_request: ChatExecutionRequest,
+    system_prompt_update: ChatThreadSystemPromptUpdate,
+    turn_guard: OwnedMutexGuard<()>,
 ) -> Result<Response, ApiError> {
     let chat_store = state.chat_store.clone();
     let thread_id_for_task = thread_id.clone();
     let model_id_for_task = model_id.clone();
     let user_message_for_start = user_message.clone();
-    let event_rx = spawn_chat_stream(state, execution_request);
+    let (event_rx, completion_rx) = spawn_chat_stream_with_completion(state, execution_request);
     let stream = thread_message_stream(
         chat_store,
         model_id_for_task,
         thread_id_for_task,
         user_message_for_start,
         event_rx,
+        Some(completion_rx),
+        system_prompt_update,
+        turn_guard,
     );
 
     Ok(Response::builder()
@@ -350,9 +393,24 @@ fn thread_message_stream(
     thread_id: String,
     user_message: ChatThreadMessage,
     mut event_rx: tokio::sync::mpsc::Receiver<ChatStreamEvent>,
+    completion_rx: Option<oneshot::Receiver<()>>,
+    system_prompt_update: ChatThreadSystemPromptUpdate,
+    turn_guard: OwnedMutexGuard<()>,
 ) -> impl Stream<Item = Result<String, Infallible>> {
-    async_stream::stream! {
-        while let Some(event) = event_rx.recv().await {
+    const THREAD_STREAM_CAPACITY: usize = 64;
+    let (client_tx, mut client_rx) = tokio::sync::mpsc::channel(THREAD_STREAM_CAPACITY);
+
+    tokio::spawn(async move {
+        let _turn_guard = turn_guard;
+        loop {
+            let event = tokio::select! {
+                _ = client_tx.closed() => None,
+                event = event_rx.recv() => event,
+            };
+            let Some(event) = event else {
+                break;
+            };
+
             let (payload, terminal) = match event {
                 ChatStreamEvent::Started => (
                     serde_json::to_string(&ThreadStreamStartEvent {
@@ -374,18 +432,22 @@ fn thread_message_stream(
                 ),
                 ChatStreamEvent::Completed(generation) => {
                     let payload = match chat_store
-                        .append_turn(
+                        .append_turn_with_system_prompt_update(
                             user_message.clone(),
                             generation.text.clone(),
                             Some(model_id.clone()),
                             generation.tokens_generated,
                             generation.generation_time_ms,
+                            system_prompt_update.clone(),
                         )
                         .await
                     {
                         Ok((persisted_user_message, assistant_message)) => {
                             debug_assert_eq!(persisted_user_message.id, user_message.id);
-                            debug_assert_eq!(persisted_user_message.created_at, user_message.created_at);
+                            debug_assert_eq!(
+                                persisted_user_message.created_at,
+                                user_message.created_at
+                            );
                             serde_json::to_string(&ThreadStreamDoneEvent {
                                 event: "done",
                                 thread_id: thread_id.clone(),
@@ -394,6 +456,7 @@ fn thread_message_stream(
                                 stats: ChatGenerationStats {
                                     tokens_generated: generation.tokens_generated,
                                     generation_time_ms: generation.generation_time_ms,
+                                    finish_reason: generation.finish_reason,
                                 },
                             })
                             .unwrap_or_default()
@@ -423,12 +486,53 @@ fn thread_message_stream(
                     true,
                 ),
             };
-            yield Ok::<_, Infallible>(format!("data: {payload}\n\n"));
+
+            if client_tx.try_send(format!("data: {payload}\n\n")).is_err() {
+                break;
+            }
             if terminal {
+                let _ = client_tx.try_send("data: [DONE]\n\n".to_string());
                 break;
             }
         }
-        yield Ok::<_, Infallible>("data: [DONE]\n\n".to_string());
+
+        // Dropping the engine receiver first requests cancellation. Keep the
+        // per-thread guard until the generation task confirms it has unwound,
+        // so an abort-and-resend cannot overlap model sessions for one thread.
+        drop(event_rx);
+        if let Some(completion_rx) = completion_rx {
+            let _ = completion_rx.await;
+        }
+    });
+
+    async_stream::stream! {
+        while let Some(payload) = client_rx.recv().await {
+            yield Ok::<_, Infallible>(payload);
+        }
+    }
+}
+
+fn normalize_system_prompt(prompt: &str) -> Option<String> {
+    let prompt = prompt.trim();
+    (!prompt.is_empty()).then(|| prompt.to_string())
+}
+
+fn resolve_thread_system_prompt(
+    stored: Option<&str>,
+    requested: Option<&str>,
+) -> (ChatThreadSystemPromptUpdate, Option<String>) {
+    match requested {
+        Some(requested) => {
+            let resolved = normalize_system_prompt(requested);
+            (
+                ChatThreadSystemPromptUpdate::Replace(resolved.clone()),
+                resolved,
+            )
+        }
+        None => (
+            ChatThreadSystemPromptUpdate::Retain,
+            stored.and_then(normalize_system_prompt),
+        ),
     }
 }
 
@@ -533,6 +637,7 @@ mod tests {
             prompt_tokens: 11,
             tokens_generated: 3,
             generation_time_ms: 4.5,
+            finish_reason: ChatGenerationFinishReason::StopToken,
         }
     }
 
@@ -594,6 +699,28 @@ mod tests {
     }
 
     #[test]
+    fn thread_system_prompt_is_inherited_updated_and_cleared_explicitly() {
+        assert_eq!(
+            resolve_thread_system_prompt(Some("stored"), None),
+            (
+                ChatThreadSystemPromptUpdate::Retain,
+                Some("stored".to_string())
+            )
+        );
+        assert_eq!(
+            resolve_thread_system_prompt(Some("stored"), Some("  replacement  ")),
+            (
+                ChatThreadSystemPromptUpdate::Replace(Some("replacement".to_string())),
+                Some("replacement".to_string())
+            )
+        );
+        assert_eq!(
+            resolve_thread_system_prompt(Some("stored"), Some("  ")),
+            (ChatThreadSystemPromptUpdate::Replace(None), None)
+        );
+    }
+
+    #[test]
     fn build_runtime_messages_collects_media_from_history_and_new_message() {
         let (messages, media_inputs) = build_runtime_messages(
             &[ChatThreadMessage {
@@ -637,6 +764,7 @@ mod tests {
             thread.id.clone(),
             "hello".to_string(),
             Some(vec![json!({"type":"text","text":"hello"})]),
+            thread.updated_at,
         );
         let pending_id = pending.id.clone();
         let pending_created_at = pending.created_at;
@@ -657,6 +785,9 @@ mod tests {
             thread.id.clone(),
             pending,
             event_rx,
+            None,
+            ChatThreadSystemPromptUpdate::Retain,
+            store.acquire_turn(&thread.id).await,
         )
         .collect::<Vec<_>>()
         .await
@@ -685,6 +816,7 @@ mod tests {
         )
         .expect("done event should be json");
         assert_eq!(done["event"], "done");
+        assert_eq!(done["stats"]["finish_reason"], "stop_token");
 
         let messages = store
             .list_messages(thread.id)
@@ -703,13 +835,19 @@ mod tests {
             .create_thread(None, Some("Qwen3.5-4B".to_string()))
             .await
             .expect("thread should create");
-        let pending = store.prepare_user_message(thread.id.clone(), "hello".to_string(), None);
+        let pending = store.prepare_user_message(
+            thread.id.clone(),
+            "hello".to_string(),
+            None,
+            thread.updated_at,
+        );
 
         let err = persist_generated_thread_turn(
             &store,
             pending,
             "Qwen3.5-4B",
             Err(ApiError::internal("inference failed")),
+            ChatThreadSystemPromptUpdate::Retain,
         )
         .await
         .expect_err("inference failure should propagate");
@@ -728,7 +866,12 @@ mod tests {
             .create_thread(None, Some("Qwen3.5-4B".to_string()))
             .await
             .expect("thread should create");
-        let pending = store.prepare_user_message(thread.id.clone(), "hello".to_string(), None);
+        let pending = store.prepare_user_message(
+            thread.id.clone(),
+            "hello".to_string(),
+            None,
+            thread.updated_at,
+        );
         let (event_tx, event_rx) = mpsc::channel(4);
         event_tx
             .send(ChatStreamEvent::Started)
@@ -746,6 +889,9 @@ mod tests {
             thread.id.clone(),
             pending,
             event_rx,
+            None,
+            ChatThreadSystemPromptUpdate::Retain,
+            store.acquire_turn(&thread.id).await,
         )
         .collect::<Vec<_>>()
         .await
@@ -769,7 +915,12 @@ mod tests {
             .create_thread(None, Some("Qwen3.5-4B".to_string()))
             .await
             .expect("thread should create");
-        let pending = store.prepare_user_message(thread.id.clone(), "hello".to_string(), None);
+        let pending = store.prepare_user_message(
+            thread.id.clone(),
+            "hello".to_string(),
+            None,
+            thread.updated_at,
+        );
         let (event_tx, event_rx) = mpsc::channel(4);
         event_tx
             .send(ChatStreamEvent::Started)
@@ -783,6 +934,9 @@ mod tests {
                 thread.id.clone(),
                 pending,
                 event_rx,
+                None,
+                ChatThreadSystemPromptUpdate::Retain,
+                store.acquire_turn(&thread.id).await,
             );
             futures::pin_mut!(stream);
             let start = stream
@@ -793,6 +947,9 @@ mod tests {
             assert!(start.contains("\"event\":\"start\""));
         }
 
+        tokio::time::timeout(std::time::Duration::from_millis(100), event_tx.closed())
+            .await
+            .expect("dropped client should cancel the engine receiver");
         assert!(event_tx
             .send(ChatStreamEvent::Completed(test_generation()))
             .await
@@ -802,5 +959,51 @@ mod tests {
             .await
             .expect("messages should list")
             .is_empty());
+    }
+
+    #[tokio::test]
+    async fn aborted_stream_holds_the_turn_lock_until_generation_unwinds() {
+        let (_temp, store) = setup_stream_store();
+        let thread = store
+            .create_thread(None, Some("Qwen3.5-4B".to_string()))
+            .await
+            .expect("thread should create");
+        let pending = store.prepare_user_message(
+            thread.id.clone(),
+            "hello".to_string(),
+            None,
+            thread.updated_at,
+        );
+        let (_event_tx, event_rx) = mpsc::channel(1);
+        let (completion_tx, completion_rx) = oneshot::channel();
+
+        let stream = thread_message_stream(
+            store.clone(),
+            "Qwen3.5-4B".to_string(),
+            thread.id.clone(),
+            pending,
+            event_rx,
+            Some(completion_rx),
+            ChatThreadSystemPromptUpdate::Retain,
+            store.acquire_turn(&thread.id).await,
+        );
+        drop(stream);
+
+        assert!(tokio::time::timeout(
+            std::time::Duration::from_millis(25),
+            store.acquire_turn(&thread.id),
+        )
+        .await
+        .is_err());
+
+        completion_tx
+            .send(())
+            .expect("generation completion should still be observed");
+        tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            store.acquire_turn(&thread.id),
+        )
+        .await
+        .expect("turn lock should release after generation completion");
     }
 }

--- a/crates/izwi-server/src/api/chat/handlers.rs
+++ b/crates/izwi-server/src/api/chat/handlers.rs
@@ -257,6 +257,7 @@ pub async fn create_thread_message(
         temperature: req.temperature,
         top_p: req.top_p,
         presence_penalty: None,
+        stop_sequences: Vec::new(),
         chat_config: ChatRequestConfig {
             enable_thinking: req.enable_thinking,
             tools: Vec::new(),

--- a/crates/izwi-server/src/api/chat/handlers.rs
+++ b/crates/izwi-server/src/api/chat/handlers.rs
@@ -7,6 +7,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use futures::Stream;
 use serde::{Deserialize, Serialize};
 
 use crate::api::request_context::RequestContext;
@@ -16,10 +17,10 @@ use crate::app::chat::{
 use crate::app::chat_content::{
     flatten_thread_content, validate_media_inputs_for_variant, FlattenedMultimodalContent,
 };
-use crate::chat_store::{ChatThreadMessage, ChatThreadSummary};
+use crate::chat_store::{ChatStore, ChatThreadMessage, ChatThreadSummary};
 use crate::error::ApiError;
 use crate::state::AppState;
-use izwi_core::{ChatMediaInput, ChatMessage, ChatRequestConfig, ChatRole};
+use izwi_core::{ChatGeneration, ChatMediaInput, ChatMessage, ChatRequestConfig, ChatRole};
 
 #[derive(Debug, Serialize)]
 pub struct ChatThreadListResponse {
@@ -242,19 +243,11 @@ pub async fn create_thread_message(
     validate_media_inputs_for_variant(model_variant, &media_inputs)
         .map_err(ApiError::bad_request)?;
 
-    let user_message = state
-        .chat_store
-        .append_message(
-            thread_id.clone(),
-            "user".to_string(),
-            flattened_content.display_text.clone(),
-            prepared_content_parts.clone(),
-            Some(model_id.clone()),
-            None,
-            None,
-        )
-        .await
-        .map_err(map_store_or_not_found)?;
+    let user_message = state.chat_store.prepare_user_message(
+        thread_id.clone(),
+        flattened_content.display_text.clone(),
+        prepared_content_parts.clone(),
+    );
 
     let execution_request = ChatExecutionRequest {
         variant: model_variant,
@@ -283,21 +276,10 @@ pub async fn create_thread_message(
         .await;
     }
 
-    let generation = generate_chat(&state, execution_request).await?;
-
-    let assistant_message = state
-        .chat_store
-        .append_message(
-            thread_id.clone(),
-            "assistant".to_string(),
-            generation.text.clone(),
-            None,
-            Some(model_id.clone()),
-            Some(generation.tokens_generated),
-            Some(generation.generation_time_ms),
-        )
-        .await
-        .map_err(map_store_or_not_found)?;
+    let generation = generate_chat(&state, execution_request).await;
+    let (generation, user_message, assistant_message) =
+        persist_generated_thread_turn(&state.chat_store, user_message, &model_id, generation)
+            .await?;
 
     let response = CreateThreadMessageResponse {
         thread_id,
@@ -313,6 +295,26 @@ pub async fn create_thread_message(
     Ok(Json(response).into_response())
 }
 
+async fn persist_generated_thread_turn(
+    chat_store: &ChatStore,
+    user_message: ChatThreadMessage,
+    model_id: &str,
+    generation: Result<ChatGeneration, ApiError>,
+) -> Result<(ChatGeneration, ChatThreadMessage, ChatThreadMessage), ApiError> {
+    let generation = generation?;
+    let (user_message, assistant_message) = chat_store
+        .append_turn(
+            user_message,
+            generation.text.clone(),
+            Some(model_id.to_string()),
+            generation.tokens_generated,
+            generation.generation_time_ms,
+        )
+        .await
+        .map_err(map_store_or_not_found)?;
+    Ok((generation, user_message, assistant_message))
+}
+
 async fn create_streaming_thread_message(
     state: AppState,
     model_id: String,
@@ -324,17 +326,39 @@ async fn create_streaming_thread_message(
     let thread_id_for_task = thread_id.clone();
     let model_id_for_task = model_id.clone();
     let user_message_for_start = user_message.clone();
-    let mut event_rx = spawn_chat_stream(state, execution_request);
+    let event_rx = spawn_chat_stream(state, execution_request);
+    let stream = thread_message_stream(
+        chat_store,
+        model_id_for_task,
+        thread_id_for_task,
+        user_message_for_start,
+        event_rx,
+    );
 
-    let stream = async_stream::stream! {
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/event-stream")
+        .header(header::CACHE_CONTROL, "no-cache")
+        .body(Body::from_stream(stream))
+        .unwrap())
+}
+
+fn thread_message_stream(
+    chat_store: std::sync::Arc<ChatStore>,
+    model_id: String,
+    thread_id: String,
+    user_message: ChatThreadMessage,
+    mut event_rx: tokio::sync::mpsc::Receiver<ChatStreamEvent>,
+) -> impl Stream<Item = Result<String, Infallible>> {
+    async_stream::stream! {
         while let Some(event) = event_rx.recv().await {
             let (payload, terminal) = match event {
                 ChatStreamEvent::Started => (
                     serde_json::to_string(&ThreadStreamStartEvent {
                         event: "start",
-                        thread_id: thread_id_for_task.clone(),
-                        model_id: model_id_for_task.clone(),
-                        user_message: user_message_for_start.clone(),
+                        thread_id: thread_id.clone(),
+                        model_id: model_id.clone(),
+                        user_message: user_message.clone(),
                     })
                     .unwrap_or_default(),
                     false,
@@ -349,28 +373,30 @@ async fn create_streaming_thread_message(
                 ),
                 ChatStreamEvent::Completed(generation) => {
                     let payload = match chat_store
-                        .append_message(
-                            thread_id_for_task.clone(),
-                            "assistant".to_string(),
+                        .append_turn(
+                            user_message.clone(),
                             generation.text.clone(),
-                            None,
-                            Some(model_id_for_task.clone()),
-                            Some(generation.tokens_generated),
-                            Some(generation.generation_time_ms),
+                            Some(model_id.clone()),
+                            generation.tokens_generated,
+                            generation.generation_time_ms,
                         )
                         .await
                     {
-                        Ok(assistant_message) => serde_json::to_string(&ThreadStreamDoneEvent {
-                            event: "done",
-                            thread_id: thread_id_for_task.clone(),
-                            model_id: model_id_for_task.clone(),
-                            assistant_message,
-                            stats: ChatGenerationStats {
-                                tokens_generated: generation.tokens_generated,
-                                generation_time_ms: generation.generation_time_ms,
-                            },
-                        })
-                        .unwrap_or_default(),
+                        Ok((persisted_user_message, assistant_message)) => {
+                            debug_assert_eq!(persisted_user_message.id, user_message.id);
+                            debug_assert_eq!(persisted_user_message.created_at, user_message.created_at);
+                            serde_json::to_string(&ThreadStreamDoneEvent {
+                                event: "done",
+                                thread_id: thread_id.clone(),
+                                model_id: model_id.clone(),
+                                assistant_message,
+                                stats: ChatGenerationStats {
+                                    tokens_generated: generation.tokens_generated,
+                                    generation_time_ms: generation.generation_time_ms,
+                                },
+                            })
+                            .unwrap_or_default()
+                        }
                         Err(err) => serde_json::to_string(&ThreadStreamErrorEvent {
                             event: "error",
                             error: format!("Failed to persist assistant message: {err}"),
@@ -402,14 +428,7 @@ async fn create_streaming_thread_message(
             }
         }
         yield Ok::<_, Infallible>("data: [DONE]\n\n".to_string());
-    };
-
-    Ok(Response::builder()
-        .status(StatusCode::OK)
-        .header(header::CONTENT_TYPE, "text/event-stream")
-        .header(header::CACHE_CONTROL, "no-cache")
-        .body(Body::from_stream(stream))
-        .unwrap())
+    }
 }
 
 fn build_runtime_messages(
@@ -492,7 +511,29 @@ fn map_store_or_not_found(err: anyhow::Error) -> ApiError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::StoreDatabase;
+    use futures::StreamExt;
     use serde_json::json;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+    use tokio::sync::mpsc;
+
+    fn setup_stream_store() -> (TempDir, Arc<ChatStore>) {
+        let temp_dir = tempfile::tempdir().expect("temp dir should create");
+        let store = ChatStore::initialize_with_database(StoreDatabase::new(
+            temp_dir.path().join("chat.sqlite3"),
+        ));
+        (temp_dir, Arc::new(store))
+    }
+
+    fn test_generation() -> ChatGeneration {
+        ChatGeneration {
+            text: "assistant reply".to_string(),
+            prompt_tokens: 11,
+            tokens_generated: 3,
+            generation_time_ms: 4.5,
+        }
+    }
 
     #[test]
     fn flattens_thread_text_parts() {
@@ -582,5 +623,183 @@ mod tests {
 
         assert_eq!(messages.len(), 2);
         assert_eq!(media_inputs.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn completed_stream_atomically_persists_the_wire_visible_user_and_assistant() {
+        let (_temp, store) = setup_stream_store();
+        let thread = store
+            .create_thread(None, Some("old-model".to_string()))
+            .await
+            .expect("thread should create");
+        let pending = store.prepare_user_message(
+            thread.id.clone(),
+            "hello".to_string(),
+            Some(vec![json!({"type":"text","text":"hello"})]),
+        );
+        let pending_id = pending.id.clone();
+        let pending_created_at = pending.created_at;
+        let (event_tx, event_rx) = mpsc::channel(4);
+        event_tx
+            .send(ChatStreamEvent::Started)
+            .await
+            .expect("start should queue");
+        event_tx
+            .send(ChatStreamEvent::Completed(test_generation()))
+            .await
+            .expect("completion should queue");
+        drop(event_tx);
+
+        let chunks = thread_message_stream(
+            store.clone(),
+            "Qwen3.5-4B".to_string(),
+            thread.id.clone(),
+            pending,
+            event_rx,
+        )
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("stream chunks should succeed");
+        assert_eq!(chunks.len(), 3);
+        let start: serde_json::Value = serde_json::from_str(
+            chunks[0]
+                .strip_prefix("data: ")
+                .expect("start data prefix")
+                .trim(),
+        )
+        .expect("start event should be json");
+        assert_eq!(start["event"], "start");
+        assert_eq!(start["user_message"]["id"], pending_id);
+        assert_eq!(
+            start["user_message"]["created_at"],
+            serde_json::Value::from(pending_created_at)
+        );
+        let done: serde_json::Value = serde_json::from_str(
+            chunks[1]
+                .strip_prefix("data: ")
+                .expect("done data prefix")
+                .trim(),
+        )
+        .expect("done event should be json");
+        assert_eq!(done["event"], "done");
+
+        let messages = store
+            .list_messages(thread.id)
+            .await
+            .expect("messages should list");
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].id, pending_id);
+        assert_eq!(messages[0].created_at, pending_created_at);
+        assert_eq!(done["assistant_message"]["id"], messages[1].id);
+    }
+
+    #[tokio::test]
+    async fn non_streaming_inference_failure_does_not_persist_the_pending_user() {
+        let (_temp, store) = setup_stream_store();
+        let thread = store
+            .create_thread(None, Some("Qwen3.5-4B".to_string()))
+            .await
+            .expect("thread should create");
+        let pending = store.prepare_user_message(thread.id.clone(), "hello".to_string(), None);
+
+        let err = persist_generated_thread_turn(
+            &store,
+            pending,
+            "Qwen3.5-4B",
+            Err(ApiError::internal("inference failed")),
+        )
+        .await
+        .expect_err("inference failure should propagate");
+        assert_eq!(err.message, "inference failed");
+        assert!(store
+            .list_messages(thread.id)
+            .await
+            .expect("messages should list")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn failed_stream_does_not_persist_an_unmatched_user_message() {
+        let (_temp, store) = setup_stream_store();
+        let thread = store
+            .create_thread(None, Some("Qwen3.5-4B".to_string()))
+            .await
+            .expect("thread should create");
+        let pending = store.prepare_user_message(thread.id.clone(), "hello".to_string(), None);
+        let (event_tx, event_rx) = mpsc::channel(4);
+        event_tx
+            .send(ChatStreamEvent::Started)
+            .await
+            .expect("start should queue");
+        event_tx
+            .send(ChatStreamEvent::Failed("inference failed".to_string()))
+            .await
+            .expect("failure should queue");
+        drop(event_tx);
+
+        let chunks = thread_message_stream(
+            store.clone(),
+            "Qwen3.5-4B".to_string(),
+            thread.id.clone(),
+            pending,
+            event_rx,
+        )
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("stream chunks should succeed");
+        assert!(chunks
+            .iter()
+            .any(|chunk| chunk.contains("inference failed")));
+        assert!(store
+            .list_messages(thread.id)
+            .await
+            .expect("messages should list")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn dropped_stream_does_not_persist_the_pending_user_message() {
+        let (_temp, store) = setup_stream_store();
+        let thread = store
+            .create_thread(None, Some("Qwen3.5-4B".to_string()))
+            .await
+            .expect("thread should create");
+        let pending = store.prepare_user_message(thread.id.clone(), "hello".to_string(), None);
+        let (event_tx, event_rx) = mpsc::channel(4);
+        event_tx
+            .send(ChatStreamEvent::Started)
+            .await
+            .expect("start should queue");
+
+        {
+            let stream = thread_message_stream(
+                store.clone(),
+                "Qwen3.5-4B".to_string(),
+                thread.id.clone(),
+                pending,
+                event_rx,
+            );
+            futures::pin_mut!(stream);
+            let start = stream
+                .next()
+                .await
+                .expect("start chunk")
+                .expect("start chunk should succeed");
+            assert!(start.contains("\"event\":\"start\""));
+        }
+
+        assert!(event_tx
+            .send(ChatStreamEvent::Completed(test_generation()))
+            .await
+            .is_err());
+        assert!(store
+            .list_messages(thread.id)
+            .await
+            .expect("messages should list")
+            .is_empty());
     }
 }

--- a/crates/izwi-server/src/api/openai/chat/completions.rs
+++ b/crates/izwi-server/src/api/openai/chat/completions.rs
@@ -16,7 +16,8 @@ use crate::api::openai::compat::{
 };
 use crate::api::request_context::RequestContext;
 use crate::app::chat::{
-    generate_chat, parse_chat_model, spawn_chat_stream, ChatExecutionRequest, ChatStreamEvent,
+    generate_chat, parse_chat_model, parse_stop_sequences, spawn_chat_stream,
+    validate_chat_stop_support, ChatExecutionRequest, ChatStreamEvent,
 };
 use crate::app::chat_content::{
     flatten_content_parts, validate_media_inputs_for_variant, FlattenedMultimodalContent,
@@ -24,7 +25,10 @@ use crate::app::chat_content::{
 use crate::error::ApiError;
 use crate::ids::new_uuid;
 use crate::state::AppState;
-use izwi_core::{ChatMediaInput, ChatMessage, ChatRequestConfig, ChatRole, ModelVariant};
+use izwi_core::{
+    ChatGenerationFinishReason, ChatMediaInput, ChatMessage, ChatRequestConfig, ChatRole,
+    ModelVariant,
+};
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
@@ -521,6 +525,7 @@ fn parse_tool_call_block(block: &str) -> Option<OpenAiOutputToolCall> {
 
 fn build_assistant_response_parts(
     text: String,
+    generation_finish_reason: ChatGenerationFinishReason,
 ) -> (
     Option<String>,
     Option<Vec<OpenAiOutputToolCall>>,
@@ -528,7 +533,15 @@ fn build_assistant_response_parts(
 ) {
     let parsed = parse_assistant_tool_output(&text);
     if parsed.tool_calls.is_empty() {
-        (Some(text), None, "stop")
+        (
+            Some(text),
+            None,
+            match generation_finish_reason {
+                ChatGenerationFinishReason::MaxTokens => "length",
+                ChatGenerationFinishReason::StopToken
+                | ChatGenerationFinishReason::StopSequence => "stop",
+            },
+        )
     } else {
         let content = if parsed.content.is_empty() {
             None
@@ -575,10 +588,6 @@ fn validate_chat_request_compatibility(
         )));
     }
 
-    if profile.is_strict() && req.stop.is_some() {
-        return Err(ApiError::bad_request(strict_guardrail_message("stop")));
-    }
-
     if profile.is_strict() {
         if let Some(tool_choice) = &req.tool_choice {
             if !tool_choice.is_null()
@@ -595,48 +604,6 @@ fn validate_chat_request_compatibility(
     Ok(())
 }
 
-fn parse_stop_sequences(stop: Option<&serde_json::Value>) -> Result<Vec<String>, ApiError> {
-    const MAX_STOP_SEQUENCES: usize = 4;
-
-    let values: Vec<&str> = match stop {
-        None | Some(serde_json::Value::Null) => return Ok(Vec::new()),
-        Some(serde_json::Value::String(value)) => vec![value.as_str()],
-        Some(serde_json::Value::Array(values)) => {
-            if values.len() > MAX_STOP_SEQUENCES {
-                return Err(ApiError::bad_request(format!(
-                    "`stop` supports at most {MAX_STOP_SEQUENCES} sequences"
-                )));
-            }
-            values
-                .iter()
-                .map(|value| {
-                    value.as_str().ok_or_else(|| {
-                        ApiError::bad_request(
-                            "`stop` must be a string or an array containing only strings",
-                        )
-                    })
-                })
-                .collect::<Result<Vec<_>, _>>()?
-        }
-        Some(_) => {
-            return Err(ApiError::bad_request(
-                "`stop` must be a string or an array containing only strings",
-            ))
-        }
-    };
-
-    let mut stop_sequences = Vec::with_capacity(values.len());
-    for value in values {
-        if value.is_empty() {
-            return Err(ApiError::bad_request("`stop` sequences cannot be empty"));
-        }
-        if !stop_sequences.iter().any(|existing| existing == value) {
-            stop_sequences.push(value.to_string());
-        }
-    }
-    Ok(stop_sequences)
-}
-
 pub async fn completions(
     State(state): State<AppState>,
     Extension(ctx): Extension<RequestContext>,
@@ -647,6 +614,7 @@ pub async fn completions(
     let stop_sequences = parse_stop_sequences(req.stop.as_ref())?;
 
     let variant = parse_chat_model(&req.model)?;
+    validate_chat_stop_support(variant, &stop_sequences)?;
     let (messages, media_inputs) = to_core_messages_with_media(
         variant,
         req.messages.clone(),
@@ -690,7 +658,7 @@ pub async fn completions(
     let completion_tokens = generation.tokens_generated;
     let prompt_tokens = generation.prompt_tokens;
     let (assistant_content, assistant_tool_calls, finish_reason) =
-        build_assistant_response_parts(generation.text);
+        build_assistant_response_parts(generation.text, generation.finish_reason);
 
     let response = OpenAiChatCompletionResponse {
         id: completion_id,
@@ -783,7 +751,7 @@ async fn complete_stream(
                 ),
                 ChatStreamEvent::Completed(generation) => {
                     let (_, tool_calls, finish_reason) =
-                        build_assistant_response_parts(generation.text);
+                        build_assistant_response_parts(generation.text, generation.finish_reason);
                     let delta_tool_calls =
                         tool_calls.as_ref().map(|calls| stream_tool_call_deltas(calls));
                     (
@@ -799,11 +767,7 @@ async fn complete_stream(
                                     content: None,
                                     tool_calls: delta_tool_calls,
                                 },
-                                finish_reason: Some(if tool_calls.is_some() {
-                                    "tool_calls"
-                                } else {
-                                    finish_reason
-                                }),
+                                finish_reason: Some(finish_reason),
                             }],
                             usage: include_usage.then_some(OpenAiUsage {
                                 prompt_tokens: generation.prompt_tokens,
@@ -1000,11 +964,25 @@ mod tests {
     fn builds_tool_call_finish_reason_when_tool_output_detected() {
         let (content, tool_calls, finish_reason) = build_assistant_response_parts(
             "<tool_call>\n<function=ping>\n</function>\n</tool_call>".to_string(),
+            ChatGenerationFinishReason::MaxTokens,
         );
 
         assert!(content.is_none());
         assert_eq!(finish_reason, "tool_calls");
         assert_eq!(tool_calls.map(|calls| calls.len()), Some(1));
+    }
+
+    #[test]
+    fn maps_generation_finish_reasons_to_openai_values() {
+        for (reason, expected) in [
+            (ChatGenerationFinishReason::MaxTokens, "length"),
+            (ChatGenerationFinishReason::StopToken, "stop"),
+            (ChatGenerationFinishReason::StopSequence, "stop"),
+        ] {
+            let (_, tools, actual) = build_assistant_response_parts("answer".to_string(), reason);
+            assert!(tools.is_none());
+            assert_eq!(actual, expected);
+        }
     }
 
     #[test]
@@ -1075,7 +1053,7 @@ mod tests {
     }
 
     #[test]
-    fn validates_rejects_stop_sequences() {
+    fn strict_profile_accepts_supported_stop_syntax() {
         let req = ChatCompletionRequest {
             model: "Qwen3-8B-GGUF".to_string(),
             messages: vec![OpenAiInboundMessage {
@@ -1099,9 +1077,8 @@ mod tests {
             enable_thinking: None,
         };
 
-        let err = validate_chat_request_compatibility(&req, OpenAiCompatibilityProfile::Strict)
-            .expect_err("should reject");
-        assert!(err.message.contains("stop"));
+        validate_chat_request_compatibility(&req, OpenAiCompatibilityProfile::Strict)
+            .expect("strict compatibility should accept standard stop sequences");
     }
 
     #[test]

--- a/crates/izwi-server/src/api/openai/chat/completions.rs
+++ b/crates/izwi-server/src/api/openai/chat/completions.rs
@@ -595,6 +595,48 @@ fn validate_chat_request_compatibility(
     Ok(())
 }
 
+fn parse_stop_sequences(stop: Option<&serde_json::Value>) -> Result<Vec<String>, ApiError> {
+    const MAX_STOP_SEQUENCES: usize = 4;
+
+    let values: Vec<&str> = match stop {
+        None | Some(serde_json::Value::Null) => return Ok(Vec::new()),
+        Some(serde_json::Value::String(value)) => vec![value.as_str()],
+        Some(serde_json::Value::Array(values)) => {
+            if values.len() > MAX_STOP_SEQUENCES {
+                return Err(ApiError::bad_request(format!(
+                    "`stop` supports at most {MAX_STOP_SEQUENCES} sequences"
+                )));
+            }
+            values
+                .iter()
+                .map(|value| {
+                    value.as_str().ok_or_else(|| {
+                        ApiError::bad_request(
+                            "`stop` must be a string or an array containing only strings",
+                        )
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?
+        }
+        Some(_) => {
+            return Err(ApiError::bad_request(
+                "`stop` must be a string or an array containing only strings",
+            ))
+        }
+    };
+
+    let mut stop_sequences = Vec::with_capacity(values.len());
+    for value in values {
+        if value.is_empty() {
+            return Err(ApiError::bad_request("`stop` sequences cannot be empty"));
+        }
+        if !stop_sequences.iter().any(|existing| existing == value) {
+            stop_sequences.push(value.to_string());
+        }
+    }
+    Ok(stop_sequences)
+}
+
 pub async fn completions(
     State(state): State<AppState>,
     Extension(ctx): Extension<RequestContext>,
@@ -602,6 +644,7 @@ pub async fn completions(
 ) -> Result<Response, ApiError> {
     let compat_profile = compatibility_profile();
     validate_chat_request_compatibility(&req, compat_profile)?;
+    let stop_sequences = parse_stop_sequences(req.stop.as_ref())?;
 
     let variant = parse_chat_model(&req.model)?;
     let (messages, media_inputs) = to_core_messages_with_media(
@@ -625,6 +668,7 @@ pub async fn completions(
         temperature: req.temperature,
         top_p: req.top_p,
         presence_penalty: req.presence_penalty,
+        stop_sequences,
         chat_config: ChatRequestConfig {
             enable_thinking: req.enable_thinking,
             tools: req.tools.clone().unwrap_or_default(),
@@ -634,7 +678,8 @@ pub async fn completions(
     };
 
     if req.stream.unwrap_or(false) {
-        let stream_response = complete_stream(state, req, execution_request, compat_profile).await?;
+        let stream_response =
+            complete_stream(state, req, execution_request, compat_profile).await?;
         return Ok(stream_response.into_response());
     }
 
@@ -1086,6 +1131,25 @@ mod tests {
 
         validate_chat_request_compatibility(&req, OpenAiCompatibilityProfile::Relaxed)
             .expect("relaxed mode should allow passthrough");
+        assert_eq!(
+            parse_stop_sequences(req.stop.as_ref()).expect("valid stop sequences"),
+            ["END"]
+        );
+    }
+
+    #[test]
+    fn parses_string_and_deduplicated_array_stop_sequences() {
+        assert_eq!(
+            parse_stop_sequences(Some(&json!("DONE"))).expect("string stop"),
+            ["DONE"]
+        );
+        assert_eq!(
+            parse_stop_sequences(Some(&json!(["END", "DONE", "END"]))).expect("array stop"),
+            ["END", "DONE"]
+        );
+        assert!(parse_stop_sequences(Some(&json!(["END", 7]))).is_err());
+        assert!(parse_stop_sequences(Some(&json!(["", "END"]))).is_err());
+        assert!(parse_stop_sequences(Some(&json!(["1", "2", "3", "4", "5"]))).is_err());
     }
 
     #[test]
@@ -1111,12 +1175,10 @@ mod tests {
                 .and_then(|function| function.name.as_deref()),
             Some("get_weather")
         );
-        assert!(
-            deltas[0]
-                .function
-                .as_ref()
-                .and_then(|function| function.arguments.as_deref())
-                .is_some_and(|args| args.contains("Harare"))
-        );
+        assert!(deltas[0]
+            .function
+            .as_ref()
+            .and_then(|function| function.arguments.as_deref())
+            .is_some_and(|args| args.contains("Harare")));
     }
 }

--- a/crates/izwi-server/src/api/openai/responses/handlers.rs
+++ b/crates/izwi-server/src/api/openai/responses/handlers.rs
@@ -62,6 +62,7 @@ pub async fn create_response(
         temperature: req.temperature,
         top_p: req.top_p,
         presence_penalty: None,
+        stop_sequences: Vec::new(),
         chat_config: ChatRequestConfig {
             enable_thinking: req.enable_thinking,
             tools: req.tools.clone().unwrap_or_default(),

--- a/crates/izwi-server/src/app/chat.rs
+++ b/crates/izwi-server/src/app/chat.rs
@@ -23,6 +23,7 @@ pub struct ChatExecutionRequest {
     pub temperature: Option<f32>,
     pub top_p: Option<f32>,
     pub presence_penalty: Option<f32>,
+    pub stop_sequences: Vec<String>,
     pub chat_config: ChatRequestConfig,
     pub correlation_id: Option<String>,
 }
@@ -46,6 +47,7 @@ impl ChatExecutionRequest {
         if let Some(presence_penalty) = self.presence_penalty {
             params.presence_penalty = presence_penalty;
         }
+        params.stop_sequences = self.stop_sequences.clone();
         params
     }
 
@@ -298,6 +300,7 @@ mod tests {
             temperature: Some(0.42),
             top_p: Some(0.73),
             presence_penalty: Some(0.25),
+            stop_sequences: vec!["END".to_string()],
             chat_config: ChatRequestConfig::default(),
             correlation_id: None,
         };
@@ -307,6 +310,7 @@ mod tests {
         assert_eq!(params.top_p, 0.73);
         assert_eq!(params.top_k, 0);
         assert_eq!(params.presence_penalty, 0.25);
+        assert_eq!(params.stop_sequences, ["END"]);
         assert_eq!(params.max_tokens, 32);
     }
 

--- a/crates/izwi-server/src/app/chat.rs
+++ b/crates/izwi-server/src/app/chat.rs
@@ -3,12 +3,14 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::Notify;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::error::ApiError;
 use crate::state::AppState;
+#[cfg(test)]
+use izwi_core::ChatGenerationFinishReason;
 use izwi_core::{
     parse_chat_model_variant, ChatGeneration, ChatMessage, ChatRequestConfig, GenerationParams,
     ModelVariant, WorkloadClass,
@@ -63,6 +65,16 @@ pub enum ChatStreamEvent {
     Completed(ChatGeneration),
     Failed(String),
     ShuttingDown,
+}
+
+struct ChatStreamCompletion(Option<oneshot::Sender<()>>);
+
+impl Drop for ChatStreamCompletion {
+    fn drop(&mut self) {
+        if let Some(sender) = self.0.take() {
+            let _ = sender.send(());
+        }
+    }
 }
 
 const CHAT_STREAM_CAPACITY: usize = 64;
@@ -162,6 +174,60 @@ pub fn parse_chat_model(model_id: &str) -> Result<ModelVariant, ApiError> {
     parse_chat_model_variant(Some(model_id)).map_err(|err| ApiError::bad_request(err.to_string()))
 }
 
+pub fn parse_stop_sequences(stop: Option<&serde_json::Value>) -> Result<Vec<String>, ApiError> {
+    const MAX_STOP_SEQUENCES: usize = 4;
+
+    let values: Vec<&str> = match stop {
+        None | Some(serde_json::Value::Null) => return Ok(Vec::new()),
+        Some(serde_json::Value::String(value)) => vec![value.as_str()],
+        Some(serde_json::Value::Array(values)) => {
+            if values.len() > MAX_STOP_SEQUENCES {
+                return Err(ApiError::bad_request(format!(
+                    "`stop` supports at most {MAX_STOP_SEQUENCES} sequences"
+                )));
+            }
+            values
+                .iter()
+                .map(|value| {
+                    value.as_str().ok_or_else(|| {
+                        ApiError::bad_request(
+                            "`stop` must be a string or an array containing only strings",
+                        )
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?
+        }
+        Some(_) => {
+            return Err(ApiError::bad_request(
+                "`stop` must be a string or an array containing only strings",
+            ))
+        }
+    };
+
+    let mut stop_sequences = Vec::with_capacity(values.len());
+    for value in values {
+        if value.is_empty() {
+            return Err(ApiError::bad_request("`stop` sequences cannot be empty"));
+        }
+        if !stop_sequences.iter().any(|existing| existing == value) {
+            stop_sequences.push(value.to_string());
+        }
+    }
+    Ok(stop_sequences)
+}
+
+pub fn validate_chat_stop_support(
+    variant: ModelVariant,
+    stop_sequences: &[String],
+) -> Result<(), ApiError> {
+    if !stop_sequences.is_empty() && !variant.is_qwen35_chat_gguf() {
+        return Err(ApiError::bad_request(format!(
+            "`stop` is currently supported only by Qwen3.5 chat models, not {variant}"
+        )));
+    }
+    Ok(())
+}
+
 pub async fn generate_chat(
     state: &AppState,
     request: ChatExecutionRequest,
@@ -193,6 +259,13 @@ pub fn spawn_chat_stream(
     state: AppState,
     request: ChatExecutionRequest,
 ) -> mpsc::Receiver<ChatStreamEvent> {
+    spawn_chat_stream_with_completion(state, request).0
+}
+
+pub(crate) fn spawn_chat_stream_with_completion(
+    state: AppState,
+    request: ChatExecutionRequest,
+) -> (mpsc::Receiver<ChatStreamEvent>, oneshot::Receiver<()>) {
     let runtime = state.runtime.clone();
     let params = request.resolved_generation_params();
     let chat_config = request.resolved_chat_config();
@@ -201,8 +274,10 @@ pub fn spawn_chat_stream(
     let correlation_id = request.correlation_id;
 
     let (event_tx, event_rx) = mpsc::channel(CHAT_STREAM_CAPACITY);
+    let (completion_tx, completion_rx) = oneshot::channel();
     let backpressure = Arc::new(ChatStreamBackpressure::default());
     tokio::spawn(async move {
+        let _completion = ChatStreamCompletion(Some(completion_tx));
         let permit = match state
             .acquire_owned_workload_permit(WorkloadClass::Streaming)
             .await
@@ -240,7 +315,7 @@ pub fn spawn_chat_stream(
         }
     });
 
-    event_rx
+    (event_rx, completion_rx)
 }
 
 #[cfg(test)]
@@ -284,6 +359,7 @@ where
 mod tests {
     use super::*;
     use izwi_core::ChatRole;
+    use serde_json::json;
     use std::time::Duration;
     use tokio::sync::Semaphore;
 
@@ -315,6 +391,23 @@ mod tests {
     }
 
     #[test]
+    fn stop_sequences_validate_and_only_qwen35_accepts_them() {
+        assert_eq!(
+            parse_stop_sequences(Some(&json!(["END", "DONE", "END"]))).unwrap(),
+            ["END", "DONE"]
+        );
+        assert!(parse_stop_sequences(Some(&json!(["END", 7]))).is_err());
+        assert!(parse_stop_sequences(Some(&json!([""]))).is_err());
+        assert!(parse_stop_sequences(Some(&json!(["1", "2", "3", "4", "5"]))).is_err());
+        assert!(
+            validate_chat_stop_support(ModelVariant::Qwen354BGguf, &["END".to_string()]).is_ok()
+        );
+        assert!(
+            validate_chat_stop_support(ModelVariant::Qwen34BGguf, &["END".to_string()]).is_err()
+        );
+    }
+
+    #[test]
     fn chat_models_default_to_4096_max_tokens_when_request_omits_limits() {
         for variant in [
             ModelVariant::Gemma34BIt,
@@ -343,6 +436,7 @@ mod tests {
                     prompt_tokens: 12,
                     tokens_generated: 2,
                     generation_time_ms: 25.0,
+                    finish_reason: ChatGenerationFinishReason::StopToken,
                 })
             });
 
@@ -384,6 +478,7 @@ mod tests {
                     prompt_tokens: 1,
                     tokens_generated: 2,
                     generation_time_ms: 1.0,
+                    finish_reason: ChatGenerationFinishReason::StopToken,
                 })
             });
 
@@ -420,6 +515,7 @@ mod tests {
                     prompt_tokens: 1,
                     tokens_generated: 1,
                     generation_time_ms: 1.0,
+                    finish_reason: ChatGenerationFinishReason::StopToken,
                 })
             },
         );

--- a/crates/izwi-server/src/chat_store.rs
+++ b/crates/izwi-server/src/chat_store.rs
@@ -8,7 +8,10 @@ use sea_orm::{
 };
 use serde::Serialize;
 use serde_json::Value as JsonValue;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex as StdMutex, Weak};
 use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 
 use crate::db::{raw, StoreDatabase};
 use crate::entity::{chat_messages, chat_threads};
@@ -21,6 +24,7 @@ pub struct ChatThreadSummary {
     pub id: String,
     pub title: String,
     pub model_id: Option<String>,
+    pub system_prompt: Option<String>,
     pub created_at: u64,
     pub updated_at: u64,
     pub last_message_preview: Option<String>,
@@ -43,17 +47,49 @@ pub struct ChatThreadMessage {
 #[derive(Clone)]
 pub struct ChatStore {
     db: StoreDatabase,
+    turn_locks: Arc<StdMutex<HashMap<String, Weak<AsyncMutex<()>>>>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChatThreadSystemPromptUpdate {
+    Retain,
+    Replace(Option<String>),
 }
 
 impl ChatStore {
     pub fn initialize() -> anyhow::Result<Self> {
         Ok(Self {
             db: StoreDatabase::from_default_path()?,
+            turn_locks: Arc::new(StdMutex::new(HashMap::new())),
         })
     }
 
     pub fn initialize_with_database(db: StoreDatabase) -> Self {
-        Self { db }
+        Self {
+            db,
+            turn_locks: Arc::new(StdMutex::new(HashMap::new())),
+        }
+    }
+
+    /// Serialize the complete history-read, generation, and persistence span
+    /// for one thread while allowing unrelated threads to proceed independently.
+    pub async fn acquire_turn(&self, thread_id: &str) -> OwnedMutexGuard<()> {
+        let turn_lock = {
+            let mut locks = self
+                .turn_locks
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            locks.retain(|_, lock| lock.strong_count() > 0);
+            match locks.get(thread_id).and_then(Weak::upgrade) {
+                Some(lock) => lock,
+                None => {
+                    let lock = Arc::new(AsyncMutex::new(()));
+                    locks.insert(thread_id.to_string(), Arc::downgrade(&lock));
+                    lock
+                }
+            }
+        };
+        turn_lock.lock_owned().await
     }
 
     pub async fn list_threads(&self) -> anyhow::Result<Vec<ChatThreadSummary>> {
@@ -75,6 +111,16 @@ impl ChatStore {
         title: Option<String>,
         model_id: Option<String>,
     ) -> anyhow::Result<ChatThreadSummary> {
+        self.create_thread_with_system_prompt(title, model_id, None)
+            .await
+    }
+
+    pub async fn create_thread_with_system_prompt(
+        &self,
+        title: Option<String>,
+        model_id: Option<String>,
+        system_prompt: Option<String>,
+    ) -> anyhow::Result<ChatThreadSummary> {
         let db = self.db.connection().await?;
         let now = now_unix_millis_i64();
         let thread_id = new_uuid();
@@ -84,6 +130,7 @@ impl ChatStore {
             id: Set(thread_id.clone()),
             title: Set(resolved_title.clone()),
             model_id: Set(model_id.clone()),
+            system_prompt: Set(system_prompt.clone()),
             created_at: Set(now),
             updated_at: Set(now),
         })
@@ -95,6 +142,7 @@ impl ChatStore {
             id: thread_id,
             title: resolved_title,
             model_id,
+            system_prompt,
             created_at: now as u64,
             updated_at: now as u64,
             last_message_preview: None,
@@ -132,21 +180,32 @@ impl ChatStore {
         let db = self.db.connection().await?;
         let now = now_unix_millis_i64();
         let resolved_title = sanitize_thread_title(Some(title.as_str()));
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start chat thread title transaction")?;
+        let Some(existing) = chat_threads::Entity::find_by_id(thread_id.clone())
+            .one(&tx)
+            .await
+            .context("Failed to load chat thread for title update")?
+        else {
+            return Ok(None);
+        };
+        let updated_at = now.max(existing.updated_at);
 
-        let result = chat_threads::Entity::update_many()
+        chat_threads::Entity::update_many()
             .col_expr(
                 chat_threads::Column::Title,
                 Expr::value(resolved_title.clone()),
             )
-            .col_expr(chat_threads::Column::UpdatedAt, Expr::value(now))
+            .col_expr(chat_threads::Column::UpdatedAt, Expr::value(updated_at))
             .filter(chat_threads::Column::Id.eq(thread_id.clone()))
-            .exec(db)
+            .exec(&tx)
             .await
             .context("Failed to update chat thread title")?;
-
-        if result.rows_affected == 0 {
-            return Ok(None);
-        }
+        tx.commit()
+            .await
+            .context("Failed to commit chat thread title transaction")?;
 
         fetch_thread_summary(db, &thread_id).await
     }
@@ -161,6 +220,7 @@ impl ChatStore {
         thread_id: String,
         content: String,
         content_parts: Option<Vec<JsonValue>>,
+        after: u64,
     ) -> ChatThreadMessage {
         ChatThreadMessage {
             id: new_uuid(),
@@ -168,7 +228,7 @@ impl ChatStore {
             role: "user".to_string(),
             content,
             content_parts,
-            created_at: now_unix_millis_u64(),
+            created_at: now_unix_millis_u64().max(after.saturating_add(1)),
             tokens_generated: None,
             generation_time_ms: None,
         }
@@ -190,7 +250,7 @@ impl ChatStore {
             .await
             .context("Failed to start chat message transaction")?;
 
-        ensure_thread_exists(&tx, &thread_id).await?;
+        let previous_updated_at = thread_updated_at(&tx, &thread_id).await?;
 
         let message = ChatThreadMessage {
             id: new_uuid(),
@@ -198,12 +258,19 @@ impl ChatStore {
             role,
             content,
             content_parts,
-            created_at: now_unix_millis_u64(),
+            created_at: now_unix_millis_u64().max(previous_updated_at.saturating_add(1)),
             tokens_generated,
             generation_time_ms,
         };
         insert_message(&tx, &message).await?;
-        update_thread_metadata(&tx, &thread_id, model_id, message.created_at).await?;
+        update_thread_metadata(
+            &tx,
+            &thread_id,
+            model_id,
+            message.created_at,
+            &ChatThreadSystemPromptUpdate::Retain,
+        )
+        .await?;
 
         tx.commit()
             .await
@@ -212,18 +279,16 @@ impl ChatStore {
         Ok(message)
     }
 
-    /// Atomically persist a completed user/assistant turn.
-    ///
-    /// The caller prepares `user_message` before generation so streaming clients
-    /// can receive a stable identity immediately. Neither message becomes
-    /// visible unless both inserts and the single thread metadata update commit.
-    pub async fn append_turn(
+    /// Atomically persist a completed turn and its effective thread system
+    /// prompt update. Failed or cancelled generation never mutates the prompt.
+    pub async fn append_turn_with_system_prompt_update(
         &self,
         user_message: ChatThreadMessage,
         assistant_content: String,
         model_id: Option<String>,
         tokens_generated: usize,
         generation_time_ms: f64,
+        system_prompt_update: ChatThreadSystemPromptUpdate,
     ) -> anyhow::Result<(ChatThreadMessage, ChatThreadMessage)> {
         validate_pending_user_message(&user_message)?;
 
@@ -255,6 +320,7 @@ impl ChatStore {
             &user_message.thread_id,
             model_id,
             assistant_message.created_at,
+            &system_prompt_update,
         )
         .await?;
         tx.commit()
@@ -269,15 +335,19 @@ async fn ensure_thread_exists<C>(db: &C, thread_id: &str) -> anyhow::Result<()>
 where
     C: ConnectionTrait,
 {
-    let exists = chat_threads::Entity::find_by_id(thread_id.to_string())
+    thread_updated_at(db, thread_id).await.map(|_| ())
+}
+
+async fn thread_updated_at<C>(db: &C, thread_id: &str) -> anyhow::Result<u64>
+where
+    C: ConnectionTrait,
+{
+    let thread = chat_threads::Entity::find_by_id(thread_id.to_string())
         .one(db)
         .await
         .context("Failed to load chat thread")?
-        .is_some();
-    if !exists {
-        return Err(anyhow!("Thread not found"));
-    }
-    Ok(())
+        .ok_or_else(|| anyhow!("Thread not found"))?;
+    Ok(i64_to_u64(thread.updated_at))
 }
 
 async fn insert_message<C>(db: &C, message: &ChatThreadMessage) -> anyhow::Result<()>
@@ -311,16 +381,24 @@ async fn update_thread_metadata<C>(
     thread_id: &str,
     model_id: Option<String>,
     updated_at: u64,
+    system_prompt_update: &ChatThreadSystemPromptUpdate,
 ) -> anyhow::Result<()>
 where
     C: ConnectionTrait,
 {
-    chat_threads::Entity::update_many()
+    let mut update = chat_threads::Entity::update_many()
         .col_expr(
             chat_threads::Column::UpdatedAt,
             Expr::value(u64_to_i64(updated_at, "updated_at")?),
         )
-        .col_expr(chat_threads::Column::ModelId, Expr::value(model_id))
+        .col_expr(chat_threads::Column::ModelId, Expr::value(model_id));
+    if let ChatThreadSystemPromptUpdate::Replace(system_prompt) = system_prompt_update {
+        update = update.col_expr(
+            chat_threads::Column::SystemPrompt,
+            Expr::value(system_prompt.clone()),
+        );
+    }
+    update
         .filter(chat_threads::Column::Id.eq(thread_id.to_string()))
         .exec(db)
         .await
@@ -345,6 +423,7 @@ const THREAD_SUMMARY_LIST_SQL: &str = r#"
         t.id,
         t.title,
         t.model_id,
+        t.system_prompt,
         t.created_at,
         t.updated_at,
         (
@@ -368,6 +447,7 @@ const THREAD_SUMMARY_BY_ID_SQL: &str = r#"
         t.id,
         t.title,
         t.model_id,
+        t.system_prompt,
         t.created_at,
         t.updated_at,
         (
@@ -417,14 +497,15 @@ async fn fetch_thread_summary(
 }
 
 fn map_thread_summary(row: &QueryResult) -> anyhow::Result<ChatThreadSummary> {
-    let message_count_raw: i64 = row.try_get_by_index(6)?;
+    let message_count_raw: i64 = row.try_get_by_index(7)?;
     Ok(ChatThreadSummary {
         id: row.try_get_by_index(0)?,
         title: row.try_get_by_index(1)?,
         model_id: row.try_get_by_index(2)?,
-        created_at: i64_to_u64(row.try_get_by_index(3)?),
-        updated_at: i64_to_u64(row.try_get_by_index(4)?),
-        last_message_preview: row.try_get_by_index(5)?,
+        system_prompt: row.try_get_by_index(3)?,
+        created_at: i64_to_u64(row.try_get_by_index(4)?),
+        updated_at: i64_to_u64(row.try_get_by_index(5)?),
+        last_message_preview: row.try_get_by_index(6)?,
         message_count: i64_to_usize(message_count_raw),
     })
 }
@@ -667,17 +748,19 @@ mod tests {
                 thread.id.clone(),
                 "hello".to_string(),
                 Some(vec![json!({"type":"text","text":"hello"})]),
+                thread.updated_at,
             );
             let pending_id = pending.id.clone();
             let pending_created_at = pending.created_at;
 
             let (user, assistant) = store
-                .append_turn(
+                .append_turn_with_system_prompt_update(
                     pending,
                     "world".to_string(),
                     Some("new-model".to_string()),
                     7,
                     12.5,
+                    ChatThreadSystemPromptUpdate::Retain,
                 )
                 .await
                 .expect("turn should append");
@@ -709,11 +792,128 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn system_prompt_round_trips_and_updates_with_completed_turn() {
+        with_env_lock(async {
+            let (_temp, store) = setup_store();
+            let thread = store
+                .create_thread_with_system_prompt(
+                    None,
+                    Some("Qwen3.5-4B".to_string()),
+                    Some("Be concise.".to_string()),
+                )
+                .await
+                .expect("thread should create");
+            assert_eq!(thread.system_prompt.as_deref(), Some("Be concise."));
+
+            let pending = store.prepare_user_message(
+                thread.id.clone(),
+                "hello".to_string(),
+                None,
+                thread.updated_at,
+            );
+            store
+                .append_turn_with_system_prompt_update(
+                    pending,
+                    "world".to_string(),
+                    Some("Qwen3.5-4B".to_string()),
+                    1,
+                    2.0,
+                    ChatThreadSystemPromptUpdate::Replace(Some("Answer in one word.".to_string())),
+                )
+                .await
+                .expect("turn should append");
+
+            let summary = store
+                .get_thread(thread.id)
+                .await
+                .expect("thread should load")
+                .expect("thread should exist");
+            assert_eq!(
+                summary.system_prompt.as_deref(),
+                Some("Answer in one word.")
+            );
+            clear_env();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn title_updates_never_move_the_thread_clock_behind_messages() {
+        with_env_lock(async {
+            let (_temp, store) = setup_store();
+            let thread = store
+                .create_thread(None, Some("Qwen3.5-4B".to_string()))
+                .await
+                .expect("thread should create");
+            let pending = store.prepare_user_message(
+                thread.id.clone(),
+                "future turn".to_string(),
+                None,
+                thread.updated_at.saturating_add(10_000),
+            );
+            let (_, assistant) = store
+                .append_turn_with_system_prompt_update(
+                    pending,
+                    "complete".to_string(),
+                    Some("Qwen3.5-4B".to_string()),
+                    1,
+                    1.0,
+                    ChatThreadSystemPromptUpdate::Retain,
+                )
+                .await
+                .expect("turn should append");
+
+            let updated = store
+                .update_thread_title(thread.id, "Renamed".to_string())
+                .await
+                .expect("title should update")
+                .expect("thread should exist");
+            assert_eq!(updated.updated_at, assistant.created_at);
+            clear_env();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn turn_locks_serialize_same_thread_but_not_different_threads() {
+        let store = ChatStore::initialize_with_database(StoreDatabase::new(
+            tempfile::tempdir()
+                .expect("temp dir")
+                .path()
+                .join("chat.sqlite3"),
+        ));
+        let first = store.acquire_turn("thread-a").await;
+        let other = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            store.acquire_turn("thread-b"),
+        )
+        .await
+        .expect("different thread should not block");
+        drop(other);
+
+        let blocked_store = store.clone();
+        let waiter = tokio::spawn(async move {
+            let _guard = blocked_store.acquire_turn("thread-a").await;
+        });
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+        drop(first);
+        tokio::time::timeout(std::time::Duration::from_millis(100), waiter)
+            .await
+            .expect("same-thread waiter should proceed after release")
+            .expect("waiter should not panic");
+    }
+
+    #[tokio::test]
     async fn append_turn_rolls_back_user_when_assistant_insert_fails() {
         with_env_lock(async {
             let (_temp, store) = setup_store();
             let thread = store
-                .create_thread(None, Some("old-model".to_string()))
+                .create_thread_with_system_prompt(
+                    None,
+                    Some("old-model".to_string()),
+                    Some("old prompt".to_string()),
+                )
                 .await
                 .expect("thread should create");
             let original_updated_at = thread.updated_at;
@@ -731,15 +931,20 @@ mod tests {
             .await
             .expect("failure trigger should create");
 
-            let pending =
-                store.prepare_user_message(thread.id.clone(), "must roll back".to_string(), None);
+            let pending = store.prepare_user_message(
+                thread.id.clone(),
+                "must roll back".to_string(),
+                None,
+                thread.updated_at,
+            );
             let err = store
-                .append_turn(
+                .append_turn_with_system_prompt_update(
                     pending,
                     "not persisted".to_string(),
                     Some("new-model".to_string()),
                     3,
                     4.0,
+                    ChatThreadSystemPromptUpdate::Replace(Some("new prompt".to_string())),
                 )
                 .await
                 .expect_err("assistant failure should abort the transaction");
@@ -756,6 +961,7 @@ mod tests {
                 .expect("thread should load")
                 .expect("thread should exist");
             assert_eq!(summary.model_id.as_deref(), Some("old-model"));
+            assert_eq!(summary.system_prompt.as_deref(), Some("old prompt"));
             assert_eq!(summary.updated_at, original_updated_at);
             assert_eq!(summary.message_count, 0);
             assert!(summary.last_message_preview.is_none());

--- a/crates/izwi-server/src/chat_store.rs
+++ b/crates/izwi-server/src/chat_store.rs
@@ -151,6 +151,29 @@ impl ChatStore {
         fetch_thread_summary(db, &thread_id).await
     }
 
+    /// Build the user half of a chat turn without making it durable yet.
+    ///
+    /// Streaming responses expose this record in their `start` event. The exact
+    /// same id and timestamp are committed with the assistant response only
+    /// after generation succeeds.
+    pub fn prepare_user_message(
+        &self,
+        thread_id: String,
+        content: String,
+        content_parts: Option<Vec<JsonValue>>,
+    ) -> ChatThreadMessage {
+        ChatThreadMessage {
+            id: new_uuid(),
+            thread_id,
+            role: "user".to_string(),
+            content,
+            content_parts,
+            created_at: now_unix_millis_u64(),
+            tokens_generated: None,
+            generation_time_ms: None,
+        }
+    }
+
     pub async fn append_message(
         &self,
         thread_id: String,
@@ -167,62 +190,154 @@ impl ChatStore {
             .await
             .context("Failed to start chat message transaction")?;
 
-        let thread_exists = chat_threads::Entity::find_by_id(thread_id.clone())
-            .one(&tx)
-            .await
-            .context("Failed to load chat thread")?
-            .is_some();
+        ensure_thread_exists(&tx, &thread_id).await?;
 
-        if !thread_exists {
-            return Err(anyhow!("Thread not found"));
-        }
-
-        let now = now_unix_millis_i64();
-        let message_id = new_uuid();
-        let tokens_i64 = opt_usize_to_i64(tokens_generated)?;
-        let serialized_content_parts = content_parts
-            .as_ref()
-            .map(serde_json::to_string)
-            .transpose()
-            .context("Failed serializing chat message content_parts")?;
-
-        chat_messages::Entity::insert(chat_messages::ActiveModel {
-            id: Set(message_id.clone()),
-            thread_id: Set(thread_id.clone()),
-            role: Set(role.clone()),
-            content: Set(content.clone()),
-            content_parts: Set(serialized_content_parts),
-            created_at: Set(now),
-            tokens_generated: Set(tokens_i64),
-            generation_time_ms: Set(generation_time_ms),
-        })
-        .exec(&tx)
-        .await
-        .context("Failed to append chat message")?;
-
-        chat_threads::Entity::update_many()
-            .col_expr(chat_threads::Column::UpdatedAt, Expr::value(now))
-            .col_expr(chat_threads::Column::ModelId, Expr::value(model_id.clone()))
-            .filter(chat_threads::Column::Id.eq(thread_id.clone()))
-            .exec(&tx)
-            .await
-            .context("Failed to update chat thread metadata")?;
+        let message = ChatThreadMessage {
+            id: new_uuid(),
+            thread_id: thread_id.clone(),
+            role,
+            content,
+            content_parts,
+            created_at: now_unix_millis_u64(),
+            tokens_generated,
+            generation_time_ms,
+        };
+        insert_message(&tx, &message).await?;
+        update_thread_metadata(&tx, &thread_id, model_id, message.created_at).await?;
 
         tx.commit()
             .await
             .context("Failed to commit chat message transaction")?;
 
-        Ok(ChatThreadMessage {
-            id: message_id,
-            thread_id,
-            role,
-            content,
-            content_parts,
-            created_at: now as u64,
-            tokens_generated,
-            generation_time_ms,
-        })
+        Ok(message)
     }
+
+    /// Atomically persist a completed user/assistant turn.
+    ///
+    /// The caller prepares `user_message` before generation so streaming clients
+    /// can receive a stable identity immediately. Neither message becomes
+    /// visible unless both inserts and the single thread metadata update commit.
+    pub async fn append_turn(
+        &self,
+        user_message: ChatThreadMessage,
+        assistant_content: String,
+        model_id: Option<String>,
+        tokens_generated: usize,
+        generation_time_ms: f64,
+    ) -> anyhow::Result<(ChatThreadMessage, ChatThreadMessage)> {
+        validate_pending_user_message(&user_message)?;
+
+        let assistant_message = ChatThreadMessage {
+            id: new_uuid(),
+            thread_id: user_message.thread_id.clone(),
+            role: "assistant".to_string(),
+            content: assistant_content,
+            content_parts: None,
+            created_at: now_unix_millis_u64().max(user_message.created_at.saturating_add(1)),
+            tokens_generated: Some(tokens_generated),
+            generation_time_ms: Some(generation_time_ms),
+        };
+
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start chat turn transaction")?;
+        ensure_thread_exists(&tx, &user_message.thread_id).await?;
+        insert_message(&tx, &user_message)
+            .await
+            .context("Failed to append chat turn user message")?;
+        insert_message(&tx, &assistant_message)
+            .await
+            .context("Failed to append chat turn assistant message")?;
+        update_thread_metadata(
+            &tx,
+            &user_message.thread_id,
+            model_id,
+            assistant_message.created_at,
+        )
+        .await?;
+        tx.commit()
+            .await
+            .context("Failed to commit chat turn transaction")?;
+
+        Ok((user_message, assistant_message))
+    }
+}
+
+async fn ensure_thread_exists<C>(db: &C, thread_id: &str) -> anyhow::Result<()>
+where
+    C: ConnectionTrait,
+{
+    let exists = chat_threads::Entity::find_by_id(thread_id.to_string())
+        .one(db)
+        .await
+        .context("Failed to load chat thread")?
+        .is_some();
+    if !exists {
+        return Err(anyhow!("Thread not found"));
+    }
+    Ok(())
+}
+
+async fn insert_message<C>(db: &C, message: &ChatThreadMessage) -> anyhow::Result<()>
+where
+    C: ConnectionTrait,
+{
+    let serialized_content_parts = message
+        .content_parts
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .context("Failed serializing chat message content_parts")?;
+    chat_messages::Entity::insert(chat_messages::ActiveModel {
+        id: Set(message.id.clone()),
+        thread_id: Set(message.thread_id.clone()),
+        role: Set(message.role.clone()),
+        content: Set(message.content.clone()),
+        content_parts: Set(serialized_content_parts),
+        created_at: Set(u64_to_i64(message.created_at, "created_at")?),
+        tokens_generated: Set(opt_usize_to_i64(message.tokens_generated)?),
+        generation_time_ms: Set(message.generation_time_ms),
+    })
+    .exec(db)
+    .await
+    .context("Failed to append chat message")?;
+    Ok(())
+}
+
+async fn update_thread_metadata<C>(
+    db: &C,
+    thread_id: &str,
+    model_id: Option<String>,
+    updated_at: u64,
+) -> anyhow::Result<()>
+where
+    C: ConnectionTrait,
+{
+    chat_threads::Entity::update_many()
+        .col_expr(
+            chat_threads::Column::UpdatedAt,
+            Expr::value(u64_to_i64(updated_at, "updated_at")?),
+        )
+        .col_expr(chat_threads::Column::ModelId, Expr::value(model_id))
+        .filter(chat_threads::Column::Id.eq(thread_id.to_string()))
+        .exec(db)
+        .await
+        .context("Failed to update chat thread metadata")?;
+    Ok(())
+}
+
+fn validate_pending_user_message(message: &ChatThreadMessage) -> anyhow::Result<()> {
+    if message.role != "user" {
+        return Err(anyhow!("Pending chat turn message must have role=user"));
+    }
+    if message.tokens_generated.is_some() || message.generation_time_ms.is_some() {
+        return Err(anyhow!(
+            "Pending chat turn user message cannot contain generation statistics"
+        ));
+    }
+    Ok(())
 }
 
 const THREAD_SUMMARY_LIST_SQL: &str = r#"
@@ -333,10 +448,14 @@ fn map_thread_message(row: &QueryResult) -> anyhow::Result<ChatThreadMessage> {
 }
 
 fn now_unix_millis_i64() -> i64 {
+    i64::try_from(now_unix_millis_u64()).unwrap_or(i64::MAX)
+}
+
+fn now_unix_millis_u64() -> u64 {
     let duration = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default();
-    duration.as_millis() as i64
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
 fn sanitize_thread_title(raw: Option<&str>) -> String {
@@ -373,6 +492,10 @@ fn opt_usize_to_i64(value: Option<usize>) -> anyhow::Result<Option<i64>> {
         )),
         None => Ok(None),
     }
+}
+
+fn u64_to_i64(value: u64, field: &str) -> anyhow::Result<i64> {
+    i64::try_from(value).with_context(|| format!("Numeric conversion overflow for {field}"))
 }
 
 fn i64_to_u64(value: i64) -> u64 {
@@ -527,6 +650,115 @@ mod tests {
                 .await
                 .expect_err("missing thread should fail");
             assert!(err.to_string().contains("Thread not found"));
+            clear_env();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn append_turn_persists_both_messages_with_stable_user_identity() {
+        with_env_lock(async {
+            let (_temp, store) = setup_store();
+            let thread = store
+                .create_thread(None, Some("old-model".to_string()))
+                .await
+                .expect("thread should create");
+            let pending = store.prepare_user_message(
+                thread.id.clone(),
+                "hello".to_string(),
+                Some(vec![json!({"type":"text","text":"hello"})]),
+            );
+            let pending_id = pending.id.clone();
+            let pending_created_at = pending.created_at;
+
+            let (user, assistant) = store
+                .append_turn(
+                    pending,
+                    "world".to_string(),
+                    Some("new-model".to_string()),
+                    7,
+                    12.5,
+                )
+                .await
+                .expect("turn should append");
+
+            assert_eq!(user.id, pending_id);
+            assert_eq!(user.created_at, pending_created_at);
+            assert!(assistant.created_at > user.created_at);
+            let messages = store
+                .list_messages(thread.id.clone())
+                .await
+                .expect("messages should list");
+            assert_eq!(messages.len(), 2);
+            assert_eq!(messages[0].id, user.id);
+            assert_eq!(messages[1].id, assistant.id);
+            assert_eq!(messages[1].tokens_generated, Some(7));
+
+            let summary = store
+                .get_thread(thread.id)
+                .await
+                .expect("thread should load")
+                .expect("thread should exist");
+            assert_eq!(summary.model_id.as_deref(), Some("new-model"));
+            assert_eq!(summary.last_message_preview.as_deref(), Some("world"));
+            assert_eq!(summary.message_count, 2);
+            assert_eq!(summary.updated_at, assistant.created_at);
+            clear_env();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn append_turn_rolls_back_user_when_assistant_insert_fails() {
+        with_env_lock(async {
+            let (_temp, store) = setup_store();
+            let thread = store
+                .create_thread(None, Some("old-model".to_string()))
+                .await
+                .expect("thread should create");
+            let original_updated_at = thread.updated_at;
+            let db = store.db.connection().await.expect("database connection");
+            db.execute_unprepared(
+                r#"
+                CREATE TRIGGER fail_chat_assistant_insert
+                BEFORE INSERT ON chat_messages
+                WHEN NEW.role = 'assistant'
+                BEGIN
+                    SELECT RAISE(ABORT, 'forced assistant insert failure');
+                END
+                "#,
+            )
+            .await
+            .expect("failure trigger should create");
+
+            let pending =
+                store.prepare_user_message(thread.id.clone(), "must roll back".to_string(), None);
+            let err = store
+                .append_turn(
+                    pending,
+                    "not persisted".to_string(),
+                    Some("new-model".to_string()),
+                    3,
+                    4.0,
+                )
+                .await
+                .expect_err("assistant failure should abort the transaction");
+            assert!(err.to_string().contains("assistant"));
+
+            assert!(store
+                .list_messages(thread.id.clone())
+                .await
+                .expect("messages should list")
+                .is_empty());
+            let summary = store
+                .get_thread(thread.id)
+                .await
+                .expect("thread should load")
+                .expect("thread should exist");
+            assert_eq!(summary.model_id.as_deref(), Some("old-model"));
+            assert_eq!(summary.updated_at, original_updated_at);
+            assert_eq!(summary.message_count, 0);
+            assert!(summary.last_message_preview.is_none());
             clear_env();
         })
         .await;

--- a/crates/izwi-server/src/db/migrator.rs
+++ b/crates/izwi-server/src/db/migrator.rs
@@ -37,6 +37,7 @@ const BASELINE_SCHEMA: &[&str] = &[
         id TEXT PRIMARY KEY,
         title TEXT NOT NULL,
         model_id TEXT NULL,
+        system_prompt TEXT NULL,
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
     );
@@ -539,6 +540,11 @@ const POST_COMPATIBILITY_SCHEMA: &[&str] = &[
 ];
 
 const COMPATIBILITY_COLUMNS: &[CompatibilityColumn] = &[
+    CompatibilityColumn {
+        table: "chat_threads",
+        column: "system_prompt",
+        definition: "TEXT NULL",
+    },
     CompatibilityColumn {
         table: "media_assets",
         column: "source_asset_id",

--- a/crates/izwi-server/src/db/schema_contract.rs
+++ b/crates/izwi-server/src/db/schema_contract.rs
@@ -12,7 +12,14 @@ struct RequiredSchemaTable {
 const REQUIRED_SCHEMA_TABLES: &[RequiredSchemaTable] = &[
     RequiredSchemaTable {
         name: "chat_threads",
-        columns: &["id", "title", "model_id", "created_at", "updated_at"],
+        columns: &[
+            "id",
+            "title",
+            "model_id",
+            "system_prompt",
+            "created_at",
+            "updated_at",
+        ],
     },
     RequiredSchemaTable {
         name: "chat_messages",

--- a/crates/izwi-server/src/db/sqlite.rs
+++ b/crates/izwi-server/src/db/sqlite.rs
@@ -277,6 +277,7 @@ mod tests {
     ];
 
     const EXPECTED_COMPAT_COLUMNS: &[(&str, &str)] = &[
+        ("chat_threads", "system_prompt"),
         ("chat_messages", "content_parts"),
         ("media_assets", "source_asset_id"),
         ("media_assets", "canonical_profile_version"),

--- a/crates/izwi-server/src/entity/mod.rs
+++ b/crates/izwi-server/src/entity/mod.rs
@@ -39,6 +39,7 @@ pub mod chat_threads {
         pub id: String,
         pub title: String,
         pub model_id: Option<String>,
+        pub system_prompt: Option<String>,
         pub created_at: i64,
         pub updated_at: i64,
     }

--- a/ui/src/features/chat/components/ChatPlayground.test.tsx
+++ b/ui/src/features/chat/components/ChatPlayground.test.tsx
@@ -92,6 +92,52 @@ describe("ChatPlayground", () => {
     );
   });
 
+  it("waits for existing thread metadata before enabling the composer", async () => {
+    const thread = {
+      id: "thread-pending",
+      title: "Custom prompt thread",
+      model_id: "Qwen3.5-4B",
+      system_prompt: "Keep the stored custom prompt.",
+      created_at: 1,
+      updated_at: 2,
+      last_message_preview: null,
+      message_count: 0,
+    };
+    let resolveThreads!: (threads: (typeof thread)[]) => void;
+    apiMocks.listChatThreads.mockReturnValue(
+      new Promise((resolve) => {
+        resolveThreads = resolve;
+      }),
+    );
+    apiMocks.getChatThread.mockResolvedValue({ thread, messages: [] });
+
+    render(
+      <MemoryRouter initialEntries={["/chat?threadId=thread-pending"]}>
+        <ChatPlayground
+          selectedModel="Qwen3.5-4B"
+          selectedModelReady={true}
+          supportsThinking={true}
+          modelLabel="Qwen3.5 4B GGUF (Q4_K_M)"
+          modelOptions={[
+            {
+              value: "Qwen3.5-4B",
+              label: "Qwen3.5 4B GGUF (Q4_K_M)",
+              statusLabel: "Ready",
+              isReady: true,
+            },
+          ]}
+          onSelectModel={vi.fn()}
+          onOpenModelManager={vi.fn()}
+          onModelRequired={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("textbox")).toBeDisabled();
+    resolveThreads([thread]);
+    await waitFor(() => expect(screen.getByRole("textbox")).toBeEnabled());
+  });
+
   it("shows the active thread title below the selector without the old conversation header", async () => {
     const thread = {
       id: "thread-1",
@@ -307,6 +353,7 @@ describe("ChatPlayground", () => {
       id: "thread-1",
       title: "Vision thread",
       model_id: "Qwen3.5-4B",
+      system_prompt: "Describe images precisely.",
       created_at: 1,
       updated_at: 2,
       last_message_preview: null,
@@ -398,6 +445,9 @@ describe("ChatPlayground", () => {
       }),
       expect.any(Object),
     );
+    expect(
+      apiMocks.sendChatThreadMessageStream.mock.calls[0]?.[1],
+    ).not.toHaveProperty("system_prompt");
   });
 
   it("allows attachment-only Qwen3.5 turns and sends a preview summary", async () => {

--- a/ui/src/features/chat/components/ChatPlayground.tsx
+++ b/ui/src/features/chat/components/ChatPlayground.tsx
@@ -149,6 +149,7 @@ export function ChatPlayground({
     !!activeThreadId &&
     (visibleMessages.length > 0 || isStreaming || messagesLoading);
   const isEmptyChatWorkspace = !hasConversation;
+  const isActiveThreadMetadataPending = !!activeThreadId && !activeThread;
   const thinkingEnabledForModel = supportsThinking && isThinkingEnabled;
   const supportsImageAttachments =
     supportsImageAttachmentsForModel(selectedModel);
@@ -479,6 +480,10 @@ export function ChatPlayground({
     try {
       const thread = await api.createChatThread({
         model_id: selectedModel ?? undefined,
+        system_prompt: systemPromptForModel(
+          selectedModel,
+          thinkingEnabledForModel,
+        ),
       });
       setThreads((previous) => [thread, ...previous]);
       setActiveThreadInUrl(thread.id);
@@ -498,6 +503,7 @@ export function ChatPlayground({
     selectedModel,
     setPendingImages,
     setActiveThreadInUrl,
+    thinkingEnabledForModel,
   ]);
 
   const openDeleteThreadConfirm = useCallback((threadId: string) => {
@@ -610,7 +616,12 @@ export function ChatPlayground({
 
   const sendMessage = async () => {
     const text = input.trim();
-    if ((text.length === 0 && pendingImages.length === 0) || isStreaming || isPreparingThread) {
+    if (
+      (text.length === 0 && pendingImages.length === 0) ||
+      isStreaming ||
+      isPreparingThread ||
+      isActiveThreadMetadataPending
+    ) {
       return;
     }
 
@@ -620,11 +631,16 @@ export function ChatPlayground({
     }
 
     let targetThreadId = activeThreadId;
+    let targetThread = activeThread;
     if (!targetThreadId) {
       setIsPreparingThread(true);
       try {
         const createdThread = await api.createChatThread({
           model_id: selectedModel ?? undefined,
+          system_prompt: systemPromptForModel(
+            selectedModel,
+            thinkingEnabledForModel,
+          ),
         });
         setThreads((previous) => [createdThread, ...previous]);
         setActiveThreadInUrl(createdThread.id);
@@ -632,6 +648,7 @@ export function ChatPlayground({
         setExpandedThoughts({});
         setStats(null);
         targetThreadId = createdThread.id;
+        targetThread = createdThread;
       } catch (threadError) {
         setError(getErrorMessage(threadError, "Failed to create a new chat."));
         setIsPreparingThread(false);
@@ -682,13 +699,13 @@ export function ChatPlayground({
       generation_time_ms: null,
     };
 
-    const systemPrompt = systemPromptForModel(
-      selectedModel,
-      thinkingEnabledForModel,
-    );
     const enableThinking =
       isQwen35ThinkingModel(selectedModel) && supportsThinking
         ? thinkingEnabledForModel
+        : undefined;
+    const systemPromptBackfill =
+      targetThread && targetThread.system_prompt == null
+        ? systemPromptForModel(selectedModel, thinkingEnabledForModel)
         : undefined;
 
     setMessages((previous) => [
@@ -707,7 +724,9 @@ export function ChatPlayground({
         model_id: selectedModel,
         content: requestPayload.content,
         content_parts: requestPayload.contentParts,
-        system_prompt: systemPrompt,
+        ...(systemPromptBackfill
+          ? { system_prompt: systemPromptBackfill }
+          : {}),
         enable_thinking: enableThinking,
       },
       {
@@ -919,7 +938,12 @@ export function ChatPlayground({
                   : "Ask anything..."
         }
         className="chat-composer-input w-full resize-none bg-transparent px-5 pt-5 pb-2 text-[0.9375rem] focus:outline-none placeholder:text-[var(--text-muted)]"
-        disabled={isStreaming || isPreparingThread || isReadingImages}
+        disabled={
+          isStreaming ||
+          isPreparingThread ||
+          isReadingImages ||
+          isActiveThreadMetadataPending
+        }
       />
 
       <input
@@ -1000,6 +1024,7 @@ export function ChatPlayground({
             disabled={
               isPreparingThread ||
               isReadingImages ||
+              (!isStreaming && isActiveThreadMetadataPending) ||
               (!isStreaming &&
                 input.trim().length === 0 &&
                 pendingImages.length === 0)

--- a/ui/src/shared/api/chat.ts
+++ b/ui/src/shared/api/chat.ts
@@ -54,6 +54,7 @@ export interface ChatThread {
   id: string;
   title: string;
   model_id: string | null;
+  system_prompt?: string | null;
   created_at: number;
   updated_at: number;
   last_message_preview: string | null;
@@ -79,6 +80,7 @@ export interface ChatThreadDetail {
 export interface ChatThreadCreateRequest {
   title?: string;
   model_id?: string;
+  system_prompt?: string;
 }
 
 export interface ChatThreadUpdateRequest {
@@ -110,7 +112,19 @@ export interface ChatThreadSendMessageRequest {
   content_parts?: ChatThreadContentPart[];
   max_tokens?: number;
   system_prompt?: string;
+  stop?: string | string[];
   enable_thinking?: boolean;
+}
+
+export type ChatGenerationFinishReason =
+  | "max_tokens"
+  | "stop_token"
+  | "stop_sequence";
+
+export interface ChatGenerationStats {
+  tokens_generated: number;
+  generation_time_ms: number;
+  finish_reason: ChatGenerationFinishReason;
 }
 
 export interface ChatThreadSendMessageResponse {
@@ -118,10 +132,7 @@ export interface ChatThreadSendMessageResponse {
   model_id: string;
   user_message: ChatThreadMessageRecord;
   assistant_message: ChatThreadMessageRecord;
-  stats: {
-    tokens_generated: number;
-    generation_time_ms: number;
-  };
+  stats: ChatGenerationStats;
 }
 
 type ChatThreadStreamEvent =
@@ -137,10 +148,7 @@ type ChatThreadStreamEvent =
       thread_id: string;
       model_id: string;
       assistant_message: ChatThreadMessageRecord;
-      stats: {
-        tokens_generated: number;
-        generation_time_ms: number;
-      };
+      stats: ChatGenerationStats;
     }
   | { event: "error"; error: string };
 
@@ -155,10 +163,7 @@ export interface ChatThreadStreamCallbacks {
     threadId: string;
     modelId: string;
     assistantMessage: ChatThreadMessageRecord;
-    stats: {
-      tokens_generated: number;
-      generation_time_ms: number;
-    };
+    stats: ChatGenerationStats;
   }) => void;
   onError?: (error: string) => void;
   onClose?: () => void;
@@ -333,6 +338,7 @@ export class ChatApiClient {
       body: JSON.stringify({
         title: request?.title,
         model_id: request?.model_id,
+        system_prompt: request?.system_prompt,
       }),
     });
   }
@@ -384,6 +390,7 @@ export class ChatApiClient {
           max_tokens: request.max_tokens,
           stream: false,
           system_prompt: request.system_prompt,
+          stop: request.stop,
           enable_thinking: request.enable_thinking,
         }),
       },
@@ -415,6 +422,7 @@ export class ChatApiClient {
               max_tokens: request.max_tokens,
               stream: true,
               system_prompt: request.system_prompt,
+              stop: request.stop,
               enable_thinking: request.enable_thinking,
             }),
             signal: abortController.signal,


### PR DESCRIPTION
Implements Candle-native Qwen3.5 prefill kernels, exact prefix-state caching, tokenizer and sampling fixes, atomic thread persistence, stop handling, lifecycle accounting, and validated multi-turn support across 0.8B, 2B, and 4B models.