### PR TITLE
Stabilize and optimize Qwen3.5 multi-turn chat with native kernels and bounded state caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3710,6 +3710,7 @@ dependencies = [
  "candle-metal-kernels",
  "candle-nn",
  "candle-transformers",
+ "cudaforge",
  "dirs 5.0.1",
  "flate2",
  "futures",

--- a/crates/izwi-core/Cargo.toml
+++ b/crates/izwi-core/Cargo.toml
@@ -95,3 +95,6 @@ accelerate = [
 
 [dev-dependencies]
 tokio-test = "0.4"
+
+[build-dependencies]
+cudaforge = "0.1.5"

--- a/crates/izwi-core/build.rs
+++ b/crates/izwi-core/build.rs
@@ -1,0 +1,20 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=src/kernels/cuda/qwen35.cu");
+
+    if env::var_os("CARGO_FEATURE_CUDA").is_none() {
+        return Ok(());
+    }
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR")?);
+    let bindings = cudaforge::KernelBuilder::new()
+        .source_files(vec!["src/kernels/cuda/qwen35.cu"])
+        .arg("-std=c++17")
+        .arg("-O3")
+        .build_ptx()?;
+    bindings.write(out_dir.join("qwen35_ptx.rs"))?;
+    Ok(())
+}

--- a/crates/izwi-core/src/engine/core.rs
+++ b/crates/izwi-core/src/engine/core.rs
@@ -19,7 +19,9 @@ use super::execution::{
 };
 #[cfg(test)]
 use super::executor::REQUEST_DEADLINE_EXCEEDED;
-use super::executor::{ExecutorOutput, ExecutorStepResult, UnifiedExecutor, WorkerConfig};
+use super::executor::{
+    CacheReleaseReport, ExecutorOutput, ExecutorStepResult, UnifiedExecutor, WorkerConfig,
+};
 use super::kv_cache::{KVCacheConfig, KVCacheManager, KVCacheStats};
 use super::metal_kv_cache::{MetalKVCacheConfig, MetalKVCacheManager};
 use super::metrics::record_engine_batch_dispatch;
@@ -1553,6 +1555,11 @@ impl EngineCore {
             }
         }
         aborted
+    }
+
+    /// Purge reusable executor cache state owned by one model variant.
+    pub async fn purge_model_cache(&mut self, variant: ModelVariant) -> CacheReleaseReport {
+        self.executor.purge_model_cache(variant).await
     }
 
     /// Abort every request tracked by the core and release executor state.

--- a/crates/izwi-core/src/engine/executor.rs
+++ b/crates/izwi-core/src/engine/executor.rs
@@ -522,6 +522,11 @@ pub trait ModelExecutor: Send + Sync {
     fn cleanup_session(&self, session: &SessionKey) -> CacheReleaseReport {
         self.cleanup_request(&session.request_id)
     }
+
+    /// Purge model-owned reusable cache state before one model is unloaded.
+    fn purge_model_cache(&self, _variant: ModelVariant) -> CacheReleaseReport {
+        CacheReleaseReport::unconfirmed()
+    }
 }
 
 /// Proof returned after an executor cache cleanup request. Preemption may only
@@ -1241,6 +1246,10 @@ impl ModelExecutor for NativeExecutor {
             .saturating_add(usize::from(reservations.remove(session).is_some()));
         CacheReleaseReport::confirmed(released)
     }
+
+    fn purge_model_cache(&self, variant: ModelVariant) -> CacheReleaseReport {
+        CacheReleaseReport::confirmed(self.qwen35_prefix_cache.purge_variant(variant))
+    }
 }
 
 /// Unified executor that wraps a model executor implementation.
@@ -1325,6 +1334,11 @@ impl UnifiedExecutor {
     pub async fn cleanup_session(&self, session: &SessionKey) -> CacheReleaseReport {
         let executor = self.inner.read().await;
         executor.cleanup_session(session)
+    }
+
+    pub async fn purge_model_cache(&self, variant: ModelVariant) -> CacheReleaseReport {
+        let executor = self.inner.read().await;
+        executor.purge_model_cache(variant)
     }
 }
 

--- a/crates/izwi-core/src/engine/executor.rs
+++ b/crates/izwi-core/src/engine/executor.rs
@@ -877,6 +877,12 @@ impl NativeExecutor {
             Error::InferenceError("cache allocation has no physical resource lease".to_string())
         })?;
         if observed_bytes > 0 {
+            if observed_bytes > reservation.reserved_bytes {
+                return Err(Error::InferenceError(format!(
+                    "materialized session cache uses {observed_bytes} bytes, exceeding its {}-byte authorization for request {} epoch {}",
+                    reservation.reserved_bytes, session.request_id, session.epoch
+                )));
+            }
             lease.record_materialized_usage(cache_resource_vector(
                 self.config.backend,
                 observed_bytes,

--- a/crates/izwi-core/src/engine/executor.rs
+++ b/crates/izwi-core/src/engine/executor.rs
@@ -18,6 +18,8 @@ mod handler_audio_chat;
 mod handler_chat;
 #[path = "executor/handler_tts.rs"]
 mod handler_tts;
+#[path = "executor/prefix_cache.rs"]
+mod prefix_cache;
 #[path = "executor/state.rs"]
 mod state;
 #[path = "executor/streaming.rs"]
@@ -44,8 +46,10 @@ use crate::backends::{
 use crate::error::{Error, Result};
 use crate::model::ModelVariant;
 use crate::models::architectures::qwen3::tts::{Qwen3TtsModel, TtsSessionCacheRequest};
+use crate::models::architectures::qwen35::chat::Qwen35PrefixSnapshot;
 use crate::models::registry::{AsrModelLease, NativeAsrModel, NativeChatModel, QwenTtsModelLease};
 use crate::models::ModelRegistry;
+use prefix_cache::{configured_qwen35_prefix_cache_bytes, ExactPrefixCache};
 use state::{ActiveAsrDecode, ActiveChatDecode, ActiveQwenTtsDecode};
 
 fn panic_payload_to_string(payload: &(dyn std::any::Any + Send)) -> String {
@@ -557,6 +561,7 @@ pub struct NativeExecutor {
     initialized: bool,
     loaded_tts_model: Option<Arc<Qwen3TtsModel>>,
     chat_decode_states: Mutex<HashMap<SessionKey, ActiveChatDecode>>,
+    qwen35_prefix_cache: ExactPrefixCache<NativeChatModel, Qwen35PrefixSnapshot>,
     asr_decode_states: Mutex<HashMap<SessionKey, ActiveAsrDecode>>,
     qwen_tts_decode_states: Mutex<HashMap<SessionKey, ActiveQwenTtsDecode>>,
     cache_resource_leases: Mutex<HashMap<SessionKey, CacheResourceReservation>>,
@@ -565,11 +570,13 @@ pub struct NativeExecutor {
 impl NativeExecutor {
     /// Create a new native executor.
     pub fn new(config: WorkerConfig) -> Self {
+        let qwen35_prefix_cache = ExactPrefixCache::new(configured_qwen35_prefix_cache_bytes());
         Self {
             config,
             initialized: false,
             loaded_tts_model: None,
             chat_decode_states: Mutex::new(HashMap::new()),
+            qwen35_prefix_cache,
             asr_decode_states: Mutex::new(HashMap::new()),
             qwen_tts_decode_states: Mutex::new(HashMap::new()),
             cache_resource_leases: Mutex::new(HashMap::new()),
@@ -1166,6 +1173,7 @@ impl ModelExecutor for NativeExecutor {
             lease.prepare_materialized_release(zero)?;
         }
         chat.clear();
+        self.qwen35_prefix_cache.clear();
         asr.clear();
         tts.clear();
         reservations.clear();

--- a/crates/izwi-core/src/engine/executor.rs
+++ b/crates/izwi-core/src/engine/executor.rs
@@ -734,13 +734,15 @@ impl NativeExecutor {
         // lock so concurrent executor entry cannot repeat it or double-reserve.
         // Later decode steps reuse this lease until exact-session cleanup.
         let authorized_bytes = authorize()?;
-        let lease = authority.reserve(
-            ReservationOwner::new(
-                ReservationClass::Cache,
-                format!("{}:{}", session.request_id, session.epoch),
-            ),
-            cache_resource_vector(self.config.backend, authorized_bytes),
-        )?;
+        let owner = ReservationOwner::new(
+            ReservationClass::Cache,
+            format!("{}:{}", session.request_id, session.epoch),
+        );
+        let resources = cache_resource_vector(self.config.backend, authorized_bytes);
+        let lease = match self.config.backend {
+            BackendKind::Cpu | BackendKind::Metal => authority.track_advisory(owner, resources)?,
+            BackendKind::Cuda => authority.reserve(owner, resources)?,
+        };
         reservations.insert(
             session.clone(),
             CacheResourceReservation {
@@ -873,20 +875,43 @@ impl NativeExecutor {
         let reservation = reservations.get_mut(&session).ok_or_else(|| {
             Error::InferenceError("cache allocation has no exact-session reservation".to_string())
         })?;
-        let lease = reservation.lease.as_ref().ok_or_else(|| {
-            Error::InferenceError("cache allocation has no physical resource lease".to_string())
-        })?;
         if observed_bytes > 0 {
             if observed_bytes > reservation.reserved_bytes {
-                return Err(Error::InferenceError(format!(
-                    "materialized session cache uses {observed_bytes} bytes, exceeding its {}-byte authorization for request {} epoch {}",
-                    reservation.reserved_bytes, session.request_id, session.epoch
-                )));
+                if matches!(self.config.backend, BackendKind::Cpu | BackendKind::Metal) {
+                    // CPU and unified-memory Metal use advisory capacity. Candle
+                    // can reuse a larger pooled allocation than the requested
+                    // power-of-two bucket, so grow the tracked lease to the
+                    // exact observed backing rather than failing inference
+                    // after the allocation already exists.
+                    reservation
+                        .lease
+                        .as_mut()
+                        .ok_or_else(|| {
+                            Error::InferenceError(
+                                "cache allocation has no physical resource lease".to_string(),
+                            )
+                        })?
+                        .resize(cache_resource_vector(self.config.backend, observed_bytes))?;
+                    reservation.reserved_bytes = observed_bytes;
+                } else {
+                    return Err(Error::InferenceError(format!(
+                        "materialized session cache uses {observed_bytes} bytes, exceeding its {}-byte authorization for request {} epoch {}",
+                        reservation.reserved_bytes, session.request_id, session.epoch
+                    )));
+                }
             }
-            lease.record_materialized_usage(cache_resource_vector(
-                self.config.backend,
-                observed_bytes,
-            ))?;
+            reservation
+                .lease
+                .as_ref()
+                .ok_or_else(|| {
+                    Error::InferenceError(
+                        "cache allocation has no physical resource lease".to_string(),
+                    )
+                })?
+                .record_materialized_usage(cache_resource_vector(
+                    self.config.backend,
+                    observed_bytes,
+                ))?;
         }
         reservation.observed_blocks = scheduled.block_ids.len();
         Ok(observation)
@@ -1724,6 +1749,42 @@ mod tests {
                 .unwrap();
             assert_eq!(authorizations.load(Ordering::Relaxed), 2);
         }
+    }
+
+    #[test]
+    fn cpu_and_metal_cache_authorization_is_advisory_while_cuda_is_guarded() {
+        for backend in [BackendKind::Cpu, BackendKind::Metal] {
+            let capacity = cache_resource_vector(backend, 8);
+            let authority = Arc::new(ResourceAuthority::new(Arc::new(FixedCapacityProvider {
+                capacity,
+            })));
+            let mut config = WorkerConfig::default();
+            config.backend = backend;
+            let executor = NativeExecutor::new(config);
+            let session = SessionKey::new(format!("{backend:?}"), 1);
+
+            executor
+                .reserve_exact_session_cache(&authority, &session, || Ok(16))
+                .expect("advisory unified-memory cache claim");
+            assert_eq!(
+                authority.snapshot().reserved,
+                cache_resource_vector(backend, 16)
+            );
+        }
+
+        let backend = BackendKind::Cuda;
+        let capacity = cache_resource_vector(backend, 8);
+        let authority = Arc::new(ResourceAuthority::new(Arc::new(FixedCapacityProvider {
+            capacity,
+        })));
+        let mut config = WorkerConfig::default();
+        config.backend = backend;
+        let executor = NativeExecutor::new(config);
+        let session = SessionKey::new("cuda".to_string(), 1);
+        assert!(matches!(
+            executor.reserve_exact_session_cache(&authority, &session, || Ok(16)),
+            Err(Error::Overloaded(_))
+        ));
     }
 
     #[test]

--- a/crates/izwi-core/src/engine/executor/handler_chat.rs
+++ b/crates/izwi-core/src/engine/executor/handler_chat.rs
@@ -1,12 +1,19 @@
+use std::sync::Arc;
 use std::time::Instant;
 
+use tracing::debug;
+
+use crate::engine::resources::{ReservationClass, ReservationOwner};
 use crate::error::{Error, Result};
+use crate::models::architectures::qwen35::chat::{Qwen35PrefixSnapshot, Qwen35PreparedPrompt};
+use crate::models::registry::NativeChatModel;
 use crate::models::shared::chat::ChatGenerationConfig;
 use crate::models::shared::chat::ChatMessage;
 
 use super::super::request::EngineCoreRequest;
 use super::super::scheduler::ScheduledRequest;
 use super::super::types::AudioOutput;
+use super::prefix_cache::{ExactPrefixHandle, ExactPrefixScope};
 use super::state::ActiveChatDecode;
 use super::{ExecutorOutput, ExecutorPhaseTiming, ModelSessionResult, NativeExecutor};
 
@@ -84,6 +91,14 @@ impl NativeExecutor {
         let generation_config = Self::chat_generation_config(request);
         let session = scheduled.session_key();
         let model = request.prepared_chat_model_for_executor()?;
+        let prefix_scope = ExactPrefixScope {
+            variant,
+            backend: self.config.backend,
+            activation_dtype: self.config.dtype.clone(),
+            kv_cache_dtype: self.config.kv_cache_dtype.clone(),
+        };
+        let prefix_cache_enabled =
+            self.qwen35_prefix_cache_enabled(prepared_qwen35_prompt, model.as_ref());
 
         // Fallback path for chat backends that do not expose incremental decode state.
         if !model.supports_incremental_decode() {
@@ -210,19 +225,48 @@ impl NativeExecutor {
                     request.id.clone(),
                 )));
             }
-            let decode_state = Self::run_blocking(|| {
-                model.start_decode_state_with_prepared(
+            let cached_prefix = prefix_cache_enabled
+                .then(|| {
+                    let prepared = prepared_qwen35_prompt
+                        .expect("enabled Qwen3.5 prefix cache requires prepared prompt");
+                    self.qwen35_prefix_cache.lookup(
+                        &model,
+                        &prefix_scope,
+                        prepared.prompt_ids(),
+                        prepared.prompt_positions(),
+                    )
+                })
+                .flatten();
+            let mut decode_state = Self::run_blocking(|| {
+                model.start_decode_state_with_prefix(
                     messages,
                     max_new_tokens,
                     &generation_config,
                     prepared_qwen35_prompt,
+                    cached_prefix.as_ref().map(|cached| cached.snapshot()),
+                    prefix_cache_enabled.then_some(self.qwen35_prefix_cache.max_retained_bytes()),
                 )
             })?;
+            let reused_prefix_tokens = decode_state.reused_qwen35_prefix_tokens();
+            if reused_prefix_tokens > 0 {
+                debug!(
+                    model = %variant,
+                    reused_prefix_tokens,
+                    prompt_tokens = request.num_prompt_tokens(),
+                    "Qwen3.5 exact-prefix cache hit"
+                );
+            }
+            let pending_prefix_snapshot = decode_state
+                .take_pending_qwen35_prefix_snapshot()
+                .and_then(|snapshot| {
+                    self.authorize_qwen35_prefix_snapshot(&prefix_scope, snapshot)
+                });
             ActiveChatDecode {
                 variant,
                 state: decode_state,
                 last_tokens_generated: 0,
                 stream_sequence: 0,
+                pending_prefix_snapshot,
             }
         };
 
@@ -278,6 +322,11 @@ impl NativeExecutor {
             }
 
             if step.finished {
+                if let Some(snapshot) = active_state.pending_prefix_snapshot.take() {
+                    let _ = self
+                        .qwen35_prefix_cache
+                        .insert(&model, prefix_scope.clone(), snapshot);
+                }
                 finished = true;
                 break;
             }
@@ -307,6 +356,43 @@ impl NativeExecutor {
             asr_diagnostics: None,
             error: None,
         }))
+    }
+
+    fn qwen35_prefix_cache_enabled(
+        &self,
+        prepared: Option<&Qwen35PreparedPrompt>,
+        model: &NativeChatModel,
+    ) -> bool {
+        self.config.resource_authority.is_some()
+            && self.qwen35_prefix_cache.max_retained_bytes() > 0
+            && matches!(model, NativeChatModel::Qwen35(_))
+            && prepared.is_some_and(Qwen35PreparedPrompt::supports_exact_prefix_reuse)
+    }
+
+    fn authorize_qwen35_prefix_snapshot(
+        &self,
+        scope: &ExactPrefixScope,
+        snapshot: Qwen35PrefixSnapshot,
+    ) -> Option<Arc<ExactPrefixHandle<Qwen35PrefixSnapshot>>> {
+        let Some(bytes) = snapshot.retained_bytes() else {
+            return None;
+        };
+        if bytes == 0 || bytes > self.qwen35_prefix_cache.max_retained_bytes() {
+            return None;
+        }
+        let Some(authority) = self.config.resource_authority.as_ref() else {
+            return None;
+        };
+        let resources = super::cache_resource_vector(scope.backend, bytes);
+        let owner = ReservationOwner::new(
+            ReservationClass::Cache,
+            format!("qwen35-prefix-pending:{}", scope.variant),
+        );
+        let Ok(lease) = authority.reserve_with_initial_materialized(owner, resources, resources)
+        else {
+            return None;
+        };
+        Some(ExactPrefixHandle::new(scope.backend, snapshot, Some(lease)))
     }
 }
 

--- a/crates/izwi-core/src/engine/executor/handler_chat.rs
+++ b/crates/izwi-core/src/engine/executor/handler_chat.rs
@@ -1,9 +1,10 @@
+use std::mem::size_of;
 use std::sync::Arc;
 use std::time::Instant;
 
 use tracing::debug;
 
-use crate::engine::resources::{ReservationClass, ReservationOwner};
+use crate::engine::resources::{ReservationClass, ReservationOwner, ResourceLease};
 use crate::error::{Error, Result};
 use crate::models::architectures::qwen35::chat::{Qwen35PrefixSnapshot, Qwen35PreparedPrompt};
 use crate::models::registry::NativeChatModel;
@@ -19,6 +20,11 @@ use super::{ExecutorOutput, ExecutorPhaseTiming, ModelSessionResult, NativeExecu
 
 const FALLBACK_CHAT_STREAM_BATCH_PIECES: usize = 4;
 const FALLBACK_CHAT_STREAM_BATCH_BYTES: usize = 32;
+
+struct PendingPrefixAuthorization {
+    max_bytes: u64,
+    lease: ResourceLease,
+}
 
 #[derive(Debug, Default)]
 struct StreamDeltaBatch {
@@ -237,6 +243,19 @@ impl NativeExecutor {
                     )
                 })
                 .flatten();
+            let pending_prefix_authorization = prefix_cache_enabled
+                .then(|| {
+                    self.preauthorize_qwen35_prefix_snapshot(
+                        request,
+                        &prefix_scope,
+                        prepared_qwen35_prompt
+                            .expect("enabled Qwen3.5 prefix cache requires prepared prompt"),
+                    )
+                })
+                .flatten();
+            let capture_prefix_max_bytes = pending_prefix_authorization
+                .as_ref()
+                .map(|authorization| authorization.max_bytes);
             let mut decode_state = Self::run_blocking(|| {
                 model.start_decode_state_with_prefix(
                     messages,
@@ -244,7 +263,7 @@ impl NativeExecutor {
                     &generation_config,
                     prepared_qwen35_prompt,
                     cached_prefix.as_ref().map(|cached| cached.snapshot()),
-                    prefix_cache_enabled.then_some(self.qwen35_prefix_cache.max_retained_bytes()),
+                    capture_prefix_max_bytes,
                 )
             })?;
             let reused_prefix_tokens = decode_state.reused_qwen35_prefix_tokens();
@@ -256,11 +275,15 @@ impl NativeExecutor {
                     "Qwen3.5 exact-prefix cache hit"
                 );
             }
-            let pending_prefix_snapshot = decode_state
-                .take_pending_qwen35_prefix_snapshot()
-                .and_then(|snapshot| {
-                    self.authorize_qwen35_prefix_snapshot(&prefix_scope, snapshot)
-                });
+            let pending_prefix_snapshot = match (
+                decode_state.take_pending_qwen35_prefix_snapshot(),
+                pending_prefix_authorization,
+            ) {
+                (Some(snapshot), Some(authorization)) => {
+                    self.materialize_qwen35_prefix_snapshot(&prefix_scope, snapshot, authorization)
+                }
+                _ => None,
+            };
             ActiveChatDecode {
                 variant,
                 state: decode_state,
@@ -369,30 +392,70 @@ impl NativeExecutor {
             && prepared.is_some_and(Qwen35PreparedPrompt::supports_exact_prefix_reuse)
     }
 
-    fn authorize_qwen35_prefix_snapshot(
+    fn preauthorize_qwen35_prefix_snapshot(
         &self,
+        request: &EngineCoreRequest,
         scope: &ExactPrefixScope,
-        snapshot: Qwen35PrefixSnapshot,
-    ) -> Option<Arc<ExactPrefixHandle<Qwen35PrefixSnapshot>>> {
-        let Some(bytes) = snapshot.retained_bytes() else {
-            return None;
-        };
-        if bytes == 0 || bytes > self.qwen35_prefix_cache.max_retained_bytes() {
+        prepared: &Qwen35PreparedPrompt,
+    ) -> Option<PendingPrefixAuthorization> {
+        let state_bytes = self.authorized_session_cache_bytes(request).ok()?;
+        let metadata_per_token = size_of::<u32>().checked_add(size_of::<[usize; 3]>())?;
+        let metadata_bytes = prepared
+            .prompt_ids()
+            .len()
+            .checked_mul(metadata_per_token)?
+            .checked_add(size_of::<Qwen35PrefixSnapshot>())?;
+        let max_bytes = state_bytes.checked_add(u64::try_from(metadata_bytes).ok()?)?;
+        if max_bytes == 0 || max_bytes > self.qwen35_prefix_cache.max_retained_bytes() {
             return None;
         }
         let Some(authority) = self.config.resource_authority.as_ref() else {
             return None;
         };
-        let resources = super::cache_resource_vector(scope.backend, bytes);
+        let resources = super::cache_resource_vector(scope.backend, max_bytes);
         let owner = ReservationOwner::new(
             ReservationClass::Cache,
             format!("qwen35-prefix-pending:{}", scope.variant),
         );
-        let Ok(lease) = authority.reserve_with_initial_materialized(owner, resources, resources)
-        else {
+        let lease = authority.reserve(owner, resources).ok()?;
+        Some(PendingPrefixAuthorization { max_bytes, lease })
+    }
+
+    fn materialize_qwen35_prefix_snapshot(
+        &self,
+        scope: &ExactPrefixScope,
+        snapshot: Qwen35PrefixSnapshot,
+        mut authorization: PendingPrefixAuthorization,
+    ) -> Option<Arc<ExactPrefixHandle<Qwen35PrefixSnapshot>>> {
+        let Some(bytes) = snapshot.retained_bytes() else {
+            drop(snapshot);
+            drop(authorization);
             return None;
         };
-        Some(ExactPrefixHandle::new(scope.backend, snapshot, Some(lease)))
+        if bytes == 0 || bytes > authorization.max_bytes {
+            drop(snapshot);
+            drop(authorization);
+            return None;
+        }
+        let resources = super::cache_resource_vector(scope.backend, bytes);
+        if authorization
+            .lease
+            .record_materialized_usage(resources)
+            .is_err()
+        {
+            drop(snapshot);
+            drop(authorization);
+            return None;
+        }
+        // The copy is complete and its exact backing size is known. Relinquish
+        // unused preauthorization while keeping the materialized snapshot fully
+        // covered for its retained lifetime.
+        let _ = authorization.lease.resize(resources);
+        Some(ExactPrefixHandle::new(
+            scope.backend,
+            snapshot,
+            Some(authorization.lease),
+        ))
     }
 }
 

--- a/crates/izwi-core/src/engine/executor/prefix_cache.rs
+++ b/crates/izwi-core/src/engine/executor/prefix_cache.rs
@@ -142,31 +142,45 @@ where
         }
 
         let requested_owner = Arc::downgrade(owner);
-        let mut state = self
-            .state
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        remove_stale_entries(&mut state);
+        let (cached, stale) = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            let stale = detach_stale_entries(&mut state);
 
-        let best = state
-            .entries
-            .iter()
-            .enumerate()
-            .filter(|(_, entry)| {
-                entry.scope == *scope
-                    && Weak::ptr_eq(&entry.owner, &requested_owner)
-                    && exact_prefix_matches(entry.cached.snapshot(), prompt_ids, prompt_positions)
-            })
-            .max_by_key(|(_, entry)| entry.cached.snapshot().token_ids().len())
-            .map(|(index, _)| index)?;
+            let best = state
+                .entries
+                .iter()
+                .enumerate()
+                .filter(|(_, entry)| {
+                    entry.scope == *scope
+                        && Weak::ptr_eq(&entry.owner, &requested_owner)
+                        && exact_prefix_matches(
+                            entry.cached.snapshot(),
+                            prompt_ids,
+                            prompt_positions,
+                        )
+                })
+                .max_by_key(|(_, entry)| entry.cached.snapshot().token_ids().len())
+                .map(|(index, _)| index);
 
-        let entry = state
-            .entries
-            .remove(best)
-            .expect("selected exact-prefix entry must still exist");
-        let cached = Arc::clone(&entry.cached);
-        state.entries.push_back(entry);
-        Some(cached)
+            let cached = best.map(|best| {
+                let entry = state
+                    .entries
+                    .remove(best)
+                    .expect("selected exact-prefix entry must still exist");
+                let cached = Arc::clone(&entry.cached);
+                state.entries.push_back(entry);
+                cached
+            });
+            (cached, stale)
+        };
+        // Resource leases and Candle/Metal storage must be released outside
+        // the cache mutex to avoid lock inversion and long device frees while
+        // other requests access the LRU.
+        drop(stale);
+        cached
     }
 
     /// Insert one immutable snapshot. Oversized or unaccountable snapshots are
@@ -185,49 +199,81 @@ where
         }
 
         let owner = Arc::downgrade(owner);
-        let mut state = self
-            .state
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        remove_stale_entries(&mut state);
+        let (inserted, detached) = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            let mut detached = detach_stale_entries(&mut state);
+            let mut remove = vec![false; state.entries.len()];
+            let replacement = cached.snapshot();
 
-        if let Some(index) = state.entries.iter().position(|entry| {
-            entry.scope == scope
-                && Weak::ptr_eq(&entry.owner, &owner)
-                && entry.cached.snapshot().token_ids() == cached.snapshot().token_ids()
-                && entry.cached.snapshot().positions() == cached.snapshot().positions()
-        }) {
-            if Arc::strong_count(&state.entries[index].cached) > 1 {
-                return false;
+            // Plan replacement and ancestor compaction before mutating the
+            // LRU. A failed fit must leave every useful entry intact.
+            for (index, entry) in state.entries.iter().enumerate() {
+                if entry.scope != scope || !Weak::ptr_eq(&entry.owner, &owner) {
+                    continue;
+                }
+                let candidate = entry.cached.snapshot();
+                let exact = candidate.token_ids() == replacement.token_ids()
+                    && candidate.positions() == replacement.positions();
+                if exact && Arc::strong_count(&entry.cached) > 1 {
+                    drop(state);
+                    drop(detached);
+                    return false;
+                }
+                let ancestor = candidate.token_ids().len() < replacement.token_ids().len()
+                    && replacement.token_ids().starts_with(candidate.token_ids())
+                    && replacement.positions().starts_with(candidate.positions());
+                if exact || (ancestor && Arc::strong_count(&entry.cached) == 1) {
+                    remove[index] = true;
+                }
             }
-            if let Some(replaced) = state.entries.remove(index) {
-                state.retained_bytes = state.retained_bytes.saturating_sub(replaced.retained_bytes);
+
+            let mut projected = state.retained_bytes;
+            for (index, entry) in state.entries.iter().enumerate() {
+                if remove[index] {
+                    projected = projected.saturating_sub(entry.retained_bytes);
+                }
             }
-        }
 
-        while state.retained_bytes.saturating_add(retained_bytes) > self.max_retained_bytes {
-            let Some(index) = state
-                .entries
-                .iter()
-                .position(|entry| Arc::strong_count(&entry.cached) == 1)
-            else {
-                return false;
-            };
-            let evicted = state
-                .entries
-                .remove(index)
-                .expect("selected evictable prefix entry must exist");
-            state.retained_bytes = state.retained_bytes.saturating_sub(evicted.retained_bytes);
-        }
+            while projected.saturating_add(retained_bytes) > self.max_retained_bytes {
+                let Some((index, entry)) =
+                    state.entries.iter().enumerate().find(|(index, entry)| {
+                        !remove[*index] && Arc::strong_count(&entry.cached) == 1
+                    })
+                else {
+                    drop(state);
+                    drop(detached);
+                    return false;
+                };
+                remove[index] = true;
+                projected = projected.saturating_sub(entry.retained_bytes);
+            }
 
-        state.retained_bytes = state.retained_bytes.saturating_add(retained_bytes);
-        state.entries.push_back(ExactPrefixEntry {
-            scope,
-            owner,
-            cached,
-            retained_bytes,
-        });
-        true
+            for index in (0..remove.len()).rev() {
+                if !remove[index] {
+                    continue;
+                }
+                let entry = state
+                    .entries
+                    .remove(index)
+                    .expect("planned exact-prefix removal must still exist");
+                state.retained_bytes = state.retained_bytes.saturating_sub(entry.retained_bytes);
+                detached.push(entry);
+            }
+
+            state.retained_bytes = state.retained_bytes.saturating_add(retained_bytes);
+            state.entries.push_back(ExactPrefixEntry {
+                scope,
+                owner,
+                cached,
+                retained_bytes,
+            });
+            (true, detached)
+        };
+        drop(detached);
+        inserted
     }
 
     pub(super) fn retained_bytes(&self) -> u64 {
@@ -237,13 +283,34 @@ where
             .retained_bytes
     }
 
+    /// Purge all checkpoints owned by one model variant.
+    ///
+    /// Model unload calls this after active requests have been aborted and
+    /// before the model residency lease is released. Any external lookup
+    /// handle remains valid and keeps its own resource lease until it drops.
+    pub(super) fn purge_variant(&self, variant: ModelVariant) -> usize {
+        let detached = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            detach_matching_entries(&mut state, |entry| entry.scope.variant == variant)
+        };
+        let removed = detached.len();
+        drop(detached);
+        removed
+    }
+
     pub(super) fn clear(&self) {
-        let mut state = self
-            .state
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        state.entries.clear();
-        state.retained_bytes = 0;
+        let detached = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            state.retained_bytes = 0;
+            std::mem::take(&mut state.entries)
+        };
+        drop(detached);
     }
 }
 
@@ -260,18 +327,33 @@ fn exact_prefix_matches<S: ExactPrefixSnapshot + ?Sized>(
         && prompt_positions.starts_with(cached_positions)
 }
 
-fn remove_stale_entries<O, S>(state: &mut ExactPrefixCacheState<O, S>) {
-    let mut retained_bytes = state.retained_bytes;
-    state.entries.retain(|entry| {
-        // A lookup handle owns the snapshot and its lease independently of the
-        // LRU entry, so a dead model owner can always be pruned immediately.
-        let retain = entry.owner.strong_count() > 0;
-        if !retain {
-            retained_bytes = retained_bytes.saturating_sub(entry.retained_bytes);
+fn detach_stale_entries<O, S>(
+    state: &mut ExactPrefixCacheState<O, S>,
+) -> Vec<ExactPrefixEntry<O, S>> {
+    // A lookup handle owns the snapshot and its lease independently of the LRU
+    // entry, so a dead model owner can always be detached immediately.
+    detach_matching_entries(state, |entry| entry.owner.strong_count() == 0)
+}
+
+fn detach_matching_entries<O, S>(
+    state: &mut ExactPrefixCacheState<O, S>,
+    mut should_detach: impl FnMut(&ExactPrefixEntry<O, S>) -> bool,
+) -> Vec<ExactPrefixEntry<O, S>> {
+    let mut detached = Vec::new();
+    let mut index = 0usize;
+    while index < state.entries.len() {
+        if should_detach(&state.entries[index]) {
+            let entry = state
+                .entries
+                .remove(index)
+                .expect("selected exact-prefix entry must still exist");
+            state.retained_bytes = state.retained_bytes.saturating_sub(entry.retained_bytes);
+            detached.push(entry);
+        } else {
+            index += 1;
         }
-        retain
-    });
-    state.retained_bytes = retained_bytes;
+    }
+    detached
 }
 
 #[cfg(test)]
@@ -315,13 +397,17 @@ mod tests {
         }
     }
 
-    fn scope() -> ExactPrefixScope {
+    fn scope_for(variant: ModelVariant) -> ExactPrefixScope {
         ExactPrefixScope {
-            variant: ModelVariant::Qwen354BGguf,
+            variant,
             backend: BackendKind::Cpu,
             activation_dtype: "float32".to_string(),
             kv_cache_dtype: "float16".to_string(),
         }
+    }
+
+    fn scope() -> ExactPrefixScope {
+        scope_for(ModelVariant::Qwen354BGguf)
     }
 
     fn snapshot(
@@ -404,6 +490,59 @@ mod tests {
             .lookup(&owner, &scope(), &[3, 9], &positions(2))
             .is_some());
         assert_eq!(cache.retained_bytes(), 10);
+    }
+
+    #[test]
+    fn monotonic_lineage_supersedes_unpinned_ancestors_but_preserves_branches() {
+        let cache = ExactPrefixCache::<(), TestSnapshot>::new(128);
+        let owner = Arc::new(());
+        assert!(cache.insert(&owner, scope(), snapshot(&[1], 4, "root")));
+        assert!(cache.insert(&owner, scope(), snapshot(&[1, 2], 5, "middle")));
+        assert!(cache.insert(&owner, scope(), snapshot(&[9, 8], 6, "branch")));
+        assert!(cache.insert(&owner, scope(), snapshot(&[1, 2, 3], 7, "tip")));
+
+        assert!(cache
+            .lookup(&owner, &scope(), &[1, 2, 9], &positions(3))
+            .is_none());
+        assert_eq!(
+            cache
+                .lookup(&owner, &scope(), &[1, 2, 3, 4], &positions(4))
+                .unwrap()
+                .snapshot()
+                .label,
+            "tip"
+        );
+        assert_eq!(
+            cache
+                .lookup(&owner, &scope(), &[9, 8, 7], &positions(3))
+                .unwrap()
+                .snapshot()
+                .label,
+            "branch"
+        );
+        assert_eq!(cache.retained_bytes(), 13);
+    }
+
+    #[test]
+    fn failed_insert_does_not_destroy_existing_ancestors() {
+        let cache = ExactPrefixCache::<(), TestSnapshot>::new(8);
+        let owner = Arc::new(());
+        assert!(cache.insert(&owner, scope(), snapshot(&[1], 8, "root")));
+        let pinned = cache
+            .lookup(&owner, &scope(), &[1, 2], &positions(2))
+            .unwrap();
+
+        assert!(!cache.insert(&owner, scope(), snapshot(&[1, 2], 8, "tip")));
+        assert_eq!(cache.retained_bytes(), 8);
+        assert_eq!(
+            cache
+                .lookup(&owner, &scope(), &[1, 3], &positions(2))
+                .unwrap()
+                .snapshot()
+                .label,
+            "root"
+        );
+        drop(pinned);
     }
 
     #[test]
@@ -494,5 +633,68 @@ mod tests {
         assert_eq!(authority.snapshot().reservations, 1);
         drop(pending);
         assert_eq!(authority.snapshot().reservations, 0);
+    }
+
+    #[test]
+    fn variant_purge_releases_only_matching_unpinned_leases() {
+        let capacity = super::super::cache_resource_vector(BackendKind::Cpu, 64);
+        let authority = Arc::new(ResourceAuthority::new(Arc::new(TestCapacityProvider {
+            snapshot: PhysicalCapacitySnapshot {
+                capacity,
+                available: capacity,
+                source: crate::engine::resources::CapacitySource::Test,
+            },
+        })));
+        let cache = ExactPrefixCache::<(), TestSnapshot>::new(64);
+        let owner = Arc::new(());
+
+        for (variant, id, label) in [
+            (ModelVariant::Qwen354BGguf, 1, "four"),
+            (ModelVariant::Qwen352BGguf, 2, "two"),
+        ] {
+            let resources = super::super::cache_resource_vector(BackendKind::Cpu, 4);
+            let lease = authority
+                .reserve_with_initial_materialized(
+                    ReservationOwner::new(ReservationClass::Cache, label),
+                    resources,
+                    resources,
+                )
+                .unwrap();
+            assert!(cache.insert(
+                &owner,
+                scope_for(variant),
+                ExactPrefixHandle::new(
+                    BackendKind::Cpu,
+                    TestSnapshot {
+                        ids: vec![id],
+                        positions: vec![[0; 3]],
+                        bytes: 4,
+                        label,
+                    },
+                    Some(lease),
+                ),
+            ));
+        }
+        assert_eq!(authority.snapshot().reservations, 2);
+
+        assert_eq!(cache.purge_variant(ModelVariant::Qwen354BGguf), 1);
+        assert_eq!(cache.retained_bytes(), 4);
+        assert_eq!(authority.snapshot().reservations, 1);
+        assert!(cache
+            .lookup(
+                &owner,
+                &scope_for(ModelVariant::Qwen354BGguf),
+                &[1, 3],
+                &positions(2),
+            )
+            .is_none());
+        assert!(cache
+            .lookup(
+                &owner,
+                &scope_for(ModelVariant::Qwen352BGguf),
+                &[2, 3],
+                &positions(2),
+            )
+            .is_some());
     }
 }

--- a/crates/izwi-core/src/engine/executor/prefix_cache.rs
+++ b/crates/izwi-core/src/engine/executor/prefix_cache.rs
@@ -1,0 +1,498 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex, Weak};
+
+use crate::backends::BackendKind;
+use crate::engine::resources::ResourceLease;
+use crate::model::ModelVariant;
+use crate::models::architectures::qwen35::chat::Qwen35PrefixSnapshot;
+
+const DEFAULT_QWEN35_PREFIX_CACHE_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_QWEN35_PREFIX_CACHE_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+
+pub(super) fn configured_qwen35_prefix_cache_bytes() -> u64 {
+    std::env::var("IZWI_QWEN35_PREFIX_CACHE_BYTES")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_QWEN35_PREFIX_CACHE_BYTES)
+        .min(MAX_QWEN35_PREFIX_CACHE_BYTES)
+}
+
+pub(super) trait ExactPrefixSnapshot: Send + Sync + 'static {
+    fn token_ids(&self) -> &[u32];
+
+    fn positions(&self) -> &[[usize; 3]];
+
+    /// All storage retained exclusively by this cache entry, including tensor
+    /// backing allocations and owned token/position metadata.
+    fn retained_bytes(&self) -> Option<u64>;
+}
+
+impl ExactPrefixSnapshot for Qwen35PrefixSnapshot {
+    fn token_ids(&self) -> &[u32] {
+        self.token_ids()
+    }
+
+    fn positions(&self) -> &[[usize; 3]] {
+        self.positions()
+    }
+
+    fn retained_bytes(&self) -> Option<u64> {
+        self.retained_bytes()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ExactPrefixScope {
+    pub(super) variant: ModelVariant,
+    pub(super) backend: BackendKind,
+    pub(super) activation_dtype: String,
+    pub(super) kv_cache_dtype: String,
+}
+
+pub(super) struct ExactPrefixHandle<S> {
+    backend: BackendKind,
+    // Snapshot precedes its lease so storage is dropped before authorization.
+    snapshot: S,
+    lease: Option<ResourceLease>,
+}
+
+impl<S> ExactPrefixHandle<S> {
+    pub(super) fn new(
+        backend: BackendKind,
+        snapshot: S,
+        lease: Option<ResourceLease>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            backend,
+            snapshot,
+            lease,
+        })
+    }
+
+    pub(super) fn snapshot(&self) -> &S {
+        &self.snapshot
+    }
+}
+
+impl<S> Drop for ExactPrefixHandle<S> {
+    fn drop(&mut self) {
+        if let Some(lease) = self.lease.as_ref() {
+            let _ =
+                lease.prepare_materialized_release(super::cache_resource_vector(self.backend, 0));
+        }
+    }
+}
+
+struct ExactPrefixEntry<O, S> {
+    scope: ExactPrefixScope,
+    owner: Weak<O>,
+    cached: Arc<ExactPrefixHandle<S>>,
+    retained_bytes: u64,
+}
+
+struct ExactPrefixCacheState<O, S> {
+    entries: VecDeque<ExactPrefixEntry<O, S>>,
+    retained_bytes: u64,
+}
+
+impl<O, S> Default for ExactPrefixCacheState<O, S> {
+    fn default() -> Self {
+        Self {
+            entries: VecDeque::new(),
+            retained_bytes: 0,
+        }
+    }
+}
+
+/// Bounded LRU of immutable exact-prefix snapshots.
+///
+/// The owner is weakly referenced so an unloaded model cannot keep cache state
+/// discoverable. Lookups clone only an `Arc` while holding the mutex; fallible
+/// Candle storage copies happen after the cache lock is released.
+pub(super) struct ExactPrefixCache<O, S> {
+    max_retained_bytes: u64,
+    state: Mutex<ExactPrefixCacheState<O, S>>,
+}
+
+impl<O, S> ExactPrefixCache<O, S>
+where
+    O: Send + Sync + 'static,
+    S: ExactPrefixSnapshot,
+{
+    pub(super) fn new(max_retained_bytes: u64) -> Self {
+        Self {
+            max_retained_bytes,
+            state: Mutex::new(ExactPrefixCacheState::default()),
+        }
+    }
+
+    pub(super) fn max_retained_bytes(&self) -> u64 {
+        self.max_retained_bytes
+    }
+
+    pub(super) fn lookup(
+        &self,
+        owner: &Arc<O>,
+        scope: &ExactPrefixScope,
+        prompt_ids: &[u32],
+        prompt_positions: &[[usize; 3]],
+    ) -> Option<Arc<ExactPrefixHandle<S>>> {
+        if self.max_retained_bytes == 0 || prompt_ids.len() != prompt_positions.len() {
+            return None;
+        }
+
+        let requested_owner = Arc::downgrade(owner);
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        remove_stale_entries(&mut state);
+
+        let best = state
+            .entries
+            .iter()
+            .enumerate()
+            .filter(|(_, entry)| {
+                entry.scope == *scope
+                    && Weak::ptr_eq(&entry.owner, &requested_owner)
+                    && exact_prefix_matches(entry.cached.snapshot(), prompt_ids, prompt_positions)
+            })
+            .max_by_key(|(_, entry)| entry.cached.snapshot().token_ids().len())
+            .map(|(index, _)| index)?;
+
+        let entry = state
+            .entries
+            .remove(best)
+            .expect("selected exact-prefix entry must still exist");
+        let cached = Arc::clone(&entry.cached);
+        state.entries.push_back(entry);
+        Some(cached)
+    }
+
+    /// Insert one immutable snapshot. Oversized or unaccountable snapshots are
+    /// skipped instead of weakening the byte bound or failing inference.
+    pub(super) fn insert(
+        &self,
+        owner: &Arc<O>,
+        scope: ExactPrefixScope,
+        cached: Arc<ExactPrefixHandle<S>>,
+    ) -> bool {
+        let Some(retained_bytes) = cached.snapshot().retained_bytes() else {
+            return false;
+        };
+        if self.max_retained_bytes == 0 || retained_bytes > self.max_retained_bytes {
+            return false;
+        }
+
+        let owner = Arc::downgrade(owner);
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        remove_stale_entries(&mut state);
+
+        if let Some(index) = state.entries.iter().position(|entry| {
+            entry.scope == scope
+                && Weak::ptr_eq(&entry.owner, &owner)
+                && entry.cached.snapshot().token_ids() == cached.snapshot().token_ids()
+                && entry.cached.snapshot().positions() == cached.snapshot().positions()
+        }) {
+            if Arc::strong_count(&state.entries[index].cached) > 1 {
+                return false;
+            }
+            if let Some(replaced) = state.entries.remove(index) {
+                state.retained_bytes = state.retained_bytes.saturating_sub(replaced.retained_bytes);
+            }
+        }
+
+        while state.retained_bytes.saturating_add(retained_bytes) > self.max_retained_bytes {
+            let Some(index) = state
+                .entries
+                .iter()
+                .position(|entry| Arc::strong_count(&entry.cached) == 1)
+            else {
+                return false;
+            };
+            let evicted = state
+                .entries
+                .remove(index)
+                .expect("selected evictable prefix entry must exist");
+            state.retained_bytes = state.retained_bytes.saturating_sub(evicted.retained_bytes);
+        }
+
+        state.retained_bytes = state.retained_bytes.saturating_add(retained_bytes);
+        state.entries.push_back(ExactPrefixEntry {
+            scope,
+            owner,
+            cached,
+            retained_bytes,
+        });
+        true
+    }
+
+    pub(super) fn retained_bytes(&self) -> u64 {
+        self.state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .retained_bytes
+    }
+
+    pub(super) fn clear(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        state.entries.clear();
+        state.retained_bytes = 0;
+    }
+}
+
+fn exact_prefix_matches<S: ExactPrefixSnapshot + ?Sized>(
+    snapshot: &S,
+    prompt_ids: &[u32],
+    prompt_positions: &[[usize; 3]],
+) -> bool {
+    let cached_ids = snapshot.token_ids();
+    let cached_positions = snapshot.positions();
+    !cached_ids.is_empty()
+        && cached_ids.len() == cached_positions.len()
+        && prompt_ids.starts_with(cached_ids)
+        && prompt_positions.starts_with(cached_positions)
+}
+
+fn remove_stale_entries<O, S>(state: &mut ExactPrefixCacheState<O, S>) {
+    let mut retained_bytes = state.retained_bytes;
+    state.entries.retain(|entry| {
+        // A lookup handle owns the snapshot and its lease independently of the
+        // LRU entry, so a dead model owner can always be pruned immediately.
+        let retain = entry.owner.strong_count() > 0;
+        if !retain {
+            retained_bytes = retained_bytes.saturating_sub(entry.retained_bytes);
+        }
+        retain
+    });
+    state.retained_bytes = retained_bytes;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::resources::{
+        PhysicalCapacityProvider, PhysicalCapacitySnapshot, ReservationClass, ReservationOwner,
+        ResourceAuthority,
+    };
+
+    #[derive(Debug)]
+    struct TestSnapshot {
+        ids: Vec<u32>,
+        positions: Vec<[usize; 3]>,
+        bytes: u64,
+        label: &'static str,
+    }
+
+    #[derive(Debug)]
+    struct TestCapacityProvider {
+        snapshot: PhysicalCapacitySnapshot,
+    }
+
+    impl PhysicalCapacityProvider for TestCapacityProvider {
+        fn snapshot(&self) -> PhysicalCapacitySnapshot {
+            self.snapshot
+        }
+    }
+
+    impl ExactPrefixSnapshot for TestSnapshot {
+        fn token_ids(&self) -> &[u32] {
+            &self.ids
+        }
+
+        fn positions(&self) -> &[[usize; 3]] {
+            &self.positions
+        }
+
+        fn retained_bytes(&self) -> Option<u64> {
+            Some(self.bytes)
+        }
+    }
+
+    fn scope() -> ExactPrefixScope {
+        ExactPrefixScope {
+            variant: ModelVariant::Qwen354BGguf,
+            backend: BackendKind::Cpu,
+            activation_dtype: "float32".to_string(),
+            kv_cache_dtype: "float16".to_string(),
+        }
+    }
+
+    fn snapshot(
+        ids: &[u32],
+        bytes: u64,
+        label: &'static str,
+    ) -> Arc<ExactPrefixHandle<TestSnapshot>> {
+        ExactPrefixHandle::new(
+            BackendKind::Cpu,
+            TestSnapshot {
+                ids: ids.to_vec(),
+                positions: (0..ids.len()).map(|index| [index; 3]).collect(),
+                bytes,
+                label,
+            },
+            None,
+        )
+    }
+
+    fn positions(len: usize) -> Vec<[usize; 3]> {
+        (0..len).map(|index| [index; 3]).collect()
+    }
+
+    #[test]
+    fn lookup_returns_the_longest_exact_token_and_position_prefix() {
+        let cache = ExactPrefixCache::<(), TestSnapshot>::new(128);
+        let owner = Arc::new(());
+        assert!(cache.insert(&owner, scope(), snapshot(&[1, 2], 10, "short")));
+        assert!(cache.insert(&owner, scope(), snapshot(&[1, 2, 3], 10, "long"),));
+
+        let hit = cache
+            .lookup(&owner, &scope(), &[1, 2, 3, 4], &positions(4))
+            .expect("longest exact prefix");
+        assert_eq!(hit.snapshot().label, "long");
+    }
+
+    #[test]
+    fn lookup_rejects_token_position_scope_and_model_mismatches() {
+        let cache = ExactPrefixCache::<(), TestSnapshot>::new(128);
+        let owner = Arc::new(());
+        assert!(cache.insert(&owner, scope(), snapshot(&[1, 2, 3], 10, "entry"),));
+
+        assert!(cache
+            .lookup(&owner, &scope(), &[1, 9, 3, 4], &positions(4))
+            .is_none());
+        let mut wrong_positions = positions(4);
+        wrong_positions[2] = [99; 3];
+        assert!(cache
+            .lookup(&owner, &scope(), &[1, 2, 3, 4], &wrong_positions)
+            .is_none());
+
+        let mut wrong_scope = scope();
+        wrong_scope.backend = BackendKind::Metal;
+        assert!(cache
+            .lookup(&owner, &wrong_scope, &[1, 2, 3, 4], &positions(4))
+            .is_none());
+        assert!(cache
+            .lookup(&Arc::new(()), &scope(), &[1, 2, 3, 4], &positions(4),)
+            .is_none());
+    }
+
+    #[test]
+    fn byte_bound_evicts_the_least_recently_used_entry() {
+        let cache = ExactPrefixCache::<(), TestSnapshot>::new(12);
+        let owner = Arc::new(());
+        assert!(cache.insert(&owner, scope(), snapshot(&[1], 4, "first")));
+        assert!(cache.insert(&owner, scope(), snapshot(&[2], 4, "second")));
+        assert!(cache
+            .lookup(&owner, &scope(), &[1, 9], &positions(2))
+            .is_some());
+        assert!(cache.insert(&owner, scope(), snapshot(&[3], 6, "third")));
+
+        assert!(cache
+            .lookup(&owner, &scope(), &[2, 9], &positions(2))
+            .is_none());
+        assert!(cache
+            .lookup(&owner, &scope(), &[1, 9], &positions(2))
+            .is_some());
+        assert!(cache
+            .lookup(&owner, &scope(), &[3, 9], &positions(2))
+            .is_some());
+        assert_eq!(cache.retained_bytes(), 10);
+    }
+
+    #[test]
+    fn stale_model_owner_is_pruned_and_oversized_entries_are_skipped() {
+        let cache = ExactPrefixCache::<(), TestSnapshot>::new(8);
+        let owner = Arc::new(());
+        assert!(cache.insert(&owner, scope(), snapshot(&[1], 8, "stale")));
+        drop(owner);
+
+        let replacement_owner = Arc::new(());
+        assert!(cache
+            .lookup(&replacement_owner, &scope(), &[1, 2], &positions(2),)
+            .is_none());
+        assert_eq!(cache.retained_bytes(), 0);
+        assert!(!cache.insert(&replacement_owner, scope(), snapshot(&[2], 9, "oversized"),));
+    }
+
+    #[test]
+    fn lookup_handle_keeps_exact_resource_lease_after_cache_clear() {
+        let capacity = super::super::cache_resource_vector(BackendKind::Cpu, 64);
+        let authority = Arc::new(ResourceAuthority::new(Arc::new(TestCapacityProvider {
+            snapshot: PhysicalCapacitySnapshot {
+                capacity,
+                available: capacity,
+                source: crate::engine::resources::CapacitySource::Test,
+            },
+        })));
+        let resources = super::super::cache_resource_vector(BackendKind::Cpu, 4);
+        let lease = authority
+            .reserve_with_initial_materialized(
+                ReservationOwner::new(ReservationClass::Cache, "prefix"),
+                resources,
+                resources,
+            )
+            .unwrap();
+        let cache = ExactPrefixCache::<(), TestSnapshot>::new(8);
+        let owner = Arc::new(());
+        let cached = ExactPrefixHandle::new(
+            BackendKind::Cpu,
+            TestSnapshot {
+                ids: vec![1],
+                positions: vec![[0; 3]],
+                bytes: 4,
+                label: "leased",
+            },
+            Some(lease),
+        );
+        assert!(cache.insert(&owner, scope(), cached));
+        let hit = cache
+            .lookup(&owner, &scope(), &[1, 2], &positions(2))
+            .unwrap();
+
+        cache.clear();
+        assert_eq!(authority.snapshot().reservations, 1);
+        assert_eq!(hit.snapshot().label, "leased");
+        drop(hit);
+        assert_eq!(authority.snapshot().reservations, 0);
+    }
+
+    #[test]
+    fn dropping_unpublished_pending_handle_releases_exact_authorization() {
+        let capacity = super::super::cache_resource_vector(BackendKind::Cpu, 64);
+        let authority = Arc::new(ResourceAuthority::new(Arc::new(TestCapacityProvider {
+            snapshot: PhysicalCapacitySnapshot {
+                capacity,
+                available: capacity,
+                source: crate::engine::resources::CapacitySource::Test,
+            },
+        })));
+        let resources = super::super::cache_resource_vector(BackendKind::Cpu, 4);
+        let lease = authority
+            .reserve_with_initial_materialized(
+                ReservationOwner::new(ReservationClass::Cache, "pending-prefix"),
+                resources,
+                resources,
+            )
+            .unwrap();
+        let pending = ExactPrefixHandle::new(
+            BackendKind::Cpu,
+            TestSnapshot {
+                ids: vec![1],
+                positions: vec![[0; 3]],
+                bytes: 4,
+                label: "pending",
+            },
+            Some(lease),
+        );
+        assert_eq!(authority.snapshot().reservations, 1);
+        drop(pending);
+        assert_eq!(authority.snapshot().reservations, 0);
+    }
+}

--- a/crates/izwi-core/src/engine/executor/prefix_cache.rs
+++ b/crates/izwi-core/src/engine/executor/prefix_cache.rs
@@ -6,7 +6,7 @@ use crate::engine::resources::ResourceLease;
 use crate::model::ModelVariant;
 use crate::models::architectures::qwen35::chat::Qwen35PrefixSnapshot;
 
-const DEFAULT_QWEN35_PREFIX_CACHE_BYTES: u64 = 256 * 1024 * 1024;
+const DEFAULT_QWEN35_PREFIX_CACHE_BYTES: u64 = 0;
 const MAX_QWEN35_PREFIX_CACHE_BYTES: u64 = 4 * 1024 * 1024 * 1024;
 
 pub(super) fn configured_qwen35_prefix_cache_bytes() -> u64 {
@@ -22,8 +22,8 @@ pub(super) trait ExactPrefixSnapshot: Send + Sync + 'static {
 
     fn positions(&self) -> &[[usize; 3]];
 
-    /// All storage retained exclusively by this cache entry, including tensor
-    /// backing allocations and owned token/position metadata.
+    /// Storage whose lifetime this cache entry can prolong, including shared
+    /// tensor backing allocations and owned token/position metadata.
     fn retained_bytes(&self) -> Option<u64>;
 }
 
@@ -107,8 +107,8 @@ impl<O, S> Default for ExactPrefixCacheState<O, S> {
 /// Bounded LRU of immutable exact-prefix snapshots.
 ///
 /// The owner is weakly referenced so an unloaded model cannot keep cache state
-/// discoverable. Lookups clone only an `Arc` while holding the mutex; fallible
-/// Candle storage copies happen after the cache lock is released.
+/// discoverable. Lookups clone only an `Arc` while holding the mutex; restored
+/// Qwen state structurally shares immutable Candle tensor storage.
 pub(super) struct ExactPrefixCache<O, S> {
     max_retained_bytes: u64,
     state: Mutex<ExactPrefixCacheState<O, S>>,
@@ -395,6 +395,23 @@ mod tests {
         fn retained_bytes(&self) -> Option<u64> {
             Some(self.bytes)
         }
+    }
+
+    #[test]
+    fn qwen35_prefix_cache_is_opt_in_and_bounded() {
+        let _guard = crate::env_test_lock().lock().expect("env lock");
+        std::env::remove_var("IZWI_QWEN35_PREFIX_CACHE_BYTES");
+        assert_eq!(configured_qwen35_prefix_cache_bytes(), 0);
+
+        std::env::set_var("IZWI_QWEN35_PREFIX_CACHE_BYTES", "1048576");
+        assert_eq!(configured_qwen35_prefix_cache_bytes(), 1_048_576);
+
+        std::env::set_var("IZWI_QWEN35_PREFIX_CACHE_BYTES", u64::MAX.to_string());
+        assert_eq!(
+            configured_qwen35_prefix_cache_bytes(),
+            MAX_QWEN35_PREFIX_CACHE_BYTES
+        );
+        std::env::remove_var("IZWI_QWEN35_PREFIX_CACHE_BYTES");
     }
 
     fn scope_for(variant: ModelVariant) -> ExactPrefixScope {

--- a/crates/izwi-core/src/engine/executor/state.rs
+++ b/crates/izwi-core/src/engine/executor/state.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+use super::prefix_cache::ExactPrefixHandle;
 use crate::model::ModelVariant;
 use crate::models::architectures::qwen3::tts::Qwen3TtsModel;
 use crate::models::architectures::qwen3::tts::TtsDecodeState as QwenTtsDecodeState;
+use crate::models::architectures::qwen35::chat::Qwen35PrefixSnapshot;
 use crate::models::registry::{
     AsrModelLease, NativeAsrDecodeState, NativeAsrModel, NativeChatDecodeState, QwenTtsModelLease,
 };
@@ -13,6 +15,7 @@ pub(super) struct ActiveChatDecode {
     pub(super) state: NativeChatDecodeState,
     pub(super) last_tokens_generated: usize,
     pub(super) stream_sequence: usize,
+    pub(super) pending_prefix_snapshot: Option<Arc<ExactPrefixHandle<Qwen35PrefixSnapshot>>>,
 }
 
 pub(super) struct ActiveAsrDecode {

--- a/crates/izwi-core/src/engine/mod.rs
+++ b/crates/izwi-core/src/engine/mod.rs
@@ -50,8 +50,8 @@ pub use execution::{
     WorkUnit, YieldReason,
 };
 pub use executor::{
-    ExecutorOutput, ExecutorStepResult, ModelExecutor, ModelSessionResult, WorkerConfig,
-    REQUEST_DEADLINE_EXCEEDED,
+    CacheReleaseReport, ExecutorOutput, ExecutorStepResult, ModelExecutor, ModelSessionResult,
+    WorkerConfig, REQUEST_DEADLINE_EXCEEDED,
 };
 pub use kv_cache::{
     BlockAllocator, CacheResidency, KVCacheConfig as KVConfig, KVCacheManager, KVCacheStats,
@@ -1105,6 +1105,11 @@ impl Engine {
             self.wake_notify.notify_one();
         }
         aborted
+    }
+
+    /// Purge reusable executor cache state owned by one model variant.
+    pub async fn purge_model_cache(&self, variant: ModelVariant) -> CacheReleaseReport {
+        self.core.write().await.purge_model_cache(variant).await
     }
 
     /// Abort every request currently tracked by the engine.

--- a/crates/izwi-core/src/engine/resources.rs
+++ b/crates/izwi-core/src/engine/resources.rs
@@ -406,7 +406,7 @@ impl AuthorityState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReservationEnforcement {
     Guarded,
-    TrackedModel,
+    Tracked,
 }
 
 /// One transactional authority for every physical-memory consumer on a backend.
@@ -476,11 +476,24 @@ impl ResourceAuthority {
         key: impl Into<String>,
         resources: ResourceVector,
     ) -> Result<ResourceLease> {
-        self.reserve_internal(
+        self.track_advisory(
             ReservationOwner::new(ReservationClass::Model, key),
             resources,
+        )
+    }
+
+    /// Track an advisory CPU/unified-memory claim in the resource ledger while
+    /// allowing its authorization to follow exact observed pooled storage.
+    pub(crate) fn track_advisory(
+        self: &Arc<Self>,
+        owner: ReservationOwner,
+        resources: ResourceVector,
+    ) -> Result<ResourceLease> {
+        self.reserve_internal(
+            owner,
+            resources,
             ResourceVector::zero(),
-            ReservationEnforcement::TrackedModel,
+            ReservationEnforcement::Tracked,
         )
     }
 
@@ -531,7 +544,7 @@ impl ResourceAuthority {
                 }
                 state.ledger.reserve(resources)?
             }
-            ReservationEnforcement::TrackedModel => state.ledger.track(resources)?,
+            ReservationEnforcement::Tracked => state.ledger.track(resources)?,
         };
         state.owners.insert(reservation.id, owner);
         state.materialized.insert(reservation.id, materialized);

--- a/crates/izwi-core/src/kernels/cuda.rs
+++ b/crates/izwi-core/src/kernels/cuda.rs
@@ -5,7 +5,7 @@
 //! by `Device::is_cuda()` and fall back to the caller's existing implementation
 //! when a shape, dtype, or build does not support the operation.
 
-use candle_core::{DType, Tensor, D};
+use candle_core::{CpuStorage, CustomOp3, DType, Layout, Shape, Tensor, D};
 
 use crate::kernels::FusedSiluMulResult;
 
@@ -99,6 +99,62 @@ pub fn try_fused_gated_rms_norm(
     normalized.broadcast_mul(&silu_gate).ok()
 }
 
+pub fn try_qwen35_causal_conv_sequence(
+    input: &Tensor,
+    weight: &Tensor,
+    history: &Tensor,
+) -> Option<(Tensor, Tensor)> {
+    if !cuda_tensor_pair_supported(input, weight)
+        || !cuda_tensor_pair_supported(input, history)
+        || input.dtype() != DType::F32
+    {
+        return None;
+    }
+    let (batch, sequence, conv_dim) = input.dims3().ok()?;
+    let (weight_channels, kernel_size) = weight.dims2().ok()?;
+    let (history_channels, history_len) = history.dims2().ok()?;
+    if batch != 1
+        || sequence == 0
+        || conv_dim == 0
+        || kernel_size < 2
+        || weight_channels != conv_dim
+        || history_channels != conv_dim
+        || history_len != kernel_size - 1
+    {
+        return None;
+    }
+
+    let input = input.contiguous().ok()?;
+    let weight = weight.contiguous().ok()?;
+    let history = history.contiguous().ok()?;
+    let output_elements = sequence.checked_mul(conv_dim)?;
+    let state_elements = history_len.checked_mul(conv_dim)?;
+    let packed = input
+        .apply_op3_no_bwd(
+            &weight,
+            &history,
+            &CudaCausalConvSequenceOp {
+                conv_dim,
+                sequence,
+                kernel_size,
+            },
+        )
+        .ok()?;
+    let output = packed
+        .narrow(0, 0, output_elements)
+        .ok()?
+        .reshape((1, sequence, conv_dim))
+        .ok()?;
+    let final_history = packed
+        .narrow(0, output_elements, state_elements)
+        .ok()?
+        .reshape((conv_dim, history_len))
+        .ok()?
+        .force_contiguous()
+        .ok()?;
+    Some((output, final_history))
+}
+
 pub fn try_fused_gated_delta_recurrent(
     query: &Tensor,
     key: &Tensor,
@@ -117,7 +173,14 @@ pub fn try_fused_gated_delta_recurrent(
         return None;
     }
 
-    fused_gated_delta_candle(query, key, value, g, beta, state)
+    let queries = query.unsqueeze(1).ok()?;
+    let keys = key.unsqueeze(1).ok()?;
+    let values = value.unsqueeze(1).ok()?;
+    let gates = g.unsqueeze(1).ok()?;
+    let betas = beta.unsqueeze(1).ok()?;
+    let (outputs, next_state) =
+        cuda_gated_delta_sequence(&queries, &keys, &values, &gates, &betas, state)?;
+    Some((outputs.squeeze(1).ok()?, next_state))
 }
 
 pub fn try_tiled_deltanet_recurrence(
@@ -127,7 +190,7 @@ pub fn try_tiled_deltanet_recurrence(
     g: &Tensor,
     beta: &Tensor,
     initial_state: &Tensor,
-    tile_size: usize,
+    _tile_size: usize,
 ) -> Option<(Tensor, Tensor)> {
     if !cuda_tensor_pair_supported(queries, keys)
         || !cuda_tensor_pair_supported(queries, values)
@@ -141,10 +204,10 @@ pub fn try_tiled_deltanet_recurrence(
 
     let (batch, seq_len, num_heads, head_k_dim) = queries.dims4().ok()?;
     let (k_batch, k_seq_len, k_num_heads, k_head_k_dim) = keys.dims4().ok()?;
-    let (v_batch, v_seq_len, v_num_heads, _v_head_dim) = values.dims4().ok()?;
+    let (v_batch, v_seq_len, v_num_heads, v_head_dim) = values.dims4().ok()?;
     let (g_batch, g_seq_len, g_heads) = g.dims3().ok()?;
     let (b_batch, b_seq_len, b_heads) = beta.dims3().ok()?;
-    let (s_batch, s_heads, s_head_k_dim, _s_head_v_dim) = initial_state.dims4().ok()?;
+    let (s_batch, s_heads, s_head_k_dim, s_head_v_dim) = initial_state.dims4().ok()?;
 
     if batch != 1
         || k_batch != batch
@@ -165,33 +228,11 @@ pub fn try_tiled_deltanet_recurrence(
     if b_heads != num_heads || k_head_k_dim != head_k_dim || s_heads != num_heads {
         return None;
     }
-    if s_head_k_dim != head_k_dim {
+    if s_head_k_dim != head_k_dim || s_head_v_dim != v_head_dim {
         return None;
     }
 
-    let tile_size = tile_size.max(1).min(seq_len.max(1));
-    let mut outputs = Vec::with_capacity(seq_len);
-    let mut state = initial_state.clone();
-
-    for tile_start in (0..seq_len).step_by(tile_size) {
-        let tile_end = (tile_start + tile_size).min(seq_len);
-        for token_idx in tile_start..tile_end {
-            let query = queries.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-            let key = keys.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-            let value = values.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-            let g_t = g.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-            let beta_t = beta.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-
-            let (output, next_state) =
-                fused_gated_delta_candle(&query, &key, &value, &g_t, &beta_t, &state)?;
-            outputs.push(output.unsqueeze(1).ok()?);
-            state = next_state;
-        }
-    }
-
-    let output_refs: Vec<&Tensor> = outputs.iter().collect();
-    let outputs = Tensor::cat(&output_refs, 1).ok()?;
-    Some((outputs, state))
+    cuda_gated_delta_sequence(queries, keys, values, g, beta, initial_state)
 }
 
 fn cuda_tensor_supported(tensor: &Tensor) -> bool {
@@ -202,45 +243,287 @@ fn cuda_tensor_pair_supported(lhs: &Tensor, rhs: &Tensor) -> bool {
     cuda_tensor_supported(lhs) && rhs.device().is_cuda() && lhs.dtype() == rhs.dtype()
 }
 
-fn fused_gated_delta_candle(
-    query: &Tensor,
-    key: &Tensor,
-    value: &Tensor,
+fn cuda_gated_delta_sequence(
+    queries: &Tensor,
+    keys: &Tensor,
+    values: &Tensor,
     g: &Tensor,
     beta: &Tensor,
-    state: &Tensor,
+    initial_state: &Tensor,
 ) -> Option<(Tensor, Tensor)> {
-    let dim = query.dim(D::Minus1).ok()?;
-    let scale = 1.0f64 / (dim as f64).sqrt();
-    let scaled_query = (query * scale).ok()?;
-    let g = g.exp().ok()?.reshape((1, g.dim(1).ok()?, 1, 1)).ok()?;
-    let beta = beta.reshape((1, beta.dim(1).ok()?, 1)).ok()?;
+    let (batch, sequence, heads, key_dim) = queries.dims4().ok()?;
+    let (key_batch, key_sequence, key_heads, key_width) = keys.dims4().ok()?;
+    let (value_batch, value_sequence, value_heads, value_dim) = values.dims4().ok()?;
+    let (g_batch, g_sequence, g_heads) = g.dims3().ok()?;
+    let (beta_batch, beta_sequence, beta_heads) = beta.dims3().ok()?;
+    let (state_batch, state_heads, state_key_dim, state_value_dim) = initial_state.dims4().ok()?;
+    if sequence == 0 || heads == 0 || key_dim == 0 || value_dim == 0 {
+        return None;
+    }
+    if (key_batch, key_sequence, key_heads, key_width) != (batch, sequence, heads, key_dim)
+        || (value_batch, value_sequence, value_heads) != (batch, sequence, heads)
+        || (g_batch, g_sequence, g_heads) != (batch, sequence, heads)
+        || (beta_batch, beta_sequence, beta_heads) != (batch, sequence, heads)
+        || (state_batch, state_heads, state_key_dim, state_value_dim)
+            != (batch, heads, key_dim, value_dim)
+    {
+        return None;
+    }
 
-    let gated_state = state.broadcast_mul(&g).ok()?;
-    let kv_mem = key
-        .unsqueeze(2)
+    let qkv = Tensor::cat(&[queries, keys, values], D::Minus1)
         .ok()?
-        .matmul(&gated_state)
-        .ok()?
-        .squeeze(2)
+        .contiguous()
         .ok()?;
-    let delta = (value - kv_mem).ok()?.broadcast_mul(&beta).ok()?;
-    let new_state = (&gated_state
-        + &key
-            .unsqueeze(3)
-            .ok()?
-            .matmul(&delta.unsqueeze(2).ok()?)
-            .ok()?)
-        .ok()?;
-    let output = scaled_query
-        .unsqueeze(2)
-        .ok()?
-        .matmul(&new_state)
-        .ok()?
-        .squeeze(2)
+    let gates = Tensor::cat(
+        &[
+            &g.unsqueeze(D::Minus1).ok()?,
+            &beta.unsqueeze(D::Minus1).ok()?,
+        ],
+        D::Minus1,
+    )
+    .ok()?
+    .contiguous()
+    .ok()?;
+    let initial_state = initial_state.contiguous().ok()?;
+    let packed = qkv
+        .apply_op3_no_bwd(
+            &gates,
+            &initial_state,
+            &CudaGatedDeltaSequenceOp {
+                batch,
+                sequence,
+                heads,
+                key_dim,
+                value_dim,
+            },
+        )
         .ok()?;
 
-    Some((output, new_state))
+    let output_elements = batch * sequence * heads * value_dim;
+    let state_elements = batch * heads * key_dim * value_dim;
+    let outputs = packed
+        .narrow(0, 0, output_elements)
+        .ok()?
+        .reshape((batch, sequence, heads, value_dim))
+        .ok()?;
+    let next_state = packed
+        .narrow(0, output_elements, state_elements)
+        .ok()?
+        .reshape((batch, heads, key_dim, value_dim))
+        .ok()?
+        // The packed custom-op result also contains sequence outputs. Detach
+        // the persistent state so it retains only its exact live allocation.
+        .force_contiguous()
+        .ok()?;
+    Some((outputs, next_state))
+}
+
+struct CudaCausalConvSequenceOp {
+    conv_dim: usize,
+    sequence: usize,
+    kernel_size: usize,
+}
+
+impl CustomOp3 for CudaCausalConvSequenceOp {
+    fn name(&self) -> &'static str {
+        "qwen35-causal-conv-sequence"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _input: &CpuStorage,
+        _input_layout: &Layout,
+        _weight: &CpuStorage,
+        _weight_layout: &Layout,
+        _history: &CpuStorage,
+        _history_layout: &Layout,
+    ) -> candle_core::Result<(CpuStorage, Shape)> {
+        candle_core::bail!("Qwen3.5 CUDA causal convolution has no CPU implementation")
+    }
+
+    #[cfg(feature = "cuda")]
+    fn cuda_fwd(
+        &self,
+        input: &candle_core::CudaStorage,
+        input_layout: &Layout,
+        weight: &candle_core::CudaStorage,
+        weight_layout: &Layout,
+        history: &candle_core::CudaStorage,
+        history_layout: &Layout,
+    ) -> candle_core::Result<(candle_core::CudaStorage, Shape)> {
+        use candle_core::backend::BackendStorage;
+        use candle_core::cuda_backend::cudarc::driver::{LaunchConfig, PushKernelArg};
+        use candle_core::cuda_backend::{CudaStorageSlice, WrapErr};
+
+        fn contiguous_slice<'a>(
+            storage: &'a CudaStorageSlice,
+            layout: &Layout,
+            name: &str,
+        ) -> candle_core::Result<candle_core::cuda_backend::cudarc::driver::CudaView<'a, f32>>
+        {
+            let CudaStorageSlice::F32(slice) = storage else {
+                candle_core::bail!("{name} must use F32 storage")
+            };
+            let Some((start, end)) = layout.contiguous_offsets() else {
+                candle_core::bail!("{name} must be contiguous")
+            };
+            Ok(slice.slice(start..end))
+        }
+
+        let input_slice = contiguous_slice(&input.slice, input_layout, "input")?;
+        let weight_slice = contiguous_slice(&weight.slice, weight_layout, "weight")?;
+        let history_slice = contiguous_slice(&history.slice, history_layout, "history")?;
+        let output_elements = self.sequence.checked_mul(self.conv_dim).ok_or_else(|| {
+            candle_core::Error::Msg("Qwen3.5 CUDA convolution output overflow".to_string())
+        })?;
+        let state_elements = (self.kernel_size - 1)
+            .checked_mul(self.conv_dim)
+            .ok_or_else(|| {
+                candle_core::Error::Msg("Qwen3.5 CUDA convolution state overflow".to_string())
+            })?;
+        let total_elements = output_elements.checked_add(state_elements).ok_or_else(|| {
+            candle_core::Error::Msg("Qwen3.5 CUDA convolution allocation overflow".to_string())
+        })?;
+        if total_elements > i32::MAX as usize {
+            candle_core::bail!("Qwen3.5 CUDA convolution tensor is too large")
+        }
+        let device = input.device();
+        // SAFETY: the custom kernel writes every element before the storage is observed.
+        let output = unsafe { device.alloc::<f32>(total_elements)? };
+        let function = device.get_or_load_custom_func(
+            "qwen35_causal_conv_sequence_f32",
+            "izwi_qwen35_causal_conv_sequence",
+            qwen35_cuda_ptx::QWEN35,
+        )?;
+        let config = LaunchConfig::for_num_elems(total_elements as u32);
+        let mut builder = function.builder();
+        builder.arg(&input_slice);
+        builder.arg(&weight_slice);
+        builder.arg(&history_slice);
+        builder.arg(&output);
+        candle_core::builder_arg!(
+            builder,
+            self.conv_dim as i32,
+            self.sequence as i32,
+            self.kernel_size as i32,
+            output_elements as i32,
+            total_elements as i32
+        );
+        // SAFETY: argument types and element bounds match the CUDA kernel signature.
+        unsafe { builder.launch(config) }.w()?;
+
+        Ok((
+            candle_core::CudaStorage {
+                slice: CudaStorageSlice::F32(output),
+                device: device.clone(),
+            },
+            Shape::from_dims(&[total_elements]),
+        ))
+    }
+}
+
+struct CudaGatedDeltaSequenceOp {
+    batch: usize,
+    sequence: usize,
+    heads: usize,
+    key_dim: usize,
+    value_dim: usize,
+}
+
+impl CustomOp3 for CudaGatedDeltaSequenceOp {
+    fn name(&self) -> &'static str {
+        "qwen35-gated-delta-sequence"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _qkv: &CpuStorage,
+        _qkv_layout: &Layout,
+        _gates: &CpuStorage,
+        _gates_layout: &Layout,
+        _state: &CpuStorage,
+        _state_layout: &Layout,
+    ) -> candle_core::Result<(CpuStorage, Shape)> {
+        candle_core::bail!("Qwen3.5 CUDA recurrence has no CPU implementation")
+    }
+
+    #[cfg(feature = "cuda")]
+    fn cuda_fwd(
+        &self,
+        qkv: &candle_core::CudaStorage,
+        qkv_layout: &Layout,
+        gates: &candle_core::CudaStorage,
+        gates_layout: &Layout,
+        state: &candle_core::CudaStorage,
+        state_layout: &Layout,
+    ) -> candle_core::Result<(candle_core::CudaStorage, Shape)> {
+        use candle_core::backend::BackendStorage;
+        use candle_core::cuda_backend::cudarc::driver::{LaunchConfig, PushKernelArg};
+        use candle_core::cuda_backend::{CudaStorageSlice, WrapErr};
+
+        fn contiguous_slice<'a>(
+            storage: &'a CudaStorageSlice,
+            layout: &Layout,
+            name: &str,
+        ) -> candle_core::Result<candle_core::cuda_backend::cudarc::driver::CudaView<'a, f32>>
+        {
+            let CudaStorageSlice::F32(slice) = storage else {
+                candle_core::bail!("{name} must use F32 storage")
+            };
+            let Some((start, end)) = layout.contiguous_offsets() else {
+                candle_core::bail!("{name} must be contiguous")
+            };
+            Ok(slice.slice(start..end))
+        }
+
+        let qkv_slice = contiguous_slice(&qkv.slice, qkv_layout, "qkv")?;
+        let gates_slice = contiguous_slice(&gates.slice, gates_layout, "gates")?;
+        let state_slice = contiguous_slice(&state.slice, state_layout, "initial_state")?;
+        let device = qkv.device();
+        let output_elements = self.batch * self.sequence * self.heads * self.value_dim;
+        let state_elements = self.batch * self.heads * self.key_dim * self.value_dim;
+        // SAFETY: the custom kernel writes every element before the storage is observed.
+        let output = unsafe { device.alloc::<f32>(output_elements + state_elements)? };
+        let function = device.get_or_load_custom_func(
+            "qwen35_gated_delta_sequence_f32",
+            "izwi_qwen35_gated_delta_sequence",
+            qwen35_cuda_ptx::QWEN35,
+        )?;
+        let block_size = self.value_dim.next_power_of_two().clamp(32, 256) as u32;
+        let config = LaunchConfig {
+            grid_dim: ((self.batch * self.heads) as u32, 1, 1),
+            block_dim: (block_size, 1, 1),
+            shared_mem_bytes: 0,
+        };
+        let mut builder = function.builder();
+        builder.arg(&qkv_slice);
+        builder.arg(&gates_slice);
+        builder.arg(&state_slice);
+        builder.arg(&output);
+        candle_core::builder_arg!(
+            builder,
+            self.batch as i32,
+            self.sequence as i32,
+            self.heads as i32,
+            self.key_dim as i32,
+            self.value_dim as i32
+        );
+        // SAFETY: argument types and launch dimensions match the CUDA kernel signature.
+        unsafe { builder.launch(config) }.w()?;
+
+        Ok((
+            candle_core::CudaStorage {
+                slice: CudaStorageSlice::F32(output),
+                device: device.clone(),
+            },
+            Shape::from_dims(&[output_elements + state_elements]),
+        ))
+    }
+}
+
+#[cfg(feature = "cuda")]
+mod qwen35_cuda_ptx {
+    include!(concat!(env!("OUT_DIR"), "/qwen35_ptx.rs"));
 }
 
 #[cfg(test)]

--- a/crates/izwi-core/src/kernels/cuda.rs
+++ b/crates/izwi-core/src/kernels/cuda.rs
@@ -149,8 +149,6 @@ pub fn try_qwen35_causal_conv_sequence(
         .narrow(0, output_elements, state_elements)
         .ok()?
         .reshape((conv_dim, history_len))
-        .ok()?
-        .force_contiguous()
         .ok()?;
     Some((output, final_history))
 }
@@ -190,7 +188,7 @@ pub fn try_tiled_deltanet_recurrence(
     g: &Tensor,
     beta: &Tensor,
     initial_state: &Tensor,
-    _tile_size: usize,
+    tile_size: usize,
 ) -> Option<(Tensor, Tensor)> {
     if !cuda_tensor_pair_supported(queries, keys)
         || !cuda_tensor_pair_supported(queries, values)
@@ -198,6 +196,7 @@ pub fn try_tiled_deltanet_recurrence(
         || !cuda_tensor_pair_supported(queries, beta)
         || !cuda_tensor_pair_supported(queries, initial_state)
         || queries.dtype() != DType::F32
+        || tile_size == 0
     {
         return None;
     }
@@ -232,7 +231,33 @@ pub fn try_tiled_deltanet_recurrence(
         return None;
     }
 
-    cuda_gated_delta_sequence(queries, keys, values, g, beta, initial_state)
+    let tile_size = tile_size.min(seq_len.max(1));
+    if tile_size >= seq_len {
+        return cuda_gated_delta_sequence(queries, keys, values, g, beta, initial_state);
+    }
+
+    let mut outputs = Vec::with_capacity(seq_len.div_ceil(tile_size));
+    let mut state = initial_state.clone();
+    for token_start in (0..seq_len).step_by(tile_size) {
+        let token_count = tile_size.min(seq_len - token_start);
+        let query_tile = queries.narrow(1, token_start, token_count).ok()?;
+        let key_tile = keys.narrow(1, token_start, token_count).ok()?;
+        let value_tile = values.narrow(1, token_start, token_count).ok()?;
+        let g_tile = g.narrow(1, token_start, token_count).ok()?;
+        let beta_tile = beta.narrow(1, token_start, token_count).ok()?;
+        let (output, next_state) = cuda_gated_delta_sequence(
+            &query_tile,
+            &key_tile,
+            &value_tile,
+            &g_tile,
+            &beta_tile,
+            &state,
+        )?;
+        outputs.push(output);
+        state = next_state;
+    }
+    let output_refs = outputs.iter().collect::<Vec<_>>();
+    Some((Tensor::cat(&output_refs, 1).ok()?, state))
 }
 
 fn cuda_tensor_supported(tensor: &Tensor) -> bool {
@@ -310,10 +335,6 @@ fn cuda_gated_delta_sequence(
         .narrow(0, output_elements, state_elements)
         .ok()?
         .reshape((batch, heads, key_dim, value_dim))
-        .ok()?
-        // The packed custom-op result also contains sequence outputs. Detach
-        // the persistent state so it retains only its exact live allocation.
-        .force_contiguous()
         .ok()?;
     Some((outputs, next_state))
 }

--- a/crates/izwi-core/src/kernels/cuda/qwen35.cu
+++ b/crates/izwi-core/src/kernels/cuda/qwen35.cu
@@ -1,0 +1,103 @@
+#include <math.h>
+
+extern "C" __global__ void qwen35_causal_conv_sequence_f32(
+    const float* __restrict__ input,
+    const float* __restrict__ weight,
+    const float* __restrict__ history,
+    float* __restrict__ packed_output,
+    int conv_dim,
+    int sequence,
+    int kernel_size,
+    int output_elements,
+    int total_elements) {
+  const int gid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (gid >= total_elements) return;
+
+  const int history_len = kernel_size - 1;
+  if (gid < output_elements) {
+    const int token_idx = gid / conv_dim;
+    const int channel_idx = gid - token_idx * conv_dim;
+    float value = 0.0f;
+    for (int tap = 0; tap < kernel_size; ++tap) {
+      const int source_idx = token_idx + tap;
+      const float source = source_idx < history_len
+          ? history[channel_idx * history_len + source_idx]
+          : input[(source_idx - history_len) * conv_dim + channel_idx];
+      value += source * weight[channel_idx * kernel_size + tap];
+    }
+    packed_output[gid] = value / (1.0f + expf(-value));
+    return;
+  }
+
+  const int state_idx = gid - output_elements;
+  const int channel_idx = state_idx / history_len;
+  const int history_idx = state_idx - channel_idx * history_len;
+  const int source_idx = sequence + history_idx;
+  packed_output[gid] = source_idx < history_len
+      ? history[channel_idx * history_len + source_idx]
+      : input[(source_idx - history_len) * conv_dim + channel_idx];
+}
+
+// Qwen3.5 Gated DeltaNet sequence recurrence for F32 tensors.
+//
+// One CUDA block owns one (batch, head) pair. Each lane owns one or more
+// value columns, so the complete recurrent state remains on-device for the
+// whole sequence and no synchronization is needed between value columns.
+extern "C" __global__ void qwen35_gated_delta_sequence_f32(
+    const float* __restrict__ qkv,
+    const float* __restrict__ gates,
+    const float* __restrict__ initial_state,
+    float* __restrict__ packed_output,
+    int batch,
+    int sequence,
+    int heads,
+    int key_dim,
+    int value_dim) {
+  const int batch_head = blockIdx.x;
+  if (batch_head >= batch * heads) {
+    return;
+  }
+  const int batch_idx = batch_head / heads;
+  const int head_idx = batch_head - batch_idx * heads;
+  const int output_elements = batch * sequence * heads * value_dim;
+  float* state = packed_output + output_elements;
+  const int state_base = batch_head * key_dim * value_dim;
+
+  for (int index = threadIdx.x; index < key_dim * value_dim;
+       index += blockDim.x) {
+    state[state_base + index] = initial_state[state_base + index];
+  }
+  __syncthreads();
+
+  const float query_scale = rsqrtf((float)key_dim);
+  const int qkv_width = key_dim * 2 + value_dim;
+  for (int value_idx = threadIdx.x; value_idx < value_dim;
+       value_idx += blockDim.x) {
+    for (int token_idx = 0; token_idx < sequence; ++token_idx) {
+      const int token_head = (batch_idx * sequence + token_idx) * heads + head_idx;
+      const int qkv_base = token_head * qkv_width;
+      const int gate_base = token_head * 2;
+      const float decay = expf(gates[gate_base]);
+      const float beta = gates[gate_base + 1];
+
+      float recalled_value = 0.0f;
+      for (int key_idx = 0; key_idx < key_dim; ++key_idx) {
+        const int state_idx = state_base + key_idx * value_dim + value_idx;
+        recalled_value += qkv[qkv_base + key_dim + key_idx]
+                            * (decay * state[state_idx]);
+      }
+      const float delta =
+          (qkv[qkv_base + key_dim * 2 + value_idx] - recalled_value) * beta;
+
+      float result = 0.0f;
+      for (int key_idx = 0; key_idx < key_dim; ++key_idx) {
+        const int state_idx = state_base + key_idx * value_dim + value_idx;
+        const float next_state = decay * state[state_idx]
+                                 + qkv[qkv_base + key_dim + key_idx] * delta;
+        state[state_idx] = next_state;
+        result += qkv[qkv_base + key_idx] * query_scale * next_state;
+      }
+      packed_output[token_head * value_dim + value_idx] = result;
+    }
+  }
+}

--- a/crates/izwi-core/src/kernels/metal.rs
+++ b/crates/izwi-core/src/kernels/metal.rs
@@ -516,6 +516,9 @@ kernel void izwi_qwen35_gated_delta_sequence_f32(
     constant uint& qkv_width [[buffer(9)]],
     constant uint& output_elem_count [[buffer(10)]],
     constant float& query_scale [[buffer(11)]],
+    constant uint& token_start [[buffer(12)]],
+    constant uint& token_count [[buffer(13)]],
+    constant uint& initialize_state [[buffer(14)]],
     uint tid [[thread_index_in_threadgroup]],
     uint head [[threadgroup_position_in_grid]],
     uint threads_per_threadgroup [[threads_per_threadgroup]]
@@ -529,10 +532,12 @@ kernel void izwi_qwen35_gated_delta_sequence_f32(
     const uint state_head_size = head_k_dim * head_v_dim;
     const uint state_base = output_elem_count + head * state_head_size;
     const uint initial_state_base = head * state_head_size;
-    for (uint idx = tid; idx < state_head_size; idx += threads_per_threadgroup) {
-        output[state_base + idx] = initial_state[initial_state_base + idx];
+    if (initialize_state != 0) {
+        for (uint idx = tid; idx < state_head_size; idx += threads_per_threadgroup) {
+            output[state_base + idx] = initial_state[initial_state_base + idx];
+        }
     }
-    threadgroup_barrier(mem_flags::mem_threadgroup);
+    threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
 
     // GGUF conversion stores V heads in tiled order, so the matching K head is
     // `v_head % num_k_heads` for both 16K/16V and 16K/32V layouts.
@@ -540,7 +545,8 @@ kernel void izwi_qwen35_gated_delta_sequence_f32(
     const uint key_width = num_k_heads * head_k_dim;
     const uint value_offset = key_width * 2;
 
-    for (uint token = 0; token < seq_len; token++) {
+    const uint token_end = min(token_start + token_count, seq_len);
+    for (uint token = token_start; token < token_end; token++) {
         const uint qkv_base = token * qkv_width;
         const uint query_base = qkv_base + key_head * head_k_dim;
         const uint key_base = qkv_base + key_width + key_head * head_k_dim;
@@ -552,7 +558,7 @@ kernel void izwi_qwen35_gated_delta_sequence_f32(
         for (uint idx = tid; idx < state_head_size; idx += threads_per_threadgroup) {
             output[state_base + idx] *= decay;
         }
-        threadgroup_barrier(mem_flags::mem_threadgroup);
+        threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
 
         for (uint value_dim = tid; value_dim < head_v_dim; value_dim += threads_per_threadgroup) {
             float memory = 0.0f;
@@ -562,14 +568,14 @@ kernel void izwi_qwen35_gated_delta_sequence_f32(
             }
             delta[value_dim] = (qkv[value_base + value_dim] - memory) * beta;
         }
-        threadgroup_barrier(mem_flags::mem_threadgroup);
+        threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
 
         for (uint idx = tid; idx < state_head_size; idx += threads_per_threadgroup) {
             const uint key_dim = idx / head_v_dim;
             const uint value_dim = idx - key_dim * head_v_dim;
             output[state_base + idx] += qkv[key_base + key_dim] * delta[value_dim];
         }
-        threadgroup_barrier(mem_flags::mem_threadgroup);
+        threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
 
         for (uint value_dim = tid; value_dim < head_v_dim; value_dim += threads_per_threadgroup) {
             float recurrent_value = 0.0f;
@@ -581,7 +587,7 @@ kernel void izwi_qwen35_gated_delta_sequence_f32(
         }
         // No thread may begin decaying the next state until every output read
         // for the current token has completed.
-        threadgroup_barrier(mem_flags::mem_threadgroup);
+        threadgroup_barrier(mem_flags::mem_threadgroup | mem_flags::mem_device);
     }
 }
 
@@ -2032,6 +2038,7 @@ fn qwen35_causal_conv_sequence_pipeline(device: &MetalDevice) -> CandleResult<Co
 #[derive(Debug, Clone, Copy)]
 struct Qwen35GatedDeltaSequenceOp {
     seq_len: usize,
+    tile_size: usize,
     num_k_heads: usize,
     num_v_heads: usize,
     head_k_dim: usize,
@@ -2080,6 +2087,7 @@ impl CustomOp3 for Qwen35GatedDeltaSequenceOp {
             bail!("izwi-qwen35-gated-delta-sequence-metal requires contiguous tensors")
         }
         if self.seq_len == 0
+            || self.tile_size == 0
             || self.num_k_heads != 16
             || !matches!(self.num_v_heads, 16 | 32)
             || self.num_v_heads % self.num_k_heads != 0
@@ -2193,18 +2201,29 @@ impl CustomOp3 for Qwen35GatedDeltaSequenceOp {
             .min(pipeline.max_total_threads_per_threadgroup())
             .min(256)
             .max(1);
-        encoder.dispatch_thread_groups(
-            objc2_metal::MTLSize {
-                width: self.num_v_heads,
-                height: 1,
-                depth: 1,
-            },
-            objc2_metal::MTLSize {
-                width: threads_per_threadgroup,
-                height: 1,
-                depth: 1,
-            },
-        );
+        let threadgroups = objc2_metal::MTLSize {
+            width: self.num_v_heads,
+            height: 1,
+            depth: 1,
+        };
+        let threads = objc2_metal::MTLSize {
+            width: threads_per_threadgroup,
+            height: 1,
+            depth: 1,
+        };
+        let tile_size = self.tile_size.min(self.seq_len);
+        for token_start in (0..self.seq_len).step_by(tile_size) {
+            if token_start != 0 {
+                // Each tile consumes the recurrent state written into the
+                // packed output buffer by the preceding dispatch.
+                encoder.insert_memory_barrier();
+            }
+            let token_count = tile_size.min(self.seq_len - token_start);
+            encoder.set_bytes(12, &(token_start as u32));
+            encoder.set_bytes(13, &(token_count as u32));
+            encoder.set_bytes(14, &u32::from(token_start == 0));
+            encoder.dispatch_thread_groups(threadgroups, threads);
+        }
         drop(encoder);
 
         Ok((
@@ -2943,7 +2962,7 @@ pub fn try_fused_gated_rms_norm(
     rms_out.broadcast_mul(&silu_gate).ok()
 }
 
-/// Try the reference Qwen3.5 Gated DeltaNet recurrence in one Metal dispatch.
+/// Try the reference Qwen3.5 Gated DeltaNet recurrence in bounded Metal dispatches.
 ///
 /// The shader keeps token causality inside each value-head threadgroup and
 /// evaluates state decay, delta correction, state update, and output reduction
@@ -2957,8 +2976,7 @@ pub fn try_fused_gated_rms_norm(
 /// * `g` - Pre-computed gate values [batch, seq, num_v_heads]
 /// * `beta` - Beta values [batch, seq, num_v_heads]
 /// * `initial_state` - Initial recurrent state [batch, num_v_heads, head_k_dim, head_v_dim]
-/// * `tile_size` - Retained for the backend-neutral API; the Metal dispatch
-///   processes the full supplied sequence.
+/// * `tile_size` - Maximum number of tokens processed by one Metal dispatch.
 ///
 /// # Returns
 /// (outputs, final_state) where outputs is [batch, seq, num_v_heads, head_v_dim]
@@ -2980,7 +2998,6 @@ pub fn try_tiled_deltanet_recurrence(
 
     #[cfg(feature = "metal")]
     {
-        let _ = tile_size;
         let (batch, seq_len, num_k_heads, head_k_dim) = queries.dims4().ok()?;
         let (k_batch, k_seq_len, k_num_heads, k_head_k_dim) = keys.dims4().ok()?;
         let (v_batch, v_seq_len, num_v_heads, head_v_dim) = values.dims4().ok()?;
@@ -2990,6 +3007,7 @@ pub fn try_tiled_deltanet_recurrence(
 
         if batch != 1
             || seq_len == 0
+            || tile_size == 0
             || k_batch != batch
             || v_batch != batch
             || g_batch != batch
@@ -3057,6 +3075,7 @@ pub fn try_tiled_deltanet_recurrence(
                 initial_state,
                 &Qwen35GatedDeltaSequenceOp {
                     seq_len,
+                    tile_size: tile_size.min(seq_len),
                     num_k_heads,
                     num_v_heads,
                     head_k_dim,
@@ -3619,7 +3638,10 @@ mod tests {
         let Ok(Ok(device)) = std::panic::catch_unwind(|| Device::new_metal(0)) else {
             return;
         };
-        let seq_len = 3;
+        // Cross several tile boundaries so the test also verifies that each
+        // dispatch observes the recurrent state written by the preceding one.
+        let seq_len = 17;
+        let tile_size = 4;
         let num_k_heads = 16;
         let head_k_dim = 3;
         let head_v_dim = 5;
@@ -3679,7 +3701,7 @@ mod tests {
                 &g_tensor,
                 &beta_tensor,
                 &state_tensor,
-                64,
+                tile_size,
             )
             .expect("Qwen3.5 Gated DeltaNet custom Metal op should run");
             assert_eq!(output.dtype(), DType::F32);
@@ -3719,6 +3741,9 @@ mod tests {
             64,
         )
         .is_none());
+        assert!(
+            try_tiled_deltanet_recurrence(&query, &key, &value, &g, &beta, &state, 0,).is_none()
+        );
 
         let invalid_value = Tensor::zeros((1, 2, 24, 3), DType::F32, &device).unwrap();
         let invalid_g = Tensor::zeros((1, 2, 24), DType::F32, &device).unwrap();

--- a/crates/izwi-core/src/kernels/metal.rs
+++ b/crates/izwi-core/src/kernels/metal.rs
@@ -458,6 +458,133 @@ kernel void izwi_decode_gqa_attention_f16(
     }
 }
 
+kernel void izwi_qwen35_causal_conv_sequence_f32(
+    device const float* input [[buffer(0)]],
+    device const float* weight [[buffer(1)]],
+    device const float* history [[buffer(2)]],
+    device float* output [[buffer(3)]],
+    constant uint& conv_dim [[buffer(4)]],
+    constant uint& seq_len [[buffer(5)]],
+    constant uint& kernel_size [[buffer(6)]],
+    constant uint& output_elem_count [[buffer(7)]],
+    constant uint& total_elem_count [[buffer(8)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= total_elem_count) {
+        return;
+    }
+
+    const uint history_len = kernel_size - 1;
+    if (gid < output_elem_count) {
+        const uint token = gid / conv_dim;
+        const uint channel = gid - token * conv_dim;
+        const uint weight_base = channel * kernel_size;
+        float value = 0.0f;
+        for (uint tap = 0; tap < kernel_size; tap++) {
+            const uint source_pos = token + tap;
+            const float source = source_pos < history_len
+                ? history[channel * history_len + source_pos]
+                : input[(source_pos - history_len) * conv_dim + channel];
+            value += source * weight[weight_base + tap];
+        }
+        output[gid] = value / (1.0f + exp(-value));
+        return;
+    }
+
+    // Persist the last `kernel_size - 1` raw inputs in oldest-to-newest order.
+    // This also handles chunks shorter than the history window by retaining the
+    // still-live suffix of the incoming history.
+    const uint state_idx = gid - output_elem_count;
+    const uint channel = state_idx / history_len;
+    const uint history_pos = state_idx - channel * history_len;
+    const uint source_pos = seq_len + history_pos;
+    output[gid] = source_pos < history_len
+        ? history[channel * history_len + source_pos]
+        : input[(source_pos - history_len) * conv_dim + channel];
+}
+
+kernel void izwi_qwen35_gated_delta_sequence_f32(
+    device const float* qkv [[buffer(0)]],
+    device const float* gates [[buffer(1)]],
+    device const float* initial_state [[buffer(2)]],
+    device float* output [[buffer(3)]],
+    constant uint& seq_len [[buffer(4)]],
+    constant uint& num_k_heads [[buffer(5)]],
+    constant uint& num_v_heads [[buffer(6)]],
+    constant uint& head_k_dim [[buffer(7)]],
+    constant uint& head_v_dim [[buffer(8)]],
+    constant uint& qkv_width [[buffer(9)]],
+    constant uint& output_elem_count [[buffer(10)]],
+    constant float& query_scale [[buffer(11)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint head [[threadgroup_position_in_grid]],
+    uint threads_per_threadgroup [[threads_per_threadgroup]]
+) {
+    threadgroup float delta[256];
+
+    if (head >= num_v_heads) {
+        return;
+    }
+
+    const uint state_head_size = head_k_dim * head_v_dim;
+    const uint state_base = output_elem_count + head * state_head_size;
+    const uint initial_state_base = head * state_head_size;
+    for (uint idx = tid; idx < state_head_size; idx += threads_per_threadgroup) {
+        output[state_base + idx] = initial_state[initial_state_base + idx];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // GGUF conversion stores V heads in tiled order, so the matching K head is
+    // `v_head % num_k_heads` for both 16K/16V and 16K/32V layouts.
+    const uint key_head = head % num_k_heads;
+    const uint key_width = num_k_heads * head_k_dim;
+    const uint value_offset = key_width * 2;
+
+    for (uint token = 0; token < seq_len; token++) {
+        const uint qkv_base = token * qkv_width;
+        const uint query_base = qkv_base + key_head * head_k_dim;
+        const uint key_base = qkv_base + key_width + key_head * head_k_dim;
+        const uint value_base = qkv_base + value_offset + head * head_v_dim;
+        const uint gate_base = token * num_v_heads * 2;
+        const float decay = exp(gates[gate_base + head]);
+        const float beta = gates[gate_base + num_v_heads + head];
+
+        for (uint idx = tid; idx < state_head_size; idx += threads_per_threadgroup) {
+            output[state_base + idx] *= decay;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (uint value_dim = tid; value_dim < head_v_dim; value_dim += threads_per_threadgroup) {
+            float memory = 0.0f;
+            for (uint key_dim = 0; key_dim < head_k_dim; key_dim++) {
+                memory += output[state_base + key_dim * head_v_dim + value_dim]
+                    * qkv[key_base + key_dim];
+            }
+            delta[value_dim] = (qkv[value_base + value_dim] - memory) * beta;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (uint idx = tid; idx < state_head_size; idx += threads_per_threadgroup) {
+            const uint key_dim = idx / head_v_dim;
+            const uint value_dim = idx - key_dim * head_v_dim;
+            output[state_base + idx] += qkv[key_base + key_dim] * delta[value_dim];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (uint value_dim = tid; value_dim < head_v_dim; value_dim += threads_per_threadgroup) {
+            float recurrent_value = 0.0f;
+            for (uint key_dim = 0; key_dim < head_k_dim; key_dim++) {
+                recurrent_value += output[state_base + key_dim * head_v_dim + value_dim]
+                    * (qkv[query_base + key_dim] * query_scale);
+            }
+            output[(token * num_v_heads + head) * head_v_dim + value_dim] = recurrent_value;
+        }
+        // No thread may begin decaying the next state until every output read
+        // for the current token has completed.
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+}
+
 kernel void izwi_lfm_shortconv_decode3_f32(
     device const float* cache [[buffer(0)]],
     device const float* bx [[buffer(1)]],
@@ -1734,6 +1861,391 @@ fn lfm_shortconv_sequence3_pipeline(device: &MetalDevice) -> CandleResult<Comput
     Ok(pipeline)
 }
 
+#[cfg(feature = "metal")]
+#[derive(Debug, Clone, Copy)]
+struct Qwen35CausalConvSequenceOp {
+    conv_dim: usize,
+    seq_len: usize,
+    kernel_size: usize,
+}
+
+#[cfg(feature = "metal")]
+impl CustomOp3 for Qwen35CausalConvSequenceOp {
+    fn name(&self) -> &'static str {
+        "izwi-qwen35-causal-conv-sequence-metal"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _s1: &CpuStorage,
+        _l1: &Layout,
+        _s2: &CpuStorage,
+        _l2: &Layout,
+        _s3: &CpuStorage,
+        _l3: &Layout,
+    ) -> CandleResult<(CpuStorage, Shape)> {
+        bail!("izwi-qwen35-causal-conv-sequence-metal requires Metal tensors")
+    }
+
+    fn metal_fwd(
+        &self,
+        input_storage: &MetalStorage,
+        input_layout: &Layout,
+        weight_storage: &MetalStorage,
+        weight_layout: &Layout,
+        history_storage: &MetalStorage,
+        history_layout: &Layout,
+    ) -> CandleResult<(MetalStorage, Shape)> {
+        if input_storage.dtype() != DType::F32
+            || weight_storage.dtype() != DType::F32
+            || history_storage.dtype() != DType::F32
+        {
+            bail!("izwi-qwen35-causal-conv-sequence-metal only supports F32 tensors")
+        }
+        if !input_layout.is_contiguous()
+            || !weight_layout.is_contiguous()
+            || !history_layout.is_contiguous()
+        {
+            bail!("izwi-qwen35-causal-conv-sequence-metal requires contiguous tensors")
+        }
+        if self.conv_dim == 0 || self.seq_len == 0 || self.kernel_size < 2 {
+            bail!(
+                "izwi-qwen35-causal-conv-sequence-metal requires non-empty dimensions and kernel_size >= 2"
+            )
+        }
+        let history_len = self.kernel_size - 1;
+        let Some(output_elem_count) = self.seq_len.checked_mul(self.conv_dim) else {
+            bail!("izwi-qwen35-causal-conv-sequence-metal output size overflow")
+        };
+        let Some(state_elem_count) = history_len.checked_mul(self.conv_dim) else {
+            bail!("izwi-qwen35-causal-conv-sequence-metal state size overflow")
+        };
+        let Some(weight_elem_count) = self.kernel_size.checked_mul(self.conv_dim) else {
+            bail!("izwi-qwen35-causal-conv-sequence-metal weight size overflow")
+        };
+        let Some(total_elem_count) = output_elem_count.checked_add(state_elem_count) else {
+            bail!("izwi-qwen35-causal-conv-sequence-metal packed output size overflow")
+        };
+        if input_layout.shape().elem_count() != output_elem_count
+            || weight_layout.shape().elem_count() != weight_elem_count
+            || history_layout.shape().elem_count() != state_elem_count
+        {
+            bail!("izwi-qwen35-causal-conv-sequence-metal input shape mismatch")
+        }
+        if total_elem_count > u32::MAX as usize
+            || output_elem_count > u32::MAX as usize
+            || self.conv_dim > u32::MAX as usize
+            || self.seq_len > u32::MAX as usize
+            || self.kernel_size > u32::MAX as usize
+        {
+            bail!("izwi-qwen35-causal-conv-sequence-metal tensor is too large")
+        }
+
+        let device = input_storage.device().clone();
+        let output = device.new_buffer(
+            total_elem_count,
+            DType::F32,
+            "izwi-qwen35-causal-conv-sequence",
+        )?;
+        let encoder = device.command_encoder()?;
+        encoder.set_label("izwi-qwen35-causal-conv-sequence");
+        let pipeline = qwen35_causal_conv_sequence_pipeline(device.metal_device())?;
+        encoder.set_compute_pipeline_state(&pipeline);
+
+        encoder.set_input_buffer(
+            0,
+            Some(input_storage.buffer()),
+            input_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_input_buffer(
+            1,
+            Some(weight_storage.buffer()),
+            weight_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_input_buffer(
+            2,
+            Some(history_storage.buffer()),
+            history_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_output_buffer(3, Some(&output), 0);
+        encoder.set_bytes(4, &(self.conv_dim as u32));
+        encoder.set_bytes(5, &(self.seq_len as u32));
+        encoder.set_bytes(6, &(self.kernel_size as u32));
+        encoder.set_bytes(7, &(output_elem_count as u32));
+        encoder.set_bytes(8, &(total_elem_count as u32));
+
+        let threads_per_threadgroup = pipeline.max_total_threads_per_threadgroup().min(256).max(1);
+        encoder.dispatch_threads(
+            objc2_metal::MTLSize {
+                width: total_elem_count,
+                height: 1,
+                depth: 1,
+            },
+            objc2_metal::MTLSize {
+                width: threads_per_threadgroup,
+                height: 1,
+                depth: 1,
+            },
+        );
+        drop(encoder);
+
+        Ok((
+            MetalStorage::new(output, device, total_elem_count, DType::F32),
+            Shape::from(total_elem_count),
+        ))
+    }
+}
+
+#[cfg(feature = "metal")]
+fn qwen35_causal_conv_sequence_pipeline(device: &MetalDevice) -> CandleResult<ComputePipeline> {
+    static PIPELINES: OnceLock<Mutex<HashMap<u64, ComputePipeline>>> = OnceLock::new();
+    let registry_id = device.registry_id();
+    let pipelines = PIPELINES.get_or_init(|| Mutex::new(HashMap::new()));
+
+    if let Some(pipeline) = pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .get(&registry_id)
+        .cloned()
+    {
+        return Ok(pipeline);
+    }
+
+    let library = device
+        .new_library_with_source(IZWI_METAL_SOURCE, None)
+        .map_err(candle_core::Error::wrap)?;
+    let function = library
+        .get_function("izwi_qwen35_causal_conv_sequence_f32", None)
+        .map_err(candle_core::Error::wrap)?;
+    let pipeline = device
+        .new_compute_pipeline_state_with_function(&function)
+        .map_err(candle_core::Error::wrap)?;
+
+    pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .insert(registry_id, pipeline.clone());
+    Ok(pipeline)
+}
+
+#[cfg(feature = "metal")]
+#[derive(Debug, Clone, Copy)]
+struct Qwen35GatedDeltaSequenceOp {
+    seq_len: usize,
+    num_k_heads: usize,
+    num_v_heads: usize,
+    head_k_dim: usize,
+    head_v_dim: usize,
+    qkv_width: usize,
+    query_scale: f32,
+}
+
+#[cfg(feature = "metal")]
+impl CustomOp3 for Qwen35GatedDeltaSequenceOp {
+    fn name(&self) -> &'static str {
+        "izwi-qwen35-gated-delta-sequence-metal"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _s1: &CpuStorage,
+        _l1: &Layout,
+        _s2: &CpuStorage,
+        _l2: &Layout,
+        _s3: &CpuStorage,
+        _l3: &Layout,
+    ) -> CandleResult<(CpuStorage, Shape)> {
+        bail!("izwi-qwen35-gated-delta-sequence-metal requires Metal tensors")
+    }
+
+    fn metal_fwd(
+        &self,
+        qkv_storage: &MetalStorage,
+        qkv_layout: &Layout,
+        gates_storage: &MetalStorage,
+        gates_layout: &Layout,
+        state_storage: &MetalStorage,
+        state_layout: &Layout,
+    ) -> CandleResult<(MetalStorage, Shape)> {
+        if qkv_storage.dtype() != DType::F32
+            || gates_storage.dtype() != DType::F32
+            || state_storage.dtype() != DType::F32
+        {
+            bail!("izwi-qwen35-gated-delta-sequence-metal only supports F32 tensors")
+        }
+        if !qkv_layout.is_contiguous()
+            || !gates_layout.is_contiguous()
+            || !state_layout.is_contiguous()
+        {
+            bail!("izwi-qwen35-gated-delta-sequence-metal requires contiguous tensors")
+        }
+        if self.seq_len == 0
+            || self.num_k_heads != 16
+            || !matches!(self.num_v_heads, 16 | 32)
+            || self.num_v_heads % self.num_k_heads != 0
+            || self.head_k_dim == 0
+            || self.head_v_dim == 0
+            || self.head_v_dim > 256
+        {
+            bail!(
+                "izwi-qwen35-gated-delta-sequence-metal requires Qwen3.5 16K/16V or 16K/32V non-empty heads with head_v_dim <= 256"
+            )
+        }
+        let Some(key_width) = self.num_k_heads.checked_mul(self.head_k_dim) else {
+            bail!("izwi-qwen35-gated-delta-sequence-metal key width overflow")
+        };
+        let Some(value_width) = self.num_v_heads.checked_mul(self.head_v_dim) else {
+            bail!("izwi-qwen35-gated-delta-sequence-metal value width overflow")
+        };
+        let Some(expected_qkv_width) = key_width
+            .checked_mul(2)
+            .and_then(|width| width.checked_add(value_width))
+        else {
+            bail!("izwi-qwen35-gated-delta-sequence-metal qkv width overflow")
+        };
+        if self.qkv_width != expected_qkv_width {
+            bail!("izwi-qwen35-gated-delta-sequence-metal qkv width mismatch")
+        }
+        let Some(qkv_elem_count) = self.seq_len.checked_mul(self.qkv_width) else {
+            bail!("izwi-qwen35-gated-delta-sequence-metal qkv size overflow")
+        };
+        let Some(gate_elem_count) = self
+            .seq_len
+            .checked_mul(self.num_v_heads)
+            .and_then(|count| count.checked_mul(2))
+        else {
+            bail!("izwi-qwen35-gated-delta-sequence-metal gate size overflow")
+        };
+        let Some(output_elem_count) = self
+            .seq_len
+            .checked_mul(self.num_v_heads)
+            .and_then(|count| count.checked_mul(self.head_v_dim))
+        else {
+            bail!("izwi-qwen35-gated-delta-sequence-metal output size overflow")
+        };
+        let Some(state_elem_count) = self
+            .num_v_heads
+            .checked_mul(self.head_k_dim)
+            .and_then(|count| count.checked_mul(self.head_v_dim))
+        else {
+            bail!("izwi-qwen35-gated-delta-sequence-metal state size overflow")
+        };
+        let Some(total_elem_count) = output_elem_count.checked_add(state_elem_count) else {
+            bail!("izwi-qwen35-gated-delta-sequence-metal packed output size overflow")
+        };
+        if qkv_layout.shape().elem_count() != qkv_elem_count
+            || gates_layout.shape().elem_count() != gate_elem_count
+            || state_layout.shape().elem_count() != state_elem_count
+        {
+            bail!("izwi-qwen35-gated-delta-sequence-metal input shape mismatch")
+        }
+        if total_elem_count > u32::MAX as usize
+            || output_elem_count > u32::MAX as usize
+            || self.seq_len > u32::MAX as usize
+            || self.num_k_heads > u32::MAX as usize
+            || self.num_v_heads > u32::MAX as usize
+            || self.head_k_dim > u32::MAX as usize
+            || self.head_v_dim > u32::MAX as usize
+            || self.qkv_width > u32::MAX as usize
+        {
+            bail!("izwi-qwen35-gated-delta-sequence-metal tensor is too large")
+        }
+
+        let device = qkv_storage.device().clone();
+        let output = device.new_buffer(
+            total_elem_count,
+            DType::F32,
+            "izwi-qwen35-gated-delta-sequence",
+        )?;
+        let encoder = device.command_encoder()?;
+        encoder.set_label("izwi-qwen35-gated-delta-sequence");
+        let pipeline = qwen35_gated_delta_sequence_pipeline(device.metal_device())?;
+        encoder.set_compute_pipeline_state(&pipeline);
+
+        encoder.set_input_buffer(
+            0,
+            Some(qkv_storage.buffer()),
+            qkv_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_input_buffer(
+            1,
+            Some(gates_storage.buffer()),
+            gates_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_input_buffer(
+            2,
+            Some(state_storage.buffer()),
+            state_layout.start_offset() * DType::F32.size_in_bytes(),
+        );
+        encoder.set_output_buffer(3, Some(&output), 0);
+        encoder.set_bytes(4, &(self.seq_len as u32));
+        encoder.set_bytes(5, &(self.num_k_heads as u32));
+        encoder.set_bytes(6, &(self.num_v_heads as u32));
+        encoder.set_bytes(7, &(self.head_k_dim as u32));
+        encoder.set_bytes(8, &(self.head_v_dim as u32));
+        encoder.set_bytes(9, &(self.qkv_width as u32));
+        encoder.set_bytes(10, &(output_elem_count as u32));
+        encoder.set_bytes(11, &self.query_scale);
+
+        let threads_per_threadgroup = self
+            .head_v_dim
+            .next_power_of_two()
+            .min(pipeline.max_total_threads_per_threadgroup())
+            .min(256)
+            .max(1);
+        encoder.dispatch_thread_groups(
+            objc2_metal::MTLSize {
+                width: self.num_v_heads,
+                height: 1,
+                depth: 1,
+            },
+            objc2_metal::MTLSize {
+                width: threads_per_threadgroup,
+                height: 1,
+                depth: 1,
+            },
+        );
+        drop(encoder);
+
+        Ok((
+            MetalStorage::new(output, device, total_elem_count, DType::F32),
+            Shape::from(total_elem_count),
+        ))
+    }
+}
+
+#[cfg(feature = "metal")]
+fn qwen35_gated_delta_sequence_pipeline(device: &MetalDevice) -> CandleResult<ComputePipeline> {
+    static PIPELINES: OnceLock<Mutex<HashMap<u64, ComputePipeline>>> = OnceLock::new();
+    let registry_id = device.registry_id();
+    let pipelines = PIPELINES.get_or_init(|| Mutex::new(HashMap::new()));
+
+    if let Some(pipeline) = pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .get(&registry_id)
+        .cloned()
+    {
+        return Ok(pipeline);
+    }
+
+    let library = device
+        .new_library_with_source(IZWI_METAL_SOURCE, None)
+        .map_err(candle_core::Error::wrap)?;
+    let function = library
+        .get_function("izwi_qwen35_gated_delta_sequence_f32", None)
+        .map_err(candle_core::Error::wrap)?;
+    let pipeline = device
+        .new_compute_pipeline_state_with_function(&function)
+        .map_err(candle_core::Error::wrap)?;
+
+    pipelines
+        .lock()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?
+        .insert(registry_id, pipeline.clone());
+    Ok(pipeline)
+}
+
 /// Try fused gated delta recurrent computation.
 ///
 /// This fuses multiple operations:
@@ -2341,6 +2853,78 @@ pub fn try_lfm_shortconv_sequence3(bx: &Tensor, conv: &Tensor) -> Option<Tensor>
     None
 }
 
+/// Run Qwen3.5's stateful causal depthwise-convolution sequence path in one
+/// Metal dispatch. Inputs use token-major `[1, sequence, channels]` layout;
+/// history is `[channels, kernel_size - 1]` in oldest-to-newest order.
+pub fn try_qwen35_causal_conv_sequence(
+    input: &Tensor,
+    weight: &Tensor,
+    history: &Tensor,
+) -> Option<(Tensor, Tensor)> {
+    #[cfg(not(feature = "metal"))]
+    let _ = (input, weight, history);
+
+    if !use_fused_kernels() {
+        return None;
+    }
+
+    #[cfg(feature = "metal")]
+    {
+        let (batch, seq_len, conv_dim) = input.dims3().ok()?;
+        let (weight_channels, kernel_size) = weight.dims2().ok()?;
+        let (history_channels, history_len) = history.dims2().ok()?;
+        if batch != 1
+            || seq_len == 0
+            || conv_dim == 0
+            || kernel_size < 2
+            || weight_channels != conv_dim
+            || history_channels != conv_dim
+            || history_len != kernel_size - 1
+            || !input.device().is_metal()
+            || !weight.device().is_metal()
+            || !history.device().is_metal()
+            || !input.device().same_device(weight.device())
+            || !input.device().same_device(history.device())
+            || input.dtype() != DType::F32
+            || weight.dtype() != DType::F32
+            || history.dtype() != DType::F32
+            || !input.is_contiguous()
+            || !weight.is_contiguous()
+            || !history.is_contiguous()
+        {
+            return None;
+        }
+
+        let output_elem_count = seq_len.checked_mul(conv_dim)?;
+        let state_elem_count = history_len.checked_mul(conv_dim)?;
+        let packed = input
+            .apply_op3_no_bwd(
+                weight,
+                history,
+                &Qwen35CausalConvSequenceOp {
+                    conv_dim,
+                    seq_len,
+                    kernel_size,
+                },
+            )
+            .ok()?;
+        let output = packed
+            .narrow(0, 0, output_elem_count)
+            .ok()?
+            .reshape((1, seq_len, conv_dim))
+            .ok()?;
+        let final_history = packed
+            .narrow(0, output_elem_count, state_elem_count)
+            .ok()?
+            .reshape((conv_dim, history_len))
+            .ok()?;
+        return Some((output, final_history));
+    }
+
+    #[allow(unreachable_code)]
+    None
+}
+
 /// Try fused gated RMS normalization.
 ///
 /// Computes: rms_norm(x) * silu(gate)
@@ -2359,27 +2943,22 @@ pub fn try_fused_gated_rms_norm(
     rms_out.broadcast_mul(&silu_gate).ok()
 }
 
-/// Try tiled DeltaNet recurrence using Metal tile memory.
+/// Try the reference Qwen3.5 Gated DeltaNet recurrence in one Metal dispatch.
 ///
-/// This processes multiple tokens (tile_size, typically 32 or 64) while keeping
-/// the hidden state in fast tile memory instead of VRAM. This eliminates
-/// memory round-trips for the recurrence h_t = A * h_{t-1} + B.
-///
-/// The tile memory is high-speed memory local to the GPU shader. By loading
-/// the hidden state into tile memory, we can process an entire sequence of
-/// tokens without writing the state back to main VRAM.
-///
-/// This is the primary optimization that enables llama.cpp to achieve 3x
-/// higher TPS than naive implementations.
+/// The shader keeps token causality inside each value-head threadgroup and
+/// evaluates state decay, delta correction, state update, and output reduction
+/// in F32. Q/K retain the converted GGUF's 16-head tiled layout while V may
+/// contain either 16 or 32 heads.
 ///
 /// # Arguments
-/// * `queries` - Query tensors [batch, seq, num_heads, head_dim]
-/// * `keys` - Key tensors [batch, seq, num_heads, head_dim]
+/// * `queries` - Query tensors [1, seq, 16, head_k_dim]
+/// * `keys` - Key tensors [1, seq, 16, head_k_dim]
 /// * `values` - Value tensors [batch, seq, num_v_heads, head_v_dim]
 /// * `g` - Pre-computed gate values [batch, seq, num_v_heads]
 /// * `beta` - Beta values [batch, seq, num_v_heads]
 /// * `initial_state` - Initial recurrent state [batch, num_v_heads, head_k_dim, head_v_dim]
-/// * `tile_size` - Number of tokens to process per tile (32 or 64 recommended)
+/// * `tile_size` - Retained for the backend-neutral API; the Metal dispatch
+///   processes the full supplied sequence.
 ///
 /// # Returns
 /// (outputs, final_state) where outputs is [batch, seq, num_v_heads, head_v_dim]
@@ -2392,72 +2971,116 @@ pub fn try_tiled_deltanet_recurrence(
     initial_state: &Tensor,
     tile_size: usize,
 ) -> Option<(Tensor, Tensor)> {
+    #[cfg(not(feature = "metal"))]
+    let _ = (queries, keys, values, g, beta, initial_state, tile_size);
+
     if !use_fused_kernels() {
         return None;
     }
 
-    // Only supported for F32 on Metal devices
-    if queries.dtype() != DType::F32 {
-        return None;
-    }
-
-    if !queries.device().is_metal() {
-        return None;
-    }
-
-    let (batch, seq_len, num_heads, head_k_dim) = queries.dims4().ok()?;
-    let (k_batch, k_seq_len, k_num_heads, k_head_k_dim) = keys.dims4().ok()?;
-    let (v_batch, v_seq_len, v_num_heads, _v_head_dim) = values.dims4().ok()?;
-    let (g_batch, g_seq_len, g_heads) = g.dims3().ok()?;
-    let (b_batch, b_seq_len, b_heads) = beta.dims3().ok()?;
-    let (s_batch, s_heads, s_head_k_dim, _s_head_v_dim) = initial_state.dims4().ok()?;
-
-    if batch != 1
-        || k_batch != batch
-        || v_batch != batch
-        || g_batch != batch
-        || b_batch != batch
-        || s_batch != batch
+    #[cfg(feature = "metal")]
     {
-        return None;
-    }
-    if k_seq_len != seq_len || v_seq_len != seq_len || g_seq_len != seq_len || b_seq_len != seq_len
-    {
-        return None;
-    }
-    if k_num_heads != num_heads || g_heads != num_heads || b_heads != num_heads {
-        return None;
-    }
-    if k_head_k_dim != head_k_dim || s_heads != num_heads || s_head_k_dim != head_k_dim {
-        return None;
-    }
-    if v_num_heads != num_heads {
-        return None;
-    }
+        let _ = tile_size;
+        let (batch, seq_len, num_k_heads, head_k_dim) = queries.dims4().ok()?;
+        let (k_batch, k_seq_len, k_num_heads, k_head_k_dim) = keys.dims4().ok()?;
+        let (v_batch, v_seq_len, num_v_heads, head_v_dim) = values.dims4().ok()?;
+        let (g_batch, g_seq_len, g_heads) = g.dims3().ok()?;
+        let (b_batch, b_seq_len, b_heads) = beta.dims3().ok()?;
+        let (s_batch, s_heads, s_head_k_dim, s_head_v_dim) = initial_state.dims4().ok()?;
 
-    let tile_size = tile_size.max(1).min(seq_len.max(1));
-    let mut outputs = Vec::with_capacity(seq_len);
-    let mut state = initial_state.clone();
-
-    for tile_start in (0..seq_len).step_by(tile_size) {
-        let tile_end = (tile_start + tile_size).min(seq_len);
-        for token_idx in tile_start..tile_end {
-            let query = queries.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-            let key = keys.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-            let value = values.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-            let g_t = g.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-            let beta_t = beta.narrow(1, token_idx, 1).ok()?.squeeze(1).ok()?;
-
-            let (output, next_state) =
-                fused_gated_delta_sequential(&query, &key, &value, &g_t, &beta_t, &state).ok()?;
-            outputs.push(output.unsqueeze(1).ok()?);
-            state = next_state;
+        if batch != 1
+            || seq_len == 0
+            || k_batch != batch
+            || v_batch != batch
+            || g_batch != batch
+            || b_batch != batch
+            || s_batch != batch
+            || k_seq_len != seq_len
+            || v_seq_len != seq_len
+            || g_seq_len != seq_len
+            || b_seq_len != seq_len
+            || num_k_heads != 16
+            || k_num_heads != num_k_heads
+            || !matches!(num_v_heads, 16 | 32)
+            || num_v_heads % num_k_heads != 0
+            || g_heads != num_v_heads
+            || b_heads != num_v_heads
+            || s_heads != num_v_heads
+            || k_head_k_dim != head_k_dim
+            || s_head_k_dim != head_k_dim
+            || s_head_v_dim != head_v_dim
+            || head_k_dim == 0
+            || head_v_dim == 0
+            || head_v_dim > 256
+            || !queries.device().is_metal()
+            || !keys.device().is_metal()
+            || !values.device().is_metal()
+            || !g.device().is_metal()
+            || !beta.device().is_metal()
+            || !initial_state.device().is_metal()
+            || !queries.device().same_device(keys.device())
+            || !queries.device().same_device(values.device())
+            || !queries.device().same_device(g.device())
+            || !queries.device().same_device(beta.device())
+            || !queries.device().same_device(initial_state.device())
+            || queries.dtype() != DType::F32
+            || keys.dtype() != DType::F32
+            || values.dtype() != DType::F32
+            || g.dtype() != DType::F32
+            || beta.dtype() != DType::F32
+            || initial_state.dtype() != DType::F32
+            || !queries.is_contiguous()
+            || !keys.is_contiguous()
+            || !values.is_contiguous()
+            || !g.is_contiguous()
+            || !beta.is_contiguous()
+            || !initial_state.is_contiguous()
+        {
+            return None;
         }
+
+        let key_width = num_k_heads.checked_mul(head_k_dim)?;
+        let value_width = num_v_heads.checked_mul(head_v_dim)?;
+        let qkv_width = key_width.checked_mul(2)?.checked_add(value_width)?;
+        let query_flat = queries.reshape((1, seq_len, key_width)).ok()?;
+        let key_flat = keys.reshape((1, seq_len, key_width)).ok()?;
+        let value_flat = values.reshape((1, seq_len, value_width)).ok()?;
+        let qkv = Tensor::cat(&[&query_flat, &key_flat, &value_flat], 2).ok()?;
+        let gates = Tensor::cat(&[g, beta], 2).ok()?;
+        let output_elem_count = seq_len.checked_mul(num_v_heads)?.checked_mul(head_v_dim)?;
+        let state_elem_count = num_v_heads
+            .checked_mul(head_k_dim)?
+            .checked_mul(head_v_dim)?;
+        let packed = qkv
+            .apply_op3_no_bwd(
+                &gates,
+                initial_state,
+                &Qwen35GatedDeltaSequenceOp {
+                    seq_len,
+                    num_k_heads,
+                    num_v_heads,
+                    head_k_dim,
+                    head_v_dim,
+                    qkv_width,
+                    query_scale: 1.0 / (head_k_dim as f32).sqrt(),
+                },
+            )
+            .ok()?;
+        let output = packed
+            .narrow(0, 0, output_elem_count)
+            .ok()?
+            .reshape((1, seq_len, num_v_heads, head_v_dim))
+            .ok()?;
+        let final_state = packed
+            .narrow(0, output_elem_count, state_elem_count)
+            .ok()?
+            .reshape((1, num_v_heads, head_k_dim, head_v_dim))
+            .ok()?;
+        return Some((output, final_state));
     }
 
-    let output_refs: Vec<&Tensor> = outputs.iter().collect();
-    let outputs = Tensor::cat(&output_refs, 1).ok()?;
-    Some((outputs, state))
+    #[allow(unreachable_code)]
+    None
 }
 
 /// Try SIMD-group softmax for attention.
@@ -2656,6 +3279,117 @@ mod tests {
     #[cfg(all(feature = "metal", target_os = "macos"))]
     use candle_nn::Module;
 
+    fn qwen35_causal_conv_reference(
+        input: &[f32],
+        weight: &[f32],
+        history: &[f32],
+        seq_len: usize,
+        conv_dim: usize,
+        kernel_size: usize,
+    ) -> (Vec<f32>, Vec<f32>) {
+        let history_len = kernel_size - 1;
+        let mut output = vec![0f32; seq_len * conv_dim];
+        for token in 0..seq_len {
+            for channel in 0..conv_dim {
+                let mut value = 0f32;
+                for tap in 0..kernel_size {
+                    let source_pos = token + tap;
+                    let source = if source_pos < history_len {
+                        history[channel * history_len + source_pos]
+                    } else {
+                        input[(source_pos - history_len) * conv_dim + channel]
+                    };
+                    value += source * weight[channel * kernel_size + tap];
+                }
+                output[token * conv_dim + channel] = value / (1.0 + (-value).exp());
+            }
+        }
+
+        let mut final_history = vec![0f32; conv_dim * history_len];
+        for channel in 0..conv_dim {
+            for history_pos in 0..history_len {
+                let source_pos = seq_len + history_pos;
+                final_history[channel * history_len + history_pos] = if source_pos < history_len {
+                    history[channel * history_len + source_pos]
+                } else {
+                    input[(source_pos - history_len) * conv_dim + channel]
+                };
+            }
+        }
+        (output, final_history)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn qwen35_gated_delta_reference(
+        query: &[f32],
+        key: &[f32],
+        value: &[f32],
+        g: &[f32],
+        beta: &[f32],
+        initial_state: &[f32],
+        seq_len: usize,
+        num_k_heads: usize,
+        num_v_heads: usize,
+        head_k_dim: usize,
+        head_v_dim: usize,
+    ) -> (Vec<f32>, Vec<f32>) {
+        let mut state = initial_state.to_vec();
+        let mut output = vec![0f32; seq_len * num_v_heads * head_v_dim];
+        let query_scale = 1.0f32 / (head_k_dim as f32).sqrt();
+        let state_head_size = head_k_dim * head_v_dim;
+        for token in 0..seq_len {
+            for value_head in 0..num_v_heads {
+                let key_head = value_head % num_k_heads;
+                let state_base = value_head * state_head_size;
+                let key_base = (token * num_k_heads + key_head) * head_k_dim;
+                let value_base = (token * num_v_heads + value_head) * head_v_dim;
+                let decay = g[token * num_v_heads + value_head].exp();
+                for state_value in &mut state[state_base..state_base + state_head_size] {
+                    *state_value *= decay;
+                }
+
+                let mut delta = vec![0f32; head_v_dim];
+                for value_dim in 0..head_v_dim {
+                    let mut memory = 0f32;
+                    for key_dim in 0..head_k_dim {
+                        memory += state[state_base + key_dim * head_v_dim + value_dim]
+                            * key[key_base + key_dim];
+                    }
+                    delta[value_dim] = (value[value_base + value_dim] - memory)
+                        * beta[token * num_v_heads + value_head];
+                }
+
+                for key_dim in 0..head_k_dim {
+                    for value_dim in 0..head_v_dim {
+                        state[state_base + key_dim * head_v_dim + value_dim] +=
+                            key[key_base + key_dim] * delta[value_dim];
+                    }
+                }
+
+                for value_dim in 0..head_v_dim {
+                    let mut recurrent_value = 0f32;
+                    for key_dim in 0..head_k_dim {
+                        recurrent_value += state[state_base + key_dim * head_v_dim + value_dim]
+                            * (query[key_base + key_dim] * query_scale);
+                    }
+                    output[value_base + value_dim] = recurrent_value;
+                }
+            }
+        }
+        (output, state)
+    }
+
+    fn assert_f32_close(actual: &[f32], expected: &[f32], tolerance: f32, context: &str) {
+        assert_eq!(actual.len(), expected.len(), "{context} length mismatch");
+        for (idx, (&actual, &expected)) in actual.iter().zip(expected.iter()).enumerate() {
+            let bound = tolerance * (1.0 + expected.abs());
+            assert!(
+                actual.is_finite() && (actual - expected).abs() <= bound,
+                "{context} mismatch at {idx}: {actual} != {expected} (bound {bound})"
+            );
+        }
+    }
+
     #[test]
     fn test_l2_norm_matches_reference() {
         let device = Device::Cpu;
@@ -2812,6 +3546,194 @@ mod tests {
         let bx = Tensor::zeros((1, 2, 1), DType::F32, &device).unwrap();
 
         assert!(try_lfm_shortconv_update3(&cache, &bx).is_none());
+    }
+
+    #[test]
+    fn qwen35_sequence_kernels_reject_cpu_tensors() {
+        let device = Device::Cpu;
+        let conv_input = Tensor::zeros((1, 2, 8), DType::F32, &device).unwrap();
+        let conv_weight = Tensor::zeros((8, 4), DType::F32, &device).unwrap();
+        let conv_history = Tensor::zeros((8, 3), DType::F32, &device).unwrap();
+        assert!(
+            try_qwen35_causal_conv_sequence(&conv_input, &conv_weight, &conv_history).is_none()
+        );
+
+        let query = Tensor::zeros((1, 2, 16, 2), DType::F32, &device).unwrap();
+        let key = Tensor::zeros((1, 2, 16, 2), DType::F32, &device).unwrap();
+        let value = Tensor::zeros((1, 2, 16, 3), DType::F32, &device).unwrap();
+        let g = Tensor::zeros((1, 2, 16), DType::F32, &device).unwrap();
+        let beta = Tensor::zeros((1, 2, 16), DType::F32, &device).unwrap();
+        let state = Tensor::zeros((1, 16, 2, 3), DType::F32, &device).unwrap();
+        assert!(
+            try_tiled_deltanet_recurrence(&query, &key, &value, &g, &beta, &state, 64).is_none()
+        );
+    }
+
+    #[cfg(all(feature = "metal", target_os = "macos"))]
+    #[test]
+    fn metal_qwen35_causal_conv_sequence_matches_cpu_reference_if_available() {
+        let Ok(Ok(device)) = std::panic::catch_unwind(|| Device::new_metal(0)) else {
+            return;
+        };
+        let seq_len = 2;
+        let conv_dim = 5;
+        let kernel_size = 4;
+        let input: Vec<f32> = (0..seq_len * conv_dim)
+            .map(|idx| ((idx % 9) as f32 - 4.0) * 0.13)
+            .collect();
+        let weight: Vec<f32> = (0..conv_dim * kernel_size)
+            .map(|idx| ((idx % 7) as f32 - 3.0) * 0.09)
+            .collect();
+        let history: Vec<f32> = (0..conv_dim * (kernel_size - 1))
+            .map(|idx| ((idx % 11) as f32 - 5.0) * 0.07)
+            .collect();
+        let (expected_output, expected_history) =
+            qwen35_causal_conv_reference(&input, &weight, &history, seq_len, conv_dim, kernel_size);
+
+        let input_tensor = Tensor::from_vec(input, (1, seq_len, conv_dim), &device).expect("input");
+        let weight_tensor =
+            Tensor::from_vec(weight, (conv_dim, kernel_size), &device).expect("weight");
+        let history_tensor =
+            Tensor::from_vec(history, (conv_dim, kernel_size - 1), &device).expect("history");
+        let (output, final_history) =
+            try_qwen35_causal_conv_sequence(&input_tensor, &weight_tensor, &history_tensor)
+                .expect("Qwen3.5 causal conv custom Metal op should run");
+        let output = output.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let final_history = final_history
+            .flatten_all()
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap();
+        assert_f32_close(&output, &expected_output, 2e-5, "causal conv output");
+        assert_f32_close(
+            &final_history,
+            &expected_history,
+            1e-6,
+            "causal conv history",
+        );
+    }
+
+    #[cfg(all(feature = "metal", target_os = "macos"))]
+    #[test]
+    fn metal_qwen35_gated_delta_matches_cpu_reference_for_both_layouts_if_available() {
+        let Ok(Ok(device)) = std::panic::catch_unwind(|| Device::new_metal(0)) else {
+            return;
+        };
+        let seq_len = 3;
+        let num_k_heads = 16;
+        let head_k_dim = 3;
+        let head_v_dim = 5;
+
+        for num_v_heads in [16usize, 32] {
+            let query: Vec<f32> = (0..seq_len * num_k_heads * head_k_dim)
+                .map(|idx| ((idx % 17) as f32 - 8.0) * 0.025)
+                .collect();
+            let key: Vec<f32> = (0..seq_len * num_k_heads * head_k_dim)
+                .map(|idx| ((idx % 13) as f32 - 6.0) * 0.021)
+                .collect();
+            let value: Vec<f32> = (0..seq_len * num_v_heads * head_v_dim)
+                .map(|idx| ((idx % 19) as f32 - 9.0) * 0.018)
+                .collect();
+            let g: Vec<f32> = (0..seq_len * num_v_heads)
+                .map(|idx| -0.015 * ((idx % 5) + 1) as f32)
+                .collect();
+            let beta: Vec<f32> = (0..seq_len * num_v_heads)
+                .map(|idx| 0.2 + 0.03 * (idx % 4) as f32)
+                .collect();
+            let initial_state: Vec<f32> = (0..num_v_heads * head_k_dim * head_v_dim)
+                .map(|idx| ((idx % 23) as f32 - 11.0) * 0.004)
+                .collect();
+            let (expected_output, expected_state) = qwen35_gated_delta_reference(
+                &query,
+                &key,
+                &value,
+                &g,
+                &beta,
+                &initial_state,
+                seq_len,
+                num_k_heads,
+                num_v_heads,
+                head_k_dim,
+                head_v_dim,
+            );
+
+            let query_tensor =
+                Tensor::from_vec(query, (1, seq_len, num_k_heads, head_k_dim), &device).unwrap();
+            let key_tensor =
+                Tensor::from_vec(key, (1, seq_len, num_k_heads, head_k_dim), &device).unwrap();
+            let value_tensor =
+                Tensor::from_vec(value, (1, seq_len, num_v_heads, head_v_dim), &device).unwrap();
+            let g_tensor = Tensor::from_vec(g, (1, seq_len, num_v_heads), &device).unwrap();
+            let beta_tensor = Tensor::from_vec(beta, (1, seq_len, num_v_heads), &device).unwrap();
+            let state_tensor = Tensor::from_vec(
+                initial_state,
+                (1, num_v_heads, head_k_dim, head_v_dim),
+                &device,
+            )
+            .unwrap();
+
+            let (output, final_state) = try_tiled_deltanet_recurrence(
+                &query_tensor,
+                &key_tensor,
+                &value_tensor,
+                &g_tensor,
+                &beta_tensor,
+                &state_tensor,
+                64,
+            )
+            .expect("Qwen3.5 Gated DeltaNet custom Metal op should run");
+            assert_eq!(output.dtype(), DType::F32);
+            assert_eq!(final_state.dtype(), DType::F32);
+            let output = output.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+            let final_state = final_state.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+            let layout = format!("16K/{num_v_heads}V");
+            assert_f32_close(&output, &expected_output, 2e-4, &format!("{layout} output"));
+            assert_f32_close(
+                &final_state,
+                &expected_state,
+                2e-4,
+                &format!("{layout} state"),
+            );
+        }
+    }
+
+    #[cfg(all(feature = "metal", target_os = "macos"))]
+    #[test]
+    fn metal_qwen35_gated_delta_rejects_invalid_dtype_and_head_layout_if_available() {
+        let Ok(Ok(device)) = std::panic::catch_unwind(|| Device::new_metal(0)) else {
+            return;
+        };
+        let query = Tensor::zeros((1, 2, 16, 2), DType::F32, &device).unwrap();
+        let key = Tensor::zeros((1, 2, 16, 2), DType::F32, &device).unwrap();
+        let value = Tensor::zeros((1, 2, 16, 3), DType::F32, &device).unwrap();
+        let g = Tensor::zeros((1, 2, 16), DType::F32, &device).unwrap();
+        let beta = Tensor::zeros((1, 2, 16), DType::F32, &device).unwrap();
+        let state = Tensor::zeros((1, 16, 2, 3), DType::F32, &device).unwrap();
+        assert!(try_tiled_deltanet_recurrence(
+            &query.to_dtype(DType::F16).unwrap(),
+            &key,
+            &value,
+            &g,
+            &beta,
+            &state,
+            64,
+        )
+        .is_none());
+
+        let invalid_value = Tensor::zeros((1, 2, 24, 3), DType::F32, &device).unwrap();
+        let invalid_g = Tensor::zeros((1, 2, 24), DType::F32, &device).unwrap();
+        let invalid_beta = Tensor::zeros((1, 2, 24), DType::F32, &device).unwrap();
+        let invalid_state = Tensor::zeros((1, 24, 2, 3), DType::F32, &device).unwrap();
+        assert!(try_tiled_deltanet_recurrence(
+            &query,
+            &key,
+            &invalid_value,
+            &invalid_g,
+            &invalid_beta,
+            &invalid_state,
+            64,
+        )
+        .is_none());
     }
 
     #[cfg(all(feature = "metal", target_os = "macos"))]

--- a/crates/izwi-core/src/kernels/metal_encoder.rs
+++ b/crates/izwi-core/src/kernels/metal_encoder.rs
@@ -5,6 +5,7 @@ pub(crate) trait IzwiMetalCommandEncoderExt {
     fn set_input_buffer(&self, index: usize, buffer: Option<&Buffer>, offset: usize);
     fn set_output_buffer(&self, index: usize, buffer: Option<&Buffer>, offset: usize);
     fn set_bytes<T>(&self, index: usize, data: &T);
+    fn insert_memory_barrier(&self);
     fn dispatch_threads(&self, threads_per_grid: MTLSize, threads_per_threadgroup: MTLSize);
     fn dispatch_thread_groups(
         &self,
@@ -24,6 +25,10 @@ impl IzwiMetalCommandEncoderExt for CommandsGuard<'_> {
 
     fn set_bytes<T>(&self, index: usize, data: &T) {
         self.as_ref().set_bytes(index, data);
+    }
+
+    fn insert_memory_barrier(&self) {
+        self.as_ref().insert_memory_barrier();
     }
 
     fn dispatch_threads(&self, threads_per_grid: MTLSize, threads_per_threadgroup: MTLSize) {

--- a/crates/izwi-core/src/kernels/mod.rs
+++ b/crates/izwi-core/src/kernels/mod.rs
@@ -268,6 +268,26 @@ pub fn try_lfm_shortconv_sequence3(bx: &Tensor, conv: &Tensor) -> Option<Tensor>
     None
 }
 
+pub fn try_qwen35_causal_conv_sequence(
+    input: &Tensor,
+    weight: &Tensor,
+    history: &Tensor,
+) -> Option<(Tensor, Tensor)> {
+    if !use_fused_kernels_for_device(input.device()) {
+        return None;
+    }
+
+    if input.device().is_cuda() {
+        return cuda::try_qwen35_causal_conv_sequence(input, weight, history);
+    }
+
+    if input.device().is_metal() {
+        return metal::try_qwen35_causal_conv_sequence(input, weight, history);
+    }
+
+    None
+}
+
 pub fn try_fused_gated_rms_norm(
     hidden: &Tensor,
     gate: &Tensor,

--- a/crates/izwi-core/src/models/architectures/qwen35/chat.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/chat.rs
@@ -16,7 +16,7 @@ use crate::backends::{BackendKind, DeviceProfile};
 use crate::error::{Error, Result};
 use crate::model::ModelVariant;
 use crate::models::shared::chat::{ChatGenerationConfig, ChatMessage, ChatRole};
-use crate::models::shared::memory::accounting::{compact_tensor_storage, TensorStorageAccounting};
+use crate::models::shared::memory::accounting::TensorStorageAccounting;
 use crate::models::shared::telemetry::record_prefill_token_mode_step;
 use crate::models::shared::weights::gguf::{GgufLoader, GgufModelInfo};
 use crate::tokenizer::{IncrementalDecoder, Tokenizer};
@@ -707,10 +707,7 @@ impl Qwen35ChatModel {
                 capture_prefix_max_bytes,
             )?
         } else {
-            (
-                compact_tensor_storage(&self.prefill_prompt(prepared_prompt, &mut text_state)?)?,
-                None,
-            )
+            (self.prefill_prompt(prepared_prompt, &mut text_state)?, None)
         };
         let track_history =
             config.repetition_penalty > 1.0 || config.presence_penalty.abs() > f32::EPSILON;
@@ -782,11 +779,11 @@ impl Qwen35ChatModel {
         }
         state.tokens_generated = state.tokens_generated.saturating_add(1);
         state.assembled.push_str(&delta);
-        state.logits = compact_tensor_storage(&self.text_model.forward_token_id_at(
+        state.logits = self.text_model.forward_token_id_at(
             next,
             [state.next_text_position; 3],
             &mut state.text_state,
-        )?)?;
+        )?;
         state.next_text_position += 1;
         if state.tokens_generated >= state.max_new_tokens {
             state.finished = true;
@@ -865,7 +862,7 @@ impl Qwen35ChatModel {
             .ok_or_else(|| {
                 Error::InferenceError("Qwen3.5 text suffix prefill produced no logits".to_string())
             })?;
-        Ok((compact_tensor_storage(&logits)?, pending))
+        Ok((logits, pending))
     }
 
     fn prefill_text_range(
@@ -1096,17 +1093,28 @@ fn qwen35_session_cache_upper_bound_bytes(
         cfg.block_count / cfg.full_attention_interval
     };
     let linear_layers = cfg.block_count.checked_sub(full_layers)?;
-    let as_u64 = |value: usize| u64::try_from(value).ok();
     let bytes_per_element = 4u64;
 
-    let kv_width = cfg
-        .attention_key_length
-        .checked_add(cfg.attention_value_length)?
-        .checked_mul(cfg.attention_head_count_kv)?;
-    let one_kv_copy = as_u64(full_layers)?
-        .checked_mul(as_u64(cache_capacity)?)?
-        .checked_mul(as_u64(kv_width)?)?
-        .checked_mul(bytes_per_element)?;
+    // Candle's Metal allocator rounds pooled buffers to byte-sized powers of
+    // two. Reserve each persistent tensor at that physical bucket rather than
+    // forcing a second exact-size allocation after every operation. This is
+    // conservative on backends whose allocator returns the logical size.
+    let allocation_bucket = |elements: usize| {
+        let bytes = u64::try_from(elements)
+            .ok()?
+            .checked_mul(bytes_per_element)?;
+        bytes.checked_next_power_of_two()
+    };
+
+    let key_elements = cache_capacity
+        .checked_mul(cfg.attention_head_count_kv)?
+        .checked_mul(cfg.attention_key_length)?;
+    let value_elements = cache_capacity
+        .checked_mul(cfg.attention_head_count_kv)?
+        .checked_mul(cfg.attention_value_length)?;
+    let one_kv_copy = allocation_bucket(key_elements)?
+        .checked_add(allocation_bucket(value_elements)?)?
+        .checked_mul(u64::try_from(full_layers).ok()?)?;
     // Account for both representations even though normal migration takes the
     // dense tensors before publishing pages. This keeps authorization safe if
     // a backend retains either backing allocation across the conversion.
@@ -1119,13 +1127,13 @@ fn qwen35_session_cache_upper_bound_bytes(
         .checked_add(cfg.ssm_inner_size)?;
     let conv_slots = cfg.ssm_conv_kernel.saturating_sub(1);
     let recurrent_width = cfg.ssm_state_size.checked_mul(cfg.ssm_inner_size)?;
-    let linear_state_width = conv_width
-        .checked_mul(conv_slots)?
-        .checked_add(recurrent_width)?;
-    let linear_bytes = as_u64(linear_layers)?
-        .checked_mul(as_u64(linear_state_width)?)?
-        .checked_mul(bytes_per_element)?;
-    let logits_bytes = as_u64(vocab_size)?.checked_mul(bytes_per_element)?;
+    let one_linear_layer = allocation_bucket(conv_width)?
+        .checked_mul(u64::try_from(conv_slots).ok()?)?
+        .checked_add(allocation_bucket(recurrent_width)?)?;
+    let linear_bytes = u64::try_from(linear_layers)
+        .ok()?
+        .checked_mul(one_linear_layer)?;
+    let logits_bytes = allocation_bucket(vocab_size)?;
 
     kv_bytes
         .checked_add(linear_bytes)?

--- a/crates/izwi-core/src/models/architectures/qwen35/chat.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/chat.rs
@@ -141,8 +141,8 @@ impl ChatDecodeState {
 /// sampler, history, RNG, and stream state are rebuilt on every restore.
 pub struct Qwen35PrefixSnapshot {
     text_state: Qwen35TextRuntimeState,
-    token_ids: Vec<u32>,
-    positions: Vec<[usize; 3]>,
+    token_ids: Box<[u32]>,
+    positions: Box<[[usize; 3]]>,
     next_text_position: usize,
 }
 
@@ -158,16 +158,10 @@ impl Qwen35PrefixSnapshot {
     pub(crate) fn retained_bytes(&self) -> Option<u64> {
         let mut accounting = TensorStorageAccounting::default();
         self.text_state.account_storage(&mut accounting)?;
+        accounting
+            .add_bytes(u64::try_from(self.token_ids.len().checked_mul(size_of::<u32>())?).ok()?)?;
         accounting.add_bytes(
-            u64::try_from(self.token_ids.capacity().checked_mul(size_of::<u32>())?).ok()?,
-        )?;
-        accounting.add_bytes(
-            u64::try_from(
-                self.positions
-                    .capacity()
-                    .checked_mul(size_of::<[usize; 3]>())?,
-            )
-            .ok()?,
+            u64::try_from(self.positions.len().checked_mul(size_of::<[usize; 3]>())?).ok()?,
         )?;
         accounting.add_bytes(u64::try_from(size_of::<Self>()).ok()?)?;
         Some(accounting.bytes())
@@ -849,8 +843,12 @@ impl Qwen35ChatModel {
                 .ok()
                 .map(|text_state| Qwen35PrefixSnapshot {
                     text_state,
-                    token_ids: prepared.prompt_ids[..checkpoint].to_vec(),
-                    positions: prepared.prompt_positions[..checkpoint].to_vec(),
+                    token_ids: prepared.prompt_ids[..checkpoint]
+                        .to_vec()
+                        .into_boxed_slice(),
+                    positions: prepared.prompt_positions[..checkpoint]
+                        .to_vec()
+                        .into_boxed_slice(),
                     next_text_position: checkpoint,
                 })
                 .filter(|snapshot| {
@@ -2076,6 +2074,32 @@ mod tests {
 
         assert_eq!(resolved.prompt_ids(), prepared.prompt_ids());
         assert_eq!(preparation_calls.load(AtomicOrdering::Relaxed), 0);
+    }
+
+    #[test]
+    fn reusable_prefix_boundary_is_an_exact_assistant_header_token_prefix() {
+        let tokenizer = synthetic_qwen35_tokenizer();
+        let rendered = "<|im_start|>user\nFirst question<|im_end|>\n\
+                        <|im_start|>assistant\nFirst answer<|im_end|>\n\
+                        <|im_start|>user\nFollow-up<|im_end|>\n\
+                        <|im_start|>assistant\n<think>\n\n</think>\n\n";
+        let full_ids = tokenizer.encode_text(rendered).unwrap();
+        let boundary_len = reusable_prefix_token_len(&tokenizer, rendered, &full_ids)
+            .unwrap()
+            .expect("assistant header should be an exact token boundary");
+        let boundary_end = rendered.rfind("<think>").unwrap();
+        let boundary_ids = tokenizer.encode_text(&rendered[..boundary_end]).unwrap();
+
+        assert_eq!(boundary_len, boundary_ids.len());
+        assert_eq!(&full_ids[..boundary_len], boundary_ids.as_slice());
+        assert!(boundary_len < full_ids.len());
+
+        let mut mismatched = full_ids;
+        mismatched[0] = u32::MAX;
+        assert_eq!(
+            reusable_prefix_token_len(&tokenizer, rendered, &mismatched).unwrap(),
+            None
+        );
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/qwen35/chat.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/chat.rs
@@ -1413,7 +1413,7 @@ fn sample_next_token(
     }
 
     let mut values = logits_to_vec(logits)?;
-    clamp_logits_to_vocab(&mut values, vocab_size);
+    truncate_logits_to_vocab(&mut values, vocab_size);
 
     if config.repetition_penalty > 1.0 && !history.is_empty() {
         let mut seen = vec![false; values.len()];
@@ -1561,10 +1561,30 @@ fn logits_to_vec(logits: &Tensor) -> Result<Vec<f32>> {
         .map_err(Error::from)
 }
 
-fn clamp_logits_to_vocab(values: &mut [f32], vocab_size: usize) {
+fn truncate_logits_to_vocab(values: &mut Vec<f32>, vocab_size: usize) {
     if vocab_size < values.len() {
-        values[vocab_size..].fill(f32::NEG_INFINITY);
+        values.truncate(vocab_size);
     }
+}
+
+fn no_valid_logits_error(values: &[f32]) -> Error {
+    let mut nan = 0usize;
+    let mut positive_infinity = 0usize;
+    let mut negative_infinity = 0usize;
+    for value in values {
+        if value.is_nan() {
+            nan = nan.saturating_add(1);
+        } else if *value == f32::INFINITY {
+            positive_infinity = positive_infinity.saturating_add(1);
+        } else if *value == f32::NEG_INFINITY {
+            negative_infinity = negative_infinity.saturating_add(1);
+        }
+    }
+    Error::InferenceError(format!(
+        "No valid Qwen3.5 logits to sample: 0 finite, {nan} NaN, \
+         {positive_infinity} +Inf, {negative_infinity} -Inf across {} in-vocabulary logits",
+        values.len()
+    ))
 }
 
 fn argmax_values(values: &[f32]) -> Result<u32> {
@@ -1580,7 +1600,7 @@ fn argmax_values(values: &[f32]) -> Result<u32> {
 
     max_idx
         .map(|idx| idx as u32)
-        .ok_or_else(|| Error::InferenceError("No valid Qwen3.5 logits to sample".to_string()))
+        .ok_or_else(|| no_valid_logits_error(values))
 }
 
 fn argmax(logits: &Tensor) -> Result<u32> {
@@ -1646,7 +1666,21 @@ fn argmax_clamped(logits: &Tensor, vocab_size: usize) -> Result<u32> {
     } else {
         logits
     };
-    argmax(&clamped)
+    let selected = argmax(&clamped)?;
+    let selected_logit = clamped
+        .i(selected as usize)?
+        .to_dtype(DType::F32)?
+        .to_scalar::<f32>()?;
+    if selected_logit.is_finite() {
+        return Ok(selected);
+    }
+
+    // Some device argmax kernels do not define useful ordering for NaNs. This
+    // slow path runs only after the selected value is non-finite: it recovers a
+    // finite candidate when one exists and otherwise returns useful counts for
+    // the exact in-vocabulary row in every sampling mode.
+    let values = clamped.to_dtype(DType::F32)?.to_vec1::<f32>()?;
+    argmax_values(&values)
 }
 
 struct SimpleRng {
@@ -2099,6 +2133,38 @@ mod tests {
         let mut rng = SimpleRng::new(7);
         let result = sample_next_token(&logits, 0, &config, &[], &mut rng);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn sampler_reports_non_finite_counts_for_greedy_and_probabilistic_modes() {
+        let logits = Tensor::from_vec(
+            vec![f32::NAN, f32::INFINITY, f32::NEG_INFINITY, 42.0],
+            (4,),
+            &candle_core::Device::Cpu,
+        )
+        .expect("logits");
+
+        for temperature in [0.0, 0.7] {
+            let config = ChatGenerationConfig {
+                temperature,
+                top_p: 1.0,
+                top_k: 0,
+                repetition_penalty: 1.0,
+                presence_penalty: 0.0,
+                stop_token_ids: Vec::new(),
+                seed: 7,
+                request: ChatRequestConfig::default(),
+            };
+            let mut rng = SimpleRng::new(7);
+            let error = sample_next_token(&logits, 3, &config, &[], &mut rng)
+                .expect_err("all in-vocabulary logits are non-finite");
+            let message = error.to_string();
+            assert!(message.contains("0 finite"));
+            assert!(message.contains("1 NaN"));
+            assert!(message.contains("1 +Inf"));
+            assert!(message.contains("1 -Inf"));
+            assert!(message.contains("3 in-vocabulary logits"));
+        }
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/qwen35/chat.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/chat.rs
@@ -4,7 +4,6 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use candle_core::quantized::gguf_file::Value as GgufValue;
@@ -19,7 +18,7 @@ use crate::models::shared::chat::{ChatGenerationConfig, ChatMessage, ChatRole};
 use crate::models::shared::memory::accounting::TensorStorageAccounting;
 use crate::models::shared::telemetry::record_prefill_token_mode_step;
 use crate::models::shared::weights::gguf::{GgufLoader, GgufModelInfo};
-use crate::tokenizer::Tokenizer;
+use crate::tokenizer::{IncrementalDecoder, Tokenizer};
 
 use super::text::{Qwen35TextModel, Qwen35TextRuntimeState};
 use super::vision::{PreparedVisionInputs, Qwen35VisionModel};
@@ -56,6 +55,20 @@ where
     }
 }
 
+fn initial_penalty_history(
+    prompt_ids: &[u32],
+    max_new_tokens: usize,
+    track_history: bool,
+) -> Vec<u32> {
+    if !track_history {
+        return Vec::new();
+    }
+
+    let mut history = Vec::with_capacity(prompt_ids.len().saturating_add(max_new_tokens.max(1)));
+    history.extend_from_slice(prompt_ids);
+    history
+}
+
 #[derive(Debug, Clone)]
 pub struct ChatGenerationOutput {
     pub text: String,
@@ -66,6 +79,7 @@ pub struct ChatDecodeState {
     text_state: Qwen35TextRuntimeState,
     logits: Tensor,
     history_ids: Vec<u32>,
+    decoder: IncrementalDecoder,
     tokens_generated: usize,
     track_history: bool,
     assembled: String,
@@ -158,12 +172,12 @@ struct Qwen35Tokenizer {
     chat_template: String,
     default_enable_thinking: bool,
     bos_token: Option<String>,
-    decode_piece_cache: Mutex<HashMap<u32, String>>,
 }
 
 #[derive(Debug)]
 struct GgufTokenizerMetadata {
     tokens: Vec<String>,
+    token_types: Vec<u32>,
     merges: Vec<String>,
     pre_tokenizer: Option<String>,
     chat_template: String,
@@ -174,7 +188,7 @@ impl Qwen35Tokenizer {
     fn load(model_dir: &Path, variant: ModelVariant, loader: &GgufLoader) -> Result<Self> {
         let gguf_meta = parse_gguf_tokenizer_metadata(loader)?;
         let config = load_tokenizer_config_file(model_dir)?;
-        let inner = match Tokenizer::from_path(model_dir) {
+        let mut inner = match Tokenizer::from_path(model_dir) {
             Ok(inner) => inner,
             Err(_) => Tokenizer::from_gguf_bpe(
                 &gguf_meta.tokens,
@@ -183,6 +197,7 @@ impl Qwen35Tokenizer {
                 false,
             )?,
         };
+        inner.register_gguf_token_types(&gguf_meta.tokens, &gguf_meta.token_types)?;
         let vocab_size = inner.vocab_size();
 
         let mut token_to_id: HashMap<String, u32> = HashMap::new();
@@ -226,15 +241,24 @@ impl Qwen35Tokenizer {
             .unwrap_or_else(|| gguf_meta.chat_template.clone());
         let default_enable_thinking = resolve_default_enable_thinking(&chat_template, variant);
 
-        let mut literal_special_tokens: Vec<(String, u32)> = token_to_id
+        let mut literal_special_tokens: Vec<(String, u32)> = gguf_meta
+            .tokens
             .iter()
-            .filter_map(|(token, id)| {
-                (token.starts_with("<|") && token.ends_with("|>")).then_some((token.clone(), *id))
+            .zip(&gguf_meta.token_types)
+            .enumerate()
+            .filter_map(|(id, (token, token_type))| {
+                matches!(token_type, 3 | 4).then_some((token.clone(), id as u32))
             })
             .collect();
+        if let Some(cfg) = &config {
+            literal_special_tokens.extend(cfg.added_tokens_decoder.iter().filter_map(
+                |(id, entry)| id.parse::<u32>().ok().map(|id| (entry.content.clone(), id)),
+            ));
+        }
         literal_special_tokens.sort_by(|(left, _), (right, _)| {
             right.len().cmp(&left.len()).then_with(|| left.cmp(right))
         });
+        literal_special_tokens.dedup_by(|(left, _), (right, _)| left == right);
 
         Ok(Self {
             inner,
@@ -251,7 +275,6 @@ impl Qwen35Tokenizer {
             chat_template,
             default_enable_thinking,
             bos_token: config.and_then(|cfg| cfg.bos_token),
-            decode_piece_cache: Mutex::new(HashMap::new()),
         })
     }
 
@@ -296,30 +319,19 @@ impl Qwen35Tokenizer {
         Ok(ids)
     }
 
-    fn decode_text(&self, ids: &[u32]) -> Result<String> {
-        let filtered: Vec<u32> = ids
-            .iter()
-            .copied()
-            .filter(|id| (*id as usize) < self.vocab_size)
-            .collect();
-        self.inner.decode(&filtered)
-    }
-
-    fn decode_token_piece(&self, token_id: u32) -> Result<String> {
+    fn decode_token_delta(
+        &self,
+        decoder: &mut IncrementalDecoder,
+        token_id: u32,
+    ) -> Result<String> {
         if token_id as usize >= self.vocab_size {
             return Ok(String::new());
         }
-        if let Ok(cache) = self.decode_piece_cache.lock() {
-            if let Some(piece) = cache.get(&token_id) {
-                return Ok(piece.clone());
-            }
-        }
+        self.inner.decode_incrementally(decoder, token_id)
+    }
 
-        let piece = self.decode_text(&[token_id])?;
-        if let Ok(mut cache) = self.decode_piece_cache.lock() {
-            cache.insert(token_id, piece.clone());
-        }
-        Ok(piece)
+    fn finish_decode(&self, decoder: &mut IncrementalDecoder) -> Result<String> {
+        self.inner.finish_incremental_decode(decoder)
     }
 }
 
@@ -568,11 +580,12 @@ impl Qwen35ChatModel {
         Ok(ChatDecodeState {
             text_state,
             logits,
-            history_ids: if track_history {
-                Vec::with_capacity(max_new_tokens.max(1))
-            } else {
-                Vec::new()
-            },
+            history_ids: initial_penalty_history(
+                &prepared_prompt.prompt_ids,
+                max_new_tokens,
+                track_history,
+            ),
+            decoder: IncrementalDecoder::new(true),
             tokens_generated: 0,
             track_history,
             assembled: String::new(),
@@ -587,9 +600,11 @@ impl Qwen35ChatModel {
     pub fn decode_step(&self, state: &mut ChatDecodeState) -> Result<ChatDecodeStep> {
         if state.finished || state.tokens_generated >= state.max_new_tokens {
             state.finished = true;
+            let delta = self.tokenizer.finish_decode(&mut state.decoder)?;
+            state.assembled.push_str(&delta);
             return Ok(ChatDecodeStep {
-                delta: String::new(),
-                text: state.assembled.trim().to_string(),
+                delta,
+                text: state.assembled.clone(),
                 tokens_generated: state.tokens_generated,
                 finished: true,
             });
@@ -609,15 +624,19 @@ impl Qwen35ChatModel {
         )?;
         if self.is_stop_token(next, &state.config) {
             state.finished = true;
+            let delta = self.tokenizer.finish_decode(&mut state.decoder)?;
+            state.assembled.push_str(&delta);
             return Ok(ChatDecodeStep {
-                delta: String::new(),
-                text: state.assembled.trim().to_string(),
+                delta,
+                text: state.assembled.clone(),
                 tokens_generated: state.tokens_generated,
                 finished: true,
             });
         }
 
-        let delta = self.tokenizer.decode_token_piece(next)?;
+        let mut delta = self
+            .tokenizer
+            .decode_token_delta(&mut state.decoder, next)?;
         if state.track_history {
             state.history_ids.push(next);
         }
@@ -631,9 +650,12 @@ impl Qwen35ChatModel {
         state.next_text_position += 1;
         if state.tokens_generated >= state.max_new_tokens {
             state.finished = true;
+            let suffix = self.tokenizer.finish_decode(&mut state.decoder)?;
+            state.assembled.push_str(&suffix);
+            delta.push_str(&suffix);
         }
         let final_text = if state.finished {
-            state.assembled.trim().to_string()
+            state.assembled.clone()
         } else {
             String::new()
         };
@@ -1177,22 +1199,17 @@ fn qwen35_gguf_filename(variant: ModelVariant) -> Result<&'static str> {
     }
 }
 
-fn resolve_default_enable_thinking(chat_template: &str, variant: ModelVariant) -> bool {
-    if chat_template.contains("enable_thinking is defined and enable_thinking is false") {
-        true
-    } else if chat_template.contains("enable_thinking is defined and enable_thinking is true") {
-        false
-    } else {
-        matches!(
-            variant,
-            ModelVariant::Qwen354BGguf | ModelVariant::Qwen359BGguf
-        )
-    }
+fn resolve_default_enable_thinking(_chat_template: &str, variant: ModelVariant) -> bool {
+    matches!(
+        variant,
+        ModelVariant::Qwen354BGguf | ModelVariant::Qwen359BGguf
+    )
 }
 
 fn parse_gguf_tokenizer_metadata(loader: &GgufLoader) -> Result<GgufTokenizerMetadata> {
     Ok(GgufTokenizerMetadata {
         tokens: required_string_array(loader, "tokenizer.ggml.tokens")?,
+        token_types: required_u32_array(loader, "tokenizer.ggml.token_type")?,
         merges: required_string_array(loader, "tokenizer.ggml.merges")?,
         pre_tokenizer: loader.get_metadata_string("tokenizer.ggml.pre"),
         chat_template: loader
@@ -1280,6 +1297,31 @@ fn required_usize_array(loader: &GgufLoader, key: &str) -> Result<Vec<usize>> {
             )));
         };
         let value = usize::try_from(raw).map_err(|_| {
+            Error::ModelLoadError(format!("Array value out of range for {key}: {raw}"))
+        })?;
+        values.push(value);
+    }
+    Ok(values)
+}
+
+fn required_u32_array(loader: &GgufLoader, key: &str) -> Result<Vec<u32>> {
+    let value = loader
+        .metadata_value(key)
+        .ok_or_else(|| Error::ModelLoadError(format!("Missing or invalid GGUF metadata: {key}")))?;
+    let GgufValue::Array(items) = value else {
+        return Err(Error::ModelLoadError(format!(
+            "Expected GGUF array metadata for {key}"
+        )));
+    };
+
+    let mut values = Vec::with_capacity(items.len());
+    for item in items {
+        let Some(raw) = gguf_to_u64(item) else {
+            return Err(Error::ModelLoadError(format!(
+                "Expected integer array values for {key}"
+            )));
+        };
+        let value = u32::try_from(raw).map_err(|_| {
             Error::ModelLoadError(format!("Array value out of range for {key}: {raw}"))
         })?;
         values.push(value);
@@ -1648,6 +1690,80 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
+    fn byte_level_char_for_test(byte: u8) -> char {
+        let mut bytes: Vec<u8> = (b'!'..=b'~')
+            .chain(b'\xA1'..=b'\xAC')
+            .chain(b'\xAE'..=b'\xFF')
+            .collect();
+        let mut codepoints: Vec<u32> = bytes.iter().map(|byte| u32::from(*byte)).collect();
+        let mut next = 0u32;
+        for candidate in 0..=u8::MAX {
+            if !bytes.contains(&candidate) {
+                bytes.push(candidate);
+                codepoints.push(256 + next);
+                next += 1;
+            }
+        }
+        let index = bytes
+            .iter()
+            .position(|candidate| *candidate == byte)
+            .expect("byte-level alphabet contains every byte");
+        char::from_u32(codepoints[index]).expect("byte-level codepoint is valid")
+    }
+
+    fn synthetic_qwen35_tokenizer() -> Qwen35Tokenizer {
+        let mut tokens: Vec<String> = (0..=u8::MAX)
+            .map(|byte| byte_level_char_for_test(byte).to_string())
+            .collect();
+        let im_start = tokens.len() as u32;
+        tokens.push("<|im_start|>".to_string());
+        let im_end = tokens.len() as u32;
+        tokens.push("<|im_end|>".to_string());
+        let image_pad = tokens.len() as u32;
+        tokens.push("<|image_pad|>".to_string());
+        let video_pad = tokens.len() as u32;
+        tokens.push("<|video_pad|>".to_string());
+        let eos_alt = tokens.len() as u32;
+        tokens.push("<|endoftext|>".to_string());
+        let think_open = tokens.len() as u32;
+        tokens.push("<think>".to_string());
+        let think_close = tokens.len() as u32;
+        tokens.push("</think>".to_string());
+
+        let mut token_types = vec![1; 256];
+        token_types.extend([3, 3, 3, 3, 3, 4, 4]);
+        let mut inner =
+            Tokenizer::from_gguf_bpe(&tokens, &[], Some("qwen35"), false).expect("tokenizer");
+        inner
+            .register_gguf_token_types(&tokens, &token_types)
+            .expect("atomic tokens");
+
+        Qwen35Tokenizer {
+            vocab_size: inner.vocab_size(),
+            inner,
+            specials: SpecialTokenIds {
+                im_start,
+                im_end,
+                image_pad,
+                video_pad,
+                eos: im_end,
+                eos_alt: Some(eos_alt),
+            },
+            literal_special_tokens: vec![
+                ("<|im_start|>".to_string(), im_start),
+                ("<|endoftext|>".to_string(), eos_alt),
+                ("<|image_pad|>".to_string(), image_pad),
+                ("<|video_pad|>".to_string(), video_pad),
+                ("<|im_end|>".to_string(), im_end),
+                ("</think>".to_string(), think_close),
+                ("<think>".to_string(), think_open),
+            ],
+            chat_template: String::new(),
+            default_enable_thinking: false,
+            bos_token: None,
+        }
+    }
+
     fn local_model_dir(name: &str) -> PathBuf {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
         PathBuf::from(home)
@@ -1674,6 +1790,16 @@ mod tests {
 
         assert_eq!(resolved.prompt_ids(), prepared.prompt_ids());
         assert_eq!(preparation_calls.load(AtomicOrdering::Relaxed), 0);
+    }
+
+    #[test]
+    fn penalty_history_starts_with_exact_prompt_ids() {
+        let prompt_ids = vec![248_000, 17, 23, 248_001];
+        let mut history = initial_penalty_history(&prompt_ids, 8, true);
+        assert_eq!(history, prompt_ids);
+        history.push(99);
+        assert_eq!(&history[..prompt_ids.len()], prompt_ids.as_slice());
+        assert!(initial_penalty_history(&prompt_ids, 8, false).is_empty());
     }
 
     #[test]
@@ -1730,18 +1856,57 @@ mod tests {
     }
 
     #[test]
-    fn resolve_default_thinking_matches_variant_templates() {
+    fn resolve_default_thinking_depends_on_variant_not_template_signature() {
         let small = "{%- if add_generation_prompt %}{%- if enable_thinking is defined and enable_thinking is true %}<think>\n{%- endif %}{%- endif %}";
         let large = "{%- if add_generation_prompt %}{%- if enable_thinking is defined and enable_thinking is false %}{%- else %}<think>\n{%- endif %}{%- endif %}";
 
         assert!(!resolve_default_enable_thinking(
-            small,
+            large,
             ModelVariant::Qwen3508BGguf
         ));
-        assert!(resolve_default_enable_thinking(
+        assert!(!resolve_default_enable_thinking(
             large,
+            ModelVariant::Qwen352BGguf
+        ));
+        assert!(resolve_default_enable_thinking(
+            small,
             ModelVariant::Qwen354BGguf
         ));
+        assert!(resolve_default_enable_thinking(
+            small,
+            ModelVariant::Qwen359BGguf
+        ));
+    }
+
+    #[test]
+    fn explicit_thinking_override_wins_over_variant_default() {
+        let messages = [ChatMessage {
+            role: ChatRole::User,
+            content: "Answer briefly.".to_string(),
+        }];
+        let enable = ChatGenerationConfig {
+            request: ChatRequestConfig {
+                enable_thinking: Some(true),
+                tools: Vec::new(),
+                media_inputs: Vec::new(),
+            },
+            ..ChatGenerationConfig::default()
+        };
+        let disable = ChatGenerationConfig {
+            request: ChatRequestConfig {
+                enable_thinking: Some(false),
+                tools: Vec::new(),
+                media_inputs: Vec::new(),
+            },
+            ..ChatGenerationConfig::default()
+        };
+
+        assert!(render_prompt(&messages, &enable, false)
+            .expect("enable thinking")
+            .ends_with("<|im_start|>assistant\n<think>\n"));
+        assert!(render_prompt(&messages, &disable, true)
+            .expect("disable thinking")
+            .ends_with("<|im_start|>assistant\n<think>\n\n</think>\n\n"));
     }
 
     #[test]
@@ -1839,6 +2004,59 @@ mod tests {
 
         assert!(prompt.contains("<|im_start|>assistant\nFinal answer<|im_end|>\n"));
         assert!(!prompt.contains("reasoning first"));
+    }
+
+    #[test]
+    fn multi_turn_rendering_preserves_unicode_assistant_content() {
+        let previous_answer = "café 中文 🌍 👨‍👩‍👧‍👦";
+        let config = ChatGenerationConfig {
+            request: ChatRequestConfig {
+                enable_thinking: Some(false),
+                tools: Vec::new(),
+                media_inputs: Vec::new(),
+            },
+            ..ChatGenerationConfig::default()
+        };
+        let prompt = render_prompt(
+            &[
+                ChatMessage {
+                    role: ChatRole::User,
+                    content: "First turn".to_string(),
+                },
+                ChatMessage {
+                    role: ChatRole::Assistant,
+                    content: previous_answer.to_string(),
+                },
+                ChatMessage {
+                    role: ChatRole::User,
+                    content: "Second turn".to_string(),
+                },
+            ],
+            &config,
+            false,
+        )
+        .expect("render multi-turn prompt");
+
+        assert!(prompt.contains(&format!(
+            "<|im_start|>assistant\n{previous_answer}<|im_end|>\n"
+        )));
+        assert!(!prompt.contains('\u{fffd}'));
+
+        let tokenizer = synthetic_qwen35_tokenizer();
+        let ids = tokenizer
+            .encode_text(&prompt)
+            .expect("encode rendered prompt");
+        assert!(ids.contains(&tokenizer.specials.im_start));
+        assert!(ids.contains(&tokenizer.specials.im_end));
+        assert!(ids.contains(&tokenizer.inner.token_to_id("<think>").unwrap()));
+        assert!(ids.contains(&tokenizer.inner.token_to_id("</think>").unwrap()));
+        assert_eq!(
+            tokenizer
+                .inner
+                .decode_with_special_tokens(&ids)
+                .expect("decode rendered ids"),
+            prompt
+        );
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/qwen35/chat.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/chat.rs
@@ -15,7 +15,7 @@ use crate::backends::{BackendKind, DeviceProfile};
 use crate::error::{Error, Result};
 use crate::model::ModelVariant;
 use crate::models::shared::chat::{ChatGenerationConfig, ChatMessage, ChatRole};
-use crate::models::shared::memory::accounting::TensorStorageAccounting;
+use crate::models::shared::memory::accounting::{compact_tensor_storage, TensorStorageAccounting};
 use crate::models::shared::telemetry::record_prefill_token_mode_step;
 use crate::models::shared::weights::gguf::{GgufLoader, GgufModelInfo};
 use crate::tokenizer::{IncrementalDecoder, Tokenizer};
@@ -25,6 +25,17 @@ use super::vision::{PreparedVisionInputs, Qwen35VisionModel};
 
 const IMAGE_PAD_PLACEHOLDER: &str = "<|image_pad|>";
 const VIDEO_PAD_PLACEHOLDER: &str = "<|video_pad|>";
+const DEFAULT_PREFILL_CHUNK_SIZE: usize = 256;
+const MAX_PREFILL_CHUNK_SIZE: usize = 2048;
+
+fn qwen35_prefill_chunk_size() -> usize {
+    std::env::var("IZWI_QWEN35_PREFILL_CHUNK_SIZE")
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_PREFILL_CHUNK_SIZE)
+        .min(MAX_PREFILL_CHUNK_SIZE)
+}
 
 /// Fully prepared Qwen3.5 prefill input. The runtime carries this exact
 /// artifact into the executor so media loading and vision encoding happen once.
@@ -573,7 +584,8 @@ impl Qwen35ChatModel {
         }
 
         let mut text_state = self.text_model.new_state();
-        let logits = self.prefill_prompt(&prepared_prompt, &mut text_state)?;
+        let logits =
+            compact_tensor_storage(&self.prefill_prompt(prepared_prompt, &mut text_state)?)?;
         let track_history =
             config.repetition_penalty > 1.0 || config.presence_penalty.abs() > f32::EPSILON;
 
@@ -642,11 +654,11 @@ impl Qwen35ChatModel {
         }
         state.tokens_generated = state.tokens_generated.saturating_add(1);
         state.assembled.push_str(&delta);
-        state.logits = self.text_model.forward_token_id_at(
+        state.logits = compact_tensor_storage(&self.text_model.forward_token_id_at(
             next,
             [state.next_text_position; 3],
             &mut state.text_state,
-        )?;
+        )?)?;
         state.next_text_position += 1;
         if state.tokens_generated >= state.max_new_tokens {
             state.finished = true;
@@ -734,14 +746,20 @@ impl Qwen35ChatModel {
                     run_end += 1;
                 }
 
-                let compute_logits = run_end == prepared_prompt.prompt_ids.len();
-                if let Some(run_logits) = self.text_model.prefill_token_ids(
-                    &prepared_prompt.prompt_ids[idx..run_end],
-                    &prepared_prompt.prompt_positions[idx..run_end],
-                    text_state,
-                    compute_logits,
-                )? {
-                    logits = Some(run_logits);
+                let chunk_size = qwen35_prefill_chunk_size();
+                let mut chunk_start = idx;
+                while chunk_start < run_end {
+                    let chunk_end = (chunk_start + chunk_size).min(run_end);
+                    let compute_logits = chunk_end == prepared_prompt.prompt_ids.len();
+                    if let Some(run_logits) = self.text_model.prefill_token_ids(
+                        &prepared_prompt.prompt_ids[chunk_start..chunk_end],
+                        &prepared_prompt.prompt_positions[chunk_start..chunk_end],
+                        text_state,
+                        compute_logits,
+                    )? {
+                        logits = Some(run_logits);
+                    }
+                    chunk_start = chunk_end;
                 }
                 idx = run_end;
                 continue;
@@ -1834,6 +1852,25 @@ mod tests {
         history.push(99);
         assert_eq!(&history[..prompt_ids.len()], prompt_ids.as_slice());
         assert!(initial_penalty_history(&prompt_ids, 8, false).is_empty());
+    }
+
+    #[test]
+    fn prefill_chunk_size_is_bounded_and_rejects_zero() {
+        let _guard = crate::env_test_lock().lock().expect("env lock");
+
+        std::env::remove_var("IZWI_QWEN35_PREFILL_CHUNK_SIZE");
+        assert_eq!(qwen35_prefill_chunk_size(), DEFAULT_PREFILL_CHUNK_SIZE);
+
+        std::env::set_var("IZWI_QWEN35_PREFILL_CHUNK_SIZE", "0");
+        assert_eq!(qwen35_prefill_chunk_size(), DEFAULT_PREFILL_CHUNK_SIZE);
+
+        std::env::set_var("IZWI_QWEN35_PREFILL_CHUNK_SIZE", "64");
+        assert_eq!(qwen35_prefill_chunk_size(), 64);
+
+        std::env::set_var("IZWI_QWEN35_PREFILL_CHUNK_SIZE", "999999");
+        assert_eq!(qwen35_prefill_chunk_size(), MAX_PREFILL_CHUNK_SIZE);
+
+        std::env::remove_var("IZWI_QWEN35_PREFILL_CHUNK_SIZE");
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/qwen35/chat.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/chat.rs
@@ -10,7 +10,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use candle_core::quantized::gguf_file::Value as GgufValue;
 use candle_core::{DType, IndexOp, Tensor, D};
 use serde::Deserialize;
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::backends::{BackendKind, DeviceProfile};
 use crate::error::{Error, Result};
@@ -456,6 +456,7 @@ impl Qwen35ChatModel {
         }
 
         let text_config = parse_text_config(&text_loader)?;
+        debug!(variant = %variant, ?text_config, "Resolved Qwen3.5 text configuration");
         let tokenizer = Qwen35Tokenizer::load(model_dir, variant, &text_loader)?;
         let text_model = Qwen35TextModel::load(&text_loader, &text_config, &device.device)?;
 

--- a/crates/izwi-core/src/models/architectures/qwen35/chat.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/chat.rs
@@ -693,10 +693,10 @@ impl Qwen35ChatModel {
 
         let reusable_prefix = prefix.filter(|prefix| prefix.matches(prepared_prompt));
         let (mut text_state, reused_prefix_tokens) = match reusable_prefix {
-            Some(prefix) => match prefix.text_state.fork_for_prefix() {
-                Ok(state) => (state, prefix.token_ids.len()),
-                Err(_) => (self.text_model.new_state(), 0),
-            },
+            Some(prefix) => (
+                prefix.text_state.fork_shared_for_prefix(),
+                prefix.token_ids.len(),
+            ),
             None => (self.text_model.new_state(), 0),
         };
         let (logits, pending_prefix_snapshot) = if prepared_prompt.vision_inputs.is_none() {
@@ -836,24 +836,21 @@ impl Qwen35ChatModel {
         }
 
         let pending = match (checkpoint, capture_prefix_max_bytes) {
-            (Some(checkpoint), Some(max_bytes)) if max_bytes > 0 => text_state
-                .fork_for_prefix()
-                .ok()
-                .map(|text_state| Qwen35PrefixSnapshot {
-                    text_state,
-                    token_ids: prepared.prompt_ids[..checkpoint]
-                        .to_vec()
-                        .into_boxed_slice(),
-                    positions: prepared.prompt_positions[..checkpoint]
-                        .to_vec()
-                        .into_boxed_slice(),
-                    next_text_position: checkpoint,
-                })
-                .filter(|snapshot| {
-                    snapshot
-                        .retained_bytes()
-                        .is_some_and(|bytes| bytes <= max_bytes)
-                }),
+            (Some(checkpoint), Some(max_bytes)) if max_bytes > 0 => Some(Qwen35PrefixSnapshot {
+                text_state: text_state.fork_shared_for_prefix(),
+                token_ids: prepared.prompt_ids[..checkpoint]
+                    .to_vec()
+                    .into_boxed_slice(),
+                positions: prepared.prompt_positions[..checkpoint]
+                    .to_vec()
+                    .into_boxed_slice(),
+                next_text_position: checkpoint,
+            })
+            .filter(|snapshot| {
+                snapshot
+                    .retained_bytes()
+                    .is_some_and(|bytes| bytes <= max_bytes)
+            }),
             _ => None,
         };
 

--- a/crates/izwi-core/src/models/architectures/qwen35/chat.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/chat.rs
@@ -3,6 +3,7 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fs;
+use std::mem::size_of;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -44,12 +45,21 @@ pub struct Qwen35PreparedPrompt {
     prompt_ids: Vec<u32>,
     prompt_positions: Vec<[usize; 3]>,
     next_text_position: usize,
+    reusable_prefix_len: Option<usize>,
     vision_inputs: Option<PreparedVisionInputs>,
 }
 
 impl Qwen35PreparedPrompt {
     pub fn prompt_ids(&self) -> &[u32] {
         &self.prompt_ids
+    }
+
+    pub(crate) fn prompt_positions(&self) -> &[[usize; 3]] {
+        &self.prompt_positions
+    }
+
+    pub(crate) fn supports_exact_prefix_reuse(&self) -> bool {
+        self.vision_inputs.is_none() && self.reusable_prefix_len.is_some()
     }
 }
 
@@ -97,6 +107,8 @@ pub struct ChatDecodeState {
     max_new_tokens: usize,
     finished: bool,
     next_text_position: usize,
+    pending_prefix_snapshot: Option<Qwen35PrefixSnapshot>,
+    reused_prefix_tokens: usize,
     config: ChatGenerationConfig,
     rng: SimpleRng,
 }
@@ -114,6 +126,65 @@ impl ChatDecodeState {
     /// Complete per-session scheduler accounting.
     pub fn session_cache_bytes(&self) -> Option<u64> {
         self.allocated_session_bytes()
+    }
+
+    pub(crate) fn take_pending_prefix_snapshot(&mut self) -> Option<Qwen35PrefixSnapshot> {
+        self.pending_prefix_snapshot.take()
+    }
+
+    pub(crate) fn reused_prefix_tokens(&self) -> usize {
+        self.reused_prefix_tokens
+    }
+}
+
+/// Immutable checkpoint at an exact rendered-token boundary. Request-specific
+/// sampler, history, RNG, and stream state are rebuilt on every restore.
+pub struct Qwen35PrefixSnapshot {
+    text_state: Qwen35TextRuntimeState,
+    token_ids: Vec<u32>,
+    positions: Vec<[usize; 3]>,
+    next_text_position: usize,
+}
+
+impl Qwen35PrefixSnapshot {
+    pub(crate) fn token_ids(&self) -> &[u32] {
+        &self.token_ids
+    }
+
+    pub(crate) fn positions(&self) -> &[[usize; 3]] {
+        &self.positions
+    }
+
+    pub(crate) fn retained_bytes(&self) -> Option<u64> {
+        let mut accounting = TensorStorageAccounting::default();
+        self.text_state.account_storage(&mut accounting)?;
+        accounting.add_bytes(
+            u64::try_from(self.token_ids.capacity().checked_mul(size_of::<u32>())?).ok()?,
+        )?;
+        accounting.add_bytes(
+            u64::try_from(
+                self.positions
+                    .capacity()
+                    .checked_mul(size_of::<[usize; 3]>())?,
+            )
+            .ok()?,
+        )?;
+        accounting.add_bytes(u64::try_from(size_of::<Self>()).ok()?)?;
+        Some(accounting.bytes())
+    }
+
+    fn matches(&self, prepared: &Qwen35PreparedPrompt) -> bool {
+        let prefix_len = self.token_ids.len();
+        prepared.vision_inputs.is_none()
+            && prefix_len > 0
+            && prefix_len == self.positions.len()
+            && self.next_text_position == prefix_len
+            && prepared.prompt_ids.starts_with(&self.token_ids)
+            && prepared.prompt_positions.starts_with(&self.positions)
+            && prepared
+                .prompt_positions
+                .get(prefix_len)
+                .is_some_and(|position| *position == [self.next_text_position; 3])
     }
 }
 
@@ -566,9 +637,34 @@ impl Qwen35ChatModel {
         config: &ChatGenerationConfig,
         prepared: Option<&Qwen35PreparedPrompt>,
     ) -> Result<ChatDecodeState> {
+        self.start_decode_state_with_optional_prepared_and_prefix(
+            messages,
+            max_new_tokens,
+            config,
+            prepared,
+            None,
+            None,
+        )
+    }
+
+    pub(crate) fn start_decode_state_with_optional_prepared_and_prefix(
+        &self,
+        messages: &[ChatMessage],
+        max_new_tokens: usize,
+        config: &ChatGenerationConfig,
+        prepared: Option<&Qwen35PreparedPrompt>,
+        prefix: Option<&Qwen35PrefixSnapshot>,
+        capture_prefix_max_bytes: Option<u64>,
+    ) -> Result<ChatDecodeState> {
         let prepared_prompt =
             resolve_prepared_prompt(prepared, || self.prepare_prompt(messages, config))?;
-        self.start_decode_state_with_prepared(&prepared_prompt, max_new_tokens, config)
+        self.start_decode_state_with_prepared_and_prefix(
+            &prepared_prompt,
+            max_new_tokens,
+            config,
+            prefix,
+            capture_prefix_max_bytes,
+        )
     }
 
     pub fn start_decode_state_with_prepared(
@@ -577,15 +673,50 @@ impl Qwen35ChatModel {
         max_new_tokens: usize,
         config: &ChatGenerationConfig,
     ) -> Result<ChatDecodeState> {
+        self.start_decode_state_with_prepared_and_prefix(
+            prepared_prompt,
+            max_new_tokens,
+            config,
+            None,
+            None,
+        )
+    }
+
+    fn start_decode_state_with_prepared_and_prefix(
+        &self,
+        prepared_prompt: &Qwen35PreparedPrompt,
+        max_new_tokens: usize,
+        config: &ChatGenerationConfig,
+        prefix: Option<&Qwen35PrefixSnapshot>,
+        capture_prefix_max_bytes: Option<u64>,
+    ) -> Result<ChatDecodeState> {
         if prepared_prompt.prompt_ids.is_empty() {
             return Err(Error::InvalidInput(
                 "Chat request must include at least one tokenizable message".to_string(),
             ));
         }
 
-        let mut text_state = self.text_model.new_state();
-        let logits =
-            compact_tensor_storage(&self.prefill_prompt(prepared_prompt, &mut text_state)?)?;
+        let reusable_prefix = prefix.filter(|prefix| prefix.matches(prepared_prompt));
+        let (mut text_state, reused_prefix_tokens) = match reusable_prefix {
+            Some(prefix) => match prefix.text_state.fork_for_prefix() {
+                Ok(state) => (state, prefix.token_ids.len()),
+                Err(_) => (self.text_model.new_state(), 0),
+            },
+            None => (self.text_model.new_state(), 0),
+        };
+        let (logits, pending_prefix_snapshot) = if prepared_prompt.vision_inputs.is_none() {
+            self.prefill_text_prompt_with_prefix_checkpoint(
+                prepared_prompt,
+                &mut text_state,
+                reused_prefix_tokens,
+                capture_prefix_max_bytes,
+            )?
+        } else {
+            (
+                compact_tensor_storage(&self.prefill_prompt(prepared_prompt, &mut text_state)?)?,
+                None,
+            )
+        };
         let track_history =
             config.repetition_penalty > 1.0 || config.presence_penalty.abs() > f32::EPSILON;
 
@@ -604,6 +735,8 @@ impl Qwen35ChatModel {
             max_new_tokens: max_new_tokens.max(1),
             finished: false,
             next_text_position: prepared_prompt.next_text_position,
+            pending_prefix_snapshot,
+            reused_prefix_tokens,
             config: config.clone(),
             rng: SimpleRng::new(config.seed),
         })
@@ -685,6 +818,82 @@ impl Qwen35ChatModel {
             || token_id == self.tokenizer.specials.eos
             || self.tokenizer.specials.eos_alt == Some(token_id)
             || config.stop_token_ids.contains(&token_id)
+    }
+
+    fn prefill_text_prompt_with_prefix_checkpoint(
+        &self,
+        prepared: &Qwen35PreparedPrompt,
+        text_state: &mut Qwen35TextRuntimeState,
+        reused_prefix_tokens: usize,
+        capture_prefix_max_bytes: Option<u64>,
+    ) -> Result<(Tensor, Option<Qwen35PrefixSnapshot>)> {
+        let token_count = prepared.prompt_ids.len();
+        if reused_prefix_tokens >= token_count {
+            return Err(Error::InferenceError(
+                "Qwen3.5 cached prefix leaves no prompt suffix for logits".to_string(),
+            ));
+        }
+
+        let checkpoint = prepared
+            .reusable_prefix_len
+            .filter(|checkpoint| *checkpoint > reused_prefix_tokens && *checkpoint < token_count);
+        let mut cursor = reused_prefix_tokens;
+        if let Some(checkpoint) = checkpoint {
+            self.prefill_text_range(prepared, text_state, cursor, checkpoint, false)?;
+            cursor = checkpoint;
+        }
+
+        let pending = match (checkpoint, capture_prefix_max_bytes) {
+            (Some(checkpoint), Some(max_bytes)) if max_bytes > 0 => text_state
+                .fork_for_prefix()
+                .ok()
+                .map(|text_state| Qwen35PrefixSnapshot {
+                    text_state,
+                    token_ids: prepared.prompt_ids[..checkpoint].to_vec(),
+                    positions: prepared.prompt_positions[..checkpoint].to_vec(),
+                    next_text_position: checkpoint,
+                })
+                .filter(|snapshot| {
+                    snapshot
+                        .retained_bytes()
+                        .is_some_and(|bytes| bytes <= max_bytes)
+                }),
+            _ => None,
+        };
+
+        let logits = self
+            .prefill_text_range(prepared, text_state, cursor, token_count, true)?
+            .ok_or_else(|| {
+                Error::InferenceError("Qwen3.5 text suffix prefill produced no logits".to_string())
+            })?;
+        Ok((compact_tensor_storage(&logits)?, pending))
+    }
+
+    fn prefill_text_range(
+        &self,
+        prepared: &Qwen35PreparedPrompt,
+        text_state: &mut Qwen35TextRuntimeState,
+        start: usize,
+        end: usize,
+        compute_final_logits: bool,
+    ) -> Result<Option<Tensor>> {
+        let mut logits = None;
+        let mut chunk_start = start;
+        let chunk_size = qwen35_prefill_chunk_size();
+        while chunk_start < end {
+            let chunk_end = (chunk_start + chunk_size).min(end);
+            let compute_logits = compute_final_logits && chunk_end == end;
+            if let Some(chunk_logits) = self.text_model.prefill_token_ids(
+                &prepared.prompt_ids[chunk_start..chunk_end],
+                &prepared.prompt_positions[chunk_start..chunk_end],
+                text_state,
+                compute_logits,
+            )? {
+                logits = Some(chunk_logits);
+            }
+            chunk_start = chunk_end;
+        }
+        Ok(logits)
     }
 
     fn prefill_prompt(
@@ -806,11 +1015,14 @@ impl Qwen35ChatModel {
                 ));
             }
             let prompt_ids = self.tokenizer.encode_text(&prompt)?;
+            let reusable_prefix_len =
+                reusable_prefix_token_len(&self.tokenizer, &prompt, &prompt_ids)?;
             let prompt_positions = build_text_positions(prompt_ids.len());
             return Ok(Qwen35PreparedPrompt {
                 next_text_position: prompt_positions.len(),
                 prompt_ids,
                 prompt_positions,
+                reusable_prefix_len,
                 vision_inputs: None,
             });
         };
@@ -841,6 +1053,7 @@ impl Qwen35ChatModel {
             prompt_ids,
             prompt_positions,
             next_text_position,
+            reusable_prefix_len: None,
             vision_inputs: Some(vision_inputs),
         })
     }
@@ -922,6 +1135,26 @@ fn qwen35_session_cache_upper_bound_bytes(
 
 fn build_text_positions(token_count: usize) -> Vec<[usize; 3]> {
     (0..token_count).map(|idx| [idx; 3]).collect()
+}
+
+fn reusable_prefix_token_len(
+    tokenizer: &Qwen35Tokenizer,
+    rendered_prompt: &str,
+    full_ids: &[u32],
+) -> Result<Option<usize>> {
+    const ASSISTANT_HEADER: &str = "<|im_start|>assistant\n";
+    let Some(header_start) = rendered_prompt.rfind(ASSISTANT_HEADER) else {
+        return Ok(None);
+    };
+    let boundary_end = header_start + ASSISTANT_HEADER.len();
+    let boundary_ids = tokenizer.encode_text(&rendered_prompt[..boundary_end])?;
+    // Tokenizers may merge across an arbitrary string boundary. Reuse is only
+    // valid when the independently encoded boundary is literally the full
+    // prompt's token prefix.
+    Ok(
+        (!boundary_ids.is_empty() && full_ids.starts_with(&boundary_ids))
+            .then_some(boundary_ids.len()),
+    )
 }
 
 fn expand_image_placeholders(prompt: &str, token_counts: &[usize]) -> Result<String> {
@@ -1829,6 +2062,7 @@ mod tests {
             prompt_ids: vec![1, 2, 3],
             prompt_positions: build_text_positions(3),
             next_text_position: 3,
+            reusable_prefix_len: Some(2),
             vision_inputs: None,
         };
         let preparation_calls = AtomicUsize::new(0);

--- a/crates/izwi-core/src/models/architectures/qwen35/text.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/text.rs
@@ -19,7 +19,9 @@ use crate::models::shared::attention::paged::{
     append_to_pages, default_kv_page_size, default_kv_quantization, materialize_pages,
     paged_decode_attention, KvCacheQuantization, KvPage,
 };
-use crate::models::shared::memory::accounting::{compact_tensor_storage, TensorStorageAccounting};
+use crate::models::shared::memory::accounting::{
+    compact_tensor_storage, deep_copy_tensor_storage, TensorStorageAccounting,
+};
 use crate::models::shared::telemetry::{
     record_decode_attention_path, record_prefill_sequence_span, record_rope_kernel,
     record_rope_manual, DecodeAttentionPath,
@@ -46,6 +48,17 @@ pub struct Qwen35TextRuntimeState {
 }
 
 impl Qwen35TextRuntimeState {
+    /// Fork all persistent tensors into independent Candle backing storage.
+    pub(crate) fn fork_for_prefix(&self) -> Result<Self> {
+        Ok(Self {
+            layers: self
+                .layers
+                .iter()
+                .map(Qwen35LayerRuntimeState::fork_for_prefix)
+                .collect::<Result<Vec<_>>>()?,
+        })
+    }
+
     /// Backing allocations retained by the per-request text runtime state.
     ///
     /// This intentionally excludes model-global caches (notably full-attention
@@ -102,6 +115,17 @@ struct ConvRingState {
 }
 
 impl ConvRingState {
+    fn fork_for_prefix(&self) -> Result<Self> {
+        Ok(Self {
+            slots: self
+                .slots
+                .iter()
+                .map(deep_copy_tensor_storage)
+                .collect::<candle_core::Result<Vec<_>>>()?,
+            next_idx: self.next_idx,
+        })
+    }
+
     /// Move logical history slots into one exact-size backing allocation.
     ///
     /// Sequence-prefill slots are views into the entire projected token span.
@@ -135,6 +159,51 @@ enum Qwen35LayerRuntimeState {
         dense_v_cache_h: Option<Tensor>,
         dense_kv_tokens: usize,
     },
+}
+
+impl Qwen35LayerRuntimeState {
+    fn fork_for_prefix(&self) -> Result<Self> {
+        match self {
+            Self::Linear {
+                conv_state,
+                recurrent_state,
+            } => Ok(Self::Linear {
+                conv_state: conv_state
+                    .as_ref()
+                    .map(ConvRingState::fork_for_prefix)
+                    .transpose()?,
+                recurrent_state: recurrent_state
+                    .as_ref()
+                    .map(deep_copy_tensor_storage)
+                    .transpose()?,
+            }),
+            Self::Full {
+                k_pages,
+                v_pages,
+                dense_k_cache_h,
+                dense_v_cache_h,
+                dense_kv_tokens,
+            } => Ok(Self::Full {
+                k_pages: k_pages
+                    .iter()
+                    .map(KvPage::deep_copy)
+                    .collect::<Result<Vec<_>>>()?,
+                v_pages: v_pages
+                    .iter()
+                    .map(KvPage::deep_copy)
+                    .collect::<Result<Vec<_>>>()?,
+                dense_k_cache_h: dense_k_cache_h
+                    .as_ref()
+                    .map(deep_copy_tensor_storage)
+                    .transpose()?,
+                dense_v_cache_h: dense_v_cache_h
+                    .as_ref()
+                    .map(deep_copy_tensor_storage)
+                    .transpose()?,
+                dense_kv_tokens: *dense_kv_tokens,
+            }),
+        }
+    }
 }
 
 fn full_attention_state_has_cached_prefix(state: &Qwen35LayerRuntimeState) -> Result<bool> {
@@ -2369,6 +2438,116 @@ mod tests {
                 .and_then(|state| state.to_vec1::<f32>())
                 .is_ok_and(|values| values.iter().all(|value| *value == 0.0))
         }));
+    }
+
+    fn assert_prefix_forks_have_independent_hybrid_state_storage(device: &Device) {
+        let state = Qwen35TextRuntimeState {
+            layers: vec![
+                Qwen35LayerRuntimeState::Linear {
+                    conv_state: Some(ConvRingState {
+                        slots: vec![Tensor::ones((1, 1, 4), DType::F32, device).unwrap()],
+                        next_idx: 0,
+                    }),
+                    recurrent_state: Some(Tensor::ones((1, 1, 2, 2), DType::F32, device).unwrap()),
+                },
+                Qwen35LayerRuntimeState::Full {
+                    k_pages: vec![KvPage::Dense(
+                        Tensor::ones((1, 1, 1, 2), DType::F32, device).unwrap(),
+                    )],
+                    v_pages: vec![KvPage::Dense(
+                        Tensor::ones((1, 1, 1, 2), DType::F32, device).unwrap(),
+                    )],
+                    dense_k_cache_h: Some(Tensor::ones((1, 1, 1, 2), DType::F32, device).unwrap()),
+                    dense_v_cache_h: Some(Tensor::ones((1, 1, 1, 2), DType::F32, device).unwrap()),
+                    dense_kv_tokens: 1,
+                },
+            ],
+        };
+        let mut first = state.fork_for_prefix().unwrap();
+        let second = state.fork_for_prefix().unwrap();
+
+        let (
+            Qwen35LayerRuntimeState::Linear {
+                conv_state: Some(first_conv),
+                recurrent_state: Some(first_recurrent),
+            },
+            Qwen35LayerRuntimeState::Linear {
+                conv_state: Some(second_conv),
+                recurrent_state: Some(second_recurrent),
+            },
+        ) = (&mut first.layers[0], &second.layers[0])
+        else {
+            panic!("linear states")
+        };
+        assert_ne!(
+            tensor_storage_address(&first_conv.slots[0]),
+            tensor_storage_address(&second_conv.slots[0])
+        );
+        assert_ne!(
+            tensor_storage_address(first_recurrent),
+            tensor_storage_address(second_recurrent)
+        );
+        first_conv.slots[0] = Tensor::zeros((1, 1, 4), DType::F32, device).unwrap();
+        *first_recurrent = Tensor::zeros((1, 1, 2, 2), DType::F32, device).unwrap();
+        assert_eq!(
+            second_conv.slots[0]
+                .flatten_all()
+                .unwrap()
+                .to_vec1::<f32>()
+                .unwrap(),
+            vec![1.0; 4]
+        );
+        assert_eq!(
+            second_recurrent
+                .flatten_all()
+                .unwrap()
+                .to_vec1::<f32>()
+                .unwrap(),
+            vec![1.0; 4]
+        );
+
+        let (
+            Qwen35LayerRuntimeState::Full {
+                k_pages: first_pages,
+                dense_k_cache_h: Some(first_dense),
+                ..
+            },
+            Qwen35LayerRuntimeState::Full {
+                k_pages: second_pages,
+                dense_k_cache_h: Some(second_dense),
+                ..
+            },
+        ) = (&first.layers[1], &second.layers[1])
+        else {
+            panic!("full states")
+        };
+        let (KvPage::Dense(first_page), KvPage::Dense(second_page)) =
+            (&first_pages[0], &second_pages[0])
+        else {
+            panic!("dense pages")
+        };
+        assert_ne!(
+            tensor_storage_address(first_page),
+            tensor_storage_address(second_page)
+        );
+        assert_ne!(
+            tensor_storage_address(first_dense),
+            tensor_storage_address(second_dense)
+        );
+    }
+
+    #[test]
+    fn prefix_forks_have_independent_hybrid_state_storage() {
+        assert_prefix_forks_have_independent_hybrid_state_storage(&Device::Cpu);
+    }
+
+    #[cfg(feature = "metal")]
+    #[test]
+    fn prefix_forks_have_independent_hybrid_state_storage_on_metal() {
+        let Ok(Ok(device)) = std::panic::catch_unwind(|| Device::new_metal(0)) else {
+            return;
+        };
+        assert_prefix_forks_have_independent_hybrid_state_storage(&device);
     }
 
     #[cfg(feature = "metal")]

--- a/crates/izwi-core/src/models/architectures/qwen35/text.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/text.rs
@@ -51,9 +51,9 @@ pub struct Qwen35TextRuntimeState {
 impl Qwen35TextRuntimeState {
     /// Fork immutable persistent state by sharing Candle tensor storage.
     ///
-    /// Every Qwen3.5 state transition replaces tensor handles or page entries;
-    /// it never mutates a backing allocation in place. A future in-place kernel
-    /// must add copy-on-write at its mutation boundary before using this path.
+    /// Recurrent, convolution, and paged transitions replace tensor handles or
+    /// page entries. Dense KV appends mutate capacity storage only after their
+    /// `Arc<Tensor>` proves unique, detaching first when a snapshot shares it.
     pub(crate) fn fork_shared_for_prefix(&self) -> Self {
         self.clone()
     }
@@ -3040,6 +3040,140 @@ mod tests {
             .to_vec1::<f32>()
             .unwrap();
         assert_eq!(flat, vec![1.0, 2.0, 5.0, 6.0, 3.0, 4.0, 7.0, 8.0]);
+    }
+
+    fn synthetic_decode_state(
+        device: &Device,
+        layer_count: usize,
+        num_v_heads: usize,
+    ) -> Qwen35TextRuntimeState {
+        let mut layers = Vec::with_capacity(layer_count);
+        for layer_idx in 0..layer_count {
+            if (layer_idx + 1).is_multiple_of(4) {
+                let initial = Tensor::zeros((1, num_v_heads, 1, 2), DType::F32, device).unwrap();
+                let mut k_cache = Qwen35DenseKvCache::default();
+                let mut v_cache = Qwen35DenseKvCache::default();
+                k_cache.append(&initial, 128, 128).unwrap();
+                v_cache.append(&initial, 128, 128).unwrap();
+                layers.push(Qwen35LayerRuntimeState::Full {
+                    k_pages: Vec::new(),
+                    v_pages: Vec::new(),
+                    dense_k_cache_h: k_cache,
+                    dense_v_cache_h: v_cache,
+                });
+            } else {
+                let conv_width = num_v_heads * 2;
+                layers.push(Qwen35LayerRuntimeState::Linear {
+                    conv_state: Some(ConvRingState {
+                        slots: (0..3)
+                            .map(|_| Tensor::zeros((conv_width, 1), DType::F32, device).unwrap())
+                            .collect(),
+                        next_idx: 0,
+                    }),
+                    recurrent_state: Some(
+                        Tensor::zeros((1, num_v_heads, 2, 2), DType::F32, device).unwrap(),
+                    ),
+                });
+            }
+        }
+        Qwen35TextRuntimeState { layers }
+    }
+
+    fn advance_synthetic_decode_state(
+        state: &mut Qwen35TextRuntimeState,
+        device: &Device,
+        num_v_heads: usize,
+    ) {
+        for layer in &mut state.layers {
+            match layer {
+                Qwen35LayerRuntimeState::Linear {
+                    conv_state: Some(conv_state),
+                    recurrent_state,
+                } => {
+                    let conv_width = num_v_heads * 2;
+                    let projection = Tensor::zeros((1, 1, conv_width), DType::F32, device).unwrap();
+                    let current = projection
+                        .i((0, 0))
+                        .unwrap()
+                        .reshape((conv_width, 1))
+                        .unwrap();
+                    conv_state.push_decode(&current).unwrap();
+                    *recurrent_state =
+                        Some(Tensor::zeros((1, num_v_heads, 2, 2), DType::F32, device).unwrap());
+                }
+                Qwen35LayerRuntimeState::Full {
+                    dense_k_cache_h,
+                    dense_v_cache_h,
+                    ..
+                } => {
+                    let token = Tensor::zeros((1, num_v_heads, 1, 2), DType::F32, device).unwrap();
+                    dense_k_cache_h.append(&token, 128, 128).unwrap();
+                    dense_v_cache_h.append(&token, 128, 128).unwrap();
+                }
+                _ => panic!("synthetic state must initialize every linear cache"),
+            }
+        }
+    }
+
+    #[test]
+    fn persistent_decode_storage_plateaus_for_small_and_large_topologies() {
+        for (layer_count, num_v_heads) in [(24, 16), (32, 32)] {
+            let mut state = synthetic_decode_state(&Device::Cpu, layer_count, num_v_heads);
+            let baseline = state.allocated_session_bytes().unwrap();
+
+            for _ in 0..96 {
+                advance_synthetic_decode_state(&mut state, &Device::Cpu, num_v_heads);
+                assert_eq!(
+                    state.allocated_session_bytes(),
+                    Some(baseline),
+                    "{layer_count}-layer/{num_v_heads}V state retained growing backing storage"
+                );
+            }
+
+            for layer in &state.layers {
+                if let Qwen35LayerRuntimeState::Full {
+                    dense_k_cache_h,
+                    dense_v_cache_h,
+                    ..
+                } = layer
+                {
+                    assert_eq!(dense_k_cache_h.len(), 97);
+                    assert_eq!(dense_v_cache_h.len(), 97);
+                    assert_eq!(dense_k_cache_h.capacity().unwrap(), 128);
+                    assert_eq!(dense_v_cache_h.capacity().unwrap(), 128);
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "metal")]
+    #[test]
+    fn dense_kv_reuses_one_metal_backing_within_capacity() {
+        let Ok(Ok(device)) = std::panic::catch_unwind(|| Device::new_metal(0)) else {
+            return;
+        };
+
+        for num_v_heads in [16, 32] {
+            let mut cache = Qwen35DenseKvCache::default();
+            let token = Tensor::zeros((1, num_v_heads, 1, 2), DType::F32, &device).unwrap();
+            cache.append(&token, 16, 16).unwrap();
+            let backing = tensor_storage_address(cache.data.as_deref().unwrap());
+            let mut accounting = super::TensorStorageAccounting::default();
+            cache.account_storage(&mut accounting).unwrap();
+            let allocated_bytes = accounting.bytes();
+
+            for _ in 1..16 {
+                cache.append(&token, 16, 16).unwrap();
+                assert_eq!(
+                    tensor_storage_address(cache.data.as_deref().unwrap()),
+                    backing
+                );
+                let mut accounting = super::TensorStorageAccounting::default();
+                cache.account_storage(&mut accounting).unwrap();
+                assert_eq!(accounting.bytes(), allocated_bytes);
+            }
+            assert_eq!(cache.len(), 16);
+        }
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/qwen35/text.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/text.rs
@@ -6,10 +6,10 @@ use candle_transformers::models::with_tracing::QMatMul;
 use candle_transformers::quantized_nn::RmsNorm;
 
 use crate::error::{Error, Result};
-use crate::kernels::buffer_pool::maybe_init_global_buffer_pool;
 use crate::kernels::{
     try_fused_gated_delta_recurrent, try_fused_gated_rms_norm, try_fused_l2_norm,
-    try_fused_silu_mul, try_tiled_deltanet_recurrence, use_block_fusion_for_device,
+    try_fused_silu_mul, try_qwen35_causal_conv_sequence, try_tiled_deltanet_recurrence,
+    use_block_fusion_for_device,
 };
 use crate::models::architectures::qwen3::core::repeat_kv;
 use crate::models::shared::attention::flash::{
@@ -19,7 +19,7 @@ use crate::models::shared::attention::paged::{
     append_to_pages, default_kv_page_size, default_kv_quantization, materialize_pages,
     paged_decode_attention, KvCacheQuantization, KvPage,
 };
-use crate::models::shared::memory::accounting::TensorStorageAccounting;
+use crate::models::shared::memory::accounting::{compact_tensor_storage, TensorStorageAccounting};
 use crate::models::shared::telemetry::{
     record_decode_attention_path, record_prefill_sequence_span, record_rope_kernel,
     record_rope_manual, DecodeAttentionPath,
@@ -113,7 +113,7 @@ impl ConvRingState {
         }
 
         let slot_refs: Vec<&Tensor> = self.slots.iter().collect();
-        let packed = Tensor::cat(&slot_refs, 1)?;
+        let packed = compact_tensor_storage(&Tensor::cat(&slot_refs, 1)?)?;
         let mut slots = Vec::with_capacity(self.slots.len());
         for idx in 0..self.slots.len() {
             slots.push(packed.narrow(1, idx, 1)?);
@@ -236,9 +236,6 @@ impl Qwen35TextModel {
                 cfg.ssm_inner_size, cfg.ssm_time_step_rank
             )));
         }
-
-        // Phase 5: initialize the shared scratch buffer pool once per process.
-        let _ = maybe_init_global_buffer_pool(device);
 
         let embedding_weights = loader
             .load_qtensor("token_embd.weight", device)?
@@ -896,7 +893,6 @@ impl Qwen35FullAttention {
         }
 
         let state_has_cached_prefix = full_attention_state_has_cached_prefix(state)?;
-
         let (k_pages, v_pages, dense_k_cache_h, dense_v_cache_h, dense_kv_tokens) = match state {
             Qwen35LayerRuntimeState::Full {
                 k_pages,
@@ -1485,7 +1481,7 @@ impl Qwen35LinearAttention {
         let g = g.reshape((1, self.num_v_heads))?;
         let (output, next_state) =
             recurrent_gated_delta(&query, &key, &value, &g, &beta, current_state)?;
-        *recurrent_state = Some(next_state);
+        *recurrent_state = Some(compact_tensor_storage(&next_state)?);
 
         let output = output.reshape((self.num_v_heads, self.head_v_dim))?;
         let z = z.reshape((self.num_v_heads, self.head_v_dim))?;
@@ -1545,18 +1541,13 @@ impl Qwen35LinearAttention {
             self.head_v_dim,
         ))?;
 
-        let mut query = l2norm(&query, 1e-6)?;
-        let mut key = l2norm(&key, 1e-6)?;
-        if self.num_v_heads != self.num_k_heads {
-            if self.num_k_heads == 0 || !self.num_v_heads.is_multiple_of(self.num_k_heads) {
-                return Err(Error::InferenceError(format!(
-                    "Invalid linear-attention head layout: num_v_heads={}, num_k_heads={}",
-                    self.num_v_heads, self.num_k_heads
-                )));
-            }
-            let repeats = self.num_v_heads / self.num_k_heads;
-            query = repeat_head_states_seq(&query, repeats)?;
-            key = repeat_head_states_seq(&key, repeats)?;
+        let query = l2norm(&query, 1e-6)?;
+        let key = l2norm(&key, 1e-6)?;
+        if self.num_k_heads == 0 || !self.num_v_heads.is_multiple_of(self.num_k_heads) {
+            return Err(Error::InferenceError(format!(
+                "Invalid linear-attention head layout: num_v_heads={}, num_k_heads={}",
+                self.num_v_heads, self.num_k_heads
+            )));
         }
 
         let current_state = if let Some(state) = recurrent_state.take() {
@@ -1573,8 +1564,8 @@ impl Qwen35LinearAttention {
         let g = g.reshape((1, seq_len, self.num_v_heads))?;
         let tile_size =
             qwen35_tiled_recurrence_tile_size(seq_len, self.tiled_recurrence_tile_size_override);
-        let (output, next_state) = if self.tiled_recurrence_enabled {
-            if let Some((tiled_output, tiled_state)) = try_tiled_deltanet_recurrence(
+        let fused_sequence = if self.tiled_recurrence_enabled {
+            try_tiled_deltanet_recurrence(
                 &query,
                 &key,
                 &value,
@@ -1582,15 +1573,44 @@ impl Qwen35LinearAttention {
                 &beta,
                 &current_state,
                 tile_size,
-            ) {
-                (tiled_output, tiled_state)
+            )
+        } else {
+            None
+        };
+        let (output, next_state) = if let Some(fused_sequence) = fused_sequence {
+            fused_sequence
+        } else {
+            // CUDA's equal-head kernel and the portable Candle reference consume
+            // tiled Q/K heads. The Metal sequence op above consumes the compact
+            // converted-GGUF 16K layout directly for both 16V and 32V models.
+            let (query, key) = if self.num_v_heads == self.num_k_heads {
+                (query, key)
+            } else {
+                let repeats = self.num_v_heads / self.num_k_heads;
+                (
+                    repeat_head_states_seq(&query, repeats)?,
+                    repeat_head_states_seq(&key, repeats)?,
+                )
+            };
+            if self.tiled_recurrence_enabled {
+                if let Some(fused_sequence) = try_tiled_deltanet_recurrence(
+                    &query,
+                    &key,
+                    &value,
+                    &g,
+                    &beta,
+                    &current_state,
+                    tile_size,
+                ) {
+                    fused_sequence
+                } else {
+                    recurrent_gated_delta_sequence(&query, &key, &value, &g, &beta, current_state)?
+                }
             } else {
                 recurrent_gated_delta_sequence(&query, &key, &value, &g, &beta, current_state)?
             }
-        } else {
-            recurrent_gated_delta_sequence(&query, &key, &value, &g, &beta, current_state)?
         };
-        *recurrent_state = Some(next_state);
+        *recurrent_state = Some(compact_tensor_storage(&next_state)?);
 
         let output = output.reshape((seq_len * self.num_v_heads, self.head_v_dim))?;
         let z = z.reshape((seq_len * self.num_v_heads, self.head_v_dim))?;
@@ -1607,6 +1627,34 @@ impl Qwen35LinearAttention {
         let seq_len = mixed_qkv.dim(1)?;
         if seq_len == 1 {
             return self.depthwise_conv_step(mixed_qkv, conv_state);
+        }
+
+        if self.kernel_size > 1 {
+            let history_len = self.kernel_size - 1;
+            let buffer = conv_state.as_mut().ok_or_else(|| {
+                Error::InferenceError("conv_state not initialized but kernel_size > 1".to_string())
+            })?;
+            if buffer.slots.len() != history_len || buffer.next_idx >= history_len {
+                return Err(Error::InferenceError(format!(
+                    "Invalid Qwen3.5 convolution history: slots={}, next_idx={}, expected_slots={history_len}",
+                    buffer.slots.len(),
+                    buffer.next_idx
+                )));
+            }
+            let logical_slots: Vec<&Tensor> = (0..history_len)
+                .map(|idx| &buffer.slots[(buffer.next_idx + idx) % history_len])
+                .collect();
+            let history = Tensor::cat(&logical_slots, 1)?;
+            if let Some((output, final_history)) =
+                try_qwen35_causal_conv_sequence(mixed_qkv, &self.conv_kernel, &history)
+            {
+                let final_history = compact_tensor_storage(&final_history)?;
+                buffer.slots = (0..history_len)
+                    .map(|idx| final_history.narrow(1, idx, 1))
+                    .collect::<candle_core::Result<Vec<_>>>()?;
+                buffer.next_idx = 0;
+                return Ok(output);
+            }
         }
 
         let mut outputs = Vec::with_capacity(seq_len);
@@ -1897,7 +1945,7 @@ fn build_rope_inv_freqs(rope_dim: usize, rope_theta: f64) -> Result<Vec<f32>> {
 /// Candle tensor views can outlive a scratch-pool checkout, so state that
 /// survives a forward call must never escape after its pool lease is released.
 fn owned_zero_tensor(shape: &[usize], dtype: DType, device: &Device) -> Result<Tensor> {
-    Tensor::zeros(shape.to_vec(), dtype, device).map_err(Error::from)
+    compact_tensor_storage(&Tensor::zeros(shape.to_vec(), dtype, device)?).map_err(Error::from)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2106,15 +2154,14 @@ fn append_dense_kv_cache_h(cache: &mut Option<Tensor>, append: &Tensor) -> Resul
         return Ok(());
     }
     let append = append.contiguous()?;
-    match cache {
+    let next = match cache {
         Some(existing) => {
             let existing_ref: &Tensor = &*existing;
-            *cache = Some(Tensor::cat(&[existing_ref, &append], 2)?);
+            Tensor::cat(&[existing_ref, &append], 2)?
         }
-        None => {
-            *cache = Some(append);
-        }
-    }
+        None => append.clone(),
+    };
+    *cache = Some(compact_tensor_storage(&next)?);
     Ok(())
 }
 
@@ -2283,6 +2330,71 @@ mod tests {
     };
     use candle_core::{DType, Device, IndexOp, Tensor};
     use candle_nn::rotary_emb;
+    use std::collections::HashSet;
+    use std::sync::{Arc, Barrier};
+
+    fn tensor_storage_address(tensor: &Tensor) -> usize {
+        let (storage, _) = tensor.storage_and_layout();
+        std::ptr::from_ref(&*storage) as usize
+    }
+
+    #[test]
+    fn owned_recurrent_states_do_not_alias_across_concurrent_sessions() {
+        const SESSION_COUNT: usize = 8;
+        let barrier = Arc::new(Barrier::new(SESSION_COUNT));
+        let handles = (0..SESSION_COUNT)
+            .map(|_| {
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    owned_zero_tensor(&[1, 2, 4, 4], DType::F32, &Device::Cpu)
+                        .expect("persistent recurrent state should allocate")
+                })
+            })
+            .collect::<Vec<_>>();
+        let states = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("allocation thread should finish"))
+            .collect::<Vec<_>>();
+
+        let storage_addresses = states
+            .iter()
+            .map(tensor_storage_address)
+            .collect::<HashSet<_>>();
+        assert_eq!(storage_addresses.len(), SESSION_COUNT);
+        assert!(states.iter().all(|state| state.dims() == [1, 2, 4, 4]));
+        assert!(states.iter().all(|state| {
+            state
+                .flatten_all()
+                .and_then(|state| state.to_vec1::<f32>())
+                .is_ok_and(|values| values.iter().all(|value| *value == 0.0))
+        }));
+    }
+
+    #[cfg(feature = "metal")]
+    #[test]
+    fn owned_recurrent_states_do_not_alias_on_metal() {
+        let Ok(Ok(device)) = std::panic::catch_unwind(|| Device::new_metal(0)) else {
+            return;
+        };
+        let first = owned_zero_tensor(&[1, 2, 4, 4], DType::F32, &device)
+            .expect("first Metal recurrent state should allocate");
+        let second = owned_zero_tensor(&[1, 2, 4, 4], DType::F32, &device)
+            .expect("second Metal recurrent state should allocate");
+
+        assert_ne!(
+            tensor_storage_address(&first),
+            tensor_storage_address(&second)
+        );
+        assert_eq!(
+            first.flatten_all().unwrap().to_vec1::<f32>().unwrap(),
+            vec![0.0; 32]
+        );
+        assert_eq!(
+            second.flatten_all().unwrap().to_vec1::<f32>().unwrap(),
+            vec![0.0; 32]
+        );
+    }
 
     #[test]
     fn repeat_head_states_uses_tiled_order() {
@@ -2407,6 +2519,20 @@ mod tests {
 
         let prefill =
             unfused_causal_attention(&query, &key, &value, 2, 1, 2).expect("causal prefill");
+        let rectangular =
+            unfused_causal_attention(&query.narrow(2, 2, 2).unwrap(), &key, &value, 2, 1, 2)
+                .expect("rectangular prefix attention");
+        let expected_rectangular = prefill.narrow(2, 2, 2).unwrap();
+        let rectangular_values = rectangular.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let expected_values = expected_rectangular
+            .flatten_all()
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap();
+        for (actual, expected) in rectangular_values.iter().zip(expected_values.iter()) {
+            assert!((actual - expected).abs() < 1e-5);
+        }
+
         let mut steps = Vec::new();
         for token_idx in 0..4 {
             let q = query.narrow(2, token_idx, 1).unwrap();

--- a/crates/izwi-core/src/models/architectures/qwen35/text.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/text.rs
@@ -126,7 +126,7 @@ impl ConvRingState {
         })
     }
 
-    /// Move logical history slots into one exact-size backing allocation.
+    /// Move every logical history slot into independent exact-size storage.
     ///
     /// Sequence-prefill slots are views into the entire projected token span.
     /// Keeping those views in runtime state would retain the full projection
@@ -136,13 +136,24 @@ impl ConvRingState {
             return Ok(());
         }
 
-        let slot_refs: Vec<&Tensor> = self.slots.iter().collect();
-        let packed = compact_tensor_storage(&Tensor::cat(&slot_refs, 1)?)?;
-        let mut slots = Vec::with_capacity(self.slots.len());
-        for idx in 0..self.slots.len() {
-            slots.push(packed.narrow(1, idx, 1)?);
+        self.slots = self
+            .slots
+            .iter()
+            .map(deep_copy_tensor_storage)
+            .collect::<candle_core::Result<Vec<_>>>()?;
+        Ok(())
+    }
+
+    fn push_owned(&mut self, current: &Tensor) -> Result<()> {
+        if self.slots.is_empty() || self.next_idx >= self.slots.len() {
+            return Err(Error::InferenceError(format!(
+                "Invalid Qwen3.5 convolution ring: slots={}, next_idx={}",
+                self.slots.len(),
+                self.next_idx
+            )));
         }
-        self.slots = slots;
+        self.slots[self.next_idx] = deep_copy_tensor_storage(current)?;
+        self.next_idx = (self.next_idx + 1) % self.slots.len();
         Ok(())
     }
 }
@@ -614,13 +625,12 @@ impl Qwen35Layer {
             ) => {
                 if conv_state.is_none() && mixer.kernel_size > 1 {
                     // Persistent runtime state cannot outlive a released scratch-pool
-                    // lease. Keep the fixed history in one exact-size allocation.
+                    // lease. Independent exact-size slots allow O(1) replacement
+                    // without retaining dead regions of a shared backing buffer.
                     let history_len = mixer.kernel_size - 1;
-                    let zero =
-                        owned_zero_tensor(&[mixer.conv_dim, history_len], DType::F32, device)?;
                     let mut slots = Vec::with_capacity(history_len);
-                    for idx in 0..history_len {
-                        slots.push(zero.narrow(1, idx, 1)?);
+                    for _ in 0..history_len {
+                        slots.push(owned_zero_tensor(&[mixer.conv_dim, 1], DType::F32, device)?);
                     }
                     *conv_state = Some(ConvRingState { slots, next_idx: 0 });
                 }
@@ -1717,9 +1727,11 @@ impl Qwen35LinearAttention {
             if let Some((output, final_history)) =
                 try_qwen35_causal_conv_sequence(mixed_qkv, &self.conv_kernel, &history)
             {
-                let final_history = compact_tensor_storage(&final_history)?;
                 buffer.slots = (0..history_len)
-                    .map(|idx| final_history.narrow(1, idx, 1))
+                    .map(|idx| {
+                        let slot = final_history.narrow(1, idx, 1)?;
+                        deep_copy_tensor_storage(&slot)
+                    })
                     .collect::<candle_core::Result<Vec<_>>>()?;
                 buffer.next_idx = 0;
                 return Ok(output);
@@ -1781,8 +1793,7 @@ impl Qwen35LinearAttention {
             }
 
             // Update the ring buffer in O(1): overwrite oldest and advance cursor.
-            buffer.slots[buffer.next_idx] = current;
-            buffer.next_idx = (buffer.next_idx + 1) % history_len;
+            buffer.push_owned(&current)?;
 
             convolved.squeeze(1)?
         };
@@ -2648,6 +2659,28 @@ mod tests {
             .compact_owned()
             .expect("compaction should succeed");
 
+        assert_eq!(state.allocated_session_bytes(), Some(3 * 32 * 4));
+    }
+
+    #[test]
+    fn conv_ring_push_does_not_retain_projection_backing() {
+        let slots = (0..3)
+            .map(|_| Tensor::zeros((32, 1), DType::F32, &Device::Cpu).unwrap())
+            .collect();
+        let mut ring = ConvRingState { slots, next_idx: 0 };
+        let projection = Tensor::zeros((1, 40, 32), DType::F32, &Device::Cpu).unwrap();
+        let current = projection.i((0, 39)).unwrap().reshape((32, 1)).unwrap();
+
+        ring.push_owned(&current).expect("ring push should copy");
+        drop(current);
+        drop(projection);
+
+        let state = Qwen35TextRuntimeState {
+            layers: vec![Qwen35LayerRuntimeState::Linear {
+                conv_state: Some(ring),
+                recurrent_state: None,
+            }],
+        };
         assert_eq!(state.allocated_session_bytes(), Some(3 * 32 * 4));
     }
 

--- a/crates/izwi-core/src/models/architectures/qwen35/text.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/text.rs
@@ -20,7 +20,7 @@ use crate::models::shared::attention::paged::{
     paged_decode_attention, KvCacheQuantization, KvPage,
 };
 use crate::models::shared::memory::accounting::{
-    compact_tensor_storage, deep_copy_tensor_storage, TensorStorageAccounting,
+    deep_copy_tensor_storage, TensorStorageAccounting,
 };
 use crate::models::shared::telemetry::{
     record_decode_attention_path, record_prefill_sequence_span, record_rope_kernel,
@@ -126,7 +126,7 @@ impl ConvRingState {
         })
     }
 
-    /// Move every logical history slot into independent exact-size storage.
+    /// Move every logical history slot into independent fixed-history storage.
     ///
     /// Sequence-prefill slots are views into the entire projected token span.
     /// Keeping those views in runtime state would retain the full projection
@@ -144,7 +144,12 @@ impl ConvRingState {
         Ok(())
     }
 
-    fn push_owned(&mut self, current: &Tensor) -> Result<()> {
+    /// Retain the current one-token projection as the newest decode slot.
+    ///
+    /// Decode projects exactly one token, so this view cannot retain a
+    /// sequence-sized backing tensor. Sequence prefill detaches its final fixed
+    /// history once at the sequence boundary instead.
+    fn push_decode(&mut self, current: &Tensor) -> Result<()> {
         if self.slots.is_empty() || self.next_idx >= self.slots.len() {
             return Err(Error::InferenceError(format!(
                 "Invalid Qwen3.5 convolution ring: slots={}, next_idx={}",
@@ -152,7 +157,7 @@ impl ConvRingState {
                 self.next_idx
             )));
         }
-        self.slots[self.next_idx] = deep_copy_tensor_storage(current)?;
+        self.slots[self.next_idx] = current.clone();
         self.next_idx = (self.next_idx + 1) % self.slots.len();
         Ok(())
     }
@@ -1560,7 +1565,9 @@ impl Qwen35LinearAttention {
         let g = g.reshape((1, self.num_v_heads))?;
         let (output, next_state) =
             recurrent_gated_delta(&query, &key, &value, &g, &beta, current_state)?;
-        *recurrent_state = Some(compact_tensor_storage(&next_state)?);
+        // The recurrent decode output owns a fresh Candle-managed allocation;
+        // retaining it avoids a full state-sized copy on every layer/token.
+        *recurrent_state = Some(next_state);
 
         let output = output.reshape((self.num_v_heads, self.head_v_dim))?;
         let z = z.reshape((self.num_v_heads, self.head_v_dim))?;
@@ -1689,7 +1696,10 @@ impl Qwen35LinearAttention {
                 recurrent_gated_delta_sequence(&query, &key, &value, &g, &beta, current_state)?
             }
         };
-        *recurrent_state = Some(compact_tensor_storage(&next_state)?);
+        // Sequence kernels may return the final state as a view into their
+        // packed output. Detach only this fixed-size escape value, using
+        // Candle-managed storage rather than an application private buffer.
+        *recurrent_state = Some(deep_copy_tensor_storage(&next_state)?);
 
         let output = output.reshape((seq_len * self.num_v_heads, self.head_v_dim))?;
         let z = z.reshape((seq_len * self.num_v_heads, self.head_v_dim))?;
@@ -1727,11 +1737,9 @@ impl Qwen35LinearAttention {
             if let Some((output, final_history)) =
                 try_qwen35_causal_conv_sequence(mixed_qkv, &self.conv_kernel, &history)
             {
+                let final_history = deep_copy_tensor_storage(&final_history)?;
                 buffer.slots = (0..history_len)
-                    .map(|idx| {
-                        let slot = final_history.narrow(1, idx, 1)?;
-                        deep_copy_tensor_storage(&slot)
-                    })
+                    .map(|idx| final_history.narrow(1, idx, 1))
                     .collect::<candle_core::Result<Vec<_>>>()?;
                 buffer.next_idx = 0;
                 return Ok(output);
@@ -1793,7 +1801,7 @@ impl Qwen35LinearAttention {
             }
 
             // Update the ring buffer in O(1): overwrite oldest and advance cursor.
-            buffer.push_owned(&current)?;
+            buffer.push_decode(&current)?;
 
             convolved.squeeze(1)?
         };
@@ -2025,7 +2033,7 @@ fn build_rope_inv_freqs(rope_dim: usize, rope_theta: f64) -> Result<Vec<f32>> {
 /// Candle tensor views can outlive a scratch-pool checkout, so state that
 /// survives a forward call must never escape after its pool lease is released.
 fn owned_zero_tensor(shape: &[usize], dtype: DType, device: &Device) -> Result<Tensor> {
-    compact_tensor_storage(&Tensor::zeros(shape.to_vec(), dtype, device)?).map_err(Error::from)
+    Tensor::zeros(shape.to_vec(), dtype, device).map_err(Error::from)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2241,7 +2249,9 @@ fn append_dense_kv_cache_h(cache: &mut Option<Tensor>, append: &Tensor) -> Resul
         }
         None => append.clone(),
     };
-    *cache = Some(compact_tensor_storage(&next)?);
+    // `Tensor::cat` already owns its Candle-managed output. A second full-cache
+    // copy here made decode allocation and memory traffic grow with context.
+    *cache = Some(next);
     Ok(())
 }
 
@@ -2663,15 +2673,18 @@ mod tests {
     }
 
     #[test]
-    fn conv_ring_push_does_not_retain_projection_backing() {
+    fn conv_ring_decode_push_reuses_one_token_projection_backing() {
         let slots = (0..3)
             .map(|_| Tensor::zeros((32, 1), DType::F32, &Device::Cpu).unwrap())
             .collect();
         let mut ring = ConvRingState { slots, next_idx: 0 };
-        let projection = Tensor::zeros((1, 40, 32), DType::F32, &Device::Cpu).unwrap();
-        let current = projection.i((0, 39)).unwrap().reshape((32, 1)).unwrap();
+        let projection = Tensor::zeros((1, 1, 32), DType::F32, &Device::Cpu).unwrap();
+        let current = projection.i((0, 0)).unwrap().reshape((32, 1)).unwrap();
+        let projection_storage = tensor_storage_address(&current);
 
-        ring.push_owned(&current).expect("ring push should copy");
+        ring.push_decode(&current)
+            .expect("ring push should succeed");
+        assert_eq!(tensor_storage_address(&ring.slots[0]), projection_storage);
         drop(current);
         drop(projection);
 

--- a/crates/izwi-core/src/models/architectures/qwen35/text.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/text.rs
@@ -6,23 +6,23 @@ use candle_transformers::models::with_tracing::QMatMul;
 use candle_transformers::quantized_nn::RmsNorm;
 
 use crate::error::{Error, Result};
-use crate::kernels::buffer_pool::{
-    global_buffer_pool_for_device, maybe_init_global_buffer_pool, SharedBufferPool,
-};
+use crate::kernels::buffer_pool::maybe_init_global_buffer_pool;
 use crate::kernels::{
     try_fused_gated_delta_recurrent, try_fused_gated_rms_norm, try_fused_l2_norm,
     try_fused_silu_mul, try_tiled_deltanet_recurrence, use_block_fusion_for_device,
 };
 use crate::models::architectures::qwen3::core::repeat_kv;
-use crate::models::shared::attention::flash::try_fused_self_attention;
+use crate::models::shared::attention::flash::{
+    try_fused_self_attention, try_fused_self_attention_preserve_dtype,
+};
 use crate::models::shared::attention::paged::{
     append_to_pages, default_kv_page_size, default_kv_quantization, materialize_pages,
     paged_decode_attention, KvCacheQuantization, KvPage,
 };
 use crate::models::shared::memory::accounting::TensorStorageAccounting;
 use crate::models::shared::telemetry::{
-    record_decode_attention_path, record_prefill_sequence_span, record_prefill_token_mode_step,
-    record_rope_kernel, record_rope_manual, DecodeAttentionPath,
+    record_decode_attention_path, record_prefill_sequence_span, record_rope_kernel,
+    record_rope_manual, DecodeAttentionPath,
 };
 use crate::models::shared::weights::gguf::GgufLoader;
 
@@ -38,6 +38,7 @@ pub struct Qwen35TextModel {
     block_fusion_decode_enabled: bool,
     block_fusion_prefill_enabled: bool,
     block_fusion_prefill_min_tokens: usize,
+    finite_diagnostics_enabled: bool,
 }
 
 pub struct Qwen35TextRuntimeState {
@@ -100,6 +101,28 @@ struct ConvRingState {
     next_idx: usize,
 }
 
+impl ConvRingState {
+    /// Move logical history slots into one exact-size backing allocation.
+    ///
+    /// Sequence-prefill slots are views into the entire projected token span.
+    /// Keeping those views in runtime state would retain the full projection
+    /// instead of the fixed `kernel_size - 1` history required by the conv.
+    fn compact_owned(&mut self) -> Result<()> {
+        if self.slots.is_empty() {
+            return Ok(());
+        }
+
+        let slot_refs: Vec<&Tensor> = self.slots.iter().collect();
+        let packed = Tensor::cat(&slot_refs, 1)?;
+        let mut slots = Vec::with_capacity(self.slots.len());
+        for idx in 0..self.slots.len() {
+            slots.push(packed.narrow(1, idx, 1)?);
+        }
+        self.slots = slots;
+        Ok(())
+    }
+}
+
 enum Qwen35LayerRuntimeState {
     Linear {
         conv_state: Option<ConvRingState>,
@@ -112,6 +135,25 @@ enum Qwen35LayerRuntimeState {
         dense_v_cache_h: Option<Tensor>,
         dense_kv_tokens: usize,
     },
+}
+
+fn full_attention_state_has_cached_prefix(state: &Qwen35LayerRuntimeState) -> Result<bool> {
+    match state {
+        Qwen35LayerRuntimeState::Full {
+            k_pages,
+            v_pages,
+            dense_k_cache_h,
+            dense_v_cache_h,
+            dense_kv_tokens,
+        } => Ok(!k_pages.is_empty()
+            || !v_pages.is_empty()
+            || dense_k_cache_h.is_some()
+            || dense_v_cache_h.is_some()
+            || *dense_kv_tokens > 0),
+        _ => Err(Error::InferenceError(
+            "Qwen3.5 layer runtime state does not match full-attention layer".to_string(),
+        )),
+    }
 }
 
 struct Qwen35Layer {
@@ -221,6 +263,7 @@ impl Qwen35TextModel {
         let block_fusion_decode_enabled = qwen35_block_fusion_decode_enabled(device);
         let (block_fusion_prefill_enabled, block_fusion_prefill_min_tokens) =
             qwen35_block_fusion_prefill_policy(device);
+        let finite_diagnostics_enabled = qwen35_env_bool("IZWI_QWEN35_FINITE_DIAGNOSTICS", false);
 
         let mut layers = Vec::with_capacity(cfg.block_count);
         for layer_idx in 0..cfg.block_count {
@@ -266,6 +309,7 @@ impl Qwen35TextModel {
             block_fusion_decode_enabled,
             block_fusion_prefill_enabled,
             block_fusion_prefill_min_tokens,
+            finite_diagnostics_enabled,
         })
     }
 
@@ -327,11 +371,23 @@ impl Qwen35TextModel {
                     let idx = layer_idx + offset;
                     let layer_state = &mut state.layers[idx];
                     hidden = self.layers[idx].forward(&hidden, layer_state, position_ids)?;
+                    validate_qwen35_finite_tensor(
+                        &hidden,
+                        idx,
+                        self.layers[idx].decode_diagnostic_path(),
+                        self.finite_diagnostics_enabled,
+                    )?;
                 }
                 layer_idx += 3;
             } else {
                 let layer_state = &mut state.layers[layer_idx];
                 hidden = self.layers[layer_idx].forward(&hidden, layer_state, position_ids)?;
+                validate_qwen35_finite_tensor(
+                    &hidden,
+                    layer_idx,
+                    self.layers[layer_idx].decode_diagnostic_path(),
+                    self.finite_diagnostics_enabled,
+                )?;
                 layer_idx += 1;
             }
         }
@@ -378,12 +434,24 @@ impl Qwen35TextModel {
                     let layer_state = &mut state.layers[idx];
                     hidden =
                         self.layers[idx].forward_sequence(&hidden, layer_state, position_ids)?;
+                    validate_qwen35_finite_tensor(
+                        &hidden,
+                        idx,
+                        self.layers[idx].prefill_diagnostic_path(),
+                        self.finite_diagnostics_enabled,
+                    )?;
                 }
                 layer_idx += 3;
             } else {
                 let layer_state = &mut state.layers[layer_idx];
                 hidden =
                     self.layers[layer_idx].forward_sequence(&hidden, layer_state, position_ids)?;
+                validate_qwen35_finite_tensor(
+                    &hidden,
+                    layer_idx,
+                    self.layers[layer_idx].prefill_diagnostic_path(),
+                    self.finite_diagnostics_enabled,
+                )?;
                 layer_idx += 1;
             }
         }
@@ -399,8 +467,21 @@ impl Qwen35TextModel {
 
     pub fn forward_hidden_to_logits(&self, hidden: &Tensor) -> Result<Tensor> {
         let hidden = self.output_norm.forward(hidden)?;
+        validate_qwen35_finite_tensor(
+            &hidden,
+            self.layers.len(),
+            "output.norm",
+            self.finite_diagnostics_enabled,
+        )?;
         let logits = self.output.forward(&hidden)?;
-        logits.i((0, 0)).map_err(Error::from)
+        let logits = logits.i((0, 0))?;
+        validate_qwen35_finite_tensor(
+            &logits,
+            self.layers.len(),
+            "output.logits",
+            self.finite_diagnostics_enabled,
+        )?;
+        Ok(logits)
     }
 
     fn validate_runtime_state(&self, state: &Qwen35TextRuntimeState) -> Result<()> {
@@ -418,6 +499,20 @@ impl Qwen35TextModel {
 impl Qwen35Layer {
     fn is_linear(&self) -> bool {
         matches!(self.mixer, Qwen35Mixer::Linear(_))
+    }
+
+    fn decode_diagnostic_path(&self) -> &'static str {
+        match self.mixer {
+            Qwen35Mixer::Linear(_) => "decode.linear_layer_output",
+            Qwen35Mixer::Full(_) => "decode.full_attention_layer_output",
+        }
+    }
+
+    fn prefill_diagnostic_path(&self) -> &'static str {
+        match self.mixer {
+            Qwen35Mixer::Linear(_) => "prefill.linear_layer_output",
+            Qwen35Mixer::Full(_) => "prefill.full_attention_layer_output",
+        }
     }
 
     fn new_state(&self) -> Qwen35LayerRuntimeState {
@@ -443,8 +538,6 @@ impl Qwen35Layer {
         state: &mut Qwen35LayerRuntimeState,
         device: &Device,
     ) -> Result<()> {
-        let pool = global_buffer_pool_for_device(device);
-
         match (&self.mixer, state) {
             (
                 Qwen35Mixer::Linear(mixer),
@@ -454,22 +547,19 @@ impl Qwen35Layer {
                 },
             ) => {
                 if conv_state.is_none() && mixer.kernel_size > 1 {
-                    // Initialize the ring buffer with zeros
-                    let mut slots = Vec::with_capacity(mixer.kernel_size - 1);
-                    let zero = pooled_zero_tensor(
-                        pool.as_ref(),
-                        &[mixer.conv_dim, 1],
-                        DType::F32,
-                        device,
-                    )?;
-                    for _ in 0..(mixer.kernel_size - 1) {
-                        slots.push(zero.clone());
+                    // Persistent runtime state cannot outlive a released scratch-pool
+                    // lease. Keep the fixed history in one exact-size allocation.
+                    let history_len = mixer.kernel_size - 1;
+                    let zero =
+                        owned_zero_tensor(&[mixer.conv_dim, history_len], DType::F32, device)?;
+                    let mut slots = Vec::with_capacity(history_len);
+                    for idx in 0..history_len {
+                        slots.push(zero.narrow(1, idx, 1)?);
                     }
                     *conv_state = Some(ConvRingState { slots, next_idx: 0 });
                 }
                 if recurrent_state.is_none() {
-                    *recurrent_state = Some(pooled_zero_tensor(
-                        pool.as_ref(),
+                    *recurrent_state = Some(owned_zero_tensor(
                         &[1, mixer.num_v_heads, mixer.head_k_dim, mixer.head_v_dim],
                         DType::F32,
                         device,
@@ -687,6 +777,10 @@ impl Qwen35FullAttention {
                 dense_v_cache_h,
             )?;
         } else {
+            // Any dense tensor associated with paged storage becomes stale as
+            // soon as a page is appended. Force a fresh materialization below.
+            *dense_k_cache_h = None;
+            *dense_v_cache_h = None;
             *dense_kv_tokens = 0;
             append_to_pages(
                 self.kv_page_size,
@@ -761,18 +855,14 @@ impl Qwen35FullAttention {
             )? {
                 out
             } else {
-                // Unfused fallback path still expects explicit KV expansion.
-                let key_states = key_states_h.transpose(1, 2)?.contiguous()?;
-                let value_states = value_states_h.transpose(1, 2)?.contiguous()?;
-                let key_states = repeat_kv(&key_states, self.num_heads, self.num_kv_heads)?;
-                let value_states = repeat_kv(&value_states, self.num_heads, self.num_kv_heads)?;
-                let key_states = key_states.transpose(1, 2)?.contiguous()?;
-                let value_states = value_states.transpose(1, 2)?.contiguous()?;
-                let key_states_t = key_states.transpose(2, 3)?.contiguous()?;
-                let attn = query_states.matmul(&key_states_t)?;
-                let attn = (attn / (self.head_dim as f64).sqrt())?;
-                let attn = ops::softmax_last_dim(&attn)?;
-                attn.contiguous()?.matmul(&value_states)?
+                unfused_causal_attention(
+                    &query_states,
+                    &key_states_h,
+                    &value_states_h,
+                    self.num_heads,
+                    self.num_kv_heads,
+                    self.head_dim,
+                )?
             };
             attn_output
                 .transpose(1, 2)?
@@ -805,30 +895,7 @@ impl Qwen35FullAttention {
             )));
         }
 
-        let has_prefix_pages = match state {
-            Qwen35LayerRuntimeState::Full {
-                k_pages, v_pages, ..
-            } => !k_pages.is_empty() || !v_pages.is_empty(),
-            _ => {
-                return Err(Error::InferenceError(
-                    "Qwen3.5 layer runtime state does not match full-attention layer".to_string(),
-                ))
-            }
-        };
-
-        // Safe fallback: if the layer already has cached prefix pages (for example after
-        // multimodal placeholder spans), keep the token-step semantics to preserve
-        // attention offset correctness.
-        if has_prefix_pages {
-            let mut outputs = Vec::with_capacity(seq_len);
-            for (idx, &position_id) in position_ids.iter().enumerate() {
-                let token_hidden = hidden_states.narrow(1, idx, 1)?;
-                record_prefill_token_mode_step();
-                outputs.push(self.forward(&token_hidden, state, position_id)?);
-            }
-            let refs: Vec<&Tensor> = outputs.iter().collect();
-            return Tensor::cat(&refs, 1).map_err(Error::from);
-        }
+        let state_has_cached_prefix = full_attention_state_has_cached_prefix(state)?;
 
         let (k_pages, v_pages, dense_k_cache_h, dense_v_cache_h, dense_kv_tokens) = match state {
             Qwen35LayerRuntimeState::Full {
@@ -884,26 +951,93 @@ impl Qwen35FullAttention {
         let query_states = query_states.transpose(1, 2)?.contiguous()?;
         let key_states_h = key_states_kv.transpose(1, 2)?.contiguous()?;
         let value_states_h = value_states_kv.transpose(1, 2)?.contiguous()?;
-        let attn_output = if let Some(out) = try_fused_self_attention(
-            &query_states,
-            &key_states_h,
-            &value_states_h,
-            None,
-            self.head_dim,
-            true,
-        )? {
-            out
+
+        // Cached chunks have rectangular Q/K lengths. Materialize the prefix
+        // once, concatenate the current K/V, and apply a bottom-right-aligned
+        // causal mask so query i sees the entire prefix plus current tokens
+        // through i. The supplied mRoPE positions above remain authoritative.
+        let cached_key_states_h = cached_kv_head_major(k_pages, dense_k_cache_h)?;
+        let cached_value_states_h = cached_kv_head_major(v_pages, dense_v_cache_h)?;
+        if cached_key_states_h.is_some() != cached_value_states_h.is_some() {
+            return Err(Error::InferenceError(
+                "Qwen3.5 full-attention key/value prefix caches are inconsistent".to_string(),
+            ));
+        }
+        if k_pages.is_empty() && v_pages.is_empty() && *dense_kv_tokens > 0 {
+            let cached_tokens = cached_key_states_h
+                .as_ref()
+                .map(|cache| cache.dim(2))
+                .transpose()?
+                .unwrap_or(0);
+            let cached_value_tokens = cached_value_states_h
+                .as_ref()
+                .map(|cache| cache.dim(2))
+                .transpose()?
+                .unwrap_or(0);
+            if cached_tokens != *dense_kv_tokens || cached_value_tokens != *dense_kv_tokens {
+                return Err(Error::InferenceError(format!(
+                    "Qwen3.5 dense KV prefix mismatch: tracked={}, k={}, v={}",
+                    *dense_kv_tokens, cached_tokens, cached_value_tokens
+                )));
+            }
+        }
+        if state_has_cached_prefix
+            && cached_key_states_h.is_none()
+            && cached_value_states_h.is_none()
+        {
+            return Err(Error::InferenceError(format!(
+                "Qwen3.5 full-attention state tracks a cached prefix ({} dense tokens) without KV storage",
+                *dense_kv_tokens
+            )));
+        }
+
+        let has_cached_prefix = state_has_cached_prefix;
+        let attention_key_states_h = if let Some(cached) = cached_key_states_h.as_ref() {
+            Tensor::cat(&[cached, &key_states_h], 2)?
         } else {
-            // Unfused fallback path still expects explicit KV expansion.
-            let key_states = repeat_kv(&key_states_kv, self.num_heads, self.num_kv_heads)?;
-            let value_states = repeat_kv(&value_states_kv, self.num_heads, self.num_kv_heads)?;
-            let key_states = key_states.transpose(1, 2)?.contiguous()?;
-            let value_states = value_states.transpose(1, 2)?.contiguous()?;
-            let key_states_t = key_states.transpose(2, 3)?.contiguous()?;
-            let attn = query_states.matmul(&key_states_t)?;
-            let attn = (attn / (self.head_dim as f64).sqrt())?;
-            let attn = ops::softmax_last_dim(&attn)?;
-            attn.contiguous()?.matmul(&value_states)?
+            key_states_h.clone()
+        };
+        let attention_value_states_h = if let Some(cached) = cached_value_states_h.as_ref() {
+            Tensor::cat(&[cached, &value_states_h], 2)?
+        } else {
+            value_states_h.clone()
+        };
+
+        // Candle's Metal vector-SDPA path (q_len <= 8) does not consume the
+        // causal flag. Keep short Metal prefills on the reference path; a
+        // single-token decode remains correct because every cached key is past.
+        let fused_prefill_has_exact_causality = !query_states.device().is_metal() || seq_len > 8;
+        let attn_output = if !has_cached_prefix && fused_prefill_has_exact_causality {
+            if let Some(out) = try_fused_self_attention_preserve_dtype(
+                &query_states,
+                &attention_key_states_h,
+                &attention_value_states_h,
+                None,
+                self.head_dim,
+                true,
+            )? {
+                out
+            } else {
+                unfused_causal_attention(
+                    &query_states,
+                    &attention_key_states_h,
+                    &attention_value_states_h,
+                    self.num_heads,
+                    self.num_kv_heads,
+                    self.head_dim,
+                )?
+            }
+        } else {
+            // Until fused kernels explicitly guarantee rectangular, offset-aware
+            // causal semantics, use the F32 reference path for cached chunks.
+            unfused_causal_attention(
+                &query_states,
+                &attention_key_states_h,
+                &attention_value_states_h,
+                self.num_heads,
+                self.num_kv_heads,
+                self.head_dim,
+            )?
         };
         let attn_output =
             attn_output
@@ -928,6 +1062,8 @@ impl Qwen35FullAttention {
                 dense_v_cache_h,
             )?;
         } else {
+            *dense_k_cache_h = None;
+            *dense_v_cache_h = None;
             *dense_kv_tokens = 0;
             append_to_pages(
                 self.kv_page_size,
@@ -1091,6 +1227,121 @@ impl Qwen35FullAttention {
         }
         matches!(dtype, DType::F16 | DType::BF16 | DType::F32)
     }
+}
+
+/// Correctness reference for Qwen3.5 causal attention. Q/K/V use head-major
+/// `[batch, heads, tokens, head_dim]` layout. When `query_len < key_len`, query
+/// positions are bottom-right aligned with the cached prefix.
+fn unfused_causal_attention(
+    query_states: &Tensor,
+    key_states_h: &Tensor,
+    value_states_h: &Tensor,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+) -> Result<Tensor> {
+    let (query_batch, query_heads, query_len, query_head_dim) = query_states.dims4()?;
+    let (key_batch, key_heads, key_len, key_head_dim) = key_states_h.dims4()?;
+    let (value_batch, value_heads, value_len, value_head_dim) = value_states_h.dims4()?;
+    if query_len == 0 || key_len == 0 || query_len > key_len {
+        return Err(Error::InvalidInput(format!(
+            "Invalid Qwen3.5 causal attention lengths: query={query_len}, key={key_len}"
+        )));
+    }
+    if query_batch != key_batch
+        || key_batch != value_batch
+        || query_heads != num_heads
+        || key_heads != num_kv_heads
+        || value_heads != num_kv_heads
+        || key_len != value_len
+        || query_head_dim != head_dim
+        || key_head_dim != head_dim
+        || value_head_dim != head_dim
+    {
+        return Err(Error::InvalidInput(format!(
+            "Invalid Qwen3.5 attention shapes: q={:?}, k={:?}, v={:?}, heads={num_heads}/{num_kv_heads}, head_dim={head_dim}",
+            query_states.dims(),
+            key_states_h.dims(),
+            value_states_h.dims(),
+        )));
+    }
+
+    // `repeat_kv` consumes sequence-major KV and returns sequence-major GQA
+    // expansion. Convert back to head-major for the score/value matmuls.
+    let key_states = key_states_h.transpose(1, 2)?.contiguous()?;
+    let value_states = value_states_h.transpose(1, 2)?.contiguous()?;
+    let key_states = repeat_kv(&key_states, num_heads, num_kv_heads)?;
+    let value_states = repeat_kv(&value_states, num_heads, num_kv_heads)?;
+    let key_states = key_states.transpose(1, 2)?.contiguous()?;
+    let value_states = value_states.transpose(1, 2)?.contiguous()?;
+
+    let output_dtype = query_states.dtype();
+    let key_states_t = key_states.transpose(2, 3)?.contiguous()?;
+    let scores = query_states.matmul(&key_states_t)?;
+    let mut scores = (scores / (head_dim as f64).sqrt())?.to_dtype(DType::F32)?;
+    if query_len > 1 {
+        let query_start = key_len - query_len;
+        let mask = qwen35_causal_attention_mask(
+            query_len,
+            key_len,
+            query_start,
+            scores.device(),
+            DType::F32,
+        )?;
+        scores = scores.broadcast_add(&mask)?;
+    }
+    let probabilities = ops::softmax_last_dim(&scores)?;
+    let values_f32 = value_states.to_dtype(DType::F32)?;
+    let output = probabilities.contiguous()?.matmul(&values_f32)?;
+    if output.dtype() == output_dtype {
+        Ok(output)
+    } else {
+        output.to_dtype(output_dtype).map_err(Error::from)
+    }
+}
+
+fn cached_kv_head_major(
+    pages: &[KvPage],
+    dense_cache_h: &Option<Tensor>,
+) -> Result<Option<Tensor>> {
+    // Pages are authoritative whenever present. A dense tensor can be a
+    // transient materialization of an earlier page set and therefore stale
+    // after a later append.
+    if !pages.is_empty() {
+        return Ok(Some(
+            materialize_pages(pages)?.transpose(1, 2)?.contiguous()?,
+        ));
+    }
+    Ok(dense_cache_h.clone())
+}
+
+fn qwen35_causal_attention_mask(
+    query_len: usize,
+    key_len: usize,
+    query_start: usize,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    if query_len == 0
+        || key_len == 0
+        || query_start > key_len
+        || query_start.saturating_add(query_len) > key_len
+    {
+        return Err(Error::InvalidInput(format!(
+            "Invalid Qwen3.5 causal mask: query={query_len}, key={key_len}, start={query_start}"
+        )));
+    }
+
+    let mut values = vec![0f32; query_len * key_len];
+    for query_idx in 0..query_len {
+        let last_visible_key = query_start + query_idx;
+        for key_idx in (last_visible_key + 1)..key_len {
+            values[query_idx * key_len + key_idx] = f32::NEG_INFINITY;
+        }
+    }
+    Tensor::from_vec(values, (1, 1, query_len, key_len), device)?
+        .to_dtype(dtype)
+        .map_err(Error::from)
 }
 
 impl Qwen35LinearAttention {
@@ -1362,6 +1613,9 @@ impl Qwen35LinearAttention {
         for idx in 0..seq_len {
             let token = mixed_qkv.narrow(1, idx, 1)?;
             outputs.push(self.depthwise_conv_step(&token, conv_state)?);
+        }
+        if let Some(conv_state) = conv_state.as_mut() {
+            conv_state.compact_owned()?;
         }
         let output_refs: Vec<&Tensor> = outputs.iter().collect();
         Tensor::cat(&output_refs, 1).map_err(Error::from)
@@ -1638,37 +1892,90 @@ fn build_rope_inv_freqs(rope_dim: usize, rope_theta: f64) -> Result<Vec<f32>> {
     Ok(inv_freqs)
 }
 
-fn pooled_zero_tensor(
-    pool: Option<&SharedBufferPool>,
-    shape: &[usize],
-    dtype: DType,
-    device: &Device,
-) -> Result<Tensor> {
-    if let Some(pool) = pool {
-        let num_elements = shape.iter().product::<usize>();
-        if let Some((size, idx, buf)) = pool.acquire(num_elements) {
-            let maybe_tensor = buf.view(shape).ok();
-            pool.release(size, idx);
-
-            if let Some(tensor) = maybe_tensor {
-                // Guard against accidental cross-device reuse from a mismatched global pool.
-                if format!("{:?}", tensor.device()) == format!("{device:?}") {
-                    if tensor.dtype() == dtype {
-                        return Ok(tensor);
-                    }
-                    if let Ok(casted) = tensor.to_dtype(dtype) {
-                        return Ok(casted);
-                    }
-                }
-            }
-        }
-    }
-
+/// Allocate persistent runtime state with independent backing storage.
+///
+/// Candle tensor views can outlive a scratch-pool checkout, so state that
+/// survives a forward call must never escape after its pool lease is released.
+fn owned_zero_tensor(shape: &[usize], dtype: DType, device: &Device) -> Result<Tensor> {
     Tensor::zeros(shape.to_vec(), dtype, device).map_err(Error::from)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct NonFiniteCounts {
+    nan: usize,
+    positive_infinity: usize,
+    negative_infinity: usize,
+}
+
+impl NonFiniteCounts {
+    fn total(self) -> usize {
+        self.nan
+            .saturating_add(self.positive_infinity)
+            .saturating_add(self.negative_infinity)
+    }
+}
+
+/// Collect diagnostics without exposing model inputs, outputs, or token data.
+/// This host readback is intentionally guarded by an opt-in environment flag
+/// at inference call sites because checking every layer synchronizes the GPU.
+fn non_finite_counts(tensor: &Tensor) -> Result<NonFiniteCounts> {
+    let values = tensor
+        .flatten_all()?
+        .to_dtype(DType::F32)?
+        .to_vec1::<f32>()?;
+    let mut counts = NonFiniteCounts {
+        nan: 0,
+        positive_infinity: 0,
+        negative_infinity: 0,
+    };
+    for value in values {
+        if value.is_nan() {
+            counts.nan = counts.nan.saturating_add(1);
+        } else if value == f32::INFINITY {
+            counts.positive_infinity = counts.positive_infinity.saturating_add(1);
+        } else if value == f32::NEG_INFINITY {
+            counts.negative_infinity = counts.negative_infinity.saturating_add(1);
+        }
+    }
+    Ok(counts)
+}
+
+fn validate_qwen35_finite_tensor(
+    tensor: &Tensor,
+    layer_idx: usize,
+    path: &str,
+    enabled: bool,
+) -> Result<()> {
+    if !enabled {
+        return Ok(());
+    }
+
+    let counts = non_finite_counts(tensor)?;
+    if counts.total() == 0 {
+        return Ok(());
+    }
+
+    Err(Error::InferenceError(format!(
+        "Qwen3.5 first non-finite tensor at {path}, layer {layer_idx}: \
+         {} of {} values ({} NaN, {} +Inf, {} -Inf), shape {:?}, dtype {:?}",
+        counts.total(),
+        tensor.elem_count(),
+        counts.nan,
+        counts.positive_infinity,
+        counts.negative_infinity,
+        tensor.dims(),
+        tensor.dtype(),
+    )))
+}
+
 fn softplus(x: &Tensor) -> Result<Tensor> {
-    (x.exp()? + 1.0)?.log().map_err(Error::from)
+    // Evaluate DeltaNet discretization in F32 with the stable identity
+    // max(x, 0) + log(1 + exp(-abs(x))). The direct log(exp(x) + 1)
+    // formulation overflows for valid large positive activations.
+    let x = x.to_dtype(DType::F32)?;
+    let positive = x.relu()?;
+    let correction = (x.abs()?.neg()?.exp()? + 1.0)?.log()?;
+    (&positive + &correction).map_err(Error::from)
 }
 
 fn l2norm(x: &Tensor, eps: f64) -> Result<Tensor> {
@@ -1968,11 +2275,13 @@ fn recurrent_gated_delta(
 #[cfg(test)]
 mod tests {
     use super::{
-        append_dense_kv_cache_h, apply_rotary_emb, build_mrope, qwen35_dense_decode_max_pages,
-        qwen35_page_count_for_tokens, repeat_head_states, repeat_head_states_seq, ConvRingState,
+        append_dense_kv_cache_h, apply_rotary_emb, build_mrope,
+        full_attention_state_has_cached_prefix, non_finite_counts, owned_zero_tensor,
+        qwen35_dense_decode_max_pages, qwen35_page_count_for_tokens, repeat_head_states,
+        repeat_head_states_seq, softplus, unfused_causal_attention, ConvRingState, KvPage,
         Qwen35LayerRuntimeState, Qwen35TextRuntimeState,
     };
-    use candle_core::{DType, Device, Tensor};
+    use candle_core::{DType, Device, IndexOp, Tensor};
     use candle_nn::rotary_emb;
 
     #[test]
@@ -2023,32 +2332,184 @@ mod tests {
     }
 
     #[test]
-    fn runtime_accounting_deduplicates_shared_conv_slots() {
-        let shared = Tensor::zeros((32, 1), DType::F32, &Device::Cpu).unwrap();
-        let single = Qwen35TextRuntimeState {
+    fn compact_conv_ring_drops_full_prefill_backing() {
+        let backing = Tensor::zeros((1, 40, 32), DType::F32, &Device::Cpu).unwrap();
+        let mut slots = Vec::new();
+        for token_idx in 37..40 {
+            slots.push(backing.i((0, token_idx)).unwrap().reshape((32, 1)).unwrap());
+        }
+        let mut state = Qwen35TextRuntimeState {
             layers: vec![Qwen35LayerRuntimeState::Linear {
-                conv_state: Some(ConvRingState {
-                    slots: vec![shared.clone()],
-                    next_idx: 0,
-                }),
-                recurrent_state: None,
-            }],
-        };
-        let repeated = Qwen35TextRuntimeState {
-            layers: vec![Qwen35LayerRuntimeState::Linear {
-                conv_state: Some(ConvRingState {
-                    slots: vec![shared.clone(), shared.clone(), shared],
-                    next_idx: 0,
-                }),
+                conv_state: Some(ConvRingState { slots, next_idx: 0 }),
                 recurrent_state: None,
             }],
         };
 
-        assert_eq!(
-            single.allocated_session_bytes(),
-            repeated.allocated_session_bytes()
-        );
-        assert!(single.allocated_session_bytes().unwrap() >= 32 * 4);
+        let retained_prefill_bytes = state.allocated_session_bytes().unwrap();
+        assert!(retained_prefill_bytes >= 40 * 32 * 4);
+
+        let Qwen35LayerRuntimeState::Linear { conv_state, .. } = &mut state.layers[0] else {
+            unreachable!("test state is linear")
+        };
+        conv_state
+            .as_mut()
+            .unwrap()
+            .compact_owned()
+            .expect("compaction should succeed");
+
+        assert_eq!(state.allocated_session_bytes(), Some(3 * 32 * 4));
+    }
+
+    #[test]
+    fn persistent_zero_states_have_independent_storage() {
+        let first = owned_zero_tensor(&[1, 2, 3, 4], DType::F32, &Device::Cpu).unwrap();
+        let second = owned_zero_tensor(&[1, 2, 3, 4], DType::F32, &Device::Cpu).unwrap();
+        let state = Qwen35TextRuntimeState {
+            layers: vec![
+                Qwen35LayerRuntimeState::Linear {
+                    conv_state: None,
+                    recurrent_state: Some(first),
+                },
+                Qwen35LayerRuntimeState::Linear {
+                    conv_state: None,
+                    recurrent_state: Some(second),
+                },
+            ],
+        };
+
+        assert_eq!(state.allocated_session_bytes(), Some(2 * 2 * 3 * 4 * 4));
+    }
+
+    #[test]
+    fn unfused_causal_prefill_and_cached_chunk_match_incremental_steps() {
+        let device = Device::Cpu;
+        let query = Tensor::from_vec(
+            vec![
+                0.2f32, 0.1, 0.3, -0.2, 0.4, 0.5, -0.1, 0.6, // head 0
+                -0.3, 0.2, 0.7, 0.1, 0.2, -0.4, 0.5, 0.3, // head 1
+            ],
+            (1, 2, 4, 2),
+            &device,
+        )
+        .unwrap();
+        let key = Tensor::from_vec(
+            vec![0.1f32, 0.3, 0.4, -0.2, 0.6, 0.5, -0.1, 0.7],
+            (1, 1, 4, 2),
+            &device,
+        )
+        .unwrap();
+        let value = Tensor::from_vec(
+            vec![1.0f32, 10.0, 2.0, 20.0, 4.0, 40.0, 8.0, 80.0],
+            (1, 1, 4, 2),
+            &device,
+        )
+        .unwrap();
+
+        let prefill =
+            unfused_causal_attention(&query, &key, &value, 2, 1, 2).expect("causal prefill");
+        let mut steps = Vec::new();
+        for token_idx in 0..4 {
+            let q = query.narrow(2, token_idx, 1).unwrap();
+            let k = key.narrow(2, 0, token_idx + 1).unwrap();
+            let v = value.narrow(2, 0, token_idx + 1).unwrap();
+            steps.push(
+                unfused_causal_attention(&q, &k, &v, 2, 1, 2).expect("incremental attention"),
+            );
+        }
+        let step_refs: Vec<&Tensor> = steps.iter().collect();
+        let incremental = Tensor::cat(&step_refs, 2).unwrap();
+        let cached_chunk =
+            unfused_causal_attention(&query.narrow(2, 2, 2).unwrap(), &key, &value, 2, 1, 2)
+                .expect("rectangular cached chunk");
+
+        let prefill_values = prefill.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let incremental_values = incremental.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        for (prefill, incremental) in prefill_values.iter().zip(incremental_values.iter()) {
+            assert!((prefill - incremental).abs() < 1e-5);
+        }
+
+        let expected_chunk = prefill.narrow(2, 2, 2).unwrap();
+        let expected_values = expected_chunk
+            .flatten_all()
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap();
+        let cached_values = cached_chunk
+            .flatten_all()
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap();
+        for (expected, cached) in expected_values.iter().zip(cached_values.iter()) {
+            assert!((expected - cached).abs() < 1e-5);
+        }
+    }
+
+    #[test]
+    fn dense_paged_and_tracked_full_attention_state_count_as_prefixes() {
+        let dense = Tensor::zeros((1, 1, 2, 2), DType::F32, &Device::Cpu).unwrap();
+        let dense_state = Qwen35LayerRuntimeState::Full {
+            k_pages: Vec::new(),
+            v_pages: Vec::new(),
+            dense_k_cache_h: Some(dense),
+            dense_v_cache_h: None,
+            dense_kv_tokens: 0,
+        };
+        assert!(full_attention_state_has_cached_prefix(&dense_state).unwrap());
+
+        let page = KvPage::Dense(Tensor::zeros((1, 2, 1, 2), DType::F32, &Device::Cpu).unwrap());
+        let paged_state = Qwen35LayerRuntimeState::Full {
+            k_pages: vec![page],
+            v_pages: Vec::new(),
+            dense_k_cache_h: None,
+            dense_v_cache_h: None,
+            dense_kv_tokens: 0,
+        };
+        assert!(full_attention_state_has_cached_prefix(&paged_state).unwrap());
+
+        let tracked_state = Qwen35LayerRuntimeState::Full {
+            k_pages: Vec::new(),
+            v_pages: Vec::new(),
+            dense_k_cache_h: None,
+            dense_v_cache_h: None,
+            dense_kv_tokens: 2,
+        };
+        assert!(full_attention_state_has_cached_prefix(&tracked_state).unwrap());
+
+        let empty = Qwen35LayerRuntimeState::Full {
+            k_pages: Vec::new(),
+            v_pages: Vec::new(),
+            dense_k_cache_h: None,
+            dense_v_cache_h: None,
+            dense_kv_tokens: 0,
+        };
+        assert!(!full_attention_state_has_cached_prefix(&empty).unwrap());
+    }
+
+    #[test]
+    fn softplus_is_f32_and_stable_for_large_magnitudes() {
+        let input = Tensor::from_vec(vec![-1000f32, 0.0, 1000.0], 3, &Device::Cpu).unwrap();
+        let output = softplus(&input).expect("softplus");
+        assert_eq!(output.dtype(), DType::F32);
+        let values = output.to_vec1::<f32>().unwrap();
+        assert!(values.iter().all(|value| value.is_finite()));
+        assert!(values[0].abs() < 1e-6);
+        assert!((values[1] - std::f32::consts::LN_2).abs() < 1e-6);
+        assert!((values[2] - 1000.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn non_finite_diagnostics_count_without_exposing_values() {
+        let tensor = Tensor::from_vec(
+            vec![0.0f32, f32::NAN, f32::INFINITY, f32::NEG_INFINITY],
+            4,
+            &Device::Cpu,
+        )
+        .unwrap();
+        let counts = non_finite_counts(&tensor).unwrap();
+        assert_eq!(counts.nan, 1);
+        assert_eq!(counts.positive_infinity, 1);
+        assert_eq!(counts.negative_infinity, 1);
+        assert_eq!(counts.total(), 3);
     }
 
     #[test]

--- a/crates/izwi-core/src/models/architectures/qwen35/text.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/text.rs
@@ -43,20 +43,19 @@ pub struct Qwen35TextModel {
     finite_diagnostics_enabled: bool,
 }
 
+#[derive(Clone)]
 pub struct Qwen35TextRuntimeState {
     layers: Vec<Qwen35LayerRuntimeState>,
 }
 
 impl Qwen35TextRuntimeState {
-    /// Fork all persistent tensors into independent Candle backing storage.
-    pub(crate) fn fork_for_prefix(&self) -> Result<Self> {
-        Ok(Self {
-            layers: self
-                .layers
-                .iter()
-                .map(Qwen35LayerRuntimeState::fork_for_prefix)
-                .collect::<Result<Vec<_>>>()?,
-        })
+    /// Fork immutable persistent state by sharing Candle tensor storage.
+    ///
+    /// Every Qwen3.5 state transition replaces tensor handles or page entries;
+    /// it never mutates a backing allocation in place. A future in-place kernel
+    /// must add copy-on-write at its mutation boundary before using this path.
+    pub(crate) fn fork_shared_for_prefix(&self) -> Self {
+        self.clone()
     }
 
     /// Backing allocations retained by the per-request text runtime state.
@@ -109,23 +108,13 @@ impl Qwen35TextRuntimeState {
     }
 }
 
+#[derive(Clone)]
 struct ConvRingState {
     slots: Vec<Tensor>,
     next_idx: usize,
 }
 
 impl ConvRingState {
-    fn fork_for_prefix(&self) -> Result<Self> {
-        Ok(Self {
-            slots: self
-                .slots
-                .iter()
-                .map(deep_copy_tensor_storage)
-                .collect::<candle_core::Result<Vec<_>>>()?,
-            next_idx: self.next_idx,
-        })
-    }
-
     /// Move every logical history slot into independent fixed-history storage.
     ///
     /// Sequence-prefill slots are views into the entire projected token span.
@@ -163,6 +152,7 @@ impl ConvRingState {
     }
 }
 
+#[derive(Clone)]
 enum Qwen35LayerRuntimeState {
     Linear {
         conv_state: Option<ConvRingState>,
@@ -175,51 +165,6 @@ enum Qwen35LayerRuntimeState {
         dense_v_cache_h: Option<Tensor>,
         dense_kv_tokens: usize,
     },
-}
-
-impl Qwen35LayerRuntimeState {
-    fn fork_for_prefix(&self) -> Result<Self> {
-        match self {
-            Self::Linear {
-                conv_state,
-                recurrent_state,
-            } => Ok(Self::Linear {
-                conv_state: conv_state
-                    .as_ref()
-                    .map(ConvRingState::fork_for_prefix)
-                    .transpose()?,
-                recurrent_state: recurrent_state
-                    .as_ref()
-                    .map(deep_copy_tensor_storage)
-                    .transpose()?,
-            }),
-            Self::Full {
-                k_pages,
-                v_pages,
-                dense_k_cache_h,
-                dense_v_cache_h,
-                dense_kv_tokens,
-            } => Ok(Self::Full {
-                k_pages: k_pages
-                    .iter()
-                    .map(KvPage::deep_copy)
-                    .collect::<Result<Vec<_>>>()?,
-                v_pages: v_pages
-                    .iter()
-                    .map(KvPage::deep_copy)
-                    .collect::<Result<Vec<_>>>()?,
-                dense_k_cache_h: dense_k_cache_h
-                    .as_ref()
-                    .map(deep_copy_tensor_storage)
-                    .transpose()?,
-                dense_v_cache_h: dense_v_cache_h
-                    .as_ref()
-                    .map(deep_copy_tensor_storage)
-                    .transpose()?,
-                dense_kv_tokens: *dense_kv_tokens,
-            }),
-        }
-    }
 }
 
 fn full_attention_state_has_cached_prefix(state: &Qwen35LayerRuntimeState) -> Result<bool> {
@@ -2412,11 +2357,11 @@ fn recurrent_gated_delta(
 #[cfg(test)]
 mod tests {
     use super::{
-        append_dense_kv_cache_h, apply_rotary_emb, build_mrope,
+        append_dense_kv_cache_h, append_to_pages, apply_rotary_emb, build_mrope,
         full_attention_state_has_cached_prefix, non_finite_counts, owned_zero_tensor,
         qwen35_dense_decode_max_pages, qwen35_page_count_for_tokens, repeat_head_states,
-        repeat_head_states_seq, softplus, unfused_causal_attention, ConvRingState, KvPage,
-        Qwen35LayerRuntimeState, Qwen35TextRuntimeState,
+        repeat_head_states_seq, softplus, unfused_causal_attention, ConvRingState,
+        KvCacheQuantization, KvPage, Qwen35LayerRuntimeState, Qwen35TextRuntimeState,
     };
     use candle_core::{DType, Device, IndexOp, Tensor};
     use candle_nn::rotary_emb;
@@ -2461,7 +2406,7 @@ mod tests {
         }));
     }
 
-    fn assert_prefix_forks_have_independent_hybrid_state_storage(device: &Device) {
+    fn assert_prefix_forks_share_immutable_hybrid_state_storage(device: &Device) {
         let state = Qwen35TextRuntimeState {
             layers: vec![
                 Qwen35LayerRuntimeState::Linear {
@@ -2484,8 +2429,8 @@ mod tests {
                 },
             ],
         };
-        let mut first = state.fork_for_prefix().unwrap();
-        let second = state.fork_for_prefix().unwrap();
+        let mut first = state.fork_shared_for_prefix();
+        let second = state.fork_shared_for_prefix();
 
         let (
             Qwen35LayerRuntimeState::Linear {
@@ -2500,11 +2445,11 @@ mod tests {
         else {
             panic!("linear states")
         };
-        assert_ne!(
+        assert_eq!(
             tensor_storage_address(&first_conv.slots[0]),
             tensor_storage_address(&second_conv.slots[0])
         );
-        assert_ne!(
+        assert_eq!(
             tensor_storage_address(first_recurrent),
             tensor_storage_address(second_recurrent)
         );
@@ -2527,48 +2472,69 @@ mod tests {
             vec![1.0; 4]
         );
 
-        let (
-            Qwen35LayerRuntimeState::Full {
-                k_pages: first_pages,
-                dense_k_cache_h: Some(first_dense),
-                ..
-            },
-            Qwen35LayerRuntimeState::Full {
-                k_pages: second_pages,
-                dense_k_cache_h: Some(second_dense),
-                ..
-            },
-        ) = (&first.layers[1], &second.layers[1])
+        let Qwen35LayerRuntimeState::Full {
+            k_pages: first_pages,
+            dense_k_cache_h: first_dense_cache,
+            ..
+        } = &mut first.layers[1]
         else {
-            panic!("full states")
+            panic!("first full state")
+        };
+        let Qwen35LayerRuntimeState::Full {
+            k_pages: second_pages,
+            dense_k_cache_h: Some(second_dense),
+            ..
+        } = &second.layers[1]
+        else {
+            panic!("second full state")
         };
         let (KvPage::Dense(first_page), KvPage::Dense(second_page)) =
             (&first_pages[0], &second_pages[0])
         else {
             panic!("dense pages")
         };
-        assert_ne!(
+        let first_dense = first_dense_cache.as_ref().expect("first dense cache");
+        assert_eq!(
             tensor_storage_address(first_page),
             tensor_storage_address(second_page)
         );
-        assert_ne!(
+        assert_eq!(
             tensor_storage_address(first_dense),
             tensor_storage_address(second_dense)
         );
+
+        append_dense_kv_cache_h(
+            first_dense_cache,
+            &Tensor::zeros((1, 1, 1, 2), DType::F32, device).unwrap(),
+        )
+        .unwrap();
+        append_to_pages(
+            2,
+            first_pages,
+            &Tensor::zeros((1, 1, 1, 2), DType::F32, device).unwrap(),
+            KvCacheQuantization::None,
+        )
+        .unwrap();
+        let KvPage::Dense(second_page) = &second_pages[0] else {
+            panic!("second dense page")
+        };
+        assert_eq!(first_dense_cache.as_ref().unwrap().dim(2).unwrap(), 2);
+        assert_eq!(second_page.dim(1).unwrap(), 1);
+        assert_eq!(second_dense.dim(2).unwrap(), 1);
     }
 
     #[test]
-    fn prefix_forks_have_independent_hybrid_state_storage() {
-        assert_prefix_forks_have_independent_hybrid_state_storage(&Device::Cpu);
+    fn prefix_forks_share_immutable_hybrid_state_storage() {
+        assert_prefix_forks_share_immutable_hybrid_state_storage(&Device::Cpu);
     }
 
     #[cfg(feature = "metal")]
     #[test]
-    fn prefix_forks_have_independent_hybrid_state_storage_on_metal() {
+    fn prefix_forks_share_immutable_hybrid_state_storage_on_metal() {
         let Ok(Ok(device)) = std::panic::catch_unwind(|| Device::new_metal(0)) else {
             return;
         };
-        assert_prefix_forks_have_independent_hybrid_state_storage(&device);
+        assert_prefix_forks_share_immutable_hybrid_state_storage(&device);
     }
 
     #[cfg(feature = "metal")]

--- a/crates/izwi-core/src/models/architectures/qwen35/text.rs
+++ b/crates/izwi-core/src/models/architectures/qwen35/text.rs
@@ -90,21 +90,127 @@ impl Qwen35TextRuntimeState {
                     v_pages,
                     dense_k_cache_h,
                     dense_v_cache_h,
-                    ..
                 } => {
                     for page in k_pages.iter().chain(v_pages.iter()) {
                         page.account_storage(accounting)?;
                     }
-                    if let Some(cache) = dense_k_cache_h {
-                        accounting.add_tensor(cache)?;
-                    }
-                    if let Some(cache) = dense_v_cache_h {
-                        accounting.add_tensor(cache)?;
-                    }
+                    dense_k_cache_h.account_storage(accounting)?;
+                    dense_v_cache_h.account_storage(accounting)?;
                 }
             }
         }
         Some(())
+    }
+}
+
+/// Copy-on-write, geometrically growing head-major KV storage.
+///
+/// The backing tensor is shared by prefix snapshots. Appends mutate it only
+/// while this cache is the sole owner; the first write after a snapshot fork
+/// detaches into a new Candle-managed allocation.
+#[derive(Clone, Default)]
+struct Qwen35DenseKvCache {
+    data: Option<Arc<Tensor>>,
+    valid_len: usize,
+}
+
+impl Qwen35DenseKvCache {
+    fn len(&self) -> usize {
+        self.valid_len
+    }
+
+    fn is_empty(&self) -> bool {
+        self.valid_len == 0
+    }
+
+    fn capacity(&self) -> Result<usize> {
+        self.data
+            .as_ref()
+            .map(|data| data.dim(2).map_err(Error::from))
+            .transpose()
+            .map(|capacity| capacity.unwrap_or(0))
+    }
+
+    fn current_data(&self) -> Result<Option<Tensor>> {
+        match self.data.as_ref() {
+            Some(data) if self.valid_len > 0 => Ok(Some(
+                data.narrow(2, 0, self.valid_len).map_err(Error::from)?,
+            )),
+            _ => Ok(None),
+        }
+    }
+
+    fn clear(&mut self) {
+        self.data = None;
+        self.valid_len = 0;
+    }
+
+    fn account_storage(&self, accounting: &mut TensorStorageAccounting) -> Option<()> {
+        if let Some(data) = self.data.as_ref() {
+            accounting.add_tensor(data)?;
+        }
+        Some(())
+    }
+
+    fn append(
+        &mut self,
+        append: &Tensor,
+        initial_capacity: usize,
+        max_capacity: usize,
+    ) -> Result<()> {
+        let append_len = append.dim(2)?;
+        if append_len == 0 {
+            return Ok(());
+        }
+        if initial_capacity == 0 || max_capacity == 0 {
+            return Err(Error::InvalidInput(
+                "Qwen3.5 dense KV capacity must be greater than zero".to_string(),
+            ));
+        }
+        let required = self.valid_len.checked_add(append_len).ok_or_else(|| {
+            Error::Overloaded("Qwen3.5 dense KV token count overflow".to_string())
+        })?;
+        if required > max_capacity {
+            return Err(Error::InvalidInput(format!(
+                "Qwen3.5 dense KV append requires {required} tokens but capacity is bounded at {max_capacity}"
+            )));
+        }
+
+        let current_capacity = self.capacity()?;
+        let shared = self
+            .data
+            .as_ref()
+            .is_some_and(|data| Arc::strong_count(data) > 1);
+        let needs_allocation = self.data.is_none() || shared || required > current_capacity;
+        let append = append.contiguous()?;
+
+        if needs_allocation {
+            let mut next_capacity = current_capacity
+                .max(initial_capacity.min(max_capacity))
+                .max(1);
+            while next_capacity < required {
+                let grown = next_capacity.saturating_mul(2).min(max_capacity);
+                if grown == next_capacity {
+                    return Err(Error::Overloaded(
+                        "Qwen3.5 dense KV capacity could not grow".to_string(),
+                    ));
+                }
+                next_capacity = grown;
+            }
+
+            let mut shape = append.dims().to_vec();
+            shape[2] = next_capacity;
+            let next = Tensor::zeros(shape, append.dtype(), append.device())?;
+            if let Some(current) = self.current_data()? {
+                next.slice_set(&current.contiguous()?, 2, 0)?;
+            }
+            next.slice_set(&append, 2, self.valid_len)?;
+            self.data = Some(Arc::new(next));
+        } else if let Some(data) = self.data.as_ref() {
+            data.slice_set(&append, 2, self.valid_len)?;
+        }
+        self.valid_len = required;
+        Ok(())
     }
 }
 
@@ -161,9 +267,8 @@ enum Qwen35LayerRuntimeState {
     Full {
         k_pages: Vec<KvPage>,
         v_pages: Vec<KvPage>,
-        dense_k_cache_h: Option<Tensor>,
-        dense_v_cache_h: Option<Tensor>,
-        dense_kv_tokens: usize,
+        dense_k_cache_h: Qwen35DenseKvCache,
+        dense_v_cache_h: Qwen35DenseKvCache,
     },
 }
 
@@ -174,12 +279,10 @@ fn full_attention_state_has_cached_prefix(state: &Qwen35LayerRuntimeState) -> Re
             v_pages,
             dense_k_cache_h,
             dense_v_cache_h,
-            dense_kv_tokens,
         } => Ok(!k_pages.is_empty()
             || !v_pages.is_empty()
-            || dense_k_cache_h.is_some()
-            || dense_v_cache_h.is_some()
-            || *dense_kv_tokens > 0),
+            || !dense_k_cache_h.is_empty()
+            || !dense_v_cache_h.is_empty()),
         _ => Err(Error::InferenceError(
             "Qwen3.5 layer runtime state does not match full-attention layer".to_string(),
         )),
@@ -551,9 +654,8 @@ impl Qwen35Layer {
             Qwen35Mixer::Full(_) => Qwen35LayerRuntimeState::Full {
                 k_pages: Vec::new(),
                 v_pages: Vec::new(),
-                dense_k_cache_h: None,
-                dense_v_cache_h: None,
-                dense_kv_tokens: 0,
+                dense_k_cache_h: Qwen35DenseKvCache::default(),
+                dense_v_cache_h: Qwen35DenseKvCache::default(),
             },
         }
     }
@@ -732,20 +834,13 @@ impl Qwen35FullAttention {
         state: &mut Qwen35LayerRuntimeState,
         position_ids: [usize; 3],
     ) -> Result<Tensor> {
-        let (k_pages, v_pages, dense_k_cache_h, dense_v_cache_h, dense_kv_tokens) = match state {
+        let (k_pages, v_pages, dense_k_cache_h, dense_v_cache_h) = match state {
             Qwen35LayerRuntimeState::Full {
                 k_pages,
                 v_pages,
                 dense_k_cache_h,
                 dense_v_cache_h,
-                dense_kv_tokens,
-            } => (
-                k_pages,
-                v_pages,
-                dense_k_cache_h,
-                dense_v_cache_h,
-                dense_kv_tokens,
-            ),
+            } => (k_pages, v_pages, dense_k_cache_h, dense_v_cache_h),
             _ => {
                 return Err(Error::InferenceError(
                     "Qwen3.5 layer runtime state does not match full-attention layer".to_string(),
@@ -783,44 +878,18 @@ impl Qwen35FullAttention {
         let (query_states, key_states) =
             self.apply_rope(&query_states, &key_states, position_ids)?;
 
-        // Keep KV in dense head-major cache while dense decode remains active.
-        // We lazily migrate to paged KV once dense threshold is exceeded.
-        if self.dense_decode_attention_enabled && k_pages.is_empty() && v_pages.is_empty() {
-            append_dense_kv_cache_h(dense_k_cache_h, &key_states.transpose(1, 2)?.contiguous()?)?;
-            append_dense_kv_cache_h(
-                dense_v_cache_h,
-                &value_states.transpose(1, 2)?.contiguous()?,
-            )?;
-            *dense_kv_tokens = dense_kv_tokens.saturating_add(1);
-            maybe_materialize_dense_kv_pages(
-                self.kv_page_size,
-                self.kv_quantization,
-                self.dense_decode_max_tokens,
-                k_pages,
-                v_pages,
-                dense_kv_tokens,
-                dense_k_cache_h,
-                dense_v_cache_h,
-            )?;
-        } else {
-            // Any dense tensor associated with paged storage becomes stale as
-            // soon as a page is appended. Force a fresh materialization below.
-            *dense_k_cache_h = None;
-            *dense_v_cache_h = None;
-            *dense_kv_tokens = 0;
-            append_to_pages(
-                self.kv_page_size,
-                k_pages,
-                &key_states,
-                self.kv_quantization,
-            )?;
-            append_to_pages(
-                self.kv_page_size,
-                v_pages,
-                &value_states,
-                self.kv_quantization,
-            )?;
-        }
+        persist_qwen35_kv(
+            self.kv_page_size,
+            self.kv_quantization,
+            self.dense_decode_attention_enabled,
+            self.dense_decode_max_tokens,
+            k_pages,
+            v_pages,
+            dense_k_cache_h,
+            dense_v_cache_h,
+            &key_states,
+            &value_states,
+        )?;
 
         let use_paged_decode = query_states.dim(1)? == 1
             && !k_pages.is_empty()
@@ -833,9 +902,8 @@ impl Qwen35FullAttention {
         let is_decode_step = query_states.dim(1)? == 1;
         let attn_output = if use_paged_decode {
             // Once decode switches to paged attention, we do not need dense caches anymore.
-            *dense_k_cache_h = None;
-            *dense_v_cache_h = None;
-            *dense_kv_tokens = 0;
+            dense_k_cache_h.clear();
+            dense_v_cache_h.clear();
             paged_decode_attention(
                 &query_states,
                 k_pages,
@@ -846,25 +914,17 @@ impl Qwen35FullAttention {
             )?
             .reshape((1, 1, self.num_heads * self.head_dim))?
         } else {
-            let key_states_h = if let Some(cached) = dense_k_cache_h.as_ref() {
-                cached.clone()
+            let key_states_h = if let Some(cached) = dense_k_cache_h.current_data()? {
+                cached
             } else {
                 let materialized = materialize_pages(k_pages)?;
-                let materialized_h = materialized.transpose(1, 2)?.contiguous()?;
-                if self.dense_decode_attention_enabled {
-                    *dense_k_cache_h = Some(materialized_h.clone());
-                }
-                materialized_h
+                materialized.transpose(1, 2)?.contiguous()?
             };
-            let value_states_h = if let Some(cached) = dense_v_cache_h.as_ref() {
-                cached.clone()
+            let value_states_h = if let Some(cached) = dense_v_cache_h.current_data()? {
+                cached
             } else {
                 let materialized = materialize_pages(v_pages)?;
-                let materialized_h = materialized.transpose(1, 2)?.contiguous()?;
-                if self.dense_decode_attention_enabled {
-                    *dense_v_cache_h = Some(materialized_h.clone());
-                }
-                materialized_h
+                materialized.transpose(1, 2)?.contiguous()?
             };
             if is_decode_step {
                 record_decode_attention_path(DecodeAttentionPath::Dense);
@@ -922,20 +982,13 @@ impl Qwen35FullAttention {
         }
 
         let state_has_cached_prefix = full_attention_state_has_cached_prefix(state)?;
-        let (k_pages, v_pages, dense_k_cache_h, dense_v_cache_h, dense_kv_tokens) = match state {
+        let (k_pages, v_pages, dense_k_cache_h, dense_v_cache_h) = match state {
             Qwen35LayerRuntimeState::Full {
                 k_pages,
                 v_pages,
                 dense_k_cache_h,
                 dense_v_cache_h,
-                dense_kv_tokens,
-            } => (
-                k_pages,
-                v_pages,
-                dense_k_cache_h,
-                dense_v_cache_h,
-                dense_kv_tokens,
-            ),
+            } => (k_pages, v_pages, dense_k_cache_h, dense_v_cache_h),
             _ => {
                 return Err(Error::InferenceError(
                     "Qwen3.5 layer runtime state does not match full-attention layer".to_string(),
@@ -988,7 +1041,10 @@ impl Qwen35FullAttention {
                 "Qwen3.5 full-attention key/value prefix caches are inconsistent".to_string(),
             ));
         }
-        if k_pages.is_empty() && v_pages.is_empty() && *dense_kv_tokens > 0 {
+        if k_pages.is_empty()
+            && v_pages.is_empty()
+            && (!dense_k_cache_h.is_empty() || !dense_v_cache_h.is_empty())
+        {
             let cached_tokens = cached_key_states_h
                 .as_ref()
                 .map(|cache| cache.dim(2))
@@ -999,10 +1055,14 @@ impl Qwen35FullAttention {
                 .map(|cache| cache.dim(2))
                 .transpose()?
                 .unwrap_or(0);
-            if cached_tokens != *dense_kv_tokens || cached_value_tokens != *dense_kv_tokens {
+            let tracked_tokens = dense_k_cache_h.len();
+            if tracked_tokens != dense_v_cache_h.len()
+                || cached_tokens != tracked_tokens
+                || cached_value_tokens != tracked_tokens
+            {
                 return Err(Error::InferenceError(format!(
                     "Qwen3.5 dense KV prefix mismatch: tracked={}, k={}, v={}",
-                    *dense_kv_tokens, cached_tokens, cached_value_tokens
+                    tracked_tokens, cached_tokens, cached_value_tokens
                 )));
             }
         }
@@ -1012,7 +1072,7 @@ impl Qwen35FullAttention {
         {
             return Err(Error::InferenceError(format!(
                 "Qwen3.5 full-attention state tracks a cached prefix ({} dense tokens) without KV storage",
-                *dense_kv_tokens
+                dense_k_cache_h.len().max(dense_v_cache_h.len())
             )));
         }
 
@@ -1072,37 +1132,18 @@ impl Qwen35FullAttention {
         let output = self.o_proj.forward(&attn_output)?;
 
         // Persist newly computed KV after the sequence attention pass.
-        if self.dense_decode_attention_enabled && k_pages.is_empty() && v_pages.is_empty() {
-            append_dense_kv_cache_h(dense_k_cache_h, &key_states_h)?;
-            append_dense_kv_cache_h(dense_v_cache_h, &value_states_h)?;
-            *dense_kv_tokens = dense_kv_tokens.saturating_add(seq_len);
-            maybe_materialize_dense_kv_pages(
-                self.kv_page_size,
-                self.kv_quantization,
-                self.dense_decode_max_tokens,
-                k_pages,
-                v_pages,
-                dense_kv_tokens,
-                dense_k_cache_h,
-                dense_v_cache_h,
-            )?;
-        } else {
-            *dense_k_cache_h = None;
-            *dense_v_cache_h = None;
-            *dense_kv_tokens = 0;
-            append_to_pages(
-                self.kv_page_size,
-                k_pages,
-                &key_states_kv,
-                self.kv_quantization,
-            )?;
-            append_to_pages(
-                self.kv_page_size,
-                v_pages,
-                &value_states_kv,
-                self.kv_quantization,
-            )?;
-        }
+        persist_qwen35_kv(
+            self.kv_page_size,
+            self.kv_quantization,
+            self.dense_decode_attention_enabled,
+            self.dense_decode_max_tokens,
+            k_pages,
+            v_pages,
+            dense_k_cache_h,
+            dense_v_cache_h,
+            &key_states_kv,
+            &value_states_kv,
+        )?;
 
         Ok(output)
     }
@@ -1327,7 +1368,7 @@ fn unfused_causal_attention(
 
 fn cached_kv_head_major(
     pages: &[KvPage],
-    dense_cache_h: &Option<Tensor>,
+    dense_cache_h: &Qwen35DenseKvCache,
 ) -> Result<Option<Tensor>> {
     // Pages are authoritative whenever present. A dense tensor can be a
     // transient materialization of an earlier page set and therefore stale
@@ -1337,7 +1378,7 @@ fn cached_kv_head_major(
             materialize_pages(pages)?.transpose(1, 2)?.contiguous()?,
         ));
     }
-    Ok(dense_cache_h.clone())
+    dense_cache_h.current_data()
 }
 
 fn qwen35_causal_attention_mask(
@@ -2182,70 +2223,104 @@ fn qwen35_use_dense_decode_attention_feature(device: &Device) -> bool {
     device.is_metal() && qwen35_env_bool("IZWI_QWEN35_DENSE_DECODE_ATTENTION", true)
 }
 
-fn append_dense_kv_cache_h(cache: &mut Option<Tensor>, append: &Tensor) -> Result<()> {
-    if append.dim(2)? == 0 {
-        return Ok(());
-    }
-    let append = append.contiguous()?;
-    let next = match cache {
-        Some(existing) => {
-            let existing_ref: &Tensor = &*existing;
-            Tensor::cat(&[existing_ref, &append], 2)?
-        }
-        None => append.clone(),
-    };
-    // `Tensor::cat` already owns its Candle-managed output. A second full-cache
-    // copy here made decode allocation and memory traffic grow with context.
-    *cache = Some(next);
-    Ok(())
-}
-
-fn maybe_materialize_dense_kv_pages(
+#[allow(clippy::too_many_arguments)]
+fn persist_qwen35_kv(
     page_size: usize,
     quantization: KvCacheQuantization,
+    dense_decode_enabled: bool,
     dense_decode_max_tokens: usize,
     k_pages: &mut Vec<KvPage>,
     v_pages: &mut Vec<KvPage>,
-    dense_kv_tokens: &mut usize,
-    dense_k_cache_h: &mut Option<Tensor>,
-    dense_v_cache_h: &mut Option<Tensor>,
+    dense_k_cache_h: &mut Qwen35DenseKvCache,
+    dense_v_cache_h: &mut Qwen35DenseKvCache,
+    key_states: &Tensor,
+    value_states: &Tensor,
 ) -> Result<()> {
-    if !k_pages.is_empty() || !v_pages.is_empty() {
+    let key_tokens = key_states.dim(1)?;
+    let value_tokens = value_states.dim(1)?;
+    if key_tokens != value_tokens {
+        return Err(Error::InferenceError(format!(
+            "Qwen3.5 key/value append mismatch: k={key_tokens}, v={value_tokens}"
+        )));
+    }
+    if key_tokens == 0 {
+        return Ok(());
+    }
+    if k_pages.is_empty() != v_pages.is_empty() {
+        return Err(Error::InferenceError(
+            "Qwen3.5 paged key/value caches are inconsistent".to_string(),
+        ));
+    }
+    if dense_k_cache_h.len() != dense_v_cache_h.len() {
+        return Err(Error::InferenceError(format!(
+            "Qwen3.5 dense key/value caches are inconsistent: k={}, v={}",
+            dense_k_cache_h.len(),
+            dense_v_cache_h.len()
+        )));
+    }
+
+    let required = dense_k_cache_h
+        .len()
+        .checked_add(key_tokens)
+        .ok_or_else(|| Error::Overloaded("Qwen3.5 KV token count overflow".to_string()))?;
+    let keep_dense =
+        dense_decode_enabled && k_pages.is_empty() && required <= dense_decode_max_tokens;
+    if keep_dense {
+        let key_states_h = key_states.transpose(1, 2)?.contiguous()?;
+        let value_states_h = value_states.transpose(1, 2)?.contiguous()?;
+        dense_k_cache_h.append(&key_states_h, page_size, dense_decode_max_tokens)?;
+        dense_v_cache_h.append(&value_states_h, page_size, dense_decode_max_tokens)?;
         return Ok(());
     }
 
-    let Some(k_cache_h) = dense_k_cache_h.as_ref() else {
-        return Ok(());
-    };
-    let Some(v_cache_h) = dense_v_cache_h.as_ref() else {
-        return Ok(());
-    };
-    if *dense_kv_tokens == 0 {
-        return Ok(());
+    if k_pages.is_empty() && !dense_k_cache_h.is_empty() {
+        migrate_qwen35_dense_kv_to_pages(
+            page_size,
+            quantization,
+            k_pages,
+            v_pages,
+            dense_k_cache_h,
+            dense_v_cache_h,
+        )?;
+    } else {
+        dense_k_cache_h.clear();
+        dense_v_cache_h.clear();
     }
-    if *dense_kv_tokens <= dense_decode_max_tokens {
-        return Ok(());
-    }
-    if k_cache_h.dim(2)? != *dense_kv_tokens || v_cache_h.dim(2)? != *dense_kv_tokens {
+    append_to_pages(page_size, k_pages, key_states, quantization)?;
+    append_to_pages(page_size, v_pages, value_states, quantization)?;
+    Ok(())
+}
+
+fn migrate_qwen35_dense_kv_to_pages(
+    page_size: usize,
+    quantization: KvCacheQuantization,
+    k_pages: &mut Vec<KvPage>,
+    v_pages: &mut Vec<KvPage>,
+    dense_k_cache_h: &mut Qwen35DenseKvCache,
+    dense_v_cache_h: &mut Qwen35DenseKvCache,
+) -> Result<()> {
+    let k_cache_h = dense_k_cache_h.current_data()?.ok_or_else(|| {
+        Error::InferenceError("Qwen3.5 missing dense key cache during page migration".to_string())
+    })?;
+    let v_cache_h = dense_v_cache_h.current_data()?.ok_or_else(|| {
+        Error::InferenceError("Qwen3.5 missing dense value cache during page migration".to_string())
+    })?;
+    if k_cache_h.dim(2)? != v_cache_h.dim(2)? {
         return Err(Error::InferenceError(format!(
-            "Qwen3.5 dense KV cache token mismatch: tracked={}, k={}, v={}",
-            *dense_kv_tokens,
+            "Qwen3.5 dense page migration mismatch: k={}, v={}",
             k_cache_h.dim(2)?,
             v_cache_h.dim(2)?
         )));
     }
 
-    let k_cache_h = dense_k_cache_h.take().ok_or_else(|| {
-        Error::InferenceError("Qwen3.5 missing dense key cache during page migration".to_string())
-    })?;
-    let v_cache_h = dense_v_cache_h.take().ok_or_else(|| {
-        Error::InferenceError("Qwen3.5 missing dense value cache during page migration".to_string())
-    })?;
+    // This is the single ownership boundary for dense-to-paged migration.
+    // Pages must not retain a mutable capacity buffer shared with a snapshot.
     let k_dense = k_cache_h.transpose(1, 2)?.contiguous()?;
     let v_dense = v_cache_h.transpose(1, 2)?.contiguous()?;
     append_to_pages(page_size, k_pages, &k_dense, quantization)?;
     append_to_pages(page_size, v_pages, &v_dense, quantization)?;
-    *dense_kv_tokens = 0;
+    dense_k_cache_h.clear();
+    dense_v_cache_h.clear();
     Ok(())
 }
 
@@ -2357,11 +2432,12 @@ fn recurrent_gated_delta(
 #[cfg(test)]
 mod tests {
     use super::{
-        append_dense_kv_cache_h, append_to_pages, apply_rotary_emb, build_mrope,
-        full_attention_state_has_cached_prefix, non_finite_counts, owned_zero_tensor,
+        append_to_pages, apply_rotary_emb, build_mrope, full_attention_state_has_cached_prefix,
+        materialize_pages, non_finite_counts, owned_zero_tensor, persist_qwen35_kv,
         qwen35_dense_decode_max_pages, qwen35_page_count_for_tokens, repeat_head_states,
         repeat_head_states_seq, softplus, unfused_causal_attention, ConvRingState,
-        KvCacheQuantization, KvPage, Qwen35LayerRuntimeState, Qwen35TextRuntimeState,
+        KvCacheQuantization, KvPage, Qwen35DenseKvCache, Qwen35LayerRuntimeState,
+        Qwen35TextRuntimeState,
     };
     use candle_core::{DType, Device, IndexOp, Tensor};
     use candle_nn::rotary_emb;
@@ -2371,6 +2447,14 @@ mod tests {
     fn tensor_storage_address(tensor: &Tensor) -> usize {
         let (storage, _) = tensor.storage_and_layout();
         std::ptr::from_ref(&*storage) as usize
+    }
+
+    fn dense_cache(tensor: &Tensor) -> Qwen35DenseKvCache {
+        let mut cache = Qwen35DenseKvCache::default();
+        cache
+            .append(tensor, tensor.dim(2).unwrap().max(1), 64)
+            .unwrap();
+        cache
     }
 
     #[test]
@@ -2423,9 +2507,12 @@ mod tests {
                     v_pages: vec![KvPage::Dense(
                         Tensor::ones((1, 1, 1, 2), DType::F32, device).unwrap(),
                     )],
-                    dense_k_cache_h: Some(Tensor::ones((1, 1, 1, 2), DType::F32, device).unwrap()),
-                    dense_v_cache_h: Some(Tensor::ones((1, 1, 1, 2), DType::F32, device).unwrap()),
-                    dense_kv_tokens: 1,
+                    dense_k_cache_h: dense_cache(
+                        &Tensor::ones((1, 1, 1, 2), DType::F32, device).unwrap(),
+                    ),
+                    dense_v_cache_h: dense_cache(
+                        &Tensor::ones((1, 1, 1, 2), DType::F32, device).unwrap(),
+                    ),
                 },
             ],
         };
@@ -2482,7 +2569,7 @@ mod tests {
         };
         let Qwen35LayerRuntimeState::Full {
             k_pages: second_pages,
-            dense_k_cache_h: Some(second_dense),
+            dense_k_cache_h: second_dense_cache,
             ..
         } = &second.layers[1]
         else {
@@ -2493,21 +2580,24 @@ mod tests {
         else {
             panic!("dense pages")
         };
-        let first_dense = first_dense_cache.as_ref().expect("first dense cache");
+        let first_dense = first_dense_cache.current_data().unwrap().unwrap();
+        let second_dense = second_dense_cache.current_data().unwrap().unwrap();
         assert_eq!(
             tensor_storage_address(first_page),
             tensor_storage_address(second_page)
         );
         assert_eq!(
-            tensor_storage_address(first_dense),
-            tensor_storage_address(second_dense)
+            tensor_storage_address(&first_dense),
+            tensor_storage_address(&second_dense)
         );
 
-        append_dense_kv_cache_h(
-            first_dense_cache,
-            &Tensor::zeros((1, 1, 1, 2), DType::F32, device).unwrap(),
-        )
-        .unwrap();
+        first_dense_cache
+            .append(
+                &Tensor::zeros((1, 1, 1, 2), DType::F32, device).unwrap(),
+                1,
+                64,
+            )
+            .unwrap();
         append_to_pages(
             2,
             first_pages,
@@ -2518,9 +2608,9 @@ mod tests {
         let KvPage::Dense(second_page) = &second_pages[0] else {
             panic!("second dense page")
         };
-        assert_eq!(first_dense_cache.as_ref().unwrap().dim(2).unwrap(), 2);
+        assert_eq!(first_dense_cache.len(), 2);
         assert_eq!(second_page.dim(1).unwrap(), 1);
-        assert_eq!(second_dense.dim(2).unwrap(), 1);
+        assert_eq!(second_dense_cache.len(), 1);
     }
 
     #[test]
@@ -2767,9 +2857,8 @@ mod tests {
         let dense_state = Qwen35LayerRuntimeState::Full {
             k_pages: Vec::new(),
             v_pages: Vec::new(),
-            dense_k_cache_h: Some(dense),
-            dense_v_cache_h: None,
-            dense_kv_tokens: 0,
+            dense_k_cache_h: dense_cache(&dense),
+            dense_v_cache_h: Qwen35DenseKvCache::default(),
         };
         assert!(full_attention_state_has_cached_prefix(&dense_state).unwrap());
 
@@ -2777,27 +2866,16 @@ mod tests {
         let paged_state = Qwen35LayerRuntimeState::Full {
             k_pages: vec![page],
             v_pages: Vec::new(),
-            dense_k_cache_h: None,
-            dense_v_cache_h: None,
-            dense_kv_tokens: 0,
+            dense_k_cache_h: Qwen35DenseKvCache::default(),
+            dense_v_cache_h: Qwen35DenseKvCache::default(),
         };
         assert!(full_attention_state_has_cached_prefix(&paged_state).unwrap());
-
-        let tracked_state = Qwen35LayerRuntimeState::Full {
-            k_pages: Vec::new(),
-            v_pages: Vec::new(),
-            dense_k_cache_h: None,
-            dense_v_cache_h: None,
-            dense_kv_tokens: 2,
-        };
-        assert!(full_attention_state_has_cached_prefix(&tracked_state).unwrap());
 
         let empty = Qwen35LayerRuntimeState::Full {
             k_pages: Vec::new(),
             v_pages: Vec::new(),
-            dense_k_cache_h: None,
-            dense_v_cache_h: None,
-            dense_kv_tokens: 0,
+            dense_k_cache_h: Qwen35DenseKvCache::default(),
+            dense_v_cache_h: Qwen35DenseKvCache::default(),
         };
         assert!(!full_attention_state_has_cached_prefix(&empty).unwrap());
     }
@@ -2926,19 +3004,92 @@ mod tests {
     }
 
     #[test]
-    fn dense_kv_cache_head_major_appends_sequence_along_token_axis() {
+    fn dense_kv_cache_grows_geometrically_and_detaches_on_shared_write() {
         let device = Device::Cpu;
-        let mut cache: Option<Tensor> = None;
+        let mut cache = Qwen35DenseKvCache::default();
         let first = Tensor::from_vec(vec![1f32, 2.0, 3.0, 4.0], (1, 2, 1, 2), &device).unwrap();
         let second = Tensor::from_vec(vec![5f32, 6.0, 7.0, 8.0], (1, 2, 1, 2), &device).unwrap();
 
-        append_dense_kv_cache_h(&mut cache, &first).expect("append first");
-        append_dense_kv_cache_h(&mut cache, &second).expect("append second");
+        cache.append(&first, 4, 8).expect("append first");
+        let first_storage = tensor_storage_address(cache.data.as_deref().unwrap());
+        assert_eq!(cache.capacity().unwrap(), 4);
+        cache.append(&second, 4, 8).expect("append second");
+        assert_eq!(
+            tensor_storage_address(cache.data.as_deref().unwrap()),
+            first_storage
+        );
 
-        let cache = cache.expect("cache should exist");
-        assert_eq!(cache.dims(), &[1, 2, 2, 2]);
-        let flat = cache.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let snapshot = cache.clone();
+        cache.append(&first, 4, 8).expect("copy-on-write append");
+        assert_ne!(
+            tensor_storage_address(cache.data.as_deref().unwrap()),
+            tensor_storage_address(snapshot.data.as_deref().unwrap())
+        );
+        assert_eq!(snapshot.len(), 2);
+        assert_eq!(cache.len(), 3);
+
+        let two_tokens = Tensor::cat(&[&first, &second], 2).unwrap();
+        cache.append(&two_tokens, 4, 8).expect("growth append");
+        assert_eq!(cache.capacity().unwrap(), 8);
+
+        let snapshot_data = snapshot.current_data().unwrap().unwrap();
+        assert_eq!(snapshot_data.dims(), &[1, 2, 2, 2]);
+        let flat = snapshot_data
+            .flatten_all()
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap();
         assert_eq!(flat, vec![1.0, 2.0, 5.0, 6.0, 3.0, 4.0, 7.0, 8.0]);
+    }
+
+    #[test]
+    fn dense_kv_crossing_threshold_migrates_before_current_append() {
+        let device = Device::Cpu;
+        let initial = Tensor::from_vec(
+            (0..6).map(|value| value as f32).collect::<Vec<_>>(),
+            (1, 3, 1, 2),
+            &device,
+        )
+        .unwrap();
+        let next = Tensor::from_vec(vec![6f32, 7.0, 8.0, 9.0], (1, 2, 1, 2), &device).unwrap();
+        let mut k_cache = Qwen35DenseKvCache::default();
+        let mut v_cache = Qwen35DenseKvCache::default();
+        k_cache
+            .append(&initial.transpose(1, 2).unwrap(), 2, 4)
+            .unwrap();
+        v_cache
+            .append(&initial.transpose(1, 2).unwrap(), 2, 4)
+            .unwrap();
+        let mut k_pages = Vec::new();
+        let mut v_pages = Vec::new();
+
+        persist_qwen35_kv(
+            2,
+            KvCacheQuantization::None,
+            true,
+            4,
+            &mut k_pages,
+            &mut v_pages,
+            &mut k_cache,
+            &mut v_cache,
+            &next,
+            &next,
+        )
+        .unwrap();
+
+        assert!(k_cache.is_empty());
+        assert!(v_cache.is_empty());
+        assert_eq!(k_pages.len(), 3);
+        let materialized = materialize_pages(&k_pages).unwrap();
+        assert_eq!(materialized.dims(), &[1, 5, 1, 2]);
+        assert_eq!(
+            materialized
+                .flatten_all()
+                .unwrap()
+                .to_vec1::<f32>()
+                .unwrap(),
+            (0..10).map(|value| value as f32).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/izwi-core/src/models/registry.rs
+++ b/crates/izwi-core/src/models/registry.rs
@@ -42,7 +42,8 @@ use crate::models::architectures::qwen3::chat::{
 };
 use crate::models::architectures::qwen3::tts::Qwen3TtsModel;
 use crate::models::architectures::qwen35::chat::{
-    ChatDecodeState as Qwen35ChatDecodeState, Qwen35ChatModel, Qwen35PreparedPrompt,
+    ChatDecodeState as Qwen35ChatDecodeState, Qwen35ChatModel, Qwen35PrefixSnapshot,
+    Qwen35PreparedPrompt,
 };
 use crate::models::architectures::sortformer::diarization::{
     SortformerDiarizerModel, SortformerWorkspaceEstimate, SortformerWorkspaceEvent,
@@ -1819,6 +1820,20 @@ impl NativeChatDecodeState {
             Self::Qwen35(state) => state.session_cache_bytes(),
         }
     }
+
+    pub(crate) fn take_pending_qwen35_prefix_snapshot(&mut self) -> Option<Qwen35PrefixSnapshot> {
+        match self {
+            Self::Qwen35(state) => state.take_pending_prefix_snapshot(),
+            Self::Qwen3(_) => None,
+        }
+    }
+
+    pub(crate) fn reused_qwen35_prefix_tokens(&self) -> usize {
+        match self {
+            Self::Qwen35(state) => state.reused_prefix_tokens(),
+            Self::Qwen3(_) => 0,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -2004,9 +2019,28 @@ impl NativeChatModel {
         config: &ChatGenerationConfig,
         prepared_qwen35: Option<&Qwen35PreparedPrompt>,
     ) -> Result<NativeChatDecodeState> {
+        self.start_decode_state_with_prefix(
+            messages,
+            max_new_tokens,
+            config,
+            prepared_qwen35,
+            None,
+            None,
+        )
+    }
+
+    pub(crate) fn start_decode_state_with_prefix(
+        &self,
+        messages: &[ChatMessage],
+        max_new_tokens: usize,
+        config: &ChatGenerationConfig,
+        prepared_qwen35: Option<&Qwen35PreparedPrompt>,
+        prefix: Option<&Qwen35PrefixSnapshot>,
+        capture_prefix_max_bytes: Option<u64>,
+    ) -> Result<NativeChatDecodeState> {
         match self {
             Self::Qwen3(model) => {
-                if prepared_qwen35.is_some() {
+                if prepared_qwen35.is_some() || prefix.is_some() {
                     return Err(Error::InvalidInput(
                         "Qwen3.5 prepared prompt was routed to a Qwen3 model".to_string(),
                     ));
@@ -2016,11 +2050,13 @@ impl NativeChatModel {
                 ))
             }
             Self::Qwen35(model) => {
-                let state = model.start_decode_state_with_optional_prepared(
+                let state = model.start_decode_state_with_optional_prepared_and_prefix(
                     messages,
                     max_new_tokens,
                     config,
                     prepared_qwen35,
+                    prefix,
+                    capture_prefix_max_bytes,
                 )?;
                 Ok(NativeChatDecodeState::Qwen35(state))
             }

--- a/crates/izwi-core/src/models/shared/attention/flash.rs
+++ b/crates/izwi-core/src/models/shared/attention/flash.rs
@@ -157,6 +157,34 @@ pub fn try_fused_self_attention(
     try_fused_self_attention_scaled(q, k, v, mask, head_dim, causal, scale)
 }
 
+/// Try fused self-attention without lowering F32 inputs to F16.
+///
+/// Candle's Metal SDPA implementation cannot safely execute every long F32
+/// prefill shape. For those shapes this contract returns `None`, allowing a
+/// model-specific correctness-preserving F32 fallback instead of silently
+/// narrowing activations.
+pub fn try_fused_self_attention_preserve_dtype(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    mask: Option<&Tensor>,
+    head_dim: usize,
+    causal: bool,
+) -> Result<Option<Tensor>> {
+    let scale = 1.0f32 / (head_dim as f32).sqrt();
+    try_fused_self_attention_with_options_and_scale(
+        q,
+        k,
+        v,
+        mask,
+        head_dim,
+        causal,
+        scale,
+        CudaFlashAttentionOptions::default(),
+        false,
+    )
+}
+
 /// Try a fused self-attention kernel with an explicit attention score scale.
 ///
 /// Input/output layout: `[batch, heads, seq, head_dim]`.
@@ -178,6 +206,7 @@ pub fn try_fused_self_attention_scaled(
         causal,
         scale,
         CudaFlashAttentionOptions::default(),
+        true,
     )
 }
 
@@ -205,6 +234,7 @@ pub fn try_fused_self_attention_with_options(
         causal,
         scale,
         cuda_options,
+        true,
     )
 }
 
@@ -217,6 +247,7 @@ fn try_fused_self_attention_with_options_and_scale(
     causal: bool,
     scale: f32,
     cuda_options: CudaFlashAttentionOptions<'_>,
+    allow_metal_f32_prefill_f16_cast: bool,
 ) -> Result<Option<Tensor>> {
     let masked = mask.is_some();
     record_fused_attention_attempt();
@@ -270,11 +301,12 @@ fn try_fused_self_attention_with_options_and_scale(
     }
 
     if q.device().is_metal() {
-        match should_try_metal_sdpa(q, k, v, mask)? {
+        match should_try_metal_sdpa(q, k, v, mask, allow_metal_f32_prefill_f16_cast)? {
             MetalSdpaDecision::Try => {
                 let q_seq = q.dim(2)?;
-                let use_f16_cast =
-                    mask.is_none() && should_use_metal_sdpa_f16_cast(q.dtype(), q_seq);
+                let use_f16_cast = allow_metal_f32_prefill_f16_cast
+                    && mask.is_none()
+                    && should_use_metal_sdpa_f16_cast(q.dtype(), q_seq);
                 let sdpa_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     if use_f16_cast {
                         run_metal_sdpa_with_f16_inputs(q, k, v, mask, causal, scale)
@@ -444,6 +476,7 @@ fn should_try_metal_sdpa(
     k: &Tensor,
     v: &Tensor,
     mask: Option<&Tensor>,
+    allow_f32_prefill_f16_cast: bool,
 ) -> Result<MetalSdpaDecision> {
     if let Some(mask) = mask {
         return should_try_metal_sdpa_masked(q, k, v, mask);
@@ -477,7 +510,10 @@ fn should_try_metal_sdpa(
 
     // F32 + full-SDPA prefill has triggered oversized threadgroup plans on some
     // Apple GPUs. We only enable this shape when the guarded F16-cast route is on.
-    if q_seq > 8 && q.dtype() == DType::F32 && !metal_sdpa_f32_prefill_cast_enabled() {
+    if q_seq > 8
+        && q.dtype() == DType::F32
+        && !(allow_f32_prefill_f16_cast && metal_sdpa_f32_prefill_cast_enabled())
+    {
         return Ok(MetalSdpaDecision::Skip(
             AttentionFallbackReason::UnsupportedBackend,
         ));
@@ -637,8 +673,8 @@ mod tests {
     use super::{
         cuda_flash_attention_capabilities, cuda_flash_attention_head_dim_supported,
         cuda_flash_attention_window, metal_sdpa_mask_shape_supported, metal_sdpa_shape_supported,
-        should_try_cuda_flash_attention, should_use_metal_sdpa_f16_cast,
-        CudaFlashAttentionDecision, CudaFlashAttentionOptions,
+        should_try_cuda_flash_attention, should_try_metal_sdpa, should_use_metal_sdpa_f16_cast,
+        CudaFlashAttentionDecision, CudaFlashAttentionOptions, MetalSdpaDecision,
         CUDA_FLASH_ATTENTION_HEAD_DIM_MULTIPLE, CUDA_FLASH_ATTENTION_MAX_HEAD_DIM,
     };
     use crate::models::shared::telemetry::AttentionFallbackReason;
@@ -672,6 +708,25 @@ mod tests {
         assert!(!should_use_metal_sdpa_f16_cast(DType::F32, 23));
 
         std::env::remove_var("IZWI_METAL_SDPA_F32_PREFILL_F16");
+    }
+
+    #[test]
+    fn preserve_dtype_policy_rejects_long_f32_metal_sdpa_shape() {
+        let _guard = crate::env_test_lock().lock().expect("env lock");
+        std::env::remove_var("IZWI_METAL_SDPA_F32_PREFILL_F16");
+
+        let q = Tensor::zeros((1, 4, 9, 256), DType::F32, &Device::Cpu).unwrap();
+        let k = Tensor::zeros((1, 1, 9, 256), DType::F32, &Device::Cpu).unwrap();
+        let v = Tensor::zeros((1, 1, 9, 256), DType::F32, &Device::Cpu).unwrap();
+
+        assert!(matches!(
+            should_try_metal_sdpa(&q, &k, &v, None, false).unwrap(),
+            MetalSdpaDecision::Skip(AttentionFallbackReason::UnsupportedBackend)
+        ));
+        assert!(matches!(
+            should_try_metal_sdpa(&q, &k, &v, None, true).unwrap(),
+            MetalSdpaDecision::Try
+        ));
     }
 
     #[test]

--- a/crates/izwi-core/src/models/shared/attention/paged.rs
+++ b/crates/izwi-core/src/models/shared/attention/paged.rs
@@ -3,7 +3,9 @@
 use candle_core::{DType, Tensor, D};
 
 use crate::error::{Error, Result};
-use crate::models::shared::memory::accounting::TensorStorageAccounting;
+use crate::models::shared::memory::accounting::{
+    compact_tensor_storage, deep_copy_tensor_storage, TensorStorageAccounting,
+};
 use crate::models::shared::telemetry::{record_decode_attention_path, DecodeAttentionPath};
 
 const Q4_0_BLOCK_SIZE: usize = 32;
@@ -84,6 +86,41 @@ pub enum KvPage {
 }
 
 impl KvPage {
+    /// Fork this page with independent Candle backing storage.
+    ///
+    /// Prefix-cache snapshots may be restored into multiple mutable decode
+    /// sessions. `Tensor::clone` shares storage, so it is not a sufficient
+    /// boundary if a backend later introduces in-place KV updates.
+    pub(crate) fn deep_copy(&self) -> Result<Self> {
+        match self {
+            Self::Dense(tensor) => Ok(Self::Dense(deep_copy_tensor_storage(tensor)?)),
+            Self::Int8 {
+                values,
+                scale,
+                target_dtype,
+            } => Ok(Self::Int8 {
+                values: deep_copy_tensor_storage(values)?,
+                scale: *scale,
+                target_dtype: *target_dtype,
+            }),
+            Self::Q4_0 {
+                values,
+                scales,
+                shape,
+                seq_len,
+                num_elements,
+                target_dtype,
+            } => Ok(Self::Q4_0 {
+                values: deep_copy_tensor_storage(values)?,
+                scales: deep_copy_tensor_storage(scales)?,
+                shape: *shape,
+                seq_len: *seq_len,
+                num_elements: *num_elements,
+                target_dtype: *target_dtype,
+            }),
+        }
+    }
+
     fn from_dense(tensor: Tensor, quantization: KvCacheQuantization) -> Result<Self> {
         // A page must own compact storage. Retaining a narrow view can keep an
         // entire previous backing allocation alive and invalidate byte accounting.

--- a/crates/izwi-core/src/models/shared/attention/paged.rs
+++ b/crates/izwi-core/src/models/shared/attention/paged.rs
@@ -4,7 +4,7 @@ use candle_core::{DType, Tensor, D};
 
 use crate::error::{Error, Result};
 use crate::models::shared::memory::accounting::{
-    compact_tensor_storage, deep_copy_tensor_storage, TensorStorageAccounting,
+    deep_copy_tensor_storage, TensorStorageAccounting,
 };
 use crate::models::shared::telemetry::{record_decode_attention_path, DecodeAttentionPath};
 
@@ -124,7 +124,7 @@ impl KvPage {
     fn from_dense(tensor: Tensor, quantization: KvCacheQuantization) -> Result<Self> {
         // A page must own compact storage. Retaining a narrow view can keep an
         // entire previous backing allocation alive and invalidate byte accounting.
-        let tensor = compact_tensor_storage(&tensor)?;
+        let tensor = deep_copy_tensor_storage(&tensor)?;
         match quantization {
             KvCacheQuantization::None => Ok(Self::Dense(tensor)),
             KvCacheQuantization::Int8 => {

--- a/crates/izwi-core/src/models/shared/attention/paged.rs
+++ b/crates/izwi-core/src/models/shared/attention/paged.rs
@@ -86,41 +86,6 @@ pub enum KvPage {
 }
 
 impl KvPage {
-    /// Fork this page with independent Candle backing storage.
-    ///
-    /// Prefix-cache snapshots may be restored into multiple mutable decode
-    /// sessions. `Tensor::clone` shares storage, so it is not a sufficient
-    /// boundary if a backend later introduces in-place KV updates.
-    pub(crate) fn deep_copy(&self) -> Result<Self> {
-        match self {
-            Self::Dense(tensor) => Ok(Self::Dense(deep_copy_tensor_storage(tensor)?)),
-            Self::Int8 {
-                values,
-                scale,
-                target_dtype,
-            } => Ok(Self::Int8 {
-                values: deep_copy_tensor_storage(values)?,
-                scale: *scale,
-                target_dtype: *target_dtype,
-            }),
-            Self::Q4_0 {
-                values,
-                scales,
-                shape,
-                seq_len,
-                num_elements,
-                target_dtype,
-            } => Ok(Self::Q4_0 {
-                values: deep_copy_tensor_storage(values)?,
-                scales: deep_copy_tensor_storage(scales)?,
-                shape: *shape,
-                seq_len: *seq_len,
-                num_elements: *num_elements,
-                target_dtype: *target_dtype,
-            }),
-        }
-    }
-
     fn from_dense(tensor: Tensor, quantization: KvCacheQuantization) -> Result<Self> {
         // A page must own compact storage. Retaining a narrow view can keep an
         // entire previous backing allocation alive and invalidate byte accounting.

--- a/crates/izwi-core/src/models/shared/attention/paged.rs
+++ b/crates/izwi-core/src/models/shared/attention/paged.rs
@@ -4,7 +4,7 @@ use candle_core::{DType, Tensor, D};
 
 use crate::error::{Error, Result};
 use crate::models::shared::memory::accounting::{
-    compact_tensor_storage, deep_copy_tensor_storage, TensorStorageAccounting,
+    deep_copy_tensor_storage, TensorStorageAccounting,
 };
 use crate::models::shared::telemetry::{record_decode_attention_path, DecodeAttentionPath};
 

--- a/crates/izwi-core/src/models/shared/attention/paged.rs
+++ b/crates/izwi-core/src/models/shared/attention/paged.rs
@@ -4,7 +4,7 @@ use candle_core::{DType, Tensor, D};
 
 use crate::error::{Error, Result};
 use crate::models::shared::memory::accounting::{
-    deep_copy_tensor_storage, TensorStorageAccounting,
+    compact_tensor_storage, deep_copy_tensor_storage, TensorStorageAccounting,
 };
 use crate::models::shared::telemetry::{record_decode_attention_path, DecodeAttentionPath};
 
@@ -124,7 +124,7 @@ impl KvPage {
     fn from_dense(tensor: Tensor, quantization: KvCacheQuantization) -> Result<Self> {
         // A page must own compact storage. Retaining a narrow view can keep an
         // entire previous backing allocation alive and invalidate byte accounting.
-        let tensor = tensor.contiguous()?;
+        let tensor = compact_tensor_storage(&tensor)?;
         match quantization {
             KvCacheQuantization::None => Ok(Self::Dense(tensor)),
             KvCacheQuantization::Int8 => {

--- a/crates/izwi-core/src/models/shared/memory/accounting.rs
+++ b/crates/izwi-core/src/models/shared/memory/accounting.rs
@@ -52,17 +52,16 @@ pub(crate) fn compact_tensor_storage(tensor: &Tensor) -> candle_core::Result<Ten
         ));
     }
 
-    Ok(tensor)
+    // `Tensor::copy` is not a physical copy on CPU, while `contiguous` may
+    // return an already-contiguous narrow view unchanged. An identity affine
+    // operation materializes exactly the logical elements on CPU and CUDA.
+    tensor.affine(1.0, 0.0)
 }
 
 /// Deep-copy persistent state without routing Metal through Candle's pooled
 /// allocator, which may return an oversized backing allocation.
 pub(crate) fn deep_copy_tensor_storage(tensor: &Tensor) -> candle_core::Result<Tensor> {
-    if tensor.device().is_metal() {
-        compact_tensor_storage(tensor)
-    } else {
-        tensor.copy()
-    }
+    compact_tensor_storage(tensor)
 }
 
 /// Accumulates the backing allocations retained by a set of Candle tensors.
@@ -171,7 +170,6 @@ fn metal_storage_bytes(_storage: &candle_core::MetalStorage) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "metal")]
     use super::compact_tensor_storage;
     use super::TensorStorageAccounting;
     use candle_core::{Device, IndexOp, Tensor};
@@ -209,6 +207,19 @@ mod tests {
     }
 
     #[test]
+    fn compact_cpu_copy_drops_source_backing() {
+        let backing = Tensor::from_vec(vec![1f32; 128], (8, 16), &Device::Cpu).unwrap();
+        let view = backing.i((7, ..4)).unwrap();
+        let compact = compact_tensor_storage(&view).unwrap();
+
+        let mut accounting = TensorStorageAccounting::default();
+        accounting.add_tensor(&compact).unwrap();
+
+        assert_eq!(accounting.bytes(), 4 * std::mem::size_of::<f32>() as u64);
+        assert_eq!(compact.to_vec1::<f32>().unwrap(), vec![1.0; 4]);
+    }
+
+    #[test]
     fn byte_overflow_fails_closed() {
         let mut accounting = TensorStorageAccounting::default();
         accounting.add_bytes(u64::MAX).unwrap();
@@ -228,5 +239,30 @@ mod tests {
 
         assert_eq!(accounting.bytes(), 3 * std::mem::size_of::<f32>() as u64);
         assert_eq!(compact.to_vec1::<f32>().unwrap(), vec![0.0; 3]);
+    }
+
+    #[cfg(feature = "metal")]
+    #[test]
+    fn persistent_metal_copy_materializes_non_contiguous_views() {
+        let Ok(Ok(device)) = std::panic::catch_unwind(|| Device::new_metal(0)) else {
+            return;
+        };
+        let values = (0..12).map(|value| value as f32).collect::<Vec<_>>();
+        let source = Tensor::from_vec(values, (3, 4), &device).unwrap();
+        let view = source.transpose(0, 1).unwrap();
+        let compact = compact_tensor_storage(&view).unwrap();
+        let mut accounting = TensorStorageAccounting::default();
+        accounting.add_tensor(&compact).unwrap();
+
+        assert_eq!(accounting.bytes(), 12 * std::mem::size_of::<f32>() as u64);
+        assert_eq!(
+            compact.to_vec2::<f32>().unwrap(),
+            vec![
+                vec![0.0, 4.0, 8.0],
+                vec![1.0, 5.0, 9.0],
+                vec![2.0, 6.0, 10.0],
+                vec![3.0, 7.0, 11.0],
+            ]
+        );
     }
 }

--- a/crates/izwi-core/src/models/shared/memory/accounting.rs
+++ b/crates/izwi-core/src/models/shared/memory/accounting.rs
@@ -4,6 +4,57 @@ use std::collections::HashSet;
 
 use candle_core::{CpuStorage, Storage, Tensor};
 
+/// Copy a tensor into storage whose backing allocation matches its logical size.
+///
+/// Candle's Metal scratch allocator may satisfy a small operation from a larger
+/// pooled buffer. Persistent recurrent/KV state must not retain that transient
+/// backing allocation because physical cache accounting would become inaccurate.
+pub(crate) fn compact_tensor_storage(tensor: &Tensor) -> candle_core::Result<Tensor> {
+    let tensor = tensor.contiguous()?;
+
+    #[cfg(feature = "metal")]
+    if let candle_core::Device::Metal(device) = tensor.device() {
+        use candle_core::{op::BackpropOp, MetalStorage};
+
+        let element_count = tensor.elem_count();
+        if element_count == 0 {
+            return Ok(tensor);
+        }
+        let dtype = tensor.dtype();
+        let byte_count = element_count
+            .checked_mul(dtype.size_in_bytes())
+            .ok_or_else(|| {
+                candle_core::Error::Msg("persistent Metal tensor byte size overflow".to_string())
+            })?;
+        let target = device.new_private_buffer(element_count, dtype, "persistent-state")?;
+        let (storage, layout) = tensor.storage_and_layout();
+        let Storage::Metal(source) = &*storage else {
+            return Err(candle_core::Error::Msg(
+                "Metal tensor exposed non-Metal storage".to_string(),
+            ));
+        };
+        let source_offset = layout
+            .start_offset()
+            .checked_mul(dtype.size_in_bytes())
+            .ok_or_else(|| {
+                candle_core::Error::Msg("persistent Metal tensor offset overflow".to_string())
+            })?;
+        {
+            let mut blit = device.blit_command_encoder()?;
+            blit.copy_from_buffer(source.buffer(), source_offset, &target, 0, byte_count);
+        }
+        let storage = MetalStorage::new(target, device.clone(), element_count, dtype);
+        return Ok(Tensor::from_storage(
+            Storage::Metal(storage),
+            tensor.shape().clone(),
+            BackpropOp::none(),
+            false,
+        ));
+    }
+
+    Ok(tensor)
+}
+
 /// Accumulates the backing allocations retained by a set of Candle tensors.
 ///
 /// Tensor views share a Candle storage allocation. Accounting logical tensor
@@ -110,6 +161,8 @@ fn metal_storage_bytes(_storage: &candle_core::MetalStorage) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "metal")]
+    use super::compact_tensor_storage;
     use super::TensorStorageAccounting;
     use candle_core::{Device, IndexOp, Tensor};
 
@@ -150,5 +203,20 @@ mod tests {
         let mut accounting = TensorStorageAccounting::default();
         accounting.add_bytes(u64::MAX).unwrap();
         assert!(accounting.add_bytes(1).is_none());
+    }
+
+    #[cfg(feature = "metal")]
+    #[test]
+    fn persistent_metal_copy_has_exact_backing_size() {
+        let Ok(Ok(device)) = std::panic::catch_unwind(|| Device::new_metal(0)) else {
+            return;
+        };
+        let pooled = Tensor::zeros((3,), candle_core::DType::F32, &device).unwrap();
+        let compact = compact_tensor_storage(&pooled).unwrap();
+        let mut accounting = TensorStorageAccounting::default();
+        accounting.add_tensor(&compact).unwrap();
+
+        assert_eq!(accounting.bytes(), 3 * std::mem::size_of::<f32>() as u64);
+        assert_eq!(compact.to_vec1::<f32>().unwrap(), vec![0.0; 3]);
     }
 }

--- a/crates/izwi-core/src/models/shared/memory/accounting.rs
+++ b/crates/izwi-core/src/models/shared/memory/accounting.rs
@@ -4,64 +4,14 @@ use std::collections::HashSet;
 
 use candle_core::{CpuStorage, Storage, Tensor};
 
-/// Copy a tensor into storage whose backing allocation matches its logical size.
+/// Materialize a tensor in independent Candle-managed storage.
 ///
-/// Candle's Metal scratch allocator may satisfy a small operation from a larger
-/// pooled buffer. Persistent recurrent/KV state must not retain that transient
-/// backing allocation because physical cache accounting would become inaccurate.
-pub(crate) fn compact_tensor_storage(tensor: &Tensor) -> candle_core::Result<Tensor> {
-    let tensor = tensor.contiguous()?;
-
-    #[cfg(feature = "metal")]
-    if let candle_core::Device::Metal(device) = tensor.device() {
-        use candle_core::{op::BackpropOp, MetalStorage};
-
-        let element_count = tensor.elem_count();
-        if element_count == 0 {
-            return Ok(tensor);
-        }
-        let dtype = tensor.dtype();
-        let byte_count = element_count
-            .checked_mul(dtype.size_in_bytes())
-            .ok_or_else(|| {
-                candle_core::Error::Msg("persistent Metal tensor byte size overflow".to_string())
-            })?;
-        let target = device.new_private_buffer(element_count, dtype, "persistent-state")?;
-        let (storage, layout) = tensor.storage_and_layout();
-        let Storage::Metal(source) = &*storage else {
-            return Err(candle_core::Error::Msg(
-                "Metal tensor exposed non-Metal storage".to_string(),
-            ));
-        };
-        let source_offset = layout
-            .start_offset()
-            .checked_mul(dtype.size_in_bytes())
-            .ok_or_else(|| {
-                candle_core::Error::Msg("persistent Metal tensor offset overflow".to_string())
-            })?;
-        {
-            let mut blit = device.blit_command_encoder()?;
-            blit.copy_from_buffer(source.buffer(), source_offset, &target, 0, byte_count);
-        }
-        let storage = MetalStorage::new(target, device.clone(), element_count, dtype);
-        return Ok(Tensor::from_storage(
-            Storage::Metal(storage),
-            tensor.shape().clone(),
-            BackpropOp::none(),
-            false,
-        ));
-    }
-
-    // `Tensor::copy` is not a physical copy on CPU, while `contiguous` may
-    // return an already-contiguous narrow view unchanged. An identity affine
-    // operation materializes exactly the logical elements on CPU and CUDA.
-    tensor.affine(1.0, 0.0)
-}
-
-/// Deep-copy persistent state without routing Metal through Candle's pooled
-/// allocator, which may return an oversized backing allocation.
+/// `contiguous` alone may preserve an already-contiguous narrow view, while an
+/// identity affine always produces a new output. Keeping this allocation in
+/// Candle's normal pool is essential: application-created Metal private
+/// buffers bypass Candle's pooled reclamation and residency-set lifecycle.
 pub(crate) fn deep_copy_tensor_storage(tensor: &Tensor) -> candle_core::Result<Tensor> {
-    compact_tensor_storage(tensor)
+    tensor.contiguous()?.affine(1.0, 0.0)
 }
 
 /// Accumulates the backing allocations retained by a set of Candle tensors.
@@ -170,7 +120,7 @@ fn metal_storage_bytes(_storage: &candle_core::MetalStorage) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
-    use super::compact_tensor_storage;
+    use super::deep_copy_tensor_storage;
     use super::TensorStorageAccounting;
     use candle_core::{Device, IndexOp, Tensor};
 
@@ -207,10 +157,10 @@ mod tests {
     }
 
     #[test]
-    fn compact_cpu_copy_drops_source_backing() {
+    fn detached_cpu_copy_drops_source_backing() {
         let backing = Tensor::from_vec(vec![1f32; 128], (8, 16), &Device::Cpu).unwrap();
         let view = backing.i((7, ..4)).unwrap();
-        let compact = compact_tensor_storage(&view).unwrap();
+        let compact = deep_copy_tensor_storage(&view).unwrap();
 
         let mut accounting = TensorStorageAccounting::default();
         accounting.add_tensor(&compact).unwrap();
@@ -228,16 +178,16 @@ mod tests {
 
     #[cfg(feature = "metal")]
     #[test]
-    fn persistent_metal_copy_has_exact_backing_size() {
+    fn persistent_metal_copy_uses_accounted_pooled_backing() {
         let Ok(Ok(device)) = std::panic::catch_unwind(|| Device::new_metal(0)) else {
             return;
         };
         let pooled = Tensor::zeros((3,), candle_core::DType::F32, &device).unwrap();
-        let compact = compact_tensor_storage(&pooled).unwrap();
+        let compact = deep_copy_tensor_storage(&pooled).unwrap();
         let mut accounting = TensorStorageAccounting::default();
         accounting.add_tensor(&compact).unwrap();
 
-        assert_eq!(accounting.bytes(), 3 * std::mem::size_of::<f32>() as u64);
+        assert!(accounting.bytes() >= 3 * std::mem::size_of::<f32>() as u64);
         assert_eq!(compact.to_vec1::<f32>().unwrap(), vec![0.0; 3]);
     }
 
@@ -250,11 +200,11 @@ mod tests {
         let values = (0..12).map(|value| value as f32).collect::<Vec<_>>();
         let source = Tensor::from_vec(values, (3, 4), &device).unwrap();
         let view = source.transpose(0, 1).unwrap();
-        let compact = compact_tensor_storage(&view).unwrap();
+        let compact = deep_copy_tensor_storage(&view).unwrap();
         let mut accounting = TensorStorageAccounting::default();
         accounting.add_tensor(&compact).unwrap();
 
-        assert_eq!(accounting.bytes(), 12 * std::mem::size_of::<f32>() as u64);
+        assert!(accounting.bytes() >= 12 * std::mem::size_of::<f32>() as u64);
         assert_eq!(
             compact.to_vec2::<f32>().unwrap(),
             vec![

--- a/crates/izwi-core/src/models/shared/memory/accounting.rs
+++ b/crates/izwi-core/src/models/shared/memory/accounting.rs
@@ -55,6 +55,16 @@ pub(crate) fn compact_tensor_storage(tensor: &Tensor) -> candle_core::Result<Ten
     Ok(tensor)
 }
 
+/// Deep-copy persistent state without routing Metal through Candle's pooled
+/// allocator, which may return an oversized backing allocation.
+pub(crate) fn deep_copy_tensor_storage(tensor: &Tensor) -> candle_core::Result<Tensor> {
+    if tensor.device().is_metal() {
+        compact_tensor_storage(tensor)
+    } else {
+        tensor.copy()
+    }
+}
+
 /// Accumulates the backing allocations retained by a set of Candle tensors.
 ///
 /// Tensor views share a Candle storage allocation. Accounting logical tensor

--- a/crates/izwi-core/src/runtime/chat.rs
+++ b/crates/izwi-core/src/runtime/chat.rs
@@ -12,6 +12,73 @@ use crate::runtime::service::{
     RuntimeService,
 };
 use crate::runtime::types::{ChatGeneration, RuntimeRequestContext};
+use tracing::warn;
+
+/// Return prefix endpoints for complete historical user/assistant turns while
+/// preserving a leading system message and the newest user query. Candidate
+/// prompts are still prepared by the loaded model; these boundaries only avoid
+/// O(turns) repeated one-pair tokenization.
+fn complete_chat_turn_prefix_ends(messages: &[ChatMessage]) -> Vec<usize> {
+    let protected_prefix = usize::from(
+        messages
+            .first()
+            .is_some_and(|message| message.role == crate::models::shared::chat::ChatRole::System),
+    );
+    let Some(last_user_index) = messages
+        .iter()
+        .rposition(|message| message.role == crate::models::shared::chat::ChatRole::User)
+    else {
+        return Vec::new();
+    };
+    let mut ends = Vec::new();
+    let mut cursor = protected_prefix;
+    while cursor < last_user_index {
+        let Some(user_offset) = messages[cursor..last_user_index]
+            .iter()
+            .position(|message| message.role == crate::models::shared::chat::ChatRole::User)
+        else {
+            break;
+        };
+        let user_index = cursor + user_offset;
+        let Some(assistant_offset) = messages[(user_index + 1)..last_user_index]
+            .iter()
+            .position(|message| message.role == crate::models::shared::chat::ChatRole::Assistant)
+        else {
+            cursor = user_index + 1;
+            continue;
+        };
+        let assistant_index = user_index + 1 + assistant_offset;
+        ends.push(assistant_index);
+        cursor = assistant_index + 1;
+    }
+    ends
+}
+
+fn chat_messages_after_prefix(messages: &[ChatMessage], prefix_end: usize) -> Vec<ChatMessage> {
+    let protected_prefix = usize::from(
+        messages
+            .first()
+            .is_some_and(|message| message.role == crate::models::shared::chat::ChatRole::System),
+    );
+    let mut compacted = Vec::with_capacity(
+        protected_prefix.saturating_add(messages.len().saturating_sub(prefix_end + 1)),
+    );
+    compacted.extend_from_slice(&messages[..protected_prefix]);
+    compacted.extend_from_slice(&messages[(prefix_end + 1)..]);
+    compacted
+}
+
+fn bounded_chat_completion_tokens(
+    prompt_tokens: usize,
+    requested_max_tokens: usize,
+    context_limit: usize,
+) -> Option<usize> {
+    (prompt_tokens < context_limit).then(|| {
+        requested_max_tokens
+            .max(1)
+            .min(context_limit - prompt_tokens)
+    })
+}
 
 impl RuntimeService {
     fn prompt_token_config(
@@ -51,6 +118,7 @@ impl RuntimeService {
             )));
         }
         let correlation_id = correlation_id.map(ToOwned::to_owned);
+        let context_limit = self.config.max_sequence_length.max(1);
         let input_bytes = retained_chat_preparation_input_bytes(
             &messages,
             messages.capacity(),
@@ -75,10 +143,97 @@ impl RuntimeService {
                 let model = registry
                     .blocking_get_chat(variant)
                     .ok_or_else(|| Error::ModelNotFound(variant.to_string()))?;
-                let (prompt_tokens, prepared_qwen35_prompt) =
-                    model.prepare_prompt_for_execution(&messages, &prompt_config)?;
+                let original_messages = messages;
+                let initial =
+                    model.prepare_prompt_for_execution(&original_messages, &prompt_config)?;
+                let (messages, prompt_tokens, prepared_qwen35_prompt, trimmed_messages) =
+                    if initial.0.len() < context_limit {
+                        (original_messages, initial.0, initial.1, 0usize)
+                    } else {
+                    if !chat_config.media_inputs.is_empty() {
+                        return Err(Error::InvalidInput(format!(
+                            "Chat prompt has {} tokens in a {context_limit}-token context; automatic history compaction is disabled for media turns so inputs cannot become misaligned",
+                            initial.0.len()
+                        )));
+                    }
+                    let prefix_ends = complete_chat_turn_prefix_ends(&original_messages);
+                    if prefix_ends.is_empty() {
+                        return Err(Error::InvalidInput(format!(
+                            "Chat prompt has {} tokens in a {context_limit}-token context and no older complete turn can be compacted",
+                            initial.0.len()
+                        )));
+                    }
+                    let protected_prefix = usize::from(
+                        original_messages.first().is_some_and(|message| {
+                            message.role == crate::models::shared::chat::ChatRole::System
+                        }),
+                    );
+                    let mut low = 0usize;
+                    let mut high = prefix_ends.len() - 1;
+                    let mut selected = None;
+                    while low <= high {
+                        let middle = low + (high - low) / 2;
+                        let prefix_end = prefix_ends[middle];
+                        let candidate =
+                            chat_messages_after_prefix(&original_messages, prefix_end);
+                        let prepared =
+                            model.prepare_prompt_for_execution(&candidate, &prompt_config)?;
+                        if prepared.0.len() < context_limit {
+                            selected = Some((candidate, prepared, prefix_end));
+                            if middle == 0 {
+                                break;
+                            }
+                            high = middle - 1;
+                        } else {
+                            low = middle + 1;
+                        }
+                    }
+                    let Some((messages, prepared, prefix_end)) = selected else {
+                        return Err(Error::InvalidInput(format!(
+                            "Chat prompt has {} tokens in a {context_limit}-token context and remains too long after compacting all older complete turns",
+                            initial.0.len()
+                        )));
+                    };
+                    (
+                        messages,
+                        prepared.0,
+                        prepared.1,
+                        prefix_end + 1 - protected_prefix,
+                    )
+                };
+                if trimmed_messages > 0 {
+                    warn!(
+                        model = %variant,
+                        trimmed_messages,
+                        remaining_messages = messages.len(),
+                        prompt_tokens = prompt_tokens.len(),
+                        context_limit,
+                        "compacted oldest complete chat turns to fit the configured context"
+                    );
+                }
 
-                params.max_tokens = params.max_tokens.max(1);
+                let requested_max_tokens = params.max_tokens.max(1);
+                params.max_tokens = bounded_chat_completion_tokens(
+                    prompt_tokens.len(),
+                    requested_max_tokens,
+                    context_limit,
+                )
+                .ok_or_else(|| {
+                    Error::InvalidInput(format!(
+                        "Chat prompt has {} tokens in a {context_limit}-token context",
+                        prompt_tokens.len()
+                    ))
+                })?;
+                if params.max_tokens < requested_max_tokens {
+                    warn!(
+                        model = %variant,
+                        requested_max_tokens,
+                        max_tokens = params.max_tokens,
+                        prompt_tokens = prompt_tokens.len(),
+                        context_limit,
+                        "clamped chat completion budget to the remaining context"
+                    );
+                }
                 let mut request = ChatRuntimeRequest::from_messages(
                     variant,
                     messages,
@@ -428,5 +583,57 @@ impl RuntimeService {
             tokens_generated: output.num_tokens,
             generation_time_ms: output.generation_time.as_secs_f64() * 1000.0,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        bounded_chat_completion_tokens, chat_messages_after_prefix, complete_chat_turn_prefix_ends,
+    };
+    use crate::models::shared::chat::{ChatMessage, ChatRole};
+
+    fn message(role: ChatRole, content: &str) -> ChatMessage {
+        ChatMessage {
+            role,
+            content: content.to_string(),
+        }
+    }
+
+    #[test]
+    fn compaction_preserves_system_and_latest_query() {
+        let messages = vec![
+            message(ChatRole::System, "system"),
+            message(ChatRole::User, "u1"),
+            message(ChatRole::Assistant, "a1"),
+            message(ChatRole::User, "u2"),
+            message(ChatRole::Assistant, "a2"),
+            message(ChatRole::User, "u3"),
+        ];
+
+        let ends = complete_chat_turn_prefix_ends(&messages);
+        assert_eq!(ends, vec![2, 4]);
+        let compacted = chat_messages_after_prefix(&messages, ends[0]);
+        assert_eq!(compacted.len(), 4);
+        assert_eq!(compacted[0].role, ChatRole::System);
+        assert_eq!(compacted[1].content, "u2");
+        assert_eq!(compacted[3].content, "u3");
+    }
+
+    #[test]
+    fn compaction_never_drops_the_only_user_query() {
+        let messages = vec![
+            message(ChatRole::System, "system"),
+            message(ChatRole::User, "latest"),
+        ];
+        assert!(complete_chat_turn_prefix_ends(&messages).is_empty());
+        assert_eq!(messages.len(), 2);
+    }
+
+    #[test]
+    fn completion_budget_never_exceeds_remaining_context() {
+        assert_eq!(bounded_chat_completion_tokens(90, 32, 100), Some(10));
+        assert_eq!(bounded_chat_completion_tokens(90, 0, 100), Some(1));
+        assert_eq!(bounded_chat_completion_tokens(100, 1, 100), None);
     }
 }

--- a/crates/izwi-core/src/runtime/lifecycle/unload.rs
+++ b/crates/izwi-core/src/runtime/lifecycle/unload.rs
@@ -85,8 +85,19 @@ impl ModelLifecycleController {
         }
     }
 
+    async fn purge_executor_model_cache(&self, variant: ModelVariant) -> Result<()> {
+        let release = self.core_engine.purge_model_cache(variant).await;
+        if variant.family() == ModelFamily::Qwen35Chat && !release.confirmed {
+            return Err(Error::InferenceError(format!(
+                "Qwen3.5 cache purge was not confirmed before unloading {variant}"
+            )));
+        }
+        Ok(())
+    }
+
     pub(super) async fn rollback_model_locked(&self, variant: ModelVariant) -> Result<()> {
         let _ = self.core_engine.abort_requests_for_variant(variant).await;
+        self.purge_executor_model_cache(variant).await?;
         self.model_manager.unload_model(variant).await?;
         self.remove_registry_and_auxiliary_state(variant).await;
         self.remove_resident_slot(variant);
@@ -121,6 +132,10 @@ impl ModelLifecycleController {
     pub(super) async fn unload_model_locked(&self, variant: ModelVariant) -> Result<()> {
         self.begin_unloading_slot(variant)?;
         let _ = self.core_engine.abort_requests_for_variant(variant).await;
+        if let Err(error) = self.purge_executor_model_cache(variant).await {
+            self.restore_ready_slot_after_failed_unload(variant);
+            return Err(error);
+        }
 
         // Clear externally visible Ready state before removing the physical
         // handle. The authoritative slot remains Unloading and retains its

--- a/crates/izwi-core/src/runtime/service.rs
+++ b/crates/izwi-core/src/runtime/service.rs
@@ -1340,6 +1340,10 @@ impl RuntimeService {
                         }
                     }
                     Ok(Err(err)) => {
+                        let error_message = match err {
+                            Error::InferenceError(message) => message,
+                            other => other.to_string(),
+                        };
                         let mut w = waiters.lock().await;
                         let pending: Vec<_> = w.drain().collect();
                         drop(w);
@@ -1350,7 +1354,7 @@ impl RuntimeService {
                         for (_, waiter) in pending {
                             let _ = waiter
                                 .sender
-                                .send(Err(Error::InferenceError(err.to_string())));
+                                .send(Err(Error::InferenceError(error_message.clone())));
                         }
                         tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
                     }

--- a/crates/izwi-core/src/tokenizer.rs
+++ b/crates/izwi-core/src/tokenizer.rs
@@ -6,17 +6,18 @@ use std::path::Path;
 use uuid::Uuid;
 
 use serde::Deserialize;
-use tokenizers::AddedToken;
-use tokenizers::SplitDelimiterBehavior;
-use tokenizers::Tokenizer as HfTokenizer;
-use tokenizers::decoders::DecoderWrapper;
 use tokenizers::decoders::byte_fallback::ByteFallback;
 use tokenizers::decoders::sequence::Sequence as DecoderSequence;
+use tokenizers::decoders::DecoderWrapper;
 use tokenizers::models::bpe::BPE;
-use tokenizers::pre_tokenizers::PreTokenizerWrapper;
 use tokenizers::pre_tokenizers::byte_level::ByteLevel;
 use tokenizers::pre_tokenizers::sequence::Sequence as PreTokenizerSequence;
 use tokenizers::pre_tokenizers::split::{Split, SplitPattern};
+use tokenizers::pre_tokenizers::PreTokenizerWrapper;
+use tokenizers::tokenizer::step_decode_stream;
+use tokenizers::AddedToken;
+use tokenizers::SplitDelimiterBehavior;
+use tokenizers::Tokenizer as HfTokenizer;
 use tracing::{debug, info, warn};
 
 use crate::error::{Error, Result};
@@ -33,6 +34,39 @@ pub struct SpecialTokens {
 pub struct Tokenizer {
     inner: HfTokenizer,
     special_tokens: SpecialTokens,
+}
+
+/// Owned state for incremental token decoding.
+///
+/// `tokenizers::DecodeStream` borrows its tokenizer, which makes it unsuitable
+/// for storing beside the tokenizer in a long-lived model/session struct. This
+/// state mirrors the upstream decoder's owned fields and additionally retains
+/// the complete generated id list so [`Tokenizer::finish_incremental_decode`]
+/// can exactly match a one-shot decode, including an incomplete final UTF-8
+/// sequence.
+#[derive(Debug, Clone)]
+pub struct IncrementalDecoder {
+    skip_special_tokens: bool,
+    stream_ids: Vec<u32>,
+    prefix: String,
+    prefix_index: usize,
+    all_ids: Vec<u32>,
+    emitted: String,
+    finished: bool,
+}
+
+impl IncrementalDecoder {
+    pub fn new(skip_special_tokens: bool) -> Self {
+        Self {
+            skip_special_tokens,
+            stream_ids: Vec::new(),
+            prefix: String::new(),
+            prefix_index: 0,
+            all_ids: Vec::new(),
+            emitted: String::new(),
+            finished: false,
+        }
+    }
 }
 
 const QWEN2_PRETOKENIZER_REGEX: &str = "(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\\r\\n\\p{L}\\p{N}]?[\\p{L}\\p{M}]+|\\p{N}| ?[^\\s\\p{L}\\p{M}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+";
@@ -199,7 +233,12 @@ impl Tokenizer {
             let id = u32::try_from(idx).map_err(|_| {
                 Error::TokenizationError(format!("GGUF tokenizer id out of range: {idx}"))
             })?;
-            vocab.insert(token.clone(), id);
+            if let Some(previous_id) = vocab.insert(token.clone(), id) {
+                return Err(Error::TokenizationError(format!(
+                    "Duplicate GGUF tokenizer token {:?} at ids {previous_id} and {id}",
+                    token
+                )));
+            }
         }
 
         let mut merge_lines = Vec::with_capacity(merges.len());
@@ -243,7 +282,7 @@ impl Tokenizer {
         let _ = fs::remove_dir(&temp_dir);
         let mut inner = HfTokenizer::new(bpe);
 
-        let byte_level = if matches!(pre_tokenizer, Some("qwen2")) {
+        let byte_level = if matches!(pre_tokenizer, Some("qwen2" | "qwen35")) {
             let split = Split::new(
                 SplitPattern::Regex(QWEN2_PRETOKENIZER_REGEX.to_string()),
                 SplitDelimiterBehavior::Isolated,
@@ -273,6 +312,66 @@ impl Tokenizer {
         Self::new_with_tokenizer(inner)
     }
 
+    /// Register GGUF control (type 3) and user-defined (type 4) tokens as
+    /// atomic added tokens while preserving their ids from the model vocab.
+    ///
+    /// Control tokens are special and therefore omitted by normal decoding;
+    /// user-defined tokens remain visible. `tokenizers` reuses the BPE model id
+    /// when the token content is already present, so this does not grow or
+    /// reorder the GGUF vocabulary.
+    pub fn register_gguf_token_types(
+        &mut self,
+        tokens: &[String],
+        token_types: &[u32],
+    ) -> Result<()> {
+        if tokens.len() != token_types.len() {
+            return Err(Error::TokenizationError(format!(
+                "GGUF tokenizer token/type length mismatch: {} tokens for {} token types",
+                tokens.len(),
+                token_types.len()
+            )));
+        }
+
+        let original_vocab_size = self.inner.get_vocab_size(true);
+        let mut atomic_tokens = Vec::new();
+        for (id, (token, token_type)) in tokens.iter().zip(token_types).enumerate() {
+            if !matches!(token_type, 3 | 4) {
+                continue;
+            }
+
+            let expected_id = u32::try_from(id).map_err(|_| {
+                Error::TokenizationError(format!("GGUF tokenizer id out of range: {id}"))
+            })?;
+            let actual_id = self.inner.token_to_id(token);
+            if actual_id != Some(expected_id) {
+                return Err(Error::TokenizationError(format!(
+                    "GGUF atomic token id mismatch for {:?}: expected {expected_id}, found {:?}",
+                    token, actual_id
+                )));
+            }
+
+            let special = *token_type == 3;
+            atomic_tokens.push(AddedToken::from(token.clone(), special).normalized(false));
+        }
+
+        self.inner.add_tokens(&atomic_tokens);
+        if self.inner.get_vocab_size(true) != original_vocab_size {
+            return Err(Error::TokenizationError(format!(
+                "Registering GGUF atomic tokens changed vocab size from {original_vocab_size} to {}",
+                self.inner.get_vocab_size(true)
+            )));
+        }
+        for (id, (token, token_type)) in tokens.iter().zip(token_types).enumerate() {
+            if matches!(token_type, 3 | 4) && self.inner.token_to_id(token) != Some(id as u32) {
+                return Err(Error::TokenizationError(format!(
+                    "Registering GGUF atomic token {:?} changed its id",
+                    token
+                )));
+            }
+        }
+        Ok(())
+    }
+
     fn new_with_tokenizer(inner: HfTokenizer) -> Result<Self> {
         let special_tokens = SpecialTokens::default();
 
@@ -300,6 +399,61 @@ impl Tokenizer {
         self.inner
             .decode(ids, false)
             .map_err(|e| Error::TokenizationError(e.to_string()))
+    }
+
+    /// Decode one token into the next complete UTF-8-safe text delta.
+    ///
+    /// An empty string means the decoder is buffering bytes until they form a
+    /// complete decoded suffix. Call [`Self::finish_incremental_decode`] when
+    /// generation finishes to emit any remaining one-shot-decoder suffix.
+    pub fn decode_incrementally(
+        &self,
+        decoder: &mut IncrementalDecoder,
+        token_id: u32,
+    ) -> Result<String> {
+        if decoder.finished {
+            return Err(Error::TokenizationError(
+                "Cannot decode another token after incremental decoding was finished".to_string(),
+            ));
+        }
+        decoder.all_ids.push(token_id);
+        let delta = step_decode_stream(
+            &self.inner,
+            vec![token_id],
+            decoder.skip_special_tokens,
+            &mut decoder.stream_ids,
+            &mut decoder.prefix,
+            &mut decoder.prefix_index,
+        )
+        .map_err(|e| Error::TokenizationError(e.to_string()))?
+        .unwrap_or_default();
+        decoder.emitted.push_str(&delta);
+        Ok(delta)
+    }
+
+    /// Finish an incremental decode and return the not-yet-emitted suffix.
+    ///
+    /// This is idempotent and deliberately compares against a one-shot decode,
+    /// ensuring streamed deltas plus this suffix have exactly the same decoder
+    /// semantics even when generation ends part-way through a byte sequence.
+    pub fn finish_incremental_decode(&self, decoder: &mut IncrementalDecoder) -> Result<String> {
+        if decoder.finished {
+            return Ok(String::new());
+        }
+        let decoded = self
+            .inner
+            .decode(&decoder.all_ids, decoder.skip_special_tokens)
+            .map_err(|e| Error::TokenizationError(e.to_string()))?;
+        let suffix = decoded.strip_prefix(&decoder.emitted).ok_or_else(|| {
+            Error::TokenizationError(format!(
+                "Incremental decode diverged from one-shot decode: emitted {:?}, decoded {:?}",
+                decoder.emitted, decoded
+            ))
+        })?;
+        let suffix = suffix.to_string();
+        decoder.emitted.push_str(&suffix);
+        decoder.finished = true;
+        Ok(suffix)
     }
 
     pub fn vocab_size(&self) -> usize {
@@ -365,4 +519,209 @@ fn load_tokenizer_config(model_dir: &Path) -> Result<Option<TokenizerConfigFile>
     let config_str = fs::read_to_string(config_path)?;
     let config: TokenizerConfigFile = serde_json::from_str(&config_str)?;
     Ok(Some(config))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn byte_level_char(byte: u8) -> char {
+        let mut bytes: Vec<u8> = (b'!'..=b'~')
+            .chain(b'\xA1'..=b'\xAC')
+            .chain(b'\xAE'..=b'\xFF')
+            .collect();
+        let mut codepoints: Vec<u32> = bytes.iter().map(|byte| u32::from(*byte)).collect();
+        let mut next = 0u32;
+        for candidate in 0..=u8::MAX {
+            if !bytes.contains(&candidate) {
+                bytes.push(candidate);
+                codepoints.push(256 + next);
+                next += 1;
+            }
+        }
+        let index = bytes
+            .iter()
+            .position(|candidate| *candidate == byte)
+            .expect("byte-level alphabet contains every byte");
+        char::from_u32(codepoints[index]).expect("byte-level codepoint is valid")
+    }
+
+    fn byte_level_piece(text: &str) -> String {
+        text.as_bytes()
+            .iter()
+            .map(|byte| byte_level_char(*byte))
+            .collect()
+    }
+
+    #[test]
+    fn qwen35_uses_qwen_regex_for_combining_marks() {
+        let combining = byte_level_piece("\u{301}");
+        let mut combining_chars = combining.chars();
+        let first = combining_chars.next().expect("first combining byte");
+        let second = combining_chars.next().expect("second combining byte");
+        assert!(combining_chars.next().is_none());
+
+        let first_merge = format!("a{first}");
+        let combined = format!("{first_merge}{second}");
+        let tokens = vec![
+            "a".to_string(),
+            first.to_string(),
+            second.to_string(),
+            first_merge.clone(),
+            combined,
+        ];
+        let merges = vec![format!("a {first}"), format!("{first_merge} {second}")];
+
+        let qwen35 = Tokenizer::from_gguf_bpe(&tokens, &merges, Some("qwen35"), false)
+            .expect("qwen35 tokenizer");
+        let generic = Tokenizer::from_gguf_bpe(&tokens, &merges, Some("unknown"), false)
+            .expect("generic tokenizer");
+
+        assert_eq!(qwen35.encode("a\u{301}").expect("qwen35 encode"), vec![4]);
+        assert_ne!(
+            generic.encode("a\u{301}").expect("generic encode"),
+            vec![4],
+            "the generic GPT-2 regex splits the combining mark away from its letter"
+        );
+    }
+
+    #[test]
+    fn gguf_control_and_user_defined_tokens_are_atomic_without_id_changes() {
+        let tokens = vec![
+            "a".to_string(),
+            "b".to_string(),
+            "<|im_start|>".to_string(),
+            "<think>".to_string(),
+            "<tool_call>".to_string(),
+        ];
+        let mut tokenizer =
+            Tokenizer::from_gguf_bpe(&tokens, &[], Some("qwen35"), false).expect("tokenizer");
+        tokenizer
+            .register_gguf_token_types(&tokens, &[1, 1, 3, 4, 4])
+            .expect("register token types");
+
+        let ids = tokenizer
+            .encode("a<|im_start|><think><tool_call>b")
+            .expect("atomic encode");
+        assert_eq!(ids, vec![0, 2, 3, 4, 1]);
+        assert_eq!(tokenizer.token_to_id("<|im_start|>"), Some(2));
+        assert_eq!(tokenizer.token_to_id("<think>"), Some(3));
+        assert_eq!(tokenizer.token_to_id("<tool_call>"), Some(4));
+        assert_eq!(tokenizer.vocab_size(), tokens.len());
+        assert_eq!(
+            tokenizer.decode(&ids).expect("skip control"),
+            "a<think><tool_call>b"
+        );
+        assert_eq!(
+            tokenizer
+                .decode_with_special_tokens(&ids)
+                .expect("include control"),
+            "a<|im_start|><think><tool_call>b"
+        );
+    }
+
+    #[test]
+    fn gguf_bpe_rejects_duplicate_token_strings() {
+        let tokens = vec!["a".to_string(), "a".to_string()];
+        assert!(matches!(
+            Tokenizer::from_gguf_bpe(&tokens, &[], Some("qwen35"), false),
+            Err(Error::TokenizationError(message)) if message.contains("Duplicate GGUF tokenizer token")
+        ));
+    }
+
+    #[test]
+    fn gguf_token_type_registration_rejects_length_mismatch() {
+        let tokens = vec!["a".to_string()];
+        let mut tokenizer =
+            Tokenizer::from_gguf_bpe(&tokens, &[], Some("qwen35"), false).expect("tokenizer");
+        assert!(matches!(
+            tokenizer.register_gguf_token_types(&tokens, &[]),
+            Err(Error::TokenizationError(message)) if message.contains("length mismatch")
+        ));
+    }
+
+    #[test]
+    fn incremental_decode_is_utf8_safe_and_matches_one_shot_with_flush() {
+        let text = "café 中文 🌍 👨‍👩‍👧‍👦";
+        let mut tokens = Vec::<String>::new();
+        for byte in text.as_bytes() {
+            let token = byte_level_char(*byte).to_string();
+            if !tokens.contains(&token) {
+                tokens.push(token);
+            }
+        }
+        let tokenizer =
+            Tokenizer::from_gguf_bpe(&tokens, &[], Some("qwen35"), false).expect("tokenizer");
+        let ids: Vec<u32> = text
+            .as_bytes()
+            .iter()
+            .map(|byte| {
+                let token = byte_level_char(*byte).to_string();
+                tokenizer.token_to_id(&token).expect("byte token id")
+            })
+            .collect();
+
+        let one_shot = tokenizer.decode(&ids).expect("one-shot decode");
+        let mut decoder = IncrementalDecoder::new(true);
+        let mut streamed = String::new();
+        for id in &ids {
+            let delta = tokenizer
+                .decode_incrementally(&mut decoder, *id)
+                .expect("incremental decode");
+            assert!(!delta.ends_with('\u{fffd}'));
+            streamed.push_str(&delta);
+        }
+        streamed.push_str(
+            &tokenizer
+                .finish_incremental_decode(&mut decoder)
+                .expect("finish decode"),
+        );
+
+        assert_eq!(one_shot, text);
+        assert_eq!(streamed, one_shot);
+        assert_eq!(
+            tokenizer
+                .finish_incremental_decode(&mut decoder)
+                .expect("idempotent finish"),
+            ""
+        );
+        assert!(matches!(
+            tokenizer.decode_incrementally(&mut decoder, ids[0]),
+            Err(Error::TokenizationError(message)) if message.contains("after incremental decoding was finished")
+        ));
+    }
+
+    #[test]
+    fn incremental_flush_matches_incomplete_one_shot_decode() {
+        let emoji = "🌍";
+        let tokens: Vec<String> = emoji
+            .as_bytes()
+            .iter()
+            .map(|byte| byte_level_char(*byte).to_string())
+            .collect();
+        let tokenizer =
+            Tokenizer::from_gguf_bpe(&tokens, &[], Some("qwen35"), false).expect("tokenizer");
+        let incomplete_ids = vec![0, 1, 2];
+        let mut decoder = IncrementalDecoder::new(true);
+        let mut streamed = String::new();
+        for id in &incomplete_ids {
+            streamed.push_str(
+                &tokenizer
+                    .decode_incrementally(&mut decoder, *id)
+                    .expect("incremental decode"),
+            );
+        }
+        streamed.push_str(
+            &tokenizer
+                .finish_incremental_decode(&mut decoder)
+                .expect("finish incomplete decode"),
+        );
+
+        assert_eq!(
+            streamed,
+            tokenizer
+                .decode(&incomplete_ids)
+                .expect("one-shot incomplete decode")
+        );
+    }
 }

--- a/crates/izwi-server/src/api/chat/handlers.rs
+++ b/crates/izwi-server/src/api/chat/handlers.rs
@@ -8,15 +8,17 @@ use axum::{
     Json,
 };
 use serde::{Deserialize, Serialize};
+use tokio::sync::OwnedMutexGuard;
 
 use crate::api::request_context::RequestContext;
 use crate::app::chat::{
-    generate_chat, parse_chat_model, spawn_chat_stream, ChatExecutionRequest, ChatStreamEvent,
+    generate_chat, parse_chat_model, spawn_chat_stream_with_keepalive, ChatExecutionRequest,
+    ChatStreamEvent,
 };
 use crate::app::chat_content::{
     flatten_thread_content, validate_media_inputs_for_variant, FlattenedMultimodalContent,
 };
-use crate::chat_store::{ChatThreadMessage, ChatThreadSummary};
+use crate::chat_store::{sanitize_system_prompt, ChatThreadMessage, ChatThreadSummary};
 use crate::error::ApiError;
 use crate::state::AppState;
 use izwi_core::{ChatMediaInput, ChatMessage, ChatRequestConfig, ChatRole};
@@ -32,6 +34,8 @@ pub struct CreateChatThreadRequest {
     pub title: Option<String>,
     #[serde(default)]
     pub model_id: Option<String>,
+    #[serde(default)]
+    pub system_prompt: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -48,7 +52,10 @@ pub struct DeleteChatThreadResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct UpdateChatThreadRequest {
-    pub title: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub system_prompt: Option<String>,
 }
 
 #[allow(dead_code)]
@@ -136,7 +143,7 @@ pub async fn create_thread(
 ) -> Result<Json<ChatThreadSummary>, ApiError> {
     let thread = state
         .chat_store
-        .create_thread(req.title, req.model_id)
+        .create_thread_with_system_prompt(req.title, req.model_id, req.system_prompt)
         .await
         .map_err(map_store_error)?;
 
@@ -196,13 +203,20 @@ pub async fn update_thread(
     Path(thread_id): Path<String>,
     Json(req): Json<UpdateChatThreadRequest>,
 ) -> Result<Json<ChatThreadSummary>, ApiError> {
-    if req.title.trim().is_empty() {
+    if req.title.is_none() && req.system_prompt.is_none() {
+        return Err(ApiError::bad_request("No thread settings were provided"));
+    }
+    if req
+        .title
+        .as_deref()
+        .is_some_and(|title| title.trim().is_empty())
+    {
         return Err(ApiError::bad_request("Thread title cannot be empty"));
     }
 
     let updated = state
         .chat_store
-        .update_thread_title(thread_id, req.title)
+        .update_thread_settings(thread_id, req.title, req.system_prompt)
         .await
         .map_err(map_store_error)?;
 
@@ -227,7 +241,16 @@ pub async fn create_thread_message(
         return Err(ApiError::bad_request("Message content cannot be empty"));
     }
 
-    get_thread_or_not_found(&state, &thread_id).await?;
+    // Hold one turn lock across history read, generation, and terminal
+    // persistence. Concurrent sends to the same thread therefore observe the
+    // preceding assistant response instead of branching from stale history.
+    let turn_guard = state.chat_store.lock_turn(&thread_id).await;
+    let thread = get_thread_or_not_found(&state, &thread_id).await?;
+    let requested_system_prompt = req.system_prompt.clone();
+    let effective_system_prompt = match requested_system_prompt.as_deref() {
+        Some(prompt) => sanitize_system_prompt(Some(prompt)),
+        None => thread.system_prompt.clone(),
+    };
     let existing_messages = state
         .chat_store
         .list_messages(thread_id.clone())
@@ -237,21 +260,17 @@ pub async fn create_thread_message(
     let (runtime_messages, media_inputs) = build_runtime_messages(
         &existing_messages,
         &flattened_content,
-        req.system_prompt.as_deref(),
+        effective_system_prompt.as_deref(),
     )?;
     validate_media_inputs_for_variant(model_variant, &media_inputs)
         .map_err(ApiError::bad_request)?;
 
     let user_message = state
         .chat_store
-        .append_message(
+        .prepare_user_message(
             thread_id.clone(),
-            "user".to_string(),
             flattened_content.display_text.clone(),
             prepared_content_parts.clone(),
-            Some(model_id.clone()),
-            None,
-            None,
         )
         .await
         .map_err(map_store_or_not_found)?;
@@ -279,22 +298,23 @@ pub async fn create_thread_message(
             thread_id,
             user_message,
             execution_request,
+            turn_guard,
+            requested_system_prompt,
         )
         .await;
     }
 
     let generation = generate_chat(&state, execution_request).await?;
 
-    let assistant_message = state
+    let (user_message, assistant_message) = state
         .chat_store
-        .append_message(
-            thread_id.clone(),
-            "assistant".to_string(),
+        .append_turn_with_system_prompt(
+            user_message,
             generation.text.clone(),
-            None,
-            Some(model_id.clone()),
-            Some(generation.tokens_generated),
-            Some(generation.generation_time_ms),
+            model_id.clone(),
+            generation.tokens_generated,
+            generation.generation_time_ms,
+            requested_system_prompt,
         )
         .await
         .map_err(map_store_or_not_found)?;
@@ -319,14 +339,18 @@ async fn create_streaming_thread_message(
     thread_id: String,
     user_message: ChatThreadMessage,
     execution_request: ChatExecutionRequest,
+    turn_guard: OwnedMutexGuard<()>,
+    system_prompt_update: Option<String>,
 ) -> Result<Response, ApiError> {
     let chat_store = state.chat_store.clone();
     let thread_id_for_task = thread_id.clone();
     let model_id_for_task = model_id.clone();
     let user_message_for_start = user_message.clone();
-    let mut event_rx = spawn_chat_stream(state, execution_request);
+    let (mut event_rx, stream_completion) =
+        spawn_chat_stream_with_keepalive(state, execution_request, turn_guard);
 
     let stream = async_stream::stream! {
+        let mut stream_completion = Some(stream_completion);
         while let Some(event) = event_rx.recv().await {
             let (payload, terminal) = match event {
                 ChatStreamEvent::Started => (
@@ -349,18 +373,17 @@ async fn create_streaming_thread_message(
                 ),
                 ChatStreamEvent::Completed(generation) => {
                     let payload = match chat_store
-                        .append_message(
-                            thread_id_for_task.clone(),
-                            "assistant".to_string(),
+                        .append_turn_with_system_prompt(
+                            user_message_for_start.clone(),
                             generation.text.clone(),
-                            None,
-                            Some(model_id_for_task.clone()),
-                            Some(generation.tokens_generated),
-                            Some(generation.generation_time_ms),
+                            model_id_for_task.clone(),
+                            generation.tokens_generated,
+                            generation.generation_time_ms,
+                            system_prompt_update.clone(),
                         )
                         .await
                     {
-                        Ok(assistant_message) => serde_json::to_string(&ThreadStreamDoneEvent {
+                        Ok((_user_message, assistant_message)) => serde_json::to_string(&ThreadStreamDoneEvent {
                             event: "done",
                             thread_id: thread_id_for_task.clone(),
                             model_id: model_id_for_task.clone(),
@@ -396,6 +419,11 @@ async fn create_streaming_thread_message(
                     true,
                 ),
             };
+            if terminal {
+                if let Some(completion) = stream_completion.take() {
+                    completion.acknowledge();
+                }
+            }
             yield Ok::<_, Infallible>(format!("data: {payload}\n\n"));
             if terminal {
                 break;

--- a/crates/izwi-server/src/app/chat.rs
+++ b/crates/izwi-server/src/app/chat.rs
@@ -3,9 +3,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::Notify;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::error::ApiError;
 use crate::state::AppState;
@@ -61,6 +61,22 @@ pub enum ChatStreamEvent {
     Completed(ChatGeneration),
     Failed(String),
     ShuttingDown,
+}
+
+/// Completion acknowledgement for a stream whose producer owns an external
+/// lifecycle guard. Dropping this value also acknowledges cancellation, while
+/// an explicit acknowledgement records that terminal handling (including any
+/// persistence) completed successfully in the response consumer.
+pub struct ChatStreamCompletion {
+    sender: Option<oneshot::Sender<()>>,
+}
+
+impl ChatStreamCompletion {
+    pub fn acknowledge(mut self) {
+        if let Some(sender) = self.sender.take() {
+            let _ = sender.send(());
+        }
+    }
 }
 
 const CHAT_STREAM_CAPACITY: usize = 64;
@@ -191,6 +207,40 @@ pub fn spawn_chat_stream(
     state: AppState,
     request: ChatExecutionRequest,
 ) -> mpsc::Receiver<ChatStreamEvent> {
+    spawn_chat_stream_inner(state, request, (), None)
+}
+
+/// Spawn a chat stream while retaining `keepalive` until inference has fully
+/// unwound and the response consumer has handled the terminal event. This is
+/// used by persisted thread chats to keep their per-thread turn lock through
+/// cancellation and atomic terminal persistence.
+pub fn spawn_chat_stream_with_keepalive<K>(
+    state: AppState,
+    request: ChatExecutionRequest,
+    keepalive: K,
+) -> (mpsc::Receiver<ChatStreamEvent>, ChatStreamCompletion)
+where
+    K: Send + 'static,
+{
+    let (completion_tx, completion_rx) = oneshot::channel();
+    let events = spawn_chat_stream_inner(state, request, keepalive, Some(completion_rx));
+    (
+        events,
+        ChatStreamCompletion {
+            sender: Some(completion_tx),
+        },
+    )
+}
+
+fn spawn_chat_stream_inner<K>(
+    state: AppState,
+    request: ChatExecutionRequest,
+    keepalive: K,
+    completion_rx: Option<oneshot::Receiver<()>>,
+) -> mpsc::Receiver<ChatStreamEvent>
+where
+    K: Send + 'static,
+{
     let runtime = state.runtime.clone();
     let params = request.resolved_generation_params();
     let chat_config = request.resolved_chat_config();
@@ -201,41 +251,49 @@ pub fn spawn_chat_stream(
     let (event_tx, event_rx) = mpsc::channel(CHAT_STREAM_CAPACITY);
     let backpressure = Arc::new(ChatStreamBackpressure::default());
     tokio::spawn(async move {
-        let permit = match state
-            .acquire_owned_workload_permit(WorkloadClass::Streaming)
-            .await
-        {
-            Ok(permit) => permit,
-            Err(_) => {
-                send_chat_terminal(event_tx, ChatStreamEvent::ShuttingDown).await;
+        async move {
+            let permit = match state
+                .acquire_owned_workload_permit(WorkloadClass::Streaming)
+                .await
+            {
+                Ok(permit) => permit,
+                Err(_) => {
+                    send_chat_terminal(event_tx, ChatStreamEvent::ShuttingDown).await;
+                    return;
+                }
+            };
+
+            if event_tx.send(ChatStreamEvent::Started).await.is_err() {
                 return;
             }
-        };
 
-        if event_tx.send(ChatStreamEvent::Started).await.is_err() {
-            return;
+            let generation = runtime.chat_generate_streaming_with_runtime_context(
+                variant,
+                messages,
+                params,
+                chat_config,
+                correlation_id.as_deref(),
+                permit.runtime_context(),
+                {
+                    let event_tx = event_tx.clone();
+                    let backpressure = backpressure.clone();
+                    move |delta| {
+                        try_send_chat_delta(&event_tx, &backpressure, delta);
+                    }
+                },
+            );
+            let terminal = resolve_chat_terminal(&event_tx, backpressure, generation).await;
+            drop(permit);
+            if let Some(terminal) = terminal {
+                send_chat_terminal(event_tx, terminal).await;
+            }
         }
+        .await;
 
-        let generation = runtime.chat_generate_streaming_with_runtime_context(
-            variant,
-            messages,
-            params,
-            chat_config,
-            correlation_id.as_deref(),
-            permit.runtime_context(),
-            {
-                let event_tx = event_tx.clone();
-                let backpressure = backpressure.clone();
-                move |delta| {
-                    try_send_chat_delta(&event_tx, &backpressure, delta);
-                }
-            },
-        );
-        let terminal = resolve_chat_terminal(&event_tx, backpressure, generation).await;
-        drop(permit);
-        if let Some(terminal) = terminal {
-            send_chat_terminal(event_tx, terminal).await;
+        if let Some(completion_rx) = completion_rx {
+            let _ = completion_rx.await;
         }
+        drop(keepalive);
     });
 
     event_rx
@@ -279,9 +337,52 @@ where
 }
 
 #[cfg(test)]
+fn spawn_chat_stream_with_task_and_keepalive<G, Fut, K>(
+    semaphore: Arc<tokio::sync::Semaphore>,
+    keepalive: K,
+    generation_task: G,
+) -> (mpsc::Receiver<ChatStreamEvent>, ChatStreamCompletion)
+where
+    G: FnOnce(mpsc::Sender<ChatStreamEvent>, Arc<ChatStreamBackpressure>) -> Fut + Send + 'static,
+    Fut: Future<Output = izwi_core::Result<ChatGeneration>> + Send + 'static,
+    K: Send + 'static,
+{
+    let (event_tx, event_rx) = mpsc::channel(CHAT_STREAM_CAPACITY);
+    let (completion_tx, completion_rx) = oneshot::channel();
+    let backpressure = Arc::new(ChatStreamBackpressure::default());
+
+    tokio::spawn(async move {
+        async move {
+            let permit = semaphore.acquire_owned().await.expect("test semaphore");
+            if event_tx.send(ChatStreamEvent::Started).await.is_err() {
+                return;
+            }
+            let generation = generation_task(event_tx.clone(), backpressure.clone());
+            let terminal = resolve_chat_terminal(&event_tx, backpressure, generation).await;
+            drop(permit);
+            if let Some(terminal) = terminal {
+                send_chat_terminal(event_tx, terminal).await;
+            }
+        }
+        .await;
+
+        let _ = completion_rx.await;
+        drop(keepalive);
+    });
+
+    (
+        event_rx,
+        ChatStreamCompletion {
+            sender: Some(completion_tx),
+        },
+    )
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use izwi_core::ChatRole;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
     use tokio::sync::Semaphore;
 
@@ -442,5 +543,69 @@ mod tests {
             Some(ChatStreamEvent::Started)
         ));
         assert!(event_rx.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn disconnect_unwinds_generation_before_releasing_stream_keepalive() {
+        struct GenerationDrop(Arc<AtomicBool>);
+        impl Drop for GenerationDrop {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::Release);
+            }
+        }
+
+        struct KeepaliveDrop {
+            generation_dropped: Arc<AtomicBool>,
+            released: Arc<AtomicBool>,
+            released_early: Arc<AtomicBool>,
+        }
+        impl Drop for KeepaliveDrop {
+            fn drop(&mut self) {
+                if !self.generation_dropped.load(Ordering::Acquire) {
+                    self.released_early.store(true, Ordering::Release);
+                }
+                self.released.store(true, Ordering::Release);
+            }
+        }
+
+        let generation_started = Arc::new(Notify::new());
+        let generation_dropped = Arc::new(AtomicBool::new(false));
+        let keepalive_released = Arc::new(AtomicBool::new(false));
+        let keepalive_released_early = Arc::new(AtomicBool::new(false));
+        let started = generation_started.clone();
+        let generation_drop_for_task = generation_dropped.clone();
+        let keepalive = KeepaliveDrop {
+            generation_dropped: generation_dropped.clone(),
+            released: keepalive_released.clone(),
+            released_early: keepalive_released_early.clone(),
+        };
+        let (mut event_rx, completion) = spawn_chat_stream_with_task_and_keepalive(
+            Arc::new(Semaphore::new(1)),
+            keepalive,
+            move |_event_tx, _backpressure| async move {
+                let _drop = GenerationDrop(generation_drop_for_task);
+                started.notify_one();
+                std::future::pending::<()>().await;
+                unreachable!("pending generation should be cancelled")
+            },
+        );
+
+        assert!(matches!(
+            event_rx.recv().await,
+            Some(ChatStreamEvent::Started)
+        ));
+        generation_started.notified().await;
+        drop(event_rx);
+        drop(completion);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !keepalive_released.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("keepalive should release after cancellation");
+        assert!(generation_dropped.load(Ordering::Acquire));
+        assert!(!keepalive_released_early.load(Ordering::Acquire));
     }
 }

--- a/crates/izwi-server/src/chat_store.rs
+++ b/crates/izwi-server/src/chat_store.rs
@@ -3,12 +3,15 @@
 use anyhow::{anyhow, Context};
 use sea_orm::sea_query::Expr;
 use sea_orm::{
-    ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryResult, Set,
-    TransactionTrait,
+    ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder,
+    QueryResult, Set, TransactionTrait,
 };
 use serde::Serialize;
 use serde_json::Value as JsonValue;
+use std::collections::HashMap;
+use std::sync::{Arc, Weak};
 use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 
 use crate::db::{raw, StoreDatabase};
 use crate::entity::{chat_messages, chat_threads};
@@ -21,6 +24,7 @@ pub struct ChatThreadSummary {
     pub id: String,
     pub title: String,
     pub model_id: Option<String>,
+    pub system_prompt: Option<String>,
     pub created_at: u64,
     pub updated_at: u64,
     pub last_message_preview: Option<String>,
@@ -43,17 +47,77 @@ pub struct ChatThreadMessage {
 #[derive(Clone)]
 pub struct ChatStore {
     db: StoreDatabase,
+    turn_locks: Arc<AsyncMutex<HashMap<String, Weak<AsyncMutex<()>>>>>,
 }
 
 impl ChatStore {
     pub fn initialize() -> anyhow::Result<Self> {
         Ok(Self {
             db: StoreDatabase::from_default_path()?,
+            turn_locks: Arc::new(AsyncMutex::new(HashMap::new())),
         })
     }
 
     pub fn initialize_with_database(db: StoreDatabase) -> Self {
-        Self { db }
+        Self {
+            db,
+            turn_locks: Arc::new(AsyncMutex::new(HashMap::new())),
+        }
+    }
+
+    /// Serialize the complete read-generate-persist lifecycle for one thread.
+    ///
+    /// Locks are weakly retained so idle thread ids do not accumulate forever.
+    /// The owned guard can move into a streaming response task and remains valid
+    /// even when the `ChatStore` handle used to acquire it is dropped.
+    pub async fn lock_turn(&self, thread_id: &str) -> OwnedMutexGuard<()> {
+        let turn_lock = {
+            let mut locks = self.turn_locks.lock().await;
+            locks.retain(|_, lock| lock.strong_count() > 0);
+
+            if let Some(lock) = locks.get(thread_id).and_then(Weak::upgrade) {
+                lock
+            } else {
+                let lock = Arc::new(AsyncMutex::new(()));
+                locks.insert(thread_id.to_string(), Arc::downgrade(&lock));
+                lock
+            }
+        };
+
+        turn_lock.lock_owned().await
+    }
+
+    /// Build the user half of a turn without writing it to storage. The exact
+    /// id is returned to streaming clients immediately and is committed only
+    /// if generation completes successfully.
+    pub async fn prepare_user_message(
+        &self,
+        thread_id: String,
+        content: String,
+        content_parts: Option<Vec<JsonValue>>,
+    ) -> anyhow::Result<ChatThreadMessage> {
+        let db = self.db.connection().await?;
+        let thread = chat_threads::Entity::find_by_id(thread_id.clone())
+            .one(db)
+            .await
+            .context("Failed to load chat thread")?
+            .ok_or_else(|| anyhow!("Thread not found"))?;
+        let previous_timestamp = latest_thread_message_timestamp(db, &thread_id)
+            .await?
+            .unwrap_or(thread.updated_at)
+            .max(thread.updated_at);
+        let created_at = now_unix_millis_i64().max(previous_timestamp.saturating_add(1));
+
+        Ok(ChatThreadMessage {
+            id: new_uuid(),
+            thread_id,
+            role: "user".to_string(),
+            content,
+            content_parts,
+            created_at: i64_to_u64(created_at),
+            tokens_generated: None,
+            generation_time_ms: None,
+        })
     }
 
     pub async fn list_threads(&self) -> anyhow::Result<Vec<ChatThreadSummary>> {
@@ -75,15 +139,27 @@ impl ChatStore {
         title: Option<String>,
         model_id: Option<String>,
     ) -> anyhow::Result<ChatThreadSummary> {
+        self.create_thread_with_system_prompt(title, model_id, None)
+            .await
+    }
+
+    pub async fn create_thread_with_system_prompt(
+        &self,
+        title: Option<String>,
+        model_id: Option<String>,
+        system_prompt: Option<String>,
+    ) -> anyhow::Result<ChatThreadSummary> {
         let db = self.db.connection().await?;
         let now = now_unix_millis_i64();
         let thread_id = new_uuid();
         let resolved_title = sanitize_thread_title(title.as_deref());
+        let system_prompt = sanitize_system_prompt(system_prompt.as_deref());
 
         chat_threads::Entity::insert(chat_threads::ActiveModel {
             id: Set(thread_id.clone()),
             title: Set(resolved_title.clone()),
             model_id: Set(model_id.clone()),
+            system_prompt: Set(system_prompt.clone()),
             created_at: Set(now),
             updated_at: Set(now),
         })
@@ -95,6 +171,7 @@ impl ChatStore {
             id: thread_id,
             title: resolved_title,
             model_id,
+            system_prompt,
             created_at: now as u64,
             updated_at: now as u64,
             last_message_preview: None,
@@ -124,25 +201,36 @@ impl ChatStore {
         rows.iter().map(map_thread_message).collect()
     }
 
-    pub async fn update_thread_title(
+    /// Update thread-owned settings. `Some("")` explicitly clears the system
+    /// prompt, while `None` inherits the existing value.
+    pub async fn update_thread_settings(
         &self,
         thread_id: String,
-        title: String,
+        title: Option<String>,
+        system_prompt: Option<String>,
     ) -> anyhow::Result<Option<ChatThreadSummary>> {
         let db = self.db.connection().await?;
         let now = now_unix_millis_i64();
-        let resolved_title = sanitize_thread_title(Some(title.as_str()));
-
-        let result = chat_threads::Entity::update_many()
-            .col_expr(
+        let mut update = chat_threads::Entity::update_many()
+            .col_expr(chat_threads::Column::UpdatedAt, Expr::value(now));
+        if let Some(title) = title {
+            update = update.col_expr(
                 chat_threads::Column::Title,
-                Expr::value(resolved_title.clone()),
-            )
-            .col_expr(chat_threads::Column::UpdatedAt, Expr::value(now))
+                Expr::value(sanitize_thread_title(Some(title.as_str()))),
+            );
+        }
+        if let Some(system_prompt) = system_prompt {
+            update = update.col_expr(
+                chat_threads::Column::SystemPrompt,
+                Expr::value(sanitize_system_prompt(Some(system_prompt.as_str()))),
+            );
+        }
+
+        let result = update
             .filter(chat_threads::Column::Id.eq(thread_id.clone()))
             .exec(db)
             .await
-            .context("Failed to update chat thread title")?;
+            .context("Failed to update chat thread settings")?;
 
         if result.rows_affected == 0 {
             return Ok(None);
@@ -223,6 +311,132 @@ impl ChatStore {
             generation_time_ms,
         })
     }
+
+    /// Atomically append a complete user/assistant turn. A generation failure
+    /// never calls this method, so no orphan user message can become part of a
+    /// future prompt. The assistant timestamp is forced after the pending user
+    /// timestamp to make ordering deterministic even within one millisecond.
+    /// Append a successful turn and an optional thread system-prompt change in
+    /// one transaction. `Some("")` clears the prompt; `None` preserves it.
+    pub async fn append_turn_with_system_prompt(
+        &self,
+        mut user_message: ChatThreadMessage,
+        assistant_content: String,
+        model_id: String,
+        tokens_generated: usize,
+        generation_time_ms: f64,
+        system_prompt_update: Option<String>,
+    ) -> anyhow::Result<(ChatThreadMessage, ChatThreadMessage)> {
+        if user_message.role != "user" {
+            return Err(anyhow!("Chat turn must start with a user message"));
+        }
+        if user_message.thread_id.is_empty() {
+            return Err(anyhow!("Chat turn requires a thread id"));
+        }
+
+        let db = self.db.connection().await?;
+        let tx = db
+            .begin()
+            .await
+            .context("Failed to start chat turn transaction")?;
+
+        let thread = chat_threads::Entity::find_by_id(user_message.thread_id.clone())
+            .one(&tx)
+            .await
+            .context("Failed to load chat thread")?
+            .ok_or_else(|| anyhow!("Thread not found"))?;
+        let previous_timestamp = latest_thread_message_timestamp(&tx, &user_message.thread_id)
+            .await?
+            .unwrap_or(thread.updated_at)
+            .max(thread.updated_at);
+        let requested_user_timestamp = i64::try_from(user_message.created_at)
+            .context("Pending chat user timestamp is out of range")?;
+        let user_created_at = requested_user_timestamp.max(previous_timestamp.saturating_add(1));
+        if user_created_at == i64::MAX {
+            return Err(anyhow!("Chat message timestamp space is exhausted"));
+        }
+        user_message.created_at = i64_to_u64(user_created_at);
+        let assistant_created_at = now_unix_millis_i64().max(user_created_at.saturating_add(1));
+        let assistant_message = ChatThreadMessage {
+            id: new_uuid(),
+            thread_id: user_message.thread_id.clone(),
+            role: "assistant".to_string(),
+            content: assistant_content,
+            content_parts: None,
+            created_at: i64_to_u64(assistant_created_at),
+            tokens_generated: Some(tokens_generated),
+            generation_time_ms: Some(generation_time_ms),
+        };
+
+        insert_thread_message(&tx, &user_message).await?;
+        insert_thread_message(&tx, &assistant_message).await?;
+
+        let mut thread_update = chat_threads::Entity::update_many()
+            .col_expr(
+                chat_threads::Column::UpdatedAt,
+                Expr::value(assistant_created_at),
+            )
+            .col_expr(chat_threads::Column::ModelId, Expr::value(Some(model_id)));
+        if let Some(system_prompt_update) = system_prompt_update {
+            thread_update = thread_update.col_expr(
+                chat_threads::Column::SystemPrompt,
+                Expr::value(sanitize_system_prompt(Some(system_prompt_update.as_str()))),
+            );
+        }
+        thread_update
+            .filter(chat_threads::Column::Id.eq(user_message.thread_id.clone()))
+            .exec(&tx)
+            .await
+            .context("Failed to update chat thread metadata")?;
+
+        tx.commit()
+            .await
+            .context("Failed to commit chat turn transaction")?;
+
+        Ok((user_message, assistant_message))
+    }
+}
+
+async fn latest_thread_message_timestamp<C>(db: &C, thread_id: &str) -> anyhow::Result<Option<i64>>
+where
+    C: ConnectionTrait,
+{
+    Ok(chat_messages::Entity::find()
+        .filter(chat_messages::Column::ThreadId.eq(thread_id.to_string()))
+        .order_by_desc(chat_messages::Column::CreatedAt)
+        .order_by_desc(chat_messages::Column::Id)
+        .one(db)
+        .await
+        .context("Failed to load latest chat message")?
+        .map(|message| message.created_at))
+}
+
+async fn insert_thread_message<C>(db: &C, message: &ChatThreadMessage) -> anyhow::Result<()>
+where
+    C: ConnectionTrait,
+{
+    let serialized_content_parts = message
+        .content_parts
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .context("Failed serializing chat message content_parts")?;
+
+    chat_messages::Entity::insert(chat_messages::ActiveModel {
+        id: Set(message.id.clone()),
+        thread_id: Set(message.thread_id.clone()),
+        role: Set(message.role.clone()),
+        content: Set(message.content.clone()),
+        content_parts: Set(serialized_content_parts),
+        created_at: Set(i64::try_from(message.created_at).unwrap_or(i64::MAX)),
+        tokens_generated: Set(opt_usize_to_i64(message.tokens_generated)?),
+        generation_time_ms: Set(message.generation_time_ms),
+    })
+    .exec(db)
+    .await
+    .context("Failed to append chat turn message")?;
+
+    Ok(())
 }
 
 const THREAD_SUMMARY_LIST_SQL: &str = r#"
@@ -230,6 +444,7 @@ const THREAD_SUMMARY_LIST_SQL: &str = r#"
         t.id,
         t.title,
         t.model_id,
+        t.system_prompt,
         t.created_at,
         t.updated_at,
         (
@@ -253,6 +468,7 @@ const THREAD_SUMMARY_BY_ID_SQL: &str = r#"
         t.id,
         t.title,
         t.model_id,
+        t.system_prompt,
         t.created_at,
         t.updated_at,
         (
@@ -302,14 +518,15 @@ async fn fetch_thread_summary(
 }
 
 fn map_thread_summary(row: &QueryResult) -> anyhow::Result<ChatThreadSummary> {
-    let message_count_raw: i64 = row.try_get_by_index(6)?;
+    let message_count_raw: i64 = row.try_get_by_index(7)?;
     Ok(ChatThreadSummary {
         id: row.try_get_by_index(0)?,
         title: row.try_get_by_index(1)?,
         model_id: row.try_get_by_index(2)?,
-        created_at: i64_to_u64(row.try_get_by_index(3)?),
-        updated_at: i64_to_u64(row.try_get_by_index(4)?),
-        last_message_preview: row.try_get_by_index(5)?,
+        system_prompt: row.try_get_by_index(3)?,
+        created_at: i64_to_u64(row.try_get_by_index(4)?),
+        updated_at: i64_to_u64(row.try_get_by_index(5)?),
+        last_message_preview: row.try_get_by_index(6)?,
         message_count: i64_to_usize(message_count_raw),
     })
 }
@@ -350,6 +567,12 @@ fn sanitize_thread_title(raw: Option<&str>) -> String {
     } else {
         truncate_string(&normalized, 80)
     }
+}
+
+pub(crate) fn sanitize_system_prompt(raw: Option<&str>) -> Option<String> {
+    raw.map(str::trim)
+        .filter(|prompt| !prompt.is_empty())
+        .map(|prompt| prompt.chars().take(65_536).collect())
 }
 
 fn truncate_string(input: &str, max_chars: usize) -> String {
@@ -432,13 +655,15 @@ mod tests {
                 .is_empty());
 
             let thread = store
-                .create_thread(
+                .create_thread_with_system_prompt(
                     Some("  A   thread title  ".to_string()),
                     Some("qwen".to_string()),
+                    Some("  Be concise.  ".to_string()),
                 )
                 .await
                 .expect("thread should create");
             assert_eq!(thread.title, "A thread title");
+            assert_eq!(thread.system_prompt.as_deref(), Some("Be concise."));
             assert_eq!(thread.message_count, 0);
 
             let content_parts = vec![json!({"type": "text", "text": "hello"})];
@@ -490,11 +715,16 @@ mod tests {
             assert_eq!(summary.message_count, 2);
 
             let updated = store
-                .update_thread_title(thread.id.clone(), "Renamed".to_string())
+                .update_thread_settings(
+                    thread.id.clone(),
+                    Some("Renamed".to_string()),
+                    Some("".to_string()),
+                )
                 .await
                 .expect("title should update")
                 .expect("thread should exist");
             assert_eq!(updated.title, "Renamed");
+            assert!(updated.system_prompt.is_none());
 
             assert!(store
                 .delete_thread(thread.id.clone())
@@ -527,6 +757,204 @@ mod tests {
                 .await
                 .expect_err("missing thread should fail");
             assert!(err.to_string().contains("Thread not found"));
+            clear_env();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn append_turn_publishes_both_messages_atomically_and_in_order() {
+        with_env_lock(async {
+            let (_temp, store) = setup_store();
+            let thread = store
+                .create_thread(None, None)
+                .await
+                .expect("thread should create");
+            let content_parts = vec![json!({"type": "text", "text": "hello"})];
+            let pending_user = store
+                .prepare_user_message(
+                    thread.id.clone(),
+                    "hello".to_string(),
+                    Some(content_parts.clone()),
+                )
+                .await
+                .expect("pending user should prepare");
+
+            assert!(store
+                .list_messages(thread.id.clone())
+                .await
+                .expect("messages should list before commit")
+                .is_empty());
+
+            let (user, assistant) = store
+                .append_turn_with_system_prompt(
+                    pending_user.clone(),
+                    "world".to_string(),
+                    "Qwen3.5-4B".to_string(),
+                    7,
+                    12.5,
+                    None,
+                )
+                .await
+                .expect("turn should append");
+            assert_eq!(user.id, pending_user.id);
+            assert!(assistant.created_at > user.created_at);
+
+            let messages = store
+                .list_messages(thread.id.clone())
+                .await
+                .expect("messages should list after commit");
+            assert_eq!(messages.len(), 2);
+            assert_eq!(messages[0].id, user.id);
+            assert_eq!(messages[0].content_parts, Some(content_parts));
+            assert_eq!(messages[1].id, assistant.id);
+            assert_eq!(messages[1].tokens_generated, Some(7));
+
+            let summary = store
+                .get_thread(thread.id)
+                .await
+                .expect("thread should load")
+                .expect("thread should exist");
+            assert_eq!(summary.message_count, 2);
+            assert_eq!(summary.last_message_preview.as_deref(), Some("world"));
+            clear_env();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn consecutive_turns_receive_strictly_monotonic_timestamps() {
+        with_env_lock(async {
+            let (_temp, store) = setup_store();
+            let thread = store
+                .create_thread_with_system_prompt(None, None, Some("original prompt".to_string()))
+                .await
+                .expect("thread should create");
+            let first_pending = store
+                .prepare_user_message(thread.id.clone(), "first".to_string(), None)
+                .await
+                .expect("first pending user");
+            let (_, first_assistant) = store
+                .append_turn_with_system_prompt(
+                    first_pending,
+                    "first answer".to_string(),
+                    "Qwen3.5-4B".to_string(),
+                    2,
+                    1.0,
+                    Some("updated prompt".to_string()),
+                )
+                .await
+                .expect("first turn");
+
+            // Simulate a wall-clock tie or rollback. Transactional ordering
+            // must advance past the already committed assistant timestamp.
+            let mut second_pending = store
+                .prepare_user_message(thread.id.clone(), "second".to_string(), None)
+                .await
+                .expect("second pending user");
+            second_pending.created_at = first_assistant.created_at;
+            let (second_user, second_assistant) = store
+                .append_turn_with_system_prompt(
+                    second_pending,
+                    "second answer".to_string(),
+                    "Qwen3.5-4B".to_string(),
+                    2,
+                    1.0,
+                    None,
+                )
+                .await
+                .expect("second turn");
+
+            assert!(second_user.created_at > first_assistant.created_at);
+            assert!(second_assistant.created_at > second_user.created_at);
+            let messages = store
+                .list_messages(thread.id.clone())
+                .await
+                .expect("messages");
+            assert_eq!(
+                messages
+                    .windows(2)
+                    .map(|pair| pair[0].created_at < pair[1].created_at)
+                    .collect::<Vec<_>>(),
+                vec![true, true, true]
+            );
+            let summary = store
+                .get_thread(thread.id)
+                .await
+                .expect("thread lookup")
+                .expect("thread exists");
+            assert_eq!(summary.system_prompt.as_deref(), Some("updated prompt"));
+            clear_env();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn failed_turn_rolls_back_messages_and_system_prompt_update() {
+        with_env_lock(async {
+            let (_temp, store) = setup_store();
+            let thread = store
+                .create_thread_with_system_prompt(None, None, Some("original prompt".to_string()))
+                .await
+                .expect("thread should create");
+            let pending = store
+                .prepare_user_message(thread.id.clone(), "hello".to_string(), None)
+                .await
+                .expect("pending user");
+
+            store
+                .append_turn_with_system_prompt(
+                    pending,
+                    "answer".to_string(),
+                    "Qwen3.5-4B".to_string(),
+                    usize::MAX,
+                    1.0,
+                    Some("must not persist".to_string()),
+                )
+                .await
+                .expect_err("overflowing token metadata should fail the transaction");
+
+            assert!(store
+                .list_messages(thread.id.clone())
+                .await
+                .expect("messages")
+                .is_empty());
+            let summary = store
+                .get_thread(thread.id)
+                .await
+                .expect("thread lookup")
+                .expect("thread exists");
+            assert_eq!(summary.system_prompt.as_deref(), Some("original prompt"));
+            clear_env();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn turn_lock_serializes_work_for_the_same_thread() {
+        with_env_lock(async {
+            let (_temp, store) = setup_store();
+            let first_guard = store.lock_turn("thread-1").await;
+            let waiter_store = store.clone();
+            let waiter = tokio::spawn(async move {
+                let _guard = waiter_store.lock_turn("thread-1").await;
+            });
+
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_millis(20), async {
+                    while !waiter.is_finished() {
+                        tokio::task::yield_now().await;
+                    }
+                })
+                .await
+                .is_err()
+            );
+
+            drop(first_guard);
+            tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+                .await
+                .expect("waiter should acquire after release")
+                .expect("waiter task should complete");
             clear_env();
         })
         .await;

--- a/crates/izwi-server/src/db/migrator.rs
+++ b/crates/izwi-server/src/db/migrator.rs
@@ -37,6 +37,7 @@ const BASELINE_SCHEMA: &[&str] = &[
         id TEXT PRIMARY KEY,
         title TEXT NOT NULL,
         model_id TEXT NULL,
+        system_prompt TEXT NULL,
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
     );
@@ -539,6 +540,11 @@ const POST_COMPATIBILITY_SCHEMA: &[&str] = &[
 ];
 
 const COMPATIBILITY_COLUMNS: &[CompatibilityColumn] = &[
+    CompatibilityColumn {
+        table: "chat_threads",
+        column: "system_prompt",
+        definition: "TEXT NULL",
+    },
     CompatibilityColumn {
         table: "media_assets",
         column: "source_asset_id",

--- a/crates/izwi-server/src/db/schema_contract.rs
+++ b/crates/izwi-server/src/db/schema_contract.rs
@@ -12,7 +12,14 @@ struct RequiredSchemaTable {
 const REQUIRED_SCHEMA_TABLES: &[RequiredSchemaTable] = &[
     RequiredSchemaTable {
         name: "chat_threads",
-        columns: &["id", "title", "model_id", "created_at", "updated_at"],
+        columns: &[
+            "id",
+            "title",
+            "model_id",
+            "system_prompt",
+            "created_at",
+            "updated_at",
+        ],
     },
     RequiredSchemaTable {
         name: "chat_messages",
@@ -572,4 +579,31 @@ async fn validate_required_seed_data(db: &DatabaseConnection) -> anyhow::Result<
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_provider_managed_schema;
+    use sea_orm::{ConnectionTrait, Database, DbBackend, Statement};
+
+    #[tokio::test]
+    async fn provider_contract_rejects_chat_threads_without_system_prompt() {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("sqlite connection");
+        db.execute_raw(Statement::from_string(
+            DbBackend::Sqlite,
+            "CREATE TABLE chat_threads (id TEXT PRIMARY KEY, title TEXT NOT NULL, model_id TEXT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)",
+        ))
+        .await
+        .expect("legacy chat_threads table");
+
+        let error = validate_provider_managed_schema(&db)
+            .await
+            .expect_err("legacy provider schema should fail");
+        assert!(
+            error.to_string().contains("chat_threads.system_prompt"),
+            "{error}"
+        );
+    }
 }

--- a/crates/izwi-server/src/db/sqlite.rs
+++ b/crates/izwi-server/src/db/sqlite.rs
@@ -277,6 +277,7 @@ mod tests {
     ];
 
     const EXPECTED_COMPAT_COLUMNS: &[(&str, &str)] = &[
+        ("chat_threads", "system_prompt"),
         ("chat_messages", "content_parts"),
         ("media_assets", "source_asset_id"),
         ("media_assets", "canonical_profile_version"),

--- a/crates/izwi-server/src/entity/mod.rs
+++ b/crates/izwi-server/src/entity/mod.rs
@@ -39,6 +39,7 @@ pub mod chat_threads {
         pub id: String,
         pub title: String,
         pub model_id: Option<String>,
+        pub system_prompt: Option<String>,
         pub created_at: i64,
         pub updated_at: i64,
     }

--- a/ui/src/shared/api/chat.ts
+++ b/ui/src/shared/api/chat.ts
@@ -54,6 +54,7 @@ export interface ChatThread {
   id: string;
   title: string;
   model_id: string | null;
+  system_prompt: string | null;
   created_at: number;
   updated_at: number;
   last_message_preview: string | null;
@@ -79,10 +80,12 @@ export interface ChatThreadDetail {
 export interface ChatThreadCreateRequest {
   title?: string;
   model_id?: string;
+  system_prompt?: string;
 }
 
 export interface ChatThreadUpdateRequest {
-  title: string;
+  title?: string;
+  system_prompt?: string;
 }
 
 export interface ChatThreadContentPart {
@@ -333,6 +336,7 @@ export class ChatApiClient {
       body: JSON.stringify({
         title: request?.title,
         model_id: request?.model_id,
+        system_prompt: request?.system_prompt,
       }),
     });
   }
@@ -345,6 +349,7 @@ export class ChatApiClient {
       method: "PATCH",
       body: JSON.stringify({
         title: request.title,
+        system_prompt: request.system_prompt,
       }),
     });
   }


### PR DESCRIPTION
Corrects Qwen3.5 tokenization, streaming decode, causal hybrid attention and persistence; adds atomic bounded chat history, Metal/CUDA sequence kernels, safe exact-prefix reuse, allocator-aware COW KV/state storage, cache lifecycle controls, and small/large-model resource and multi-turn regressions.